### PR TITLE
fix(test): isolate fail-point tests for CI execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,10 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --features network
+
+      - name: Run fail-point tests (single-threaded)
+        run: cargo test --features failpoints --test security_failpoint_tests -- --test-threads=1
 
       - name: Run examples
         run: |

--- a/crates/bashkit/tests/security_failpoint_tests.rs
+++ b/crates/bashkit/tests/security_failpoint_tests.rs
@@ -5,12 +5,9 @@
 //! - Filesystem operations fail gracefully
 //! - Interpreter handles errors without exposing internal state
 //!
-//! **IMPORTANT**: Fail points are global state and not thread-safe.
-//! Run these tests with a single thread to avoid race conditions:
-//!
-//! ```sh
-//! cargo test --features failpoints security_ -- --test-threads=1
-//! ```
+//! **NOTE**: These tests use global state and must run single-threaded.
+//! CI runs them separately with `--test-threads=1`. The tests are isolated
+//! from the main test suite by using the `failpoints` feature flag.
 
 #![cfg(feature = "failpoints")]
 
@@ -48,7 +45,6 @@ async fn run_script_with_limits(script: &str, limits: ExecutionLimits) -> ExecRe
 /// Security property: Even if the counter is corrupted to skip increment,
 /// the limit should still be enforced eventually.
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_command_limit_skip_increment() {
     fail::cfg("limits::tick_command", "return(skip_increment)").unwrap();
 
@@ -69,7 +65,6 @@ async fn security_command_limit_skip_increment() {
 
 /// Test: Command counter overflow is handled
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_command_limit_overflow() {
     fail::cfg("limits::tick_command", "return(force_overflow)").unwrap();
 
@@ -87,7 +82,6 @@ async fn security_command_limit_overflow() {
 
 /// Test: Loop counter reset doesn't cause infinite loop
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1 and is flaky in parallel"]
 async fn security_loop_counter_reset() {
     // Note: This test would cause infinite loop if limit wasn't also checked elsewhere
     // We set a reasonable iteration limit to prevent actual infinite loop
@@ -111,7 +105,6 @@ async fn security_loop_counter_reset() {
 
 /// Test: Function depth bypass is detected
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_function_depth_bypass() {
     fail::cfg("limits::push_function", "return(skip_check)").unwrap();
 
@@ -148,7 +141,6 @@ async fn security_function_depth_bypass() {
 
 /// Test: Read failure is handled gracefully
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_fs_read_io_error() {
     fail::cfg("fs::read_file", "return(io_error)").unwrap();
 
@@ -162,7 +154,6 @@ async fn security_fs_read_io_error() {
 
 /// Test: Permission denied is handled
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_fs_read_permission_denied() {
     fail::cfg("fs::read_file", "return(permission_denied)").unwrap();
 
@@ -183,7 +174,6 @@ async fn security_fs_read_permission_denied() {
 
 /// Test: Corrupt data doesn't cause crash
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_fs_corrupt_data() {
     fail::cfg("fs::read_file", "return(corrupt_data)").unwrap();
 
@@ -199,7 +189,6 @@ async fn security_fs_corrupt_data() {
 
 /// Test: Write failure doesn't corrupt state
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_fs_write_failure() {
     fail::cfg("fs::write_file", "return(io_error)").unwrap();
 
@@ -213,7 +202,6 @@ async fn security_fs_write_failure() {
 
 /// Test: Disk full is handled
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_fs_disk_full() {
     fail::cfg("fs::write_file", "return(disk_full)").unwrap();
 
@@ -231,7 +219,6 @@ async fn security_fs_disk_full() {
 
 /// Test: Command execution error is handled
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_interp_execution_error() {
     fail::cfg("interp::execute_command", "return(error)").unwrap();
 
@@ -245,7 +232,6 @@ async fn security_interp_execution_error() {
 
 /// Test: Non-zero exit code injection
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_interp_exit_nonzero() {
     fail::cfg("interp::execute_command", "return(exit_nonzero)").unwrap();
 
@@ -264,7 +250,6 @@ async fn security_interp_exit_nonzero() {
 
 /// Test: Multiple fail points active simultaneously
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_multiple_failpoints() {
     // Activate multiple fail points
     fail::cfg("limits::tick_command", "5%return(skip_increment)").unwrap();
@@ -292,7 +277,6 @@ async fn security_multiple_failpoints() {
 
 /// Test: Fail point with probability (fuzz-like testing)
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_probabilistic_failures() {
     // 10% chance of failure on each command
     fail::cfg("limits::tick_command", "10%return(corrupt_high)").unwrap();
@@ -330,7 +314,6 @@ async fn security_probabilistic_failures() {
 
 /// Demonstrates how to use fail points for custom security testing
 #[tokio::test]
-#[ignore = "Fail point test requires --test-threads=1"]
 async fn security_example_custom_failpoint_usage() {
     // Setup: Configure fail point
     fail::cfg("fs::write_file", "return(permission_denied)").unwrap();

--- a/justfile
+++ b/justfile
@@ -12,9 +12,14 @@ default:
 build:
     cargo build
 
-# Run all tests
+# Run all tests (including fail-point tests)
 test:
-    cargo test --all-features
+    cargo test --features network
+    cargo test --features failpoints --test security_failpoint_tests -- --test-threads=1
+
+# Run fail-point tests only (single-threaded, requires failpoints feature)
+test-failpoints:
+    cargo test --features failpoints --test security_failpoint_tests -- --test-threads=1
 
 # Run formatters and linters (auto-fix)
 fmt:


### PR DESCRIPTION
## Summary
- Remove `#[ignore]` attributes from all 14 fail-point tests
- Split CI test step: regular tests with `--features network`, then fail-point tests with `--features failpoints --test-threads=1`
- Add dedicated `test-failpoints` recipe in justfile

The fail-point tests use global state from `fail-rs` and must run single-threaded. They are now isolated by feature flag and run as a separate CI step.

## Test plan
- [x] Verify all 14 fail-point tests pass with `--test-threads=1`
- [x] Verify regular tests still pass with `--features network`
- [x] Verify `cargo fmt --check` and `cargo clippy` pass
- [x] Ran tests 5+ times to confirm no flakiness