### PR TITLE
ci: add AddressSanitizer job for stack overflow detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,3 +129,38 @@ jobs:
           name: geiger-report
           path: geiger-report.txt
           retention-days: 30
+
+  # AddressSanitizer for memory safety (catches stack overflow, buffer overflow, use-after-free)
+  asan:
+    name: AddressSanitizer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-asan-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-asan-
+
+      - name: Run tests with AddressSanitizer
+        env:
+          RUSTFLAGS: "-Z sanitizer=address"
+          ASAN_OPTIONS: "detect_stack_use_after_return=1:detect_leaks=0"
+        run: |
+          # Build and test with ASAN
+          # Note: ASAN significantly increases memory usage and slows execution
+          # We run core tests to catch memory safety issues including stack overflow
+          cargo +nightly test -Z build-std --target x86_64-unknown-linux-gnu --lib --tests \
+            -- --test-threads=1
+        timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Add ASAN CI job to catch memory safety issues (stack overflow, buffer overflow, use-after-free)
- Uses Rust nightly with `-Z sanitizer=address` and `-Z build-std`
- Runs single-threaded with 30-minute timeout to account for ASAN overhead

## Test plan
- [ ] CI passes with new ASAN job
- [ ] ASAN job completes within timeout

https://claude.ai/code/session_01DMyNbBxMuMic1AUrufdhhb