### PR TITLE
test(builtins): add example and integration tests for custom builtins

### DIFF
--- a/crates/bashkit/examples/custom_builtins.rs
+++ b/crates/bashkit/examples/custom_builtins.rs
@@ -1,0 +1,200 @@
+//! Custom Builtins Example
+//!
+//! Demonstrates how to extend bashkit with custom builtin commands.
+//! Custom builtins have access to arguments, environment, filesystem, and stdin.
+//!
+//! Run with: cargo run --example custom_builtins
+
+use async_trait::async_trait;
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// A simple greeting command
+struct Greet {
+    default_name: String,
+}
+
+#[async_trait]
+impl Builtin for Greet {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let name = ctx
+            .args
+            .first()
+            .map(|s| s.as_str())
+            .unwrap_or(&self.default_name);
+        Ok(ExecResult::ok(format!("Hello, {}!\n", name)))
+    }
+}
+
+/// A command that transforms input to uppercase
+struct Upper;
+
+#[async_trait]
+impl Builtin for Upper {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let input = ctx.stdin.unwrap_or("");
+        Ok(ExecResult::ok(input.to_uppercase()))
+    }
+}
+
+/// A counter command with shared state
+struct Counter {
+    count: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl Builtin for Counter {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let increment: u64 = ctx.args.first().and_then(|s| s.parse().ok()).unwrap_or(1);
+        let new_value = self.count.fetch_add(increment, Ordering::SeqCst) + increment;
+        Ok(ExecResult::ok(format!("{}\n", new_value)))
+    }
+}
+
+/// A command that reads environment variables
+struct EnvReader;
+
+#[async_trait]
+impl Builtin for EnvReader {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let var_name = ctx.args.first().map(|s| s.as_str()).unwrap_or("HOME");
+        let value = ctx
+            .env
+            .get(var_name)
+            .map(|s| s.as_str())
+            .unwrap_or("(not set)");
+        Ok(ExecResult::ok(format!("{}={}\n", var_name, value)))
+    }
+}
+
+/// A key-value store command (simulating a database)
+struct KvStore {
+    data: Arc<tokio::sync::RwLock<HashMap<String, String>>>,
+}
+
+#[async_trait]
+impl Builtin for KvStore {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let cmd = ctx.args.first().map(|s| s.as_str()).unwrap_or("help");
+
+        match cmd {
+            "get" => {
+                let key = ctx.args.get(1).map(|s| s.as_str()).unwrap_or("");
+                let data = self.data.read().await;
+                match data.get(key) {
+                    Some(value) => Ok(ExecResult::ok(format!("{}\n", value))),
+                    None => Ok(ExecResult::err(format!("key not found: {}\n", key), 1)),
+                }
+            }
+            "set" => {
+                let key = ctx.args.get(1).cloned().unwrap_or_default();
+                let value = ctx.args.get(2).cloned().unwrap_or_default();
+                let mut data = self.data.write().await;
+                data.insert(key, value);
+                Ok(ExecResult::ok(String::new()))
+            }
+            "list" => {
+                let data = self.data.read().await;
+                let mut output = String::new();
+                for (k, v) in data.iter() {
+                    output.push_str(&format!("{}={}\n", k, v));
+                }
+                Ok(ExecResult::ok(output))
+            }
+            _ => Ok(ExecResult::err(
+                "Usage: kv <get|set|list> [key] [value]\n".to_string(),
+                1,
+            )),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("=== Custom Builtins Demo ===\n");
+
+    // Create shared state for stateful builtins
+    let counter = Arc::new(AtomicU64::new(0));
+    let kv_data = Arc::new(tokio::sync::RwLock::new(HashMap::new()));
+
+    // Build bash with custom builtins
+    let mut bash = Bash::builder()
+        .env("API_KEY", "secret-123")
+        .env("DATABASE_URL", "postgres://localhost/mydb")
+        .builtin(
+            "greet",
+            Box::new(Greet {
+                default_name: "World".to_string(),
+            }),
+        )
+        .builtin("upper", Box::new(Upper))
+        .builtin("counter", Box::new(Counter { count: counter }))
+        .builtin("getenv", Box::new(EnvReader))
+        .builtin("kv", Box::new(KvStore { data: kv_data }))
+        .build();
+
+    // Demo 1: Simple greeting command
+    println!("--- Greeting Command ---");
+    let result = bash.exec("greet").await?;
+    print!("greet: {}", result.stdout);
+
+    let result = bash.exec("greet Alice").await?;
+    print!("greet Alice: {}", result.stdout);
+
+    // Demo 2: Pipeline with custom command
+    println!("\n--- Pipeline with Upper ---");
+    let result = bash.exec("echo 'hello world' | upper").await?;
+    print!("echo 'hello world' | upper: {}", result.stdout);
+
+    // Demo 3: Stateful counter
+    println!("\n--- Stateful Counter ---");
+    let result = bash.exec("counter").await?;
+    print!("counter (1st call): {}", result.stdout);
+
+    let result = bash.exec("counter").await?;
+    print!("counter (2nd call): {}", result.stdout);
+
+    let result = bash.exec("counter 10").await?;
+    print!("counter 10: {}", result.stdout);
+
+    // Demo 4: Environment access
+    println!("\n--- Environment Access ---");
+    let result = bash.exec("getenv API_KEY").await?;
+    print!("{}", result.stdout);
+
+    let result = bash.exec("getenv DATABASE_URL").await?;
+    print!("{}", result.stdout);
+
+    // Demo 5: Key-value store (simulating database)
+    println!("\n--- Key-Value Store ---");
+    bash.exec("kv set name Alice").await?;
+    bash.exec("kv set email alice@example.com").await?;
+
+    let result = bash.exec("kv get name").await?;
+    print!("kv get name: {}", result.stdout);
+
+    let result = bash.exec("kv list").await?;
+    println!("kv list:\n{}", result.stdout);
+
+    // Demo 6: Custom builtins in scripts
+    println!("--- Custom Builtins in Scripts ---");
+    let script = r#"
+        for name in Alice Bob Charlie; do
+            greet $name
+        done
+    "#;
+    let result = bash.exec(script).await?;
+    print!("{}", result.stdout);
+
+    // Demo 7: Conditional execution
+    println!("\n--- Conditional Execution ---");
+    let result = bash
+        .exec("kv get missing || echo 'Key not found, using default'")
+        .await?;
+    print!("{}", result.stdout);
+
+    println!("\n=== Demo Complete ===");
+    Ok(())
+}

--- a/crates/bashkit/tests/custom_builtins_tests.rs
+++ b/crates/bashkit/tests/custom_builtins_tests.rs
@@ -1,0 +1,489 @@
+//! Integration tests for custom builtins
+//!
+//! Tests the public API for registering and using custom builtin commands.
+
+use async_trait::async_trait;
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, FileSystem, InMemoryFs};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Helper struct for testing - a simple echo with prefix
+struct PrefixEcho {
+    prefix: String,
+}
+
+#[async_trait]
+impl Builtin for PrefixEcho {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let msg = ctx.args.join(" ");
+        Ok(ExecResult::ok(format!("{}{}\n", self.prefix, msg)))
+    }
+}
+
+/// Helper struct - transforms stdin
+struct Transform {
+    transform_fn: fn(&str) -> String,
+}
+
+#[async_trait]
+impl Builtin for Transform {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let input = ctx.stdin.unwrap_or("");
+        Ok(ExecResult::ok((self.transform_fn)(input)))
+    }
+}
+
+/// Helper struct - reads from filesystem
+struct FileReader;
+
+#[async_trait]
+impl Builtin for FileReader {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let path = match ctx.args.first() {
+            Some(p) => std::path::Path::new(p),
+            None => return Ok(ExecResult::err("Usage: readfile <path>\n".to_string(), 1)),
+        };
+        match ctx.fs.read_file(path).await {
+            Ok(content) => Ok(ExecResult::ok(
+                String::from_utf8_lossy(&content).to_string(),
+            )),
+            Err(e) => Ok(ExecResult::err(format!("Error: {}\n", e), 1)),
+        }
+    }
+}
+
+/// Helper struct - counter with shared state
+struct Counter {
+    count: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl Builtin for Counter {
+    async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let value = self.count.fetch_add(1, Ordering::SeqCst) + 1;
+        Ok(ExecResult::ok(format!("{}\n", value)))
+    }
+}
+
+/// Helper struct - returns error
+struct Fail {
+    message: String,
+    code: i32,
+}
+
+#[async_trait]
+impl Builtin for Fail {
+    async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        Ok(ExecResult::err(format!("{}\n", self.message), self.code))
+    }
+}
+
+/// Helper struct - reads env vars
+struct EnvDumper;
+
+#[async_trait]
+impl Builtin for EnvDumper {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let mut output = String::new();
+        let mut keys: Vec<_> = ctx.env.keys().collect();
+        keys.sort();
+        for key in keys {
+            if let Some(value) = ctx.env.get(key) {
+                output.push_str(&format!("{}={}\n", key, value));
+            }
+        }
+        Ok(ExecResult::ok(output))
+    }
+}
+
+// =============================================================================
+// Basic functionality tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_simple() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "prefix",
+            Box::new(PrefixEcho {
+                prefix: "[LOG] ".to_string(),
+            }),
+        )
+        .build();
+
+    let result = bash.exec("prefix hello world").await.unwrap();
+    assert_eq!(result.stdout, "[LOG] hello world\n");
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_custom_builtin_no_args() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "prefix",
+            Box::new(PrefixEcho {
+                prefix: ">>> ".to_string(),
+            }),
+        )
+        .build();
+
+    let result = bash.exec("prefix").await.unwrap();
+    assert_eq!(result.stdout, ">>> \n");
+}
+
+// =============================================================================
+// Pipeline tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_in_pipeline() {
+    fn to_upper(s: &str) -> String {
+        s.to_uppercase()
+    }
+
+    let mut bash = Bash::builder()
+        .builtin(
+            "upper",
+            Box::new(Transform {
+                transform_fn: to_upper,
+            }),
+        )
+        .build();
+
+    let result = bash.exec("echo hello | upper").await.unwrap();
+    assert_eq!(result.stdout, "HELLO\n");
+}
+
+#[tokio::test]
+async fn test_custom_builtin_pipeline_chain() {
+    fn to_upper(s: &str) -> String {
+        s.to_uppercase()
+    }
+
+    fn reverse(s: &str) -> String {
+        s.chars().rev().collect()
+    }
+
+    let mut bash = Bash::builder()
+        .builtin(
+            "upper",
+            Box::new(Transform {
+                transform_fn: to_upper,
+            }),
+        )
+        .builtin(
+            "reverse",
+            Box::new(Transform {
+                transform_fn: reverse,
+            }),
+        )
+        .build();
+
+    let result = bash.exec("echo abc | upper | reverse").await.unwrap();
+    // "abc\n" -> "ABC\n" -> "\nCBA"
+    assert_eq!(result.stdout, "\nCBA");
+}
+
+// =============================================================================
+// Filesystem access tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_filesystem_access() {
+    let fs = Arc::new(InMemoryFs::new());
+    // Create parent directory first
+    fs.mkdir(std::path::Path::new("/data"), false)
+        .await
+        .unwrap();
+    fs.write_file(
+        std::path::Path::new("/data/test.txt"),
+        b"custom content here",
+    )
+    .await
+    .unwrap();
+
+    let mut bash = Bash::builder()
+        .fs(fs)
+        .builtin("readfile", Box::new(FileReader))
+        .build();
+
+    let result = bash.exec("readfile /data/test.txt").await.unwrap();
+    assert_eq!(result.stdout, "custom content here");
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn test_custom_builtin_filesystem_error() {
+    let mut bash = Bash::builder()
+        .builtin("readfile", Box::new(FileReader))
+        .build();
+
+    let result = bash.exec("readfile /nonexistent").await.unwrap();
+    assert!(result.stderr.contains("Error:"));
+    assert_eq!(result.exit_code, 1);
+}
+
+// =============================================================================
+// Stateful builtin tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_shared_state() {
+    let counter = Arc::new(AtomicU64::new(0));
+
+    let mut bash = Bash::builder()
+        .builtin(
+            "counter",
+            Box::new(Counter {
+                count: counter.clone(),
+            }),
+        )
+        .build();
+
+    let result = bash.exec("counter").await.unwrap();
+    assert_eq!(result.stdout, "1\n");
+
+    let result = bash.exec("counter").await.unwrap();
+    assert_eq!(result.stdout, "2\n");
+
+    let result = bash.exec("counter").await.unwrap();
+    assert_eq!(result.stdout, "3\n");
+
+    // Verify counter state
+    assert_eq!(counter.load(Ordering::SeqCst), 3);
+}
+
+// =============================================================================
+// Error handling tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_returns_error() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "fail",
+            Box::new(Fail {
+                message: "Something went wrong".to_string(),
+                code: 42,
+            }),
+        )
+        .build();
+
+    let result = bash.exec("fail").await.unwrap();
+    assert_eq!(result.stderr, "Something went wrong\n");
+    assert_eq!(result.exit_code, 42);
+}
+
+#[tokio::test]
+async fn test_custom_builtin_error_in_conditional() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "fail",
+            Box::new(Fail {
+                message: "error".to_string(),
+                code: 1,
+            }),
+        )
+        .builtin(
+            "prefix",
+            Box::new(PrefixEcho {
+                prefix: "".to_string(),
+            }),
+        )
+        .build();
+
+    // fail || echo should run echo
+    let result = bash.exec("fail || prefix success").await.unwrap();
+    assert_eq!(result.stdout, "success\n");
+    assert_eq!(result.exit_code, 0);
+}
+
+// =============================================================================
+// Override default builtin tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_override_echo() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "echo",
+            Box::new(PrefixEcho {
+                prefix: "[CUSTOM] ".to_string(),
+            }),
+        )
+        .build();
+
+    let result = bash.exec("echo hello").await.unwrap();
+    assert_eq!(result.stdout, "[CUSTOM] hello\n");
+}
+
+// =============================================================================
+// Environment access tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_environment_access() {
+    let mut bash = Bash::builder()
+        .env("FOO", "bar")
+        .env("BAZ", "qux")
+        .builtin("dumpenv", Box::new(EnvDumper))
+        .build();
+
+    let result = bash.exec("dumpenv").await.unwrap();
+    assert!(result.stdout.contains("FOO=bar"));
+    assert!(result.stdout.contains("BAZ=qux"));
+}
+
+// =============================================================================
+// Script integration tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_in_for_loop() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "prefix",
+            Box::new(PrefixEcho {
+                prefix: "- ".to_string(),
+            }),
+        )
+        .build();
+
+    let script = r#"
+        for item in a b c; do
+            prefix $item
+        done
+    "#;
+
+    let result = bash.exec(script).await.unwrap();
+    assert_eq!(result.stdout, "- a\n- b\n- c\n");
+}
+
+#[tokio::test]
+async fn test_custom_builtin_in_if_condition() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "fail",
+            Box::new(Fail {
+                message: "".to_string(),
+                code: 1,
+            }),
+        )
+        .build();
+
+    let script = r#"
+        if fail; then
+            echo "should not reach"
+        else
+            echo "correctly handled"
+        fi
+    "#;
+
+    let result = bash.exec(script).await.unwrap();
+    assert_eq!(result.stdout, "correctly handled\n");
+}
+
+#[tokio::test]
+async fn test_custom_builtin_with_variable_expansion() {
+    let mut bash = Bash::builder()
+        .builtin(
+            "prefix",
+            Box::new(PrefixEcho {
+                prefix: "".to_string(),
+            }),
+        )
+        .build();
+
+    let result = bash.exec("NAME=Alice; prefix Hello $NAME").await.unwrap();
+    assert_eq!(result.stdout, "Hello Alice\n");
+}
+
+// =============================================================================
+// Multiple custom builtins tests
+// =============================================================================
+
+#[tokio::test]
+async fn test_multiple_custom_builtins() {
+    fn to_upper(s: &str) -> String {
+        s.to_uppercase()
+    }
+
+    let counter = Arc::new(AtomicU64::new(0));
+
+    let mut bash = Bash::builder()
+        .builtin(
+            "prefix",
+            Box::new(PrefixEcho {
+                prefix: "[LOG] ".to_string(),
+            }),
+        )
+        .builtin(
+            "upper",
+            Box::new(Transform {
+                transform_fn: to_upper,
+            }),
+        )
+        .builtin("counter", Box::new(Counter { count: counter }))
+        .builtin(
+            "fail",
+            Box::new(Fail {
+                message: "error".to_string(),
+                code: 1,
+            }),
+        )
+        .build();
+
+    // Test all work independently
+    let result = bash.exec("prefix test").await.unwrap();
+    assert_eq!(result.stdout, "[LOG] test\n");
+
+    let result = bash.exec("echo hello | upper").await.unwrap();
+    assert_eq!(result.stdout, "HELLO\n");
+
+    let result = bash.exec("counter").await.unwrap();
+    assert_eq!(result.stdout, "1\n");
+
+    let result = bash.exec("fail").await.unwrap();
+    assert_eq!(result.exit_code, 1);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[tokio::test]
+async fn test_custom_builtin_empty_name() {
+    // Empty command names should work (though unusual)
+    struct Empty;
+
+    #[async_trait]
+    impl Builtin for Empty {
+        async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+            Ok(ExecResult::ok("empty\n".to_string()))
+        }
+    }
+
+    let mut bash = Bash::builder().builtin("_", Box::new(Empty)).build();
+
+    let result = bash.exec("_").await.unwrap();
+    assert_eq!(result.stdout, "empty\n");
+}
+
+#[tokio::test]
+async fn test_custom_builtin_special_characters_in_output() {
+    struct SpecialOutput;
+
+    #[async_trait]
+    impl Builtin for SpecialOutput {
+        async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+            Ok(ExecResult::ok("line1\nline2\ttab\n".to_string()))
+        }
+    }
+
+    let mut bash = Bash::builder()
+        .builtin("special", Box::new(SpecialOutput))
+        .build();
+
+    let result = bash.exec("special").await.unwrap();
+    assert_eq!(result.stdout, "line1\nline2\ttab\n");
+}


### PR DESCRIPTION
## Summary

Adds comprehensive example and integration tests for the custom builtins feature.

## Changes

### Example (`examples/custom_builtins.rs`)

Demonstrates real-world usage patterns:
- **Greet**: Simple command with default arguments
- **Upper**: Pipeline transformation using stdin
- **Counter**: Stateful builtin with `Arc<AtomicU64>`
- **EnvReader**: Accessing environment variables
- **KvStore**: Simulated key-value database with get/set/list

### Integration Tests (`tests/custom_builtins_tests.rs`)

17 test cases covering:
- Basic builtin execution
- Pipeline integration (single and chained)
- Filesystem access via `ctx.fs`
- Shared state persistence across calls
- Error handling and exit codes
- Overriding default builtins (e.g., `echo`)
- Environment variable access
- Script integration (for loops, if conditions, variable expansion)
- Multiple custom builtins in one instance
- Edge cases (special characters, empty names)

## Test plan

- [x] `cargo test --test custom_builtins_tests` - 17 tests pass
- [x] `cargo run --example custom_builtins` - Example runs successfully
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - No warnings
- [x] `cargo fmt --check` - Formatted correctly

https://claude.ai/code/session_017p3j2Cw8eh3dzNdhqtMy2P