### PR TITLE
fix(ci): add checks:write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Add `checks:write` permission to publish.yml so it can call ci.yml as a reusable workflow.

The ci.yml workflow uses cargo-audit which requires `checks:write` to post check results.

https://claude.ai/code/session_012H3ZE2AarYg9zNjH4okkTV