### PR TITLE
fix(ci): wrap if condition in expression syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     # Only run if commit message starts with "chore(release): prepare v"
-    if: startsWith(github.event.head_commit.message, 'chore(release): prepare v')
+    if: ${{ startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Fix YAML syntax error on line 16 of release workflow
- The colon in `'chore(release): prepare v'` was being parsed as a key-value separator
- Wrapping in `${{ }}` makes YAML treat it as a literal expression

## Test plan
- [ ] CI passes
- [ ] Workflow file validates

https://claude.ai/code/session_01RBwS2nnNcn6PASsdnnVb4b