### PR TITLE
docs: add licensing and attribution files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Everruns
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,103 @@
+BashKit
+Copyright (c) 2024-2026 Everruns
+
+This product is an independent implementation of a sandboxed bash interpreter.
+
+================================================================================
+ACKNOWLEDGMENTS
+================================================================================
+
+BashKit is an independent implementation that draws design inspiration from
+several open source projects. We gratefully acknowledge:
+
+--------------------------------------------------------------------------------
+just-bash
+--------------------------------------------------------------------------------
+Copyright (c) Vercel Inc.
+Licensed under the Apache License, Version 2.0
+
+Repository: https://github.com/vercel/just-bash
+
+BashKit's sandboxing architecture and multi-tenant design was inspired by
+just-bash's approach to safe bash execution. No code was copied; this is an
+independent Rust implementation.
+
+--------------------------------------------------------------------------------
+Oils (formerly Oil Shell)
+--------------------------------------------------------------------------------
+Copyright (c) Andy Chu and contributors
+Licensed under the Apache License, Version 2.0
+
+Repository: https://github.com/oilshell/oil
+
+The Oils project's comprehensive bash compatibility testing approach inspired
+our spec test methodology. Our test cases are independently written following
+similar testing principles.
+
+--------------------------------------------------------------------------------
+One True AWK
+--------------------------------------------------------------------------------
+Copyright (c) Lucent Technologies
+Licensed under the Lucent Public License
+
+Repository: https://github.com/onetrueawk/awk
+
+The behavior and semantics of our AWK builtin implementation are informed by
+the One True AWK specification. Our implementation is written from scratch in
+Rust using the original AWK language definition as reference.
+
+--------------------------------------------------------------------------------
+jq
+--------------------------------------------------------------------------------
+Copyright (c) Stephen Dolan
+Licensed under the MIT License
+
+Repository: https://github.com/jqlang/jq
+
+Our jq builtin aims for compatibility with jq's query syntax and behavior.
+The implementation uses the jaq Rust crates (MIT licensed) rather than jq
+source code directly.
+
+================================================================================
+RUST DEPENDENCIES
+================================================================================
+
+BashKit uses the following notable Rust crates. Full dependency information
+is available via `cargo tree` or in the Cargo.lock file.
+
+jaq-core, jaq-std, jaq-json (MIT)
+  - JQ expression parsing and evaluation
+  - Copyright (c) Michael Färber
+
+grep, grep-regex, grep-searcher (MIT/Apache-2.0)
+  - Text search functionality
+  - Part of the ripgrep project by Andrew Gallant
+
+tokio (MIT)
+  - Async runtime
+  - Copyright (c) Tokio Contributors
+
+serde, serde_json (MIT/Apache-2.0)
+  - Serialization framework
+  - Copyright (c) David Tolnay and serde contributors
+
+regex (MIT/Apache-2.0)
+  - Regular expression engine
+  - Copyright (c) The Rust Project Developers
+
+All dependencies are permissively licensed (MIT, Apache-2.0, BSD, ISC, Zlib).
+See THIRD_PARTY_LICENSES/ for full license texts of key dependencies.
+
+================================================================================
+INDEPENDENT IMPLEMENTATION NOTICE
+================================================================================
+
+BashKit is an independent implementation of a bash-like shell interpreter.
+It is not affiliated with, endorsed by, or derived from:
+
+- GNU Bash (GPL licensed)
+- The original Bourne shell
+- Any of the projects mentioned above
+
+The shell syntax parser, interpreter, virtual filesystem, and all builtins
+(except where noted) are original implementations written in Rust.

--- a/THIRD_PARTY_LICENSES/APACHE-2.0.txt
+++ b/THIRD_PARTY_LICENSES/APACHE-2.0.txt
@@ -1,0 +1,182 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+--------------------------------------------------------------------------------
+This license applies to:
+- just-bash (Vercel Inc.)
+- Oils project (Andy Chu and contributors)
+--------------------------------------------------------------------------------

--- a/THIRD_PARTY_LICENSES/LUCENT.txt
+++ b/THIRD_PARTY_LICENSES/LUCENT.txt
@@ -1,0 +1,27 @@
+Lucent Public License Version 1.02
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in this Software without prior written authorization of the
+copyright holder.
+
+The complete Lucent Public License Version 1.02 is available at:
+https://opensource.org/licenses/LPL-1.02
+
+--------------------------------------------------------------------------------
+This license applies to:
+- One True AWK (Lucent Technologies / Brian Kernighan)
+  Repository: https://github.com/onetrueawk/awk
+
+  BashKit's AWK builtin implementation is informed by the One True AWK
+  language specification and behavior, but is an independent implementation
+  written from scratch in Rust.
+--------------------------------------------------------------------------------

--- a/THIRD_PARTY_LICENSES/MIT.txt
+++ b/THIRD_PARTY_LICENSES/MIT.txt
@@ -1,0 +1,26 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+This license applies to:
+- jq (Stephen Dolan)
+- jaq Rust crates (Michael Färber)
+- Many Rust dependencies (see Cargo.lock for full list)
+--------------------------------------------------------------------------------

--- a/THIRD_PARTY_LICENSES/README.md
+++ b/THIRD_PARTY_LICENSES/README.md
@@ -1,0 +1,43 @@
+# Third-Party Licenses
+
+This directory contains license texts for projects that have influenced
+BashKit's design or whose test case formats have inspired our testing approach.
+
+## Important Notes
+
+1. **BashKit is an independent implementation.** No source code has been copied
+   from any of these projects. All Rust code in BashKit is original.
+
+2. **Test cases are original.** While our testing methodology was inspired by
+   projects like Oils, the actual test cases are written specifically for
+   BashKit.
+
+3. **Dependencies are via Cargo.** Rust dependencies (like jaq for jq support)
+   are included via standard Cargo dependency management, not by copying source.
+
+## License Files
+
+| File | Projects | License Type |
+|------|----------|--------------|
+| `APACHE-2.0.txt` | just-bash, Oils | Apache License 2.0 |
+| `MIT.txt` | jq, jaq crates, most dependencies | MIT License |
+| `LUCENT.txt` | One True AWK | Lucent Public License |
+
+## Full Dependency Licenses
+
+For a complete list of all Rust dependencies and their licenses, run:
+
+```bash
+cargo tree --format "{p} {l}"
+```
+
+Or use cargo-deny for license compliance checking:
+
+```bash
+cargo deny check licenses
+```
+
+## Contact
+
+If you have questions about licensing, please open an issue at:
+https://github.com/everruns/bashkit/issues


### PR DESCRIPTION
## Summary

- Add MIT LICENSE file for BashKit
- Add NOTICE file with attribution for design inspirations:
  - just-bash (Apache 2.0, Vercel Inc.) - sandboxing architecture inspiration
  - Oils project (Apache 2.0) - spec test methodology inspiration
  - One True AWK (Lucent License) - AWK language reference
  - jq (MIT) - jq query syntax compatibility target
- Add THIRD_PARTY_LICENSES/ directory with license texts

## Key Points

- Clearly states BashKit is an **independent implementation** with no copied code
- All test cases are original (inspired by testing approaches, not copied)
- Documents Rust dependencies (jaq, grep crates, etc.)

## Test plan

- [x] Files are correctly formatted
- [x] All attributed projects have corresponding license texts