### PR TITLE
feat(builtins): add custom builtins support

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -1,4 +1,26 @@
 //! Built-in shell commands
+//!
+//! This module provides the [`Builtin`] trait for implementing custom commands
+//! and the [`Context`] struct for execution context.
+//!
+//! # Custom Builtins
+//!
+//! Implement the [`Builtin`] trait to create custom commands:
+//!
+//! ```rust
+//! use bashkit::{Builtin, BuiltinContext, ExecResult, async_trait};
+//!
+//! struct MyCommand;
+//!
+//! #[async_trait]
+//! impl Builtin for MyCommand {
+//!     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+//!         Ok(ExecResult::ok("Hello!\n".to_string()))
+//!     }
+//! }
+//! ```
+//!
+//! Register via [`BashBuilder::builtin`](crate::BashBuilder::builtin).
 
 mod archive;
 mod awk;
@@ -73,26 +95,116 @@ use crate::error::Result;
 use crate::fs::FileSystem;
 use crate::interpreter::ExecResult;
 
-/// Context for builtin command execution.
+/// Execution context for builtin commands.
+///
+/// Provides access to the shell execution environment including arguments,
+/// variables, filesystem, and pipeline input.
+///
+/// # Example
+///
+/// ```rust
+/// use bashkit::{Builtin, BuiltinContext, ExecResult, async_trait};
+///
+/// struct Echo;
+///
+/// #[async_trait]
+/// impl Builtin for Echo {
+///     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+///         // Access command arguments
+///         let output = ctx.args.join(" ");
+///
+///         // Access environment variables
+///         let _home = ctx.env.get("HOME");
+///
+///         // Access pipeline input
+///         if let Some(stdin) = ctx.stdin {
+///             return Ok(ExecResult::ok(stdin.to_string()));
+///         }
+///
+///         Ok(ExecResult::ok(format!("{}\n", output)))
+///     }
+/// }
+/// ```
 pub struct Context<'a> {
-    /// Command arguments (not including the command name)
+    /// Command arguments (not including the command name).
+    ///
+    /// For `mycommand arg1 arg2`, this contains `["arg1", "arg2"]`.
     pub args: &'a [String],
-    /// Environment variables
+
+    /// Environment variables.
+    ///
+    /// Read-only access to variables set via [`BashBuilder::env`](crate::BashBuilder::env)
+    /// or the `export` builtin.
     pub env: &'a HashMap<String, String>,
-    /// Shell variables
+
+    /// Shell variables (mutable).
+    ///
+    /// Allows builtins to set or modify shell variables.
     #[allow(dead_code)] // Will be used by set, export, declare builtins
     pub variables: &'a mut HashMap<String, String>,
-    /// Current working directory
+
+    /// Current working directory (mutable).
+    ///
+    /// Used by `cd` and path resolution.
     pub cwd: &'a mut PathBuf,
-    /// Filesystem
+
+    /// Virtual filesystem.
+    ///
+    /// Provides async file operations (read, write, mkdir, etc.).
     pub fs: Arc<dyn FileSystem>,
-    /// Standard input (from pipeline)
+
+    /// Standard input from pipeline.
+    ///
+    /// Contains output from the previous command in a pipeline.
+    /// For `echo hello | mycommand`, stdin will be `Some("hello\n")`.
     pub stdin: Option<&'a str>,
 }
 
-/// Trait for builtin commands.
+/// Trait for implementing builtin commands.
+///
+/// All custom builtins must implement this trait. The trait requires `Send + Sync`
+/// for thread safety in async contexts.
+///
+/// # Example
+///
+/// ```rust
+/// use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, async_trait};
+///
+/// struct Greet {
+///     default_name: String,
+/// }
+///
+/// #[async_trait]
+/// impl Builtin for Greet {
+///     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+///         let name = ctx.args.first()
+///             .map(|s| s.as_str())
+///             .unwrap_or(&self.default_name);
+///         Ok(ExecResult::ok(format!("Hello, {}!\n", name)))
+///     }
+/// }
+///
+/// // Register the builtin
+/// let bash = Bash::builder()
+///     .builtin("greet", Box::new(Greet { default_name: "World".into() }))
+///     .build();
+/// ```
+///
+/// # Return Values
+///
+/// Return [`ExecResult::ok`](crate::ExecResult::ok) for success with output,
+/// or [`ExecResult::err`](crate::ExecResult::err) for errors with exit code.
 #[async_trait]
 pub trait Builtin: Send + Sync {
     /// Execute the builtin command.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The execution context containing arguments, environment, and filesystem
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(ExecResult)` - Execution result with stdout, stderr, and exit code
+    /// * `Err(Error)` - Fatal error that should abort execution
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult>;
 }

--- a/docs/custom_builtins.md
+++ b/docs/custom_builtins.md
@@ -1,0 +1,288 @@
+# Custom Builtins
+
+BashKit supports registering custom builtin commands to extend the shell with
+domain-specific functionality. Custom builtins have full access to the execution
+context including arguments, environment variables, shell variables, and the
+virtual filesystem.
+
+## Quick Start
+
+```rust
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, async_trait};
+
+struct MyCommand;
+
+#[async_trait]
+impl Builtin for MyCommand {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let name = ctx.args.first().map(|s| s.as_str()).unwrap_or("World");
+        Ok(ExecResult::ok(format!("Hello, {}!\n", name)))
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut bash = Bash::builder()
+        .builtin("greet", Box::new(MyCommand))
+        .build();
+
+    let result = bash.exec("greet Alice").await?;
+    assert_eq!(result.stdout, "Hello, Alice!\n");
+    Ok(())
+}
+```
+
+## The Builtin Trait
+
+All custom builtins must implement the `Builtin` trait:
+
+```rust
+#[async_trait]
+pub trait Builtin: Send + Sync {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> Result<ExecResult>;
+}
+```
+
+The trait is async-first (via `async_trait`) and requires `Send + Sync` for
+thread safety in async contexts.
+
+## Execution Context
+
+The `BuiltinContext` provides access to the execution environment:
+
+```rust
+pub struct BuiltinContext<'a> {
+    /// Command arguments (not including the command name)
+    pub args: &'a [String],
+
+    /// Environment variables
+    pub env: &'a HashMap<String, String>,
+
+    /// Shell variables (mutable)
+    pub variables: &'a mut HashMap<String, String>,
+
+    /// Current working directory (mutable)
+    pub cwd: &'a mut PathBuf,
+
+    /// Virtual filesystem
+    pub fs: Arc<dyn FileSystem>,
+
+    /// Standard input (from pipeline)
+    pub stdin: Option<&'a str>,
+}
+```
+
+### Arguments
+
+Arguments are passed as a slice of strings, excluding the command name itself:
+
+```rust
+// For "mycommand arg1 arg2", ctx.args = ["arg1", "arg2"]
+let first_arg = ctx.args.first().map(|s| s.as_str()).unwrap_or("default");
+```
+
+### Environment Variables
+
+Read-only access to environment variables set via `BashBuilder::env()` or `export`:
+
+```rust
+let home = ctx.env.get("HOME").map(|s| s.as_str()).unwrap_or("/");
+```
+
+### Shell Variables
+
+Mutable access to shell variables allows builtins to set variables:
+
+```rust
+ctx.variables.insert("RESULT".to_string(), "computed_value".to_string());
+```
+
+### Filesystem Access
+
+The virtual filesystem supports all standard operations:
+
+```rust
+// Read a file
+let content = ctx.fs.read_file(Path::new("/data/input.txt")).await?;
+
+// Write a file
+ctx.fs.write_file(Path::new("/output/result.txt"), b"output").await?;
+
+// Check existence
+if ctx.fs.exists(Path::new("/config")).await? {
+    // ...
+}
+```
+
+### Standard Input
+
+When the builtin is invoked in a pipeline, stdin contains the output from the
+previous command:
+
+```rust
+// echo "hello" | mycommand
+let input = ctx.stdin.unwrap_or("");
+let processed = input.to_uppercase();
+```
+
+## Return Values
+
+Builtins return `Result<ExecResult>`:
+
+```rust
+pub struct ExecResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+```
+
+Helper constructors:
+
+```rust
+// Success with output
+ExecResult::ok("output\n".to_string())
+
+// Error with message and exit code
+ExecResult::err("error message\n".to_string(), 1)
+```
+
+## Examples
+
+### Database Query Builtin
+
+```rust
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, async_trait};
+use sqlx::PgPool;
+use std::sync::Arc;
+
+struct Psql {
+    pool: Arc<PgPool>,
+}
+
+#[async_trait]
+impl Builtin for Psql {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        // Parse -c "query" argument
+        let query = match ctx.args.iter().position(|a| a == "-c") {
+            Some(i) => ctx.args.get(i + 1).map(|s| s.as_str()).unwrap_or(""),
+            None => return Ok(ExecResult::err("Usage: psql -c 'query'\n".into(), 1)),
+        };
+
+        // Execute query (simplified - real impl would format results)
+        match sqlx::query(query).fetch_all(&*self.pool).await {
+            Ok(rows) => Ok(ExecResult::ok(format!("{} rows\n", rows.len()))),
+            Err(e) => Ok(ExecResult::err(format!("ERROR: {}\n", e), 1)),
+        }
+    }
+}
+
+// Usage
+let pool = Arc::new(PgPool::connect("postgres://...").await?);
+let mut bash = Bash::builder()
+    .builtin("psql", Box::new(Psql { pool }))
+    .build();
+
+bash.exec("psql -c 'SELECT * FROM users'").await?;
+```
+
+### HTTP Client Builtin
+
+```rust
+struct HttpGet {
+    client: reqwest::Client,
+}
+
+#[async_trait]
+impl Builtin for HttpGet {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let url = match ctx.args.first() {
+            Some(url) => url,
+            None => return Ok(ExecResult::err("Usage: httpget <url>\n".into(), 1)),
+        };
+
+        match self.client.get(url).send().await {
+            Ok(resp) => {
+                let body = resp.text().await.unwrap_or_default();
+                Ok(ExecResult::ok(body))
+            }
+            Err(e) => Ok(ExecResult::err(format!("Error: {}\n", e), 1)),
+        }
+    }
+}
+```
+
+### Overriding Default Builtins
+
+Custom builtins can override default builtins by using the same name:
+
+```rust
+struct SecureEcho;
+
+#[async_trait]
+impl Builtin for SecureEcho {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        // Redact sensitive patterns
+        let output: Vec<_> = ctx.args.iter()
+            .map(|s| if s.contains("password") { "[REDACTED]" } else { s.as_str() })
+            .collect();
+        Ok(ExecResult::ok(format!("{}\n", output.join(" "))))
+    }
+}
+
+let bash = Bash::builder()
+    .builtin("echo", Box::new(SecureEcho))  // Overrides default echo
+    .build();
+```
+
+## Best Practices
+
+1. **Return proper exit codes**: Use 0 for success, non-zero for errors
+2. **Include newlines**: Output should end with `\n` for proper formatting
+3. **Handle missing args gracefully**: Provide usage messages for incorrect invocations
+4. **Use stderr for errors**: Write error messages to `ExecResult::stderr`
+5. **Keep builtins stateless when possible**: Use `Arc` for shared state that needs mutation
+
+## Thread Safety
+
+The `Builtin` trait requires `Send + Sync`. For builtins with mutable state, use
+appropriate synchronization:
+
+```rust
+struct Counter {
+    count: Arc<std::sync::atomic::AtomicU64>,
+}
+
+#[async_trait]
+impl Builtin for Counter {
+    async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let n = self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(ExecResult::ok(format!("{}\n", n)))
+    }
+}
+```
+
+## Integration with Scripts
+
+Custom builtins integrate seamlessly with bash scripting:
+
+```bash
+# Variables work
+NAME="Alice"
+greet $NAME
+
+# Pipelines work
+echo "hello world" | upper | head -1
+
+# Conditionals work
+if mycheck; then
+    echo "passed"
+else
+    echo "failed"
+fi
+
+# Loops work
+for item in a b c; do
+    process $item
+done
+```

--- a/specs/005-builtins.md
+++ b/specs/005-builtins.md
@@ -83,9 +83,38 @@ pub struct Context<'a> {
     pub variables: &'a mut HashMap<String, String>,
     pub cwd: &'a mut PathBuf,
     pub fs: Arc<dyn FileSystem>,
-    pub stdin: Option<String>,
+    pub stdin: Option<&'a str>,
 }
 ```
+
+### Custom Builtins
+
+BashKit supports registering custom builtins via `BashBuilder`:
+
+```rust
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, async_trait};
+
+struct MyCommand;
+
+#[async_trait]
+impl Builtin for MyCommand {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        Ok(ExecResult::ok("Hello!\n".to_string()))
+    }
+}
+
+let bash = Bash::builder()
+    .builtin("mycommand", Box::new(MyCommand))
+    .build();
+```
+
+Custom builtins:
+- Have full access to execution context (args, env, fs, stdin)
+- Can override default builtins if registered with the same name
+- Must implement `Send + Sync` for async safety
+- Integrate seamlessly with pipelines, conditionals, and loops
+
+See `docs/custom_builtins.md` for detailed documentation.
 
 ### Safety Constraints
 


### PR DESCRIPTION
## Summary

- Add the ability to register custom builtin commands via `BashBuilder`
- Export `Builtin` trait and `BuiltinContext` publicly for client code
- Custom builtins can override default builtins if registered with the same name
- Full access to execution context (args, env, fs, stdin)

## Changes

- **Public API**: Export `Builtin` trait and `Context` as `BuiltinContext`
- **BashBuilder**: Add `.builtin(name, impl)` method for registration
- **Interpreter**: Merge custom builtins with defaults (custom takes precedence)
- **Tests**: 11 comprehensive test cases covering all use cases
- **Documentation**: `docs/custom_builtins.md` with examples
- **Specs**: Updated `specs/005-builtins.md`
- **Rust Docs**: Extensive doc comments with examples on `Builtin`, `Context`, and `BashBuilder`

## Example Usage

```rust
use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, async_trait};

struct Psql { /* connection state */ }

#[async_trait]
impl Builtin for Psql {
    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
        let query = ctx.args.get(1).map(|s| s.as_str()).unwrap_or("");
        Ok(ExecResult::ok(format!("Result: {}\n", query)))
    }
}

let mut bash = Bash::builder()
    .builtin("psql", Box::new(Psql { /* ... */ }))
    .build();

bash.exec("psql -c 'SELECT * FROM users'").await?;
```

## Test plan

- [x] `cargo test --lib -- custom_builtins` - All 11 tests pass
- [x] `cargo test --doc` - All doc tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - No warnings
- [x] `cargo fmt --check` - Formatted correctly

https://claude.ai/code/session_017p3j2Cw8eh3dzNdhqtMy2P