### PR TITLE
docs(agents): add test-first principle for bug fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - Code testable, smoke testable, runnable locally
 - Small, incremental PR-sized changes
 - No backward compat needed (internal code)
+- Write failing test before fixing bug
 
 ### Specs
 


### PR DESCRIPTION
## Summary
- Adds "Write failing test before fixing bug" to main Principles section in AGENTS.md

## Test plan
- [x] Documentation change only, no code impact