### PR TITLE
feat(grep): implement -o flag for only-matching output

### DIFF
--- a/crates/bashkit/tests/spec_cases/grep/grep.test.sh
+++ b/crates/bashkit/tests/spec_cases/grep/grep.test.sh
@@ -97,7 +97,7 @@ bar foo baz
 ### end
 
 ### grep_only_matching
-### skip: -o flag not implemented
+# Only show matching part
 printf 'hello world\n' | grep -o 'world'
 ### expect
 world

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -70,10 +70,10 @@ crates/bashkit/tests/
 |----------|------------|-------|------|------|
 | Bash | 209 | **NO** (ignored) | - | - |
 | AWK | 19 | Yes | 17 | 2 |
-| Grep | 15 | Yes | 12 | 3 |
+| Grep | 15 | Yes | 13 | 2 |
 | Sed | 17 | Yes | 13 | 4 |
 | JQ | 21 | Yes | 20 | 1 |
-| **Total** | **281** | **72** | 62 | 10 |
+| **Total** | **281** | **72** | 63 | 9 |
 
 ### Test File Format
 
@@ -128,7 +128,7 @@ cargo test --test spec_tests -- bash_comparison_tests --ignored
 Coverage is tracked manually via spec test pass rates.
 
 ### Current Status
-- Text processing tools: 86% pass rate (62/72 running in CI)
+- Text processing tools: 88% pass rate (63/72 running in CI)
 - Core bash specs: Not running in CI (209 cases ignored)
 
 ## TODO: Testing Gaps
@@ -138,9 +138,9 @@ The following items need attention:
 - [ ] **Enable bash_spec_tests in CI** - 209 test cases currently ignored
 - [ ] **Fix control-flow.test.sh** - Currently skipped (.skip suffix)
 - [ ] **Add coverage tooling** - Consider cargo-tarpaulin or codecov
-- [ ] **Fix skipped spec tests** (10 total):
+- [ ] **Fix skipped spec tests** (9 total):
   - AWK: 2 skipped
-  - Grep: 3 skipped
+  - Grep: 2 skipped
   - Sed: 4 skipped
   - JQ: 1 skipped
 - [ ] **Add bash_comparison_tests to CI** - Currently ignored, runs manually


### PR DESCRIPTION
## Summary
- Add support for grep's `-o` (only-matching) flag that outputs only the matched portion of each line
- Enable the `grep_only_matching` spec test that was previously skipped
- Update spec counts: grep tests now 13/15 passing (was 12/15), total 63/72 (was 62/72)

## Test plan
- [x] Unit tests added for `-o` flag (basic and multiple matches)
- [x] `cargo test --features network` passes
- [x] `cargo clippy` passes
- [x] Spec test `grep_only_matching` now passes