### PR TITLE
fix(parser,interpreter): add support for arithmetic commands and C-style for loops

### DIFF
--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -83,6 +83,8 @@ pub enum CompoundCommand {
     If(IfCommand),
     /// For loop
     For(ForCommand),
+    /// C-style for loop: for ((init; cond; step))
+    ArithmeticFor(ArithmeticForCommand),
     /// While loop
     While(WhileCommand),
     /// Until loop
@@ -93,6 +95,8 @@ pub enum CompoundCommand {
     Subshell(Vec<Command>),
     /// Brace group
     BraceGroup(Vec<Command>),
+    /// Arithmetic command ((expression))
+    Arithmetic(String),
 }
 
 /// If statement.
@@ -109,6 +113,19 @@ pub struct IfCommand {
 pub struct ForCommand {
     pub variable: String,
     pub words: Option<Vec<Word>>,
+    pub body: Vec<Command>,
+}
+
+/// C-style arithmetic for loop: for ((init; cond; step)); do body; done
+#[derive(Debug, Clone)]
+pub struct ArithmeticForCommand {
+    /// Initialization expression
+    pub init: String,
+    /// Condition expression
+    pub condition: String,
+    /// Step/update expression
+    pub step: String,
+    /// Loop body
     pub body: Vec<Command>,
 }
 

--- a/crates/bashkit/src/parser/tokens.rs
+++ b/crates/bashkit/src/parser/tokens.rs
@@ -52,6 +52,12 @@ pub enum Token {
     /// Right parenthesis ())
     RightParen,
 
+    /// Double left parenthesis ((()
+    DoubleLeftParen,
+
+    /// Double right parenthesis ()))
+    DoubleRightParen,
+
     /// Left brace ({)
     LeftBrace,
 


### PR DESCRIPTION
## Summary
- Fixes 4 benchmark timeouts (arith_increment, ctrl_for_range, str_concat, complex_string_build)
- Adds support for variable assignment with quoted strings (`a="Hello"`)
- Adds support for arithmetic commands (`((x++))`)
- Adds support for C-style for loops (`for ((i=0; i<5; i++))`)

## Test plan
- [x] All 284 library tests pass
- [x] Clippy passes with no warnings
- [x] All 4 previously failing benchmarks now pass:
  - `arith_increment`: 0.017ms (was 1000ms timeout)
  - `ctrl_for_range`: 0.019ms (was 1000ms timeout)
  - `str_concat`: 0.014ms (was 1000ms timeout)
  - `complex_string_build`: 0.018ms (was 1000ms timeout)