### PR TITLE
feat(bashkit-cli): Add CLI binary for command line usage

### DIFF
--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -1,0 +1,21 @@
+# BashKit CLI - Command line interface for bashkit
+# Run bash scripts in a sandboxed environment
+
+[package]
+name = "bashkit-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Command line interface for BashKit sandboxed bash interpreter"
+
+[[bin]]
+name = "bashkit"
+path = "src/main.rs"
+
+[dependencies]
+bashkit = { path = "../bashkit" }
+tokio.workspace = true
+clap.workspace = true
+anyhow.workspace = true

--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -1,0 +1,66 @@
+//! BashKit CLI - Command line interface for sandboxed bash execution
+//!
+//! Usage:
+//!   bashkit -c 'echo hello'        # Execute a command string
+//!   bashkit script.sh              # Execute a script file
+//!   bashkit                         # Interactive REPL (not yet implemented)
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::PathBuf;
+
+/// BashKit - Sandboxed bash interpreter
+#[derive(Parser, Debug)]
+#[command(name = "bashkit")]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Execute the given command string
+    #[arg(short = 'c')]
+    command: Option<String>,
+
+    /// Script file to execute
+    #[arg()]
+    script: Option<PathBuf>,
+
+    /// Arguments to pass to the script
+    #[arg(trailing_var_arg = true)]
+    args: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let mut bash = bashkit::Bash::new();
+
+    // Execute command string if provided
+    if let Some(cmd) = args.command {
+        let result = bash.exec(&cmd).await.context("Failed to execute command")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
+        std::process::exit(result.exit_code);
+    }
+
+    // Execute script file if provided
+    if let Some(script_path) = args.script {
+        let script = std::fs::read_to_string(&script_path)
+            .with_context(|| format!("Failed to read script: {}", script_path.display()))?;
+
+        let result = bash
+            .exec(&script)
+            .await
+            .context("Failed to execute script")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
+        std::process::exit(result.exit_code);
+    }
+
+    // Interactive REPL (not yet implemented)
+    eprintln!("bashkit: interactive mode not yet implemented");
+    eprintln!("Usage: bashkit -c 'command' or bashkit script.sh");
+    std::process::exit(1);
+}


### PR DESCRIPTION
## Summary

Add a CLI binary for running BashKit from the command line.

## Usage

```bash
# Execute a command string
bashkit -c 'echo hello'

# Execute a script file
bashkit script.sh

# Show help
bashkit --help
```

## Features

- `-c <command>` - Execute a command string
- Script file execution
- Proper exit code handling
- stdout/stderr separation
- Error messages via anyhow

## Examples

```bash
# Simple echo
$ bashkit -c 'echo "Hello, World!"'
Hello, World!

# Arithmetic
$ bashkit -c 'echo $((10 + 20))'
30

# Arrays
$ bashkit -c 'arr=(a b c); echo ${#arr[@]}'
3

# For loop
$ bashkit -c 'for i in 1 2 3; do echo $i; done'
1
2
3
```

## Test plan
- [x] 104 tests passing (library)
- [x] CLI help works
- [x] Command execution works
- [x] Script file execution works
- [x] Clippy clean