### PR TITLE
docs: add PR convention to never include Claude session links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,4 +83,6 @@ Types: feat, fix, docs, refactor, test, chore
 
 Squash and Merge. Use PR template if exists.
 
+**NEVER add links to Claude sessions in PR body.**
+
 See `CONTRIBUTING.md` for details.


### PR DESCRIPTION
## Summary

- Adds explicit guidance in AGENTS.md PRs section to never include Claude session links in PR body

## Test plan

- [x] Documentation change only, no code changes