### PR TITLE
feat(bashkit): Phase 5 - Array support

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -745,4 +745,42 @@ mod tests {
         let result = bash.exec("X=file.tar.gz; echo ${X%.*}").await.unwrap();
         assert_eq!(result.stdout, "file.tar\n");
     }
+
+    #[tokio::test]
+    async fn test_array_basic() {
+        let mut bash = Bash::new();
+        // Basic array declaration and access
+        let result = bash.exec("arr=(a b c); echo ${arr[1]}").await.unwrap();
+        assert_eq!(result.stdout, "b\n");
+    }
+
+    #[tokio::test]
+    async fn test_array_all_elements() {
+        let mut bash = Bash::new();
+        // ${arr[@]} - all elements
+        let result = bash
+            .exec("arr=(one two three); echo ${arr[@]}")
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "one two three\n");
+    }
+
+    #[tokio::test]
+    async fn test_array_length() {
+        let mut bash = Bash::new();
+        // ${#arr[@]} - number of elements
+        let result = bash.exec("arr=(a b c d e); echo ${#arr[@]}").await.unwrap();
+        assert_eq!(result.stdout, "5\n");
+    }
+
+    #[tokio::test]
+    async fn test_array_indexed_assignment() {
+        let mut bash = Bash::new();
+        // arr[n]=value assignment
+        let result = bash
+            .exec("arr[0]=first; arr[1]=second; echo ${arr[0]} ${arr[1]}")
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "first second\n");
+    }
 }

--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -188,6 +188,8 @@ impl fmt::Display for Word {
                     write!(f, "${{{}{}{}}}", name, op_str, operand)?
                 }
                 WordPart::Length(name) => write!(f, "${{#{}}}", name)?,
+                WordPart::ArrayAccess { name, index } => write!(f, "${{{}[{}]}}", name, index)?,
+                WordPart::ArrayLength(name) => write!(f, "${{#{}[@]}}", name)?,
             }
         }
         Ok(())
@@ -213,6 +215,10 @@ pub enum WordPart {
     },
     /// Length expansion ${#var}
     Length(String),
+    /// Array element access ${arr[index]} or ${arr[@]} or ${arr[*]}
+    ArrayAccess { name: String, index: String },
+    /// Array length ${#arr[@]} or ${#arr[*]}
+    ArrayLength(String),
 }
 
 /// Parameter expansion operators
@@ -272,5 +278,16 @@ pub enum RedirectKind {
 #[derive(Debug, Clone)]
 pub struct Assignment {
     pub name: String,
-    pub value: Word,
+    /// Optional array index for indexed assignments like arr[0]=value
+    pub index: Option<String>,
+    pub value: AssignmentValue,
+}
+
+/// Value in an assignment - scalar or array
+#[derive(Debug, Clone)]
+pub enum AssignmentValue {
+    /// Scalar value: VAR=value
+    Scalar(Word),
+    /// Array value: VAR=(a b c)
+    Array(Vec<Word>),
 }


### PR DESCRIPTION
## Summary

Add indexed array support to the bash interpreter.

## Features

### Array Declaration
- `arr=(a b c)` - Array literal assignment
- `arr[0]=value` - Indexed element assignment

### Array Access
- `${arr[0]}` - Single element access
- `${arr[@]}` and `${arr[*]}` - All elements
- `${#arr[@]}` - Array length (number of elements)

## Implementation

### AST Changes
- `Assignment` now has optional `index` field for `arr[n]=value`
- New `AssignmentValue` enum: `Scalar(Word)` vs `Array(Vec<Word>)`
- New `WordPart::ArrayAccess { name, index }` for `${arr[...]}`
- New `WordPart::ArrayLength(name)` for `${#arr[@]}`

### Parser Changes
- Handle `arr=(...)` syntax where `(` is a separate token
- Parse array subscripts in assignments
- Parse `${arr[...]}` access patterns in words
- Avoid treating `arr=(` as function definition

### Interpreter Changes
- Added `arrays: HashMap<String, HashMap<usize, String>>` storage
- Expand array access with `@` or `*` to all elements
- Evaluate arithmetic expressions in array indices

## Test plan
- [x] 104 tests passing (+4 new array tests)
- [x] Basic array declaration and access
- [x] All elements expansion
- [x] Array length
- [x] Indexed assignment
- [x] Clippy clean