### PR TITLE
docs: update testing docs to reflect current status

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -9,11 +9,11 @@ BashKit is a sandboxed bash interpreter designed for AI agents. It prioritizes s
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
 | Bash (core) | 209 | **No** | - | - | `bash_spec_tests` ignored in CI |
-| AWK | 19 | Yes | 17 | 2 | gsub regex, split |
-| Grep | 15 | Yes | 13 | 2 | -w, -l stdin |
+| AWK | 19 | Yes | 17 | 2 | gsub regex, split (blocked by parser bug) |
+| Grep | 15 | Yes | 15 | 0 | All tests pass |
 | Sed | 17 | Yes | 13 | 4 | -i flag, multiple commands |
 | JQ | 21 | Yes | 21 | 0 | All tests pass |
-| **Total** | **281** | **72** | 64 | 8 | |
+| **Total** | **281** | **72** | 66 | 6 | |
 
 ### Bash Spec Tests Breakdown (not in CI)
 
@@ -95,8 +95,7 @@ BashKit is a sandboxed bash interpreter designed for AI agents. It prioritizes s
 - In-place editing (`-i`)
 
 ### Grep Limitations
-- Word boundary `-w`
-- Stdin filename with `-l`
+- No known limitations (all spec tests pass)
 
 ### JQ Limitations
 - Pretty printing (outputs compact JSON)

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -70,10 +70,10 @@ crates/bashkit/tests/
 |----------|------------|-------|------|------|
 | Bash | 209 | **NO** (ignored) | - | - |
 | AWK | 19 | Yes | 17 | 2 |
-| Grep | 15 | Yes | 13 | 2 |
+| Grep | 15 | Yes | 15 | 0 |
 | Sed | 17 | Yes | 13 | 4 |
 | JQ | 21 | Yes | 21 | 0 |
-| **Total** | **281** | **72** | 64 | 8 |
+| **Total** | **281** | **72** | 66 | 6 |
 
 ### Test File Format
 
@@ -138,9 +138,8 @@ The following items need attention:
 - [ ] **Enable bash_spec_tests in CI** - 209 test cases currently ignored
 - [ ] **Fix control-flow.test.sh** - Currently skipped (.skip suffix)
 - [ ] **Add coverage tooling** - Consider cargo-tarpaulin or codecov
-- [ ] **Fix skipped spec tests** (8 total):
-  - AWK: 2 skipped
-  - Grep: 2 skipped
+- [ ] **Fix skipped spec tests** (6 total):
+  - AWK: 2 skipped (blocked by multi-statement action parsing bug)
   - Sed: 4 skipped
 - [ ] **Add bash_comparison_tests to CI** - Currently ignored, runs manually
 


### PR DESCRIPTION
## Summary

Update testing documentation to reflect the current spec test status after merging JQ and Grep fixes:

- Grep: 15/15 passing (up from 13/15, -w and -l fixes merged)
- JQ: 21/21 passing  
- AWK: 17/19 (blocked by multi-statement parser bug)
- Sed: 13/17 (4 skipped)
- **Total: 66/72 passing, 6 skipped**

## Test plan

- [x] Documentation update only
- [x] Verified counts match actual test output