### PR TITLE
docs: add comprehensive rustdoc documentation for public API

### DIFF
--- a/crates/bashkit/src/fs/mod.rs
+++ b/crates/bashkit/src/fs/mod.rs
@@ -1,9 +1,250 @@
-//! Virtual filesystem for BashKit
+//! Virtual filesystem for BashKit.
 //!
-//! Provides an async filesystem trait and implementations:
-//! - `InMemoryFs`: Simple in-memory filesystem
-//! - `OverlayFs`: Copy-on-write overlay with whiteouts
-//! - `MountableFs`: Multiple filesystems at mount points
+//! This module provides a virtual filesystem abstraction that allows BashKit to
+//! operate in a sandboxed environment without accessing the real filesystem.
+//!
+//! # Overview
+//!
+//! BashKit provides three filesystem implementations:
+//!
+//! | Type | Description | Use Case |
+//! |------|-------------|----------|
+//! | [`InMemoryFs`] | Simple HashMap-based storage | Default, isolated execution |
+//! | [`OverlayFs`] | Copy-on-write layered filesystem | Templates, immutable bases |
+//! | [`MountableFs`] | Multiple filesystems at mount points | Complex multi-source setups |
+//!
+//! All implementations are thread-safe (`Send + Sync`) and fully async.
+//!
+//! # Quick Start
+//!
+//! ## Using InMemoryFs (Default)
+//!
+//! [`InMemoryFs`] is the default filesystem when using [`Bash::new()`](crate::Bash::new):
+//!
+//! ```rust
+//! use bashkit::Bash;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> bashkit::Result<()> {
+//! let mut bash = Bash::new();
+//!
+//! // Files are stored entirely in memory
+//! bash.exec("echo 'hello' > /tmp/test.txt").await?;
+//! let result = bash.exec("cat /tmp/test.txt").await?;
+//! assert_eq!(result.stdout, "hello\n");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Using OverlayFs
+//!
+//! [`OverlayFs`] provides copy-on-write semantics - reads fall through to a base
+//! layer while writes go to an overlay layer:
+//!
+//! ```rust
+//! use bashkit::{Bash, FileSystem, InMemoryFs, OverlayFs};
+//! use std::path::Path;
+//! use std::sync::Arc;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> bashkit::Result<()> {
+//! // Create a base filesystem with template files
+//! let base = Arc::new(InMemoryFs::new());
+//! base.mkdir(Path::new("/templates"), false).await?;
+//! base.write_file(Path::new("/templates/config.txt"), b"default=true").await?;
+//!
+//! // Create overlay - base is read-only, changes go to overlay
+//! let overlay = Arc::new(OverlayFs::new(base.clone()));
+//!
+//! let mut bash = Bash::builder().fs(overlay).build();
+//!
+//! // Read from base layer
+//! let result = bash.exec("cat /templates/config.txt").await?;
+//! assert_eq!(result.stdout, "default=true");
+//!
+//! // Modify - changes go to overlay, base is unchanged
+//! bash.exec("echo 'modified=true' > /templates/config.txt").await?;
+//!
+//! // Base still has original content
+//! let original = base.read_file(Path::new("/templates/config.txt")).await?;
+//! assert_eq!(original, b"default=true");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Using MountableFs
+//!
+//! [`MountableFs`] allows mounting different filesystems at specific paths:
+//!
+//! ```rust
+//! use bashkit::{Bash, FileSystem, InMemoryFs, MountableFs};
+//! use std::path::Path;
+//! use std::sync::Arc;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> bashkit::Result<()> {
+//! // Create root and a separate data filesystem
+//! let root = Arc::new(InMemoryFs::new());
+//! let data_fs = Arc::new(InMemoryFs::new());
+//!
+//! // Pre-populate the data filesystem
+//! data_fs.write_file(Path::new("/users.json"), br#"["alice", "bob"]"#).await?;
+//!
+//! // Create mountable filesystem and mount data_fs at /mnt/data
+//! let mountable = MountableFs::new(root);
+//! mountable.mount("/mnt/data", data_fs)?;
+//!
+//! let mut bash = Bash::builder().fs(Arc::new(mountable)).build();
+//!
+//! // Access the mounted filesystem
+//! let result = bash.exec("cat /mnt/data/users.json").await?;
+//! assert!(result.stdout.contains("alice"));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Direct Filesystem Access
+//!
+//! Access the filesystem directly for pre-populating files or reading output:
+//!
+//! ```rust
+//! use bashkit::{Bash, FileSystem};
+//! use std::path::Path;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> bashkit::Result<()> {
+//! let mut bash = Bash::new();
+//! let fs = bash.fs();
+//!
+//! // Create directories
+//! fs.mkdir(Path::new("/data"), false).await?;
+//! fs.mkdir(Path::new("/data/input"), false).await?;
+//! fs.mkdir(Path::new("/data/output"), false).await?;
+//!
+//! // Pre-populate input files
+//! fs.write_file(Path::new("/data/input/data.csv"), b"name,value\nalice,100").await?;
+//!
+//! // Run a script that processes the data
+//! bash.exec("cat /data/input/data.csv | grep alice > /data/output/result.txt").await?;
+//!
+//! // Read the output directly
+//! let output = fs.read_file(Path::new("/data/output/result.txt")).await?;
+//! assert_eq!(output, b"alice,100\n");
+//!
+//! // Check file exists
+//! assert!(fs.exists(Path::new("/data/output/result.txt")).await?);
+//!
+//! // Get file metadata
+//! let stat = fs.stat(Path::new("/data/output/result.txt")).await?;
+//! assert!(stat.file_type.is_file());
+//!
+//! // List directory contents
+//! let entries = fs.read_dir(Path::new("/data")).await?;
+//! let names: Vec<_> = entries.iter().map(|e| e.name.as_str()).collect();
+//! assert!(names.contains(&"input"));
+//! assert!(names.contains(&"output"));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Binary File Support
+//!
+//! The filesystem fully supports binary data including null bytes:
+//!
+//! ```rust
+//! use bashkit::{Bash, FileSystem};
+//! use std::path::Path;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> bashkit::Result<()> {
+//! let bash = Bash::new();
+//! let fs = bash.fs();
+//!
+//! // Write binary data (e.g., PNG header)
+//! let binary_data = vec![0x89, 0x50, 0x4E, 0x47, 0x00, 0xFF];
+//! fs.write_file(Path::new("/tmp/image.bin"), &binary_data).await?;
+//!
+//! // Read it back
+//! let content = fs.read_file(Path::new("/tmp/image.bin")).await?;
+//! assert_eq!(content, binary_data);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Implementing Custom Filesystems
+//!
+//! Implement the [`FileSystem`] trait to create custom storage backends:
+//!
+//! ```rust
+//! use bashkit::{async_trait, FileSystem, DirEntry, Metadata, FileType, Result, Error};
+//! use std::path::{Path, PathBuf};
+//! use std::collections::HashMap;
+//! use std::sync::RwLock;
+//! use std::time::SystemTime;
+//!
+//! /// A simple custom filesystem example
+//! pub struct SimpleFs {
+//!     files: RwLock<HashMap<PathBuf, Vec<u8>>>,
+//! }
+//!
+//! impl SimpleFs {
+//!     pub fn new() -> Self {
+//!         let mut files = HashMap::new();
+//!         // Initialize with root and common directories
+//!         files.insert(PathBuf::from("/"), Vec::new());
+//!         files.insert(PathBuf::from("/tmp"), Vec::new());
+//!         Self { files: RwLock::new(files) }
+//!     }
+//! }
+//!
+//! #[async_trait]
+//! impl FileSystem for SimpleFs {
+//!     async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+//!         let files = self.files.read().unwrap();
+//!         files.get(path)
+//!             .cloned()
+//!             .ok_or_else(|| Error::Io(std::io::Error::new(
+//!                 std::io::ErrorKind::NotFound,
+//!                 "file not found"
+//!             )))
+//!     }
+//!
+//!     async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+//!         let mut files = self.files.write().unwrap();
+//!         files.insert(path.to_path_buf(), content.to_vec());
+//!         Ok(())
+//!     }
+//!
+//!     // ... implement remaining methods
+//! #   async fn append_file(&self, _path: &Path, _content: &[u8]) -> Result<()> { Ok(()) }
+//! #   async fn mkdir(&self, _path: &Path, _recursive: bool) -> Result<()> { Ok(()) }
+//! #   async fn remove(&self, _path: &Path, _recursive: bool) -> Result<()> { Ok(()) }
+//! #   async fn stat(&self, _path: &Path) -> Result<Metadata> {
+//! #       Ok(Metadata::default())
+//! #   }
+//! #   async fn read_dir(&self, _path: &Path) -> Result<Vec<DirEntry>> { Ok(vec![]) }
+//! #   async fn exists(&self, _path: &Path) -> Result<bool> { Ok(false) }
+//! #   async fn rename(&self, _from: &Path, _to: &Path) -> Result<()> { Ok(()) }
+//! #   async fn copy(&self, _from: &Path, _to: &Path) -> Result<()> { Ok(()) }
+//! #   async fn symlink(&self, _target: &Path, _link: &Path) -> Result<()> { Ok(()) }
+//! #   async fn read_link(&self, _path: &Path) -> Result<PathBuf> { Ok(PathBuf::new()) }
+//! #   async fn chmod(&self, _path: &Path, _mode: u32) -> Result<()> { Ok(()) }
+//! }
+//! ```
+//!
+//! For a complete custom filesystem implementation example, see
+//! `examples/custom_filesystem_impl.rs`.
+//!
+//! # Default Directory Structure
+//!
+//! [`InMemoryFs::new()`] creates these directories by default:
+//!
+//! - `/` - Root directory
+//! - `/tmp` - Temporary files
+//! - `/home` - Home directories
+//! - `/home/user` - Default user home
+//! - `/dev` - Device files
+//! - `/dev/null` - Null device (discards writes, returns empty on read)
 
 mod memory;
 mod mountable;

--- a/crates/bashkit/src/fs/mountable.rs
+++ b/crates/bashkit/src/fs/mountable.rs
@@ -1,6 +1,6 @@
-//! Mountable filesystem implementation
+//! Mountable filesystem implementation.
 //!
-//! MountableFs allows mounting multiple filesystems at different paths,
+//! [`MountableFs`] allows mounting multiple filesystems at different paths,
 //! similar to Unix mount semantics.
 
 // RwLock.read()/write().unwrap() only panics on lock poisoning (prior panic
@@ -16,9 +16,126 @@ use std::sync::{Arc, RwLock};
 use super::traits::{DirEntry, FileSystem, FileType, Metadata};
 use crate::error::Result;
 
-/// A filesystem that supports mounting other filesystems at specific paths.
+/// Filesystem with Unix-style mount points.
 ///
-/// Mount points are checked from longest to shortest path, allowing nested mounts.
+/// `MountableFs` allows mounting different filesystem implementations at
+/// specific paths, similar to how Unix systems mount devices at directories.
+/// This enables complex multi-source filesystem setups.
+///
+/// # Features
+///
+/// - **Multiple mount points**: Mount different filesystems at different paths
+/// - **Nested mounts**: Mount filesystems within other mounts (longest-prefix matching)
+/// - **Dynamic mounting**: Add/remove mounts at runtime
+/// - **Cross-mount operations**: Copy/move files between different mounted filesystems
+///
+/// # Use Cases
+///
+/// - **Hybrid storage**: Combine in-memory temp storage with persistent data stores
+/// - **Multi-tenant isolation**: Mount separate filesystems for different tenants
+/// - **Plugin systems**: Each plugin gets its own mounted filesystem
+/// - **Testing**: Mount mock filesystems for specific paths
+///
+/// # Example: Basic Mounting
+///
+/// ```rust
+/// use bashkit::{Bash, FileSystem, InMemoryFs, MountableFs};
+/// use std::path::Path;
+/// use std::sync::Arc;
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// // Create root and separate data filesystem
+/// let root = Arc::new(InMemoryFs::new());
+/// let data_fs = Arc::new(InMemoryFs::new());
+///
+/// // Pre-populate data filesystem
+/// data_fs.write_file(Path::new("/users.json"), br#"["alice", "bob"]"#).await?;
+///
+/// // Create mountable filesystem
+/// let mountable = MountableFs::new(root.clone());
+///
+/// // Mount data_fs at /mnt/data
+/// mountable.mount("/mnt/data", data_fs.clone())?;
+///
+/// // Use with Bash
+/// let mut bash = Bash::builder().fs(Arc::new(mountable)).build();
+///
+/// // Access mounted filesystem
+/// let result = bash.exec("cat /mnt/data/users.json").await?;
+/// assert!(result.stdout.contains("alice"));
+///
+/// // Access root filesystem
+/// bash.exec("echo hello > /root.txt").await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Example: Nested Mounts
+///
+/// ```rust
+/// use bashkit::{FileSystem, InMemoryFs, MountableFs};
+/// use std::path::Path;
+/// use std::sync::Arc;
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// let root = Arc::new(InMemoryFs::new());
+/// let outer = Arc::new(InMemoryFs::new());
+/// let inner = Arc::new(InMemoryFs::new());
+///
+/// outer.write_file(Path::new("/outer.txt"), b"outer").await?;
+/// inner.write_file(Path::new("/inner.txt"), b"inner").await?;
+///
+/// let mountable = MountableFs::new(root);
+/// mountable.mount("/mnt", outer)?;
+/// mountable.mount("/mnt/nested", inner)?;
+///
+/// // Access outer mount
+/// let content = mountable.read_file(Path::new("/mnt/outer.txt")).await?;
+/// assert_eq!(content, b"outer");
+///
+/// // Access nested mount (longest-prefix matching)
+/// let content = mountable.read_file(Path::new("/mnt/nested/inner.txt")).await?;
+/// assert_eq!(content, b"inner");
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Example: Dynamic Mount/Unmount
+///
+/// ```rust
+/// use bashkit::{FileSystem, InMemoryFs, MountableFs};
+/// use std::path::Path;
+/// use std::sync::Arc;
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// let root = Arc::new(InMemoryFs::new());
+/// let plugin_fs = Arc::new(InMemoryFs::new());
+/// plugin_fs.write_file(Path::new("/plugin.so"), b"binary").await?;
+///
+/// let mountable = MountableFs::new(root);
+///
+/// // Mount plugin filesystem
+/// mountable.mount("/plugins", plugin_fs)?;
+/// assert!(mountable.exists(Path::new("/plugins/plugin.so")).await?);
+///
+/// // Unmount when done
+/// mountable.unmount("/plugins")?;
+/// assert!(!mountable.exists(Path::new("/plugins/plugin.so")).await?);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Path Resolution
+///
+/// When resolving a path, `MountableFs` uses longest-prefix matching to find
+/// the appropriate filesystem. For example, with mounts at `/mnt` and `/mnt/data`:
+///
+/// - `/mnt/file.txt` → resolves to `/mnt` mount
+/// - `/mnt/data/file.txt` → resolves to `/mnt/data` mount (longer prefix wins)
+/// - `/other/file.txt` → resolves to root filesystem
 pub struct MountableFs {
     /// Root filesystem (for paths not covered by any mount)
     root: Arc<dyn FileSystem>,
@@ -28,7 +145,27 @@ pub struct MountableFs {
 }
 
 impl MountableFs {
-    /// Create a new MountableFs with the given root filesystem.
+    /// Create a new `MountableFs` with the given root filesystem.
+    ///
+    /// The root filesystem is used for all paths that don't match any mount point.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{FileSystem, InMemoryFs, MountableFs};
+    /// use std::path::Path;
+    /// use std::sync::Arc;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let root = Arc::new(InMemoryFs::new());
+    /// let mountable = MountableFs::new(root);
+    ///
+    /// // Paths not covered by mounts go to root
+    /// mountable.write_file(Path::new("/tmp/test.txt"), b"hello").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn new(root: Arc<dyn FileSystem>) -> Self {
         Self {
             root,
@@ -38,7 +175,40 @@ impl MountableFs {
 
     /// Mount a filesystem at the given path.
     ///
-    /// The mount point must be an absolute path.
+    /// After mounting, all operations on paths under the mount point will be
+    /// directed to the mounted filesystem.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The mount point (must be an absolute path)
+    /// * `fs` - The filesystem to mount
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path is not absolute.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{FileSystem, InMemoryFs, MountableFs};
+    /// use std::path::Path;
+    /// use std::sync::Arc;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let root = Arc::new(InMemoryFs::new());
+    /// let data_fs = Arc::new(InMemoryFs::new());
+    /// data_fs.write_file(Path::new("/data.txt"), b"data").await?;
+    ///
+    /// let mountable = MountableFs::new(root);
+    /// mountable.mount("/data", data_fs)?;
+    ///
+    /// // Access via mount point
+    /// let content = mountable.read_file(Path::new("/data/data.txt")).await?;
+    /// assert_eq!(content, b"data");
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn mount(&self, path: impl AsRef<Path>, fs: Arc<dyn FileSystem>) -> Result<()> {
         let path = Self::normalize_path(path.as_ref());
 
@@ -52,6 +222,41 @@ impl MountableFs {
     }
 
     /// Unmount a filesystem at the given path.
+    ///
+    /// After unmounting, paths that previously resolved to the mounted filesystem
+    /// will fall back to the root filesystem or a shorter mount prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no filesystem is mounted at the given path.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{FileSystem, InMemoryFs, MountableFs};
+    /// use std::path::Path;
+    /// use std::sync::Arc;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let root = Arc::new(InMemoryFs::new());
+    /// let plugin = Arc::new(InMemoryFs::new());
+    /// plugin.write_file(Path::new("/lib.so"), b"binary").await?;
+    ///
+    /// let mountable = MountableFs::new(root);
+    /// mountable.mount("/plugin", plugin)?;
+    ///
+    /// // File is accessible
+    /// assert!(mountable.exists(Path::new("/plugin/lib.so")).await?);
+    ///
+    /// // Unmount
+    /// mountable.unmount("/plugin")?;
+    ///
+    /// // No longer accessible
+    /// assert!(!mountable.exists(Path::new("/plugin/lib.so")).await?);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn unmount(&self, path: impl AsRef<Path>) -> Result<()> {
         let path = Self::normalize_path(path.as_ref());
 

--- a/crates/bashkit/src/fs/traits.rs
+++ b/crates/bashkit/src/fs/traits.rs
@@ -1,4 +1,4 @@
-//! Filesystem trait definitions
+//! Filesystem trait definitions.
 
 use async_trait::async_trait;
 use std::path::Path;
@@ -6,63 +6,228 @@ use std::time::SystemTime;
 
 use crate::error::Result;
 
-/// Async filesystem trait.
+/// Async virtual filesystem trait.
 ///
-/// All filesystem implementations must implement this trait.
+/// This trait defines the interface for all filesystem implementations in BashKit.
+/// Implement this trait to create custom storage backends.
+///
+/// # Thread Safety
+///
+/// All implementations must be `Send + Sync` to support concurrent access from
+/// multiple tasks. Use interior mutability patterns (e.g., `RwLock`, `Mutex`)
+/// for mutable state.
+///
+/// # Implementing FileSystem
+///
+/// To create a custom filesystem, implement all methods in this trait.
+/// See `examples/custom_filesystem_impl.rs` for a complete implementation.
+///
+/// ```rust,ignore
+/// use bashkit::{async_trait, FileSystem, Result};
+///
+/// pub struct MyFileSystem { /* ... */ }
+///
+/// #[async_trait]
+/// impl FileSystem for MyFileSystem {
+///     async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+///         // Your implementation
+///     }
+///     // ... implement all other methods
+/// }
+/// ```
+///
+/// # Using Custom Filesystems
+///
+/// Pass your filesystem to [`Bash::builder()`](crate::Bash::builder):
+///
+/// ```rust,ignore
+/// use bashkit::Bash;
+/// use std::sync::Arc;
+///
+/// let custom_fs = Arc::new(MyFileSystem::new());
+/// let mut bash = Bash::builder().fs(custom_fs).build();
+/// ```
+///
+/// # Built-in Implementations
+///
+/// BashKit provides three implementations:
+///
+/// - [`InMemoryFs`](crate::InMemoryFs) - HashMap-based in-memory storage
+/// - [`OverlayFs`](crate::OverlayFs) - Copy-on-write layered filesystem
+/// - [`MountableFs`](crate::MountableFs) - Multiple mount points
 #[async_trait]
 pub trait FileSystem: Send + Sync {
-    /// Read a file's contents.
+    /// Read a file's contents as bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The file does not exist (`NotFound`)
+    /// - The path is a directory
+    /// - I/O error occurs
     async fn read_file(&self, path: &Path) -> Result<Vec<u8>>;
 
-    /// Write contents to a file.
+    /// Write contents to a file, creating it if necessary.
+    ///
+    /// If the file exists, its contents are replaced. If it doesn't exist,
+    /// a new file is created (parent directory must exist).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The parent directory does not exist
+    /// - The path is a directory
+    /// - I/O error occurs
     async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()>;
 
-    /// Append contents to a file.
+    /// Append contents to a file, creating it if necessary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path is a directory
+    /// - I/O error occurs
     async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()>;
 
     /// Create a directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The directory path to create
+    /// * `recursive` - If true, create parent directories as needed (like `mkdir -p`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `recursive` is false and parent directory doesn't exist
+    /// - Directory already exists (when not recursive)
     async fn mkdir(&self, path: &Path, recursive: bool) -> Result<()>;
 
     /// Remove a file or directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to remove
+    /// * `recursive` - If true and path is a directory, remove all contents (like `rm -r`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist
+    /// - Path is a non-empty directory and `recursive` is false
     async fn remove(&self, path: &Path, recursive: bool) -> Result<()>;
 
-    /// Get file metadata.
+    /// Get file or directory metadata.
+    ///
+    /// Returns information about the file including type, size, permissions,
+    /// and timestamps.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path does not exist.
     async fn stat(&self, path: &Path) -> Result<Metadata>;
 
-    /// Read directory entries.
+    /// List directory contents.
+    ///
+    /// Returns a list of entries (files, directories, symlinks) in the directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist
+    /// - The path is not a directory
     async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>>;
 
     /// Check if a path exists.
+    ///
+    /// Returns `true` if the path exists (file, directory, or symlink).
     async fn exists(&self, path: &Path) -> Result<bool>;
 
-    /// Rename/move a file or directory.
+    /// Rename or move a file or directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The source path does not exist
+    /// - The destination parent directory does not exist
     async fn rename(&self, from: &Path, to: &Path) -> Result<()>;
 
     /// Copy a file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The source file does not exist
+    /// - The source is a directory
     async fn copy(&self, from: &Path, to: &Path) -> Result<()>;
 
     /// Create a symbolic link.
+    ///
+    /// Creates a symlink at `link` that points to `target`.
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - The path the symlink will point to
+    /// * `link` - The path where the symlink will be created
     async fn symlink(&self, target: &Path, link: &Path) -> Result<()>;
 
     /// Read a symbolic link's target.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist
+    /// - The path is not a symlink
     async fn read_link(&self, path: &Path) -> Result<std::path::PathBuf>;
 
     /// Change file permissions.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The file path
+    /// * `mode` - Unix permission mode (e.g., `0o644`, `0o755`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the path does not exist.
     async fn chmod(&self, path: &Path, mode: u32) -> Result<()>;
 }
 
-/// File metadata.
+/// File or directory metadata.
+///
+/// Returned by [`FileSystem::stat()`] and included in [`DirEntry`].
+///
+/// # Example
+///
+/// ```rust
+/// use bashkit::{Bash, FileSystem, FileType};
+/// use std::path::Path;
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// let bash = Bash::new();
+/// let fs = bash.fs();
+///
+/// fs.write_file(Path::new("/tmp/test.txt"), b"hello").await?;
+///
+/// let stat = fs.stat(Path::new("/tmp/test.txt")).await?;
+/// assert!(stat.file_type.is_file());
+/// assert_eq!(stat.size, 5);  // "hello" = 5 bytes
+/// assert_eq!(stat.mode, 0o644);  // Default file permissions
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Metadata {
-    /// File type
+    /// The type of this entry (file, directory, or symlink).
     pub file_type: FileType,
-    /// File size in bytes
+    /// File size in bytes. For directories, this is typically 0.
     pub size: u64,
-    /// File permissions (Unix mode)
+    /// Unix permission mode (e.g., `0o644` for files, `0o755` for directories).
     pub mode: u32,
-    /// Last modification time
+    /// Last modification time.
     pub modified: SystemTime,
-    /// Creation time
+    /// Creation time.
     pub created: SystemTime,
 }
 
@@ -78,39 +243,94 @@ impl Default for Metadata {
     }
 }
 
-/// File type.
+/// Type of a filesystem entry.
+///
+/// Used in [`Metadata`] to indicate whether an entry is a file, directory,
+/// or symbolic link.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum FileType {
-    /// Regular file
+    /// Regular file containing data.
     File,
-    /// Directory
+    /// Directory that can contain other entries.
     Directory,
-    /// Symbolic link
+    /// Symbolic link pointing to another path.
     Symlink,
 }
 
 impl FileType {
-    /// Check if this is a file.
+    /// Returns `true` if this is a regular file.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::FileType;
+    ///
+    /// assert!(FileType::File.is_file());
+    /// assert!(!FileType::Directory.is_file());
+    /// ```
     pub fn is_file(&self) -> bool {
         matches!(self, FileType::File)
     }
 
-    /// Check if this is a directory.
+    /// Returns `true` if this is a directory.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::FileType;
+    ///
+    /// assert!(FileType::Directory.is_dir());
+    /// assert!(!FileType::File.is_dir());
+    /// ```
     pub fn is_dir(&self) -> bool {
         matches!(self, FileType::Directory)
     }
 
-    /// Check if this is a symlink.
+    /// Returns `true` if this is a symbolic link.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::FileType;
+    ///
+    /// assert!(FileType::Symlink.is_symlink());
+    /// assert!(!FileType::File.is_symlink());
+    /// ```
     pub fn is_symlink(&self) -> bool {
         matches!(self, FileType::Symlink)
     }
 }
 
-/// Directory entry.
+/// An entry in a directory listing.
+///
+/// Returned by [`FileSystem::read_dir()`]. Contains the entry name (not the
+/// full path) and its metadata.
+///
+/// # Example
+///
+/// ```rust
+/// use bashkit::{Bash, FileSystem};
+/// use std::path::Path;
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// let bash = Bash::new();
+/// let fs = bash.fs();
+///
+/// fs.mkdir(Path::new("/data"), false).await?;
+/// fs.write_file(Path::new("/data/file.txt"), b"content").await?;
+///
+/// let entries = fs.read_dir(Path::new("/data")).await?;
+/// for entry in entries {
+///     println!("Name: {}, Size: {}", entry.name, entry.metadata.size);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct DirEntry {
-    /// Entry name (not full path)
+    /// Entry name (filename only, not the full path).
     pub name: String,
-    /// Entry metadata
+    /// Metadata for this entry.
     pub metadata: Metadata,
 }


### PR DESCRIPTION
## Summary

- Add crate-level docs with quick start, basic usage, control flow, and file operations examples
- Add `fs` module overview with quick start examples for InMemoryFs, OverlayFs, MountableFs
- Add custom filesystem implementation guidance
- Add `FileSystem` trait documentation with detailed method docs
- Add `InMemoryFs` docs with binary data support and default directory examples
- Add `OverlayFs` docs with copy-on-write patterns and whiteout handling
- Add `MountableFs` docs with mount/unmount examples and path resolution

## Test plan

- [x] All doc tests pass (38 tests)
- [x] `cargo doc --no-deps` builds successfully
- [x] Compatible with docs.rs rendering

https://claude.ai/code/session_01UufRqfqtY4eEMiHTA8X1NJ