### PR TITLE
fix(awk): fix multi-statement parsing and add gsub/split support

### DIFF
--- a/crates/bashkit/tests/spec_cases/awk/awk.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/awk.test.sh
@@ -117,14 +117,14 @@ hello
 ### end
 
 ### awk_gsub
-### skip: regex literal in function args not implemented
+# gsub with regex literal
 printf 'hello hello hello\n' | awk '{gsub(/hello/, "hi"); print}'
 ### expect
 hi hi hi
 ### end
 
 ### awk_split
-### skip: split with array assignment not fully implemented
+# split with array indexing
 printf 'a:b:c\n' | awk '{n = split($0, arr, ":"); print arr[2]}'
 ### expect
 b


### PR DESCRIPTION
## Summary
- Fix multi-statement parsing bug that caused `{x=1; print x}` to output empty string
- Add regex literal parsing (`/pattern/`) for gsub function
- Add array indexing syntax (`arr[index]`) for split function
- Fix gsub to update $0 when no explicit target is provided

## Root Cause
The bug was in `skip_whitespace()` which treated semicolons as whitespace. This caused `parse_concat()` to consume subsequent statements as string concatenation instead of separate actions.

## Changes
1. **Multi-statement fix**: Removed `;` from `skip_whitespace()` so semicolons are properly handled as statement separators in `parse_action_block()`

2. **Regex literal support**: Added `/pattern/` parsing in `parse_primary()` to support `gsub(/hello/, "hi")`

3. **Array indexing**: Added `arr[index]` syntax parsing to support `split($0, arr, ":"); print arr[2]`

4. **gsub $0 fix**: Updated gsub to handle `Field` target expressions, not just `Variable` targets

## Test plan
- [x] `test_awk_multi_statement` passes
- [x] `test_awk_gsub_with_print` passes
- [x] `test_awk_split_with_array_access` passes
- [x] All 17 AWK unit tests pass
- [x] `awk_gsub` and `awk_split` spec tests unskipped and pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
