### PR TITLE
fix(ci): pass secrets to ci.yml reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   # Publish bashkit (core library) to crates.io
   publish-bashkit:


### PR DESCRIPTION
## Summary

Add `secrets: inherit` to pass secrets (including `ANTHROPIC_API_KEY`) to the ci.yml reusable workflow.

The agent_tool example requires this secret to run.

https://claude.ai/code/session_012H3ZE2AarYg9zNjH4okkTV