### PR TITLE
feat(bashkit): Phase 1 - Foundation with variables, pipes, redirects

### DIFF
--- a/crates/bashkit/src/builtins/cat.rs
+++ b/crates/bashkit/src/builtins/cat.rs
@@ -1,0 +1,57 @@
+//! cat builtin command
+
+use async_trait::async_trait;
+use std::path::Path;
+
+use super::{Builtin, Context};
+use crate::error::Result;
+use crate::interpreter::ExecResult;
+
+/// The cat builtin command.
+pub struct Cat;
+
+#[async_trait]
+impl Builtin for Cat {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        let mut output = String::new();
+
+        // If no arguments and stdin is provided, output stdin
+        if ctx.args.is_empty() {
+            if let Some(stdin) = ctx.stdin {
+                output.push_str(stdin);
+            }
+        } else {
+            // Read files
+            for arg in ctx.args {
+                // Handle - as stdin
+                if arg == "-" {
+                    if let Some(stdin) = ctx.stdin {
+                        output.push_str(stdin);
+                    }
+                } else {
+                    let path = if Path::new(arg).is_absolute() {
+                        arg.to_string()
+                    } else {
+                        ctx.cwd.join(arg).to_string_lossy().to_string()
+                    };
+
+                    match ctx.fs.read_file(Path::new(&path)).await {
+                        Ok(content) => {
+                            let text = String::from_utf8_lossy(&content);
+                            output.push_str(&text);
+                        }
+                        Err(e) => {
+                            return Ok(ExecResult {
+                                stdout: String::new(),
+                                stderr: format!("cat: {}: {}\n", arg, e),
+                                exit_code: 1,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ExecResult::ok(output))
+    }
+}

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -1,9 +1,11 @@
 //! Built-in shell commands
 
+mod cat;
 mod echo;
 mod flow;
 mod navigation;
 
+pub use cat::Cat;
 pub use echo::Echo;
 pub use flow::{Exit, False, True};
 pub use navigation::{Cd, Pwd};
@@ -30,6 +32,8 @@ pub struct Context<'a> {
     pub cwd: &'a mut PathBuf,
     /// Filesystem
     pub fs: Arc<dyn FileSystem>,
+    /// Standard input (from pipeline)
+    pub stdin: Option<&'a str>,
 }
 
 /// Trait for builtin commands.

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -33,10 +33,13 @@ impl<'a> Parser<'a> {
         let mut commands = Vec::new();
 
         while self.current_token.is_some() {
-            if let Some(cmd) = self.parse_command()? {
+            self.skip_newlines();
+            if self.current_token.is_none() {
+                break;
+            }
+            if let Some(cmd) = self.parse_command_list()? {
                 commands.push(cmd);
             }
-            self.skip_newlines();
         }
 
         Ok(Script { commands })
@@ -52,51 +55,235 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_command(&mut self) -> Result<Option<Command>> {
-        self.skip_newlines();
+    /// Parse a command list (commands connected by && or ||)
+    fn parse_command_list(&mut self) -> Result<Option<Command>> {
+        let first = match self.parse_pipeline()? {
+            Some(cmd) => cmd,
+            None => return Ok(None),
+        };
 
-        match &self.current_token {
-            None => Ok(None),
-            Some(tokens::Token::Word(_)) => {
-                let simple_cmd = self.parse_simple_command()?;
-                Ok(Some(Command::Simple(simple_cmd)))
+        let mut rest = Vec::new();
+
+        loop {
+            let op = match &self.current_token {
+                Some(tokens::Token::And) => {
+                    self.advance();
+                    ListOperator::And
+                }
+                Some(tokens::Token::Or) => {
+                    self.advance();
+                    ListOperator::Or
+                }
+                Some(tokens::Token::Semicolon) => {
+                    self.advance();
+                    self.skip_newlines();
+                    // Check if there's more to parse
+                    if self.current_token.is_none()
+                        || matches!(self.current_token, Some(tokens::Token::Newline))
+                    {
+                        break;
+                    }
+                    ListOperator::Semicolon
+                }
+                _ => break,
+            };
+
+            self.skip_newlines();
+
+            if let Some(cmd) = self.parse_pipeline()? {
+                rest.push((op, cmd));
+            } else {
+                break;
             }
-            Some(token) => Err(Error::Parse(format!("unexpected token: {:?}", token))),
+        }
+
+        if rest.is_empty() {
+            Ok(Some(first))
+        } else {
+            Ok(Some(Command::List(CommandList {
+                first: Box::new(first),
+                rest,
+            })))
         }
     }
 
-    fn parse_simple_command(&mut self) -> Result<SimpleCommand> {
-        let mut words = Vec::new();
+    /// Parse a pipeline (commands connected by |)
+    fn parse_pipeline(&mut self) -> Result<Option<Command>> {
+        let first = match self.parse_simple_command()? {
+            Some(cmd) => cmd,
+            None => return Ok(None),
+        };
 
-        while let Some(token) = &self.current_token {
-            match token {
-                tokens::Token::Word(w) => {
-                    words.push(Word {
-                        parts: vec![WordPart::Literal(w.clone())],
+        let mut commands = vec![Command::Simple(first)];
+
+        while matches!(self.current_token, Some(tokens::Token::Pipe)) {
+            self.advance();
+            self.skip_newlines();
+
+            if let Some(cmd) = self.parse_simple_command()? {
+                commands.push(Command::Simple(cmd));
+            } else {
+                return Err(Error::Parse("expected command after |".to_string()));
+            }
+        }
+
+        if commands.len() == 1 {
+            Ok(Some(commands.remove(0)))
+        } else {
+            Ok(Some(Command::Pipeline(Pipeline {
+                negated: false,
+                commands,
+            })))
+        }
+    }
+
+    /// Parse a simple command with redirections
+    fn parse_simple_command(&mut self) -> Result<Option<SimpleCommand>> {
+        self.skip_newlines();
+
+        let mut words = Vec::new();
+        let mut redirects = Vec::new();
+
+        loop {
+            match &self.current_token {
+                Some(tokens::Token::Word(w)) => {
+                    words.push(self.parse_word(w.clone()));
+                    self.advance();
+                }
+                Some(tokens::Token::RedirectOut) => {
+                    self.advance();
+                    let target = self.expect_word()?;
+                    redirects.push(Redirect {
+                        fd: None,
+                        kind: RedirectKind::Output,
+                        target,
                     });
-                    self.advance();
                 }
-                tokens::Token::Newline | tokens::Token::Semicolon => {
+                Some(tokens::Token::RedirectAppend) => {
                     self.advance();
-                    break;
+                    let target = self.expect_word()?;
+                    redirects.push(Redirect {
+                        fd: None,
+                        kind: RedirectKind::Append,
+                        target,
+                    });
                 }
+                Some(tokens::Token::RedirectIn) => {
+                    self.advance();
+                    let target = self.expect_word()?;
+                    redirects.push(Redirect {
+                        fd: None,
+                        kind: RedirectKind::Input,
+                        target,
+                    });
+                }
+                Some(tokens::Token::HereString) => {
+                    self.advance();
+                    let target = self.expect_word()?;
+                    redirects.push(Redirect {
+                        fd: None,
+                        kind: RedirectKind::HereString,
+                        target,
+                    });
+                }
+                Some(tokens::Token::Newline)
+                | Some(tokens::Token::Semicolon)
+                | Some(tokens::Token::Pipe)
+                | Some(tokens::Token::And)
+                | Some(tokens::Token::Or)
+                | None => break,
                 _ => break,
             }
         }
 
         if words.is_empty() {
-            return Err(Error::Parse("empty command".to_string()));
+            return Ok(None);
         }
 
         let name = words.remove(0);
         let args = words;
 
-        Ok(SimpleCommand {
+        Ok(Some(SimpleCommand {
             name,
             args,
-            redirects: Vec::new(),
+            redirects,
             assignments: Vec::new(),
-        })
+        }))
+    }
+
+    /// Expect a word token and return it as a Word
+    fn expect_word(&mut self) -> Result<Word> {
+        match &self.current_token {
+            Some(tokens::Token::Word(w)) => {
+                let word = self.parse_word(w.clone());
+                self.advance();
+                Ok(word)
+            }
+            _ => Err(Error::Parse("expected word".to_string())),
+        }
+    }
+
+    /// Parse a word string into a Word with proper parts (variables, literals)
+    fn parse_word(&self, s: String) -> Word {
+        let mut parts = Vec::new();
+        let mut chars = s.chars().peekable();
+        let mut current = String::new();
+
+        while let Some(ch) = chars.next() {
+            if ch == '$' {
+                // Flush current literal
+                if !current.is_empty() {
+                    parts.push(WordPart::Literal(std::mem::take(&mut current)));
+                }
+
+                // Parse variable name
+                if chars.peek() == Some(&'{') {
+                    // ${VAR} format
+                    chars.next(); // consume '{'
+                    let mut var_name = String::new();
+                    while let Some(&c) = chars.peek() {
+                        if c == '}' {
+                            chars.next(); // consume '}'
+                            break;
+                        }
+                        var_name.push(chars.next().unwrap());
+                    }
+                    if !var_name.is_empty() {
+                        parts.push(WordPart::Variable(var_name));
+                    }
+                } else {
+                    // $VAR format
+                    let mut var_name = String::new();
+                    while let Some(&c) = chars.peek() {
+                        if c.is_ascii_alphanumeric() || c == '_' {
+                            var_name.push(chars.next().unwrap());
+                        } else {
+                            break;
+                        }
+                    }
+                    if !var_name.is_empty() {
+                        parts.push(WordPart::Variable(var_name));
+                    } else {
+                        // Just a literal $
+                        current.push('$');
+                    }
+                }
+            } else {
+                current.push(ch);
+            }
+        }
+
+        // Flush remaining literal
+        if !current.is_empty() {
+            parts.push(WordPart::Literal(current));
+        }
+
+        // If no parts, create an empty literal
+        if parts.is_empty() {
+            parts.push(WordPart::Literal(String::new()));
+        }
+
+        Word { parts }
     }
 }
 
@@ -133,5 +320,88 @@ mod tests {
         } else {
             panic!("expected simple command");
         }
+    }
+
+    #[test]
+    fn test_parse_variable() {
+        let parser = Parser::new("echo $HOME");
+        let script = parser.parse().unwrap();
+
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.args.len(), 1);
+            assert_eq!(cmd.args[0].parts.len(), 1);
+            assert!(matches!(&cmd.args[0].parts[0], WordPart::Variable(v) if v == "HOME"));
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
+    fn test_parse_pipeline() {
+        let parser = Parser::new("echo hello | cat");
+        let script = parser.parse().unwrap();
+
+        assert_eq!(script.commands.len(), 1);
+        assert!(matches!(&script.commands[0], Command::Pipeline(_)));
+
+        if let Command::Pipeline(pipeline) = &script.commands[0] {
+            assert_eq!(pipeline.commands.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_parse_redirect_out() {
+        let parser = Parser::new("echo hello > /tmp/out");
+        let script = parser.parse().unwrap();
+
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.redirects.len(), 1);
+            assert_eq!(cmd.redirects[0].kind, RedirectKind::Output);
+            assert_eq!(cmd.redirects[0].target.to_string(), "/tmp/out");
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
+    fn test_parse_redirect_append() {
+        let parser = Parser::new("echo hello >> /tmp/out");
+        let script = parser.parse().unwrap();
+
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.redirects.len(), 1);
+            assert_eq!(cmd.redirects[0].kind, RedirectKind::Append);
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
+    fn test_parse_redirect_in() {
+        let parser = Parser::new("cat < /tmp/in");
+        let script = parser.parse().unwrap();
+
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.redirects.len(), 1);
+            assert_eq!(cmd.redirects[0].kind, RedirectKind::Input);
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
+    fn test_parse_command_list_and() {
+        let parser = Parser::new("true && echo success");
+        let script = parser.parse().unwrap();
+
+        assert!(matches!(&script.commands[0], Command::List(_)));
+    }
+
+    #[test]
+    fn test_parse_command_list_or() {
+        let parser = Parser::new("false || echo fallback");
+        let script = parser.parse().unwrap();
+
+        assert!(matches!(&script.commands[0], Command::List(_)));
     }
 }

--- a/specs/002-parser.md
+++ b/specs/002-parser.md
@@ -1,0 +1,152 @@
+# 002: Parser Design
+
+## Status
+Implementing
+
+## Decision
+
+BashKit uses a recursive descent parser with a context-aware lexer.
+
+### Tokenization Flow
+
+```
+Input → Lexer → Tokens → Parser → AST
+```
+
+### Token Types
+
+```rust
+pub enum Token {
+    // Literals
+    Word(String),           // Unquoted or quoted words
+    Number(i64),            // Integer literals
+
+    // Operators
+    Pipe,                   // |
+    And,                    // &&
+    Or,                     // ||
+    Semicolon,              // ;
+    Newline,                // \n
+    Background,             // &
+
+    // Redirections
+    RedirectOut,            // >
+    RedirectAppend,         // >>
+    RedirectIn,             // <
+    HereDoc,                // <<
+    HereString,             // <<<
+
+    // File descriptor redirections (future)
+    // 2>&1, &>, etc.
+
+    // Grouping
+    LeftParen,              // (
+    RightParen,             // )
+    LeftBrace,              // {
+    RightBrace,             // }
+    DoubleLeftBracket,      // [[
+    DoubleRightBracket,     // ]]
+
+    // Keywords (detected after lexing)
+    // if, then, else, elif, fi
+    // for, while, until, do, done
+    // case, esac, in
+    // function
+}
+```
+
+### AST Structure
+
+```rust
+pub struct Script {
+    pub commands: Vec<Command>,
+}
+
+pub enum Command {
+    Simple(SimpleCommand),      // ls -la
+    Pipeline(Pipeline),         // cmd1 | cmd2 | cmd3
+    List(CommandList),          // cmd1 && cmd2 || cmd3
+    Compound(CompoundCommand),  // if, for, while, case, { }, ( )
+    Function(FunctionDef),      // function foo() { }
+}
+
+pub struct SimpleCommand {
+    pub name: Word,
+    pub args: Vec<Word>,
+    pub redirects: Vec<Redirect>,
+    pub assignments: Vec<Assignment>,  // VAR=value cmd
+}
+
+pub struct Word {
+    pub parts: Vec<WordPart>,
+}
+
+pub enum WordPart {
+    Literal(String),
+    Variable(String),           // $VAR
+    CommandSub(Script),         // $(cmd) or `cmd`
+    ArithmeticSub(String),      // $((expr))
+    DoubleQuoted(Vec<WordPart>), // "text $var"
+}
+```
+
+### Parser Rules (Simplified)
+
+```
+script        → command_list EOF
+command_list  → pipeline (('&&' | '||') pipeline)*
+pipeline      → command ('|' command)*
+command       → simple_command | compound_command | function_def
+simple_command → (assignment)* word (word | redirect)*
+redirect      → ('>' | '>>' | '<' | '<<' | '<<<') word
+               | NUMBER ('>' | '<') word
+```
+
+### Context-Aware Lexing
+
+The lexer must handle bash's context-sensitivity:
+- `$var` in double quotes: expand variable
+- `$var` in single quotes: literal text
+- Word splitting after expansion
+- Glob patterns (*, ?, [])
+
+### Error Recovery
+
+Parser produces errors with:
+- Line and column numbers
+- Expected vs. found token
+- Context (what was being parsed)
+
+## Alternatives Considered
+
+### PEG parser (pest, pom)
+Rejected because:
+- Bash grammar is context-sensitive
+- PEG can't handle here-docs well
+- Manual parser gives better error messages
+
+### Tree-sitter
+Rejected because:
+- Designed for incremental parsing (overkill)
+- Would add large dependency
+- Harder to customize for our needs
+
+## Verification
+
+```rust
+#[test]
+fn test_parse_pipeline() {
+    let parser = Parser::new("echo hello | cat");
+    let script = parser.parse().unwrap();
+    assert!(matches!(script.commands[0], Command::Pipeline(_)));
+}
+
+#[test]
+fn test_parse_redirect() {
+    let parser = Parser::new("echo hello > /tmp/out");
+    let script = parser.parse().unwrap();
+    if let Command::Simple(cmd) = &script.commands[0] {
+        assert_eq!(cmd.redirects.len(), 1);
+    }
+}
+```

--- a/specs/003-vfs.md
+++ b/specs/003-vfs.md
@@ -1,0 +1,154 @@
+# 003: Virtual Filesystem Design
+
+## Status
+Implemented (InMemoryFs), Planned (OverlayFs, MountableFs)
+
+## Decision
+
+BashKit uses an async virtual filesystem trait with multiple implementations.
+
+### FileSystem Trait
+
+```rust
+#[async_trait]
+pub trait FileSystem: Send + Sync {
+    // Read operations
+    async fn read_file(&self, path: &Path) -> Result<Vec<u8>>;
+    async fn stat(&self, path: &Path) -> Result<Metadata>;
+    async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>>;
+    async fn exists(&self, path: &Path) -> Result<bool>;
+    async fn read_link(&self, path: &Path) -> Result<PathBuf>;
+
+    // Write operations
+    async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()>;
+    async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()>;
+    async fn mkdir(&self, path: &Path, recursive: bool) -> Result<()>;
+    async fn remove(&self, path: &Path, recursive: bool) -> Result<()>;
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()>;
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()>;
+    async fn symlink(&self, target: &Path, link: &Path) -> Result<()>;
+    async fn chmod(&self, path: &Path, mode: u32) -> Result<()>;
+}
+```
+
+### Metadata
+
+```rust
+pub struct Metadata {
+    pub file_type: FileType,
+    pub size: u64,
+    pub mode: u32,        // Unix permissions
+    pub modified: SystemTime,
+    pub created: SystemTime,
+}
+
+pub enum FileType {
+    File,
+    Directory,
+    Symlink,
+}
+
+pub struct DirEntry {
+    pub name: String,
+    pub metadata: Metadata,
+}
+```
+
+### Implementations
+
+#### InMemoryFs (Implemented)
+- All files stored in `HashMap<PathBuf, FsEntry>`
+- Thread-safe via `RwLock`
+- Initial directories: `/`, `/tmp`, `/home`, `/home/user`
+- No persistence - state lost on drop
+
+#### OverlayFs (Planned)
+- Copy-on-write layer over another FileSystem
+- Read from base, write to overlay
+- Useful for: temp modifications, testing, sandboxing
+
+```rust
+pub struct OverlayFs {
+    base: Arc<dyn FileSystem>,
+    overlay: InMemoryFs,
+    deleted: HashSet<PathBuf>,  // Whiteout files
+}
+```
+
+#### MountableFs (Planned)
+- Mount multiple filesystems at different paths
+- Like Unix mount points
+
+```rust
+pub struct MountableFs {
+    root: Arc<dyn FileSystem>,
+    mounts: BTreeMap<PathBuf, Arc<dyn FileSystem>>,
+}
+```
+
+#### RealFs (Planned, Optional)
+- Direct access to real filesystem
+- Must be explicitly enabled (security)
+- Useful for development/testing
+
+### Path Handling
+
+All paths normalized before use:
+- Resolve `.` and `..` components
+- Remove trailing slashes
+- Ensure absolute paths start with `/`
+
+```rust
+fn normalize_path(path: &Path) -> PathBuf {
+    // "/foo/../bar/./baz" → "/bar/baz"
+}
+```
+
+### Symlink Handling
+
+Current: Symlinks stored but not followed (TODO comment in code)
+Planned: Follow symlinks with loop detection (max 40 levels like Linux)
+
+### Error Handling
+
+All operations return `Result<T>` with IO errors:
+- `NotFound` - file/directory doesn't exist
+- `AlreadyExists` - path already exists
+- `Other("is a directory")` - operation not valid for directories
+- `Other("not a directory")` - expected directory
+- `Other("directory not empty")` - non-recursive delete of non-empty dir
+
+## Alternatives Considered
+
+### Real filesystem with chroot
+Rejected because:
+- Requires root privileges
+- Not portable across OSes
+- Doesn't work in WASM
+
+### tokio::fs wrapper
+Rejected because:
+- Always hits real filesystem
+- Can't sandbox or virtualize
+- No multi-tenant isolation
+
+## Verification
+
+```rust
+#[tokio::test]
+async fn test_write_and_read() {
+    let fs = InMemoryFs::new();
+    fs.write_file(Path::new("/tmp/test"), b"hello").await.unwrap();
+    let content = fs.read_file(Path::new("/tmp/test")).await.unwrap();
+    assert_eq!(content, b"hello");
+}
+
+#[tokio::test]
+async fn test_mkdir_recursive() {
+    let fs = InMemoryFs::new();
+    fs.mkdir(Path::new("/a/b/c"), true).await.unwrap();
+    assert!(fs.exists(Path::new("/a")).await.unwrap());
+    assert!(fs.exists(Path::new("/a/b")).await.unwrap());
+    assert!(fs.exists(Path::new("/a/b/c")).await.unwrap());
+}
+```


### PR DESCRIPTION
## Summary

Phase 1 implementation - Foundation with core shell features:

- **Parser**: Extended to handle pipelines, redirections, command lists (&&, ||)
- **Lexer**: Enhanced variable handling ($VAR, ${VAR})
- **Interpreter**: 
  - Pipeline execution with stdin/stdout passing between commands
  - Command list execution with short-circuit evaluation
  - Output redirections (>, >>)
- **Builtins**: Added `cat` (reads files and stdin for pipelines)
- **Specs**: Added 002-parser.md and 003-vfs.md design documents

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (35 unit tests + 1 doc test)
- [x] Phase 1 target verified: `echo $HOME | cat > /tmp/out && cat /tmp/out` works

## New tests added

- Variable expansion ($VAR, ${VAR})
- Pipeline execution (2 and 3 command pipelines)
- Output redirections (>, >>)
- Command lists (&& and || with short-circuit behavior)