### PR TITLE
fix(timeout): make timeout tests reliable with virtual time

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/timeout.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/timeout.test.sh
@@ -81,17 +81,17 @@ input data
 ### end
 
 ### timeout_expired
-### skip: timing-dependent test, verified manually
 # Timeout that expires should return 124
-timeout 0.001 sleep 10
+# Note: Also tested in interpreter::tests::test_timeout_expires_deterministically with paused time
+timeout 0.1 sleep 100
 echo $?
 ### expect
 124
 ### end
 
 ### timeout_zero
-### skip: timing-dependent test, verified manually
 # Timeout of 0 should timeout immediately
+# Note: Also tested in interpreter::tests::test_timeout_zero_deterministically with paused time
 timeout 0 sleep 1
 echo $?
 ### expect


### PR DESCRIPTION
## Summary
- Fix subsecond duration parsing in `parse_timeout_duration` to use `Duration::from_secs_f64()` instead of truncating to `u64`
- Fix duration capping to preserve subsecond precision
- Add deterministic unit tests using `#[tokio::test(start_paused = true)]` (virtual time)
- Add `paused_time` directive support to spec runner for future timing tests
- Update spec tests with more reliable timing margins

## Test plan
- [x] Unit tests pass with paused time (`cargo test interpreter::tests::`)
- [x] All existing tests pass (`cargo test --all-features`)
- [x] `cargo clippy --all-features` passes
- [x] `cargo fmt --check` passes

https://claude.ai/code/session_017cxMrLhpgMU4VkKNhoeiJw