### PR TITLE
feat(jq): implement -r/--raw-output flag

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -10,10 +10,10 @@ BashKit is a sandboxed bash interpreter designed for AI agents. It prioritizes s
 |----------|-------|-------|------|------|-------|
 | Bash (core) | 209 | **No** | - | - | `bash_spec_tests` ignored in CI |
 | AWK | 19 | Yes | 17 | 2 | gsub regex, split |
-| Grep | 15 | Yes | 12 | 3 | -w, -o, -l stdin |
+| Grep | 15 | Yes | 13 | 2 | -w, -l stdin |
 | Sed | 17 | Yes | 13 | 4 | -i flag, multiple commands |
-| JQ | 21 | Yes | 20 | 1 | -r flag |
-| **Total** | **281** | **72** | 62 | 10 | |
+| JQ | 21 | Yes | 21 | 0 | All tests pass |
+| **Total** | **281** | **72** | 64 | 8 | |
 
 ### Bash Spec Tests Breakdown (not in CI)
 
@@ -96,11 +96,9 @@ BashKit is a sandboxed bash interpreter designed for AI agents. It prioritizes s
 
 ### Grep Limitations
 - Word boundary `-w`
-- Only matching `-o`
 - Stdin filename with `-l`
 
 ### JQ Limitations
-- Raw output `-r` flag
 - Pretty printing (outputs compact JSON)
 
 ## Parser Limitations

--- a/crates/bashkit/tests/spec_cases/jq/jq.test.sh
+++ b/crates/bashkit/tests/spec_cases/jq/jq.test.sh
@@ -79,7 +79,7 @@ echo '[1,2,3]' | jq 'add'
 ### end
 
 ### jq_raw_output
-### skip: -r flag not implemented
+# Raw output mode outputs strings without quotes
 echo '{"name":"test"}' | jq -r '.name'
 ### expect
 test

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -72,8 +72,8 @@ crates/bashkit/tests/
 | AWK | 19 | Yes | 17 | 2 |
 | Grep | 15 | Yes | 13 | 2 |
 | Sed | 17 | Yes | 13 | 4 |
-| JQ | 21 | Yes | 20 | 1 |
-| **Total** | **281** | **72** | 63 | 9 |
+| JQ | 21 | Yes | 21 | 0 |
+| **Total** | **281** | **72** | 64 | 8 |
 
 ### Test File Format
 
@@ -138,11 +138,10 @@ The following items need attention:
 - [ ] **Enable bash_spec_tests in CI** - 209 test cases currently ignored
 - [ ] **Fix control-flow.test.sh** - Currently skipped (.skip suffix)
 - [ ] **Add coverage tooling** - Consider cargo-tarpaulin or codecov
-- [ ] **Fix skipped spec tests** (9 total):
+- [ ] **Fix skipped spec tests** (8 total):
   - AWK: 2 skipped
   - Grep: 2 skipped
   - Sed: 4 skipped
-  - JQ: 1 skipped
 - [ ] **Add bash_comparison_tests to CI** - Currently ignored, runs manually
 
 ## Adding New Tests


### PR DESCRIPTION
## Summary

- Implement jq's `-r`/`--raw-output` flag which outputs string values without JSON quotes
- Fixes the last skipped JQ test, bringing JQ test suite from 20/21 to **21/21 passing**
- Updates testing documentation and known limitations

## Test plan

- [x] Added unit tests for `-r` flag
- [x] Added unit tests for `--raw-output` flag
- [x] Enabled `jq_raw_output` spec test (previously skipped)
- [x] `cargo test --test spec_tests jq_spec_tests` passes with 21/21
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes