### PR TITLE
docs: rename compatibility_guide to compatibility_reference

### DIFF
--- a/crates/bashkit/docs/compatibility.md
+++ b/crates/bashkit/docs/compatibility.md
@@ -1,10 +1,12 @@
-# BashKit Compatibility Reference
+# BashKit Compatibility Scorecard
 
-> Dense reference for all bash features and builtins
+> Feature parity tracking for bash and common tools
 
 **See also:**
 - [API Documentation](https://docs.rs/bashkit) - Full API reference
 - [Custom Builtins Guide](./custom_builtins.md) - Extending BashKit with custom commands
+
+**Legend:** ✅ Implemented | ⚠️ Partial | ❌ Not implemented | N/A Security exclusion
 
 ## POSIX Shell Compliance
 

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -10,7 +10,7 @@
 //! - **Resource Limits**: Control command count, loop iterations, and function depth
 //! - **Sandboxed Identity**: Customizable username/hostname for `whoami`, `hostname`, etc.
 //! - **Custom Builtins**: Extend with domain-specific commands (psql, kubectl, etc.)
-//! - **30+ Built-in Commands**: `echo`, `cat`, `grep`, `sed`, `awk`, `jq`, and more
+//! - **66 Built-in Commands**: Shell builtins, text processing, file operations, and networking
 //! - **Full Bash Syntax**: Variables, pipelines, redirects, loops, functions, arrays
 //!
 //! # Quick Start
@@ -247,7 +247,10 @@
 //! # Guides
 //!
 //! - [`custom_builtins_guide`] - Creating custom builtins
-//! - [`compatibility_guide`] - Full bash compatibility reference
+//!
+//! # References
+//!
+//! - [`compatibility_reference`] - Bash compatibility scorecard
 
 // Stricter panic prevention - prefer proper error handling over unwrap()
 #![warn(clippy::unwrap_used)]
@@ -644,21 +647,21 @@ impl BashBuilder {
 /// - Working with arguments, environment, and filesystem
 /// - Best practices and examples
 ///
-/// **Related:** [`BashBuilder::builtin`], [`compatibility_guide`]
+/// **Related:** [`BashBuilder::builtin`], [`compatibility_reference`]
 #[doc = include_str!("../docs/custom_builtins.md")]
 pub mod custom_builtins_guide {}
 
-/// Comprehensive reference for supported bash features.
+/// Bash compatibility scorecard - tracks feature parity with real bash.
 ///
-/// This reference covers:
-/// - All implemented builtins and their flags
-/// - Shell syntax (operators, redirections, control flow)
-/// - Variable expansion and special variables
-/// - Arrays, test operators, and resource limits
+/// This reference provides:
+/// - Quick status of implemented features vs bash
+/// - Detailed compatibility tables for builtins, syntax, expansions
+/// - POSIX compliance status
+/// - Resource limits and security boundaries
 ///
 /// **Related:** [`custom_builtins_guide`]
 #[doc = include_str!("../docs/compatibility.md")]
-pub mod compatibility_guide {}
+pub mod compatibility_reference {}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/specs/008-documentation.md
+++ b/specs/008-documentation.md
@@ -16,15 +16,20 @@ Use `include_str!` macro to embed external markdown files into rustdoc as docume
 ```
 crates/bashkit/
 ├── docs/
-│   ├── compatibility.md      # Bash feature compatibility reference
+│   ├── compatibility.md      # Bash compatibility scorecard (reference)
 │   ├── custom_builtins.md    # Guide for extending BashKit
-│   └── (future guides...)
+│   └── (future docs...)
 └── src/
     └── lib.rs
-        ├── //! crate docs with links to guides
-        └── pub mod custom_builtins_guide {}   # Empty module with include_str!
-            pub mod compatibility_guide {}
+        ├── //! crate docs with links to guides and references
+        └── pub mod custom_builtins_guide {}      # Tutorial-style guide
+            pub mod compatibility_reference {}    # Dense reference/scorecard
 ```
+
+### Guides vs References
+
+- **Guides** (`*_guide`): Tutorial-style docs with examples, step-by-step instructions
+- **References** (`*_reference`): Dense lookup tables, compatibility scorecards, quick status
 
 Note: Docs live inside `crates/bashkit/docs/` to ensure they are included in
 the published crate package. This allows `include_str!` to work correctly
@@ -56,13 +61,16 @@ Add "See also" section at top of each markdown file:
 
 ### Crate Docs
 
-Add "Guides" section to main crate documentation:
+Add "Guides" and "References" sections to main crate documentation:
 
 ```rust
 //! # Guides
 //!
 //! - [`custom_builtins_guide`] - Creating custom builtins
-//! - [`compatibility_guide`] - Full bash compatibility reference
+//!
+//! # References
+//!
+//! - [`compatibility_reference`] - Bash compatibility scorecard
 ```
 
 ## Adding New Guides


### PR DESCRIPTION
## Summary

- Fix outdated "30+ Built-in Commands" to accurate count (66)
- Rename `compatibility_guide` module to `compatibility_reference` (it's a scorecard, not a tutorial guide)
- Separate "Guides" and "References" sections in rustdoc
- Update compatibility.md title to "Compatibility Scorecard"
- Update spec 008-documentation.md with guides vs references distinction

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] `cargo doc` builds successfully
- [x] Pre-existing test failures in security_failpoint_tests unrelated to these changes

https://claude.ai/code/session_012byxqB5Z2D2n35ch697637