### PR TITLE
feat(test): add script to check expected outputs against bash

### DIFF
--- a/justfile
+++ b/justfile
@@ -36,6 +36,14 @@ check:
 pre-pr: check vet
     @echo "Pre-PR checks passed"
 
+# Check spec tests against real bash
+check-bash-compat:
+    ./scripts/update-spec-expected.sh
+
+# Check spec tests against real bash (verbose)
+check-bash-compat-verbose:
+    ./scripts/update-spec-expected.sh --verbose
+
 # Clean build artifacts
 clean:
     cargo clean

--- a/scripts/update-spec-expected.sh
+++ b/scripts/update-spec-expected.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Check and update expected outputs in spec test files
+#
+# Usage:
+#   ./scripts/update-spec-expected.sh           # Check all tests match real bash
+#   ./scripts/update-spec-expected.sh --verbose # Show details for each test
+#
+# This script runs the bash comparison tests to verify that expected outputs
+# match what real bash produces. Tests marked with ### skip or ### bash_diff
+# are excluded from comparison.
+#
+# To update expected outputs:
+# 1. Run this script to see which tests differ
+# 2. Edit the .test.sh files manually
+# 3. Or add ### bash_diff marker if the difference is intentional
+#
+# This is a wrapper around: cargo test --test spec_tests -- bash_comparison_tests
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+
+VERBOSE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Check that spec test expected outputs match real bash."
+            echo ""
+            echo "Options:"
+            echo "  --verbose, -v   Show all test comparisons"
+            echo "  --help, -h      Show this help message"
+            echo ""
+            echo "Exit codes:"
+            echo "  0 - All non-excluded tests match real bash"
+            echo "  1 - Some tests have mismatches"
+            echo ""
+            echo "Tests are excluded from comparison if they have:"
+            echo "  ### skip: reason      - Not yet implemented"
+            echo "  ### bash_diff: reason - Known intentional difference"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+cd "$ROOT_DIR"
+
+echo "Checking spec tests against real bash..."
+echo ""
+
+if $VERBOSE; then
+    cargo test --test spec_tests -- bash_comparison_tests_verbose --ignored --nocapture 2>&1
+else
+    cargo test --test spec_tests -- bash_comparison_tests --nocapture 2>&1
+fi
+
+exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+    echo ""
+    echo "All non-excluded tests match real bash."
+else
+    echo ""
+    echo "Some tests have differences from real bash."
+    echo ""
+    echo "To fix:"
+    echo "  1. Update the expected output in .test.sh to match real bash, or"
+    echo "  2. Add '### bash_diff: reason' if the difference is intentional"
+    echo ""
+    echo "Run with --verbose to see all comparisons."
+fi
+
+exit $exit_code

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -120,8 +120,14 @@ cargo test --test spec_tests -- bash_spec_tests
 # With output
 cargo test --test spec_tests -- --nocapture
 
-# Comparison against real bash (ignored by default)
-cargo test --test spec_tests -- bash_comparison_tests --ignored
+# Check spec tests match real bash
+just check-bash-compat
+
+# Check spec tests match real bash (verbose - shows each test)
+just check-bash-compat-verbose
+
+# Or directly with cargo:
+cargo test --test spec_tests -- bash_comparison_tests --nocapture
 ```
 
 ## Coverage
@@ -156,9 +162,26 @@ The following items need attention:
 
 1. Create or edit `.test.sh` file in appropriate category
 2. Use the standard format with `### test_name`, `### expect`, `### end`
-3. Run tests to verify
+3. Run `just check-bash-compat` to verify expected output matches real bash
 4. If test fails due to unimplemented feature, add `### skip: reason`
-5. Update `KNOWN_LIMITATIONS.md` for skipped tests
+5. If BashKit intentionally differs from bash, add `### bash_diff: reason`
+6. Update `KNOWN_LIMITATIONS.md` for skipped tests
+
+### Checking Expected Outputs
+
+The `scripts/update-spec-expected.sh` script helps verify expected outputs:
+
+```bash
+# Check all tests match real bash
+./scripts/update-spec-expected.sh
+
+# Show detailed comparison for each test
+./scripts/update-spec-expected.sh --verbose
+```
+
+If a test fails, either:
+1. Fix the expected output to match real bash, or
+2. Add `### bash_diff: reason` if the difference is intentional
 
 ## Comparison Testing
 


### PR DESCRIPTION
## Summary

Add helper script and justfile commands to verify spec test expected outputs match real bash.

## Changes

- Add `scripts/update-spec-expected.sh`:
  - Runs bash_comparison_tests to check for mismatches
  - `--verbose` flag shows each test comparison
  - Clear instructions on how to fix mismatches

- Add justfile commands:
  - `just check-bash-compat` - Quick check
  - `just check-bash-compat-verbose` - Detailed output

- Update `specs/004-testing.md`:
  - Document new commands and workflow
  - Update "Adding New Tests" section

## Test plan

- [x] Script works: `./scripts/update-spec-expected.sh --help`
- [x] Just commands work: `just check-bash-compat`
- [x] All spec tests pass
- [ ] CI passes

https://claude.ai/code/session_01CFh6WZw1QDSGhTnCUW57qi