### PR TITLE
fix(ci): add checks:write permission for cargo-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Add `checks: write` permission to CI workflow to fix `rustsec/audit-check@v2.0.0` action failure
- The action needs this permission to create GitHub check runs

## Test plan
- [ ] CI passes (cargo-audit step no longer fails with "Resource not accessible by integration")

https://claude.ai/code/session_01PdLPh5w136s6JmBTMv7d9i