### PR TITLE
chore(ci): add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,8 +13,8 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    # Only run if commit message starts with "chore(release): prepare v"
-    if: ${{ startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}
+    # Only run if manually triggered OR commit message starts with "chore(release): prepare v"
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to release workflow
- Update `if` condition to allow manual triggers

Enables running `gh workflow run release.yml` for manual releases.

https://claude.ai/code/session_01RBwS2nnNcn6PASsdnnVb4b