### PR TITLE
feat(vfs): add text_file and readonly_text builder methods

### DIFF
--- a/crates/bashkit/examples/text_files.rs
+++ b/crates/bashkit/examples/text_files.rs
@@ -1,0 +1,151 @@
+//! Text file pre-population example
+//!
+//! Demonstrates using `text_file()` and `readonly_text()` builder methods
+//! to pre-populate the virtual filesystem before running scripts.
+//!
+//! Run with: cargo run --example text_files
+
+use bashkit::Bash;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("=== Text File Pre-population Example ===\n");
+
+    basic_text_files().await?;
+    println!();
+
+    readonly_config_files().await?;
+    println!();
+
+    json_data_files().await?;
+    println!();
+
+    mixed_permissions().await?;
+
+    Ok(())
+}
+
+/// Basic text file usage
+async fn basic_text_files() -> anyhow::Result<()> {
+    println!("--- Basic Text Files ---");
+
+    // Pre-populate files using the builder
+    let mut bash = Bash::builder()
+        .text_file(
+            "/config/app.conf",
+            "debug=true\nport=8080\nhost=localhost\n",
+        )
+        .text_file("/data/greeting.txt", "Hello from pre-populated file!")
+        .build();
+
+    // Scripts can read the pre-populated files
+    println!("Reading config file:");
+    let result = bash.exec("cat /config/app.conf").await?;
+    print!("{}", result.stdout);
+
+    println!("\nGreeting file:");
+    let result = bash.exec("cat /data/greeting.txt").await?;
+    println!("{}", result.stdout);
+
+    // Scripts can also modify writable files
+    bash.exec("echo 'log_level=info' >> /config/app.conf")
+        .await?;
+    println!("After appending to config:");
+    let result = bash.exec("cat /config/app.conf").await?;
+    print!("{}", result.stdout);
+
+    Ok(())
+}
+
+/// Readonly configuration files
+async fn readonly_config_files() -> anyhow::Result<()> {
+    println!("--- Readonly Configuration Files ---");
+
+    // Use readonly_text for files that shouldn't be modified
+    let bash = Bash::builder()
+        .readonly_text("/etc/version", "1.2.3")
+        .readonly_text(
+            "/etc/system.conf",
+            "# System configuration (readonly)\nmode=production\n",
+        )
+        .build();
+
+    // Read the readonly files
+    println!("System version:");
+    let mut bash_mut = bash;
+    let result = bash_mut.exec("cat /etc/version").await?;
+    println!("{}", result.stdout);
+
+    // Check file permissions
+    let stat = bash_mut
+        .fs()
+        .stat(std::path::Path::new("/etc/version"))
+        .await?;
+    println!("Permission mode: {:o} (readonly)", stat.mode);
+
+    Ok(())
+}
+
+/// JSON data files for script processing
+async fn json_data_files() -> anyhow::Result<()> {
+    println!("--- JSON Data Files ---");
+
+    let mut bash = Bash::builder()
+        .text_file(
+            "/data/users.json",
+            r#"[{"name": "alice", "role": "admin"}, {"name": "bob", "role": "user"}]"#,
+        )
+        .text_file(
+            "/data/config.json",
+            r#"{"api_url": "https://api.example.com", "timeout": 30}"#,
+        )
+        .build();
+
+    // Process JSON with jq
+    println!("User data:");
+    let result = bash.exec("cat /data/users.json | jq '.[0].name'").await?;
+    print!("First user: {}", result.stdout);
+
+    println!("Config data:");
+    let result = bash.exec("cat /data/config.json | jq '.timeout'").await?;
+    print!("Timeout: {}", result.stdout);
+
+    Ok(())
+}
+
+/// Mix of writable and readonly files
+async fn mixed_permissions() -> anyhow::Result<()> {
+    println!("--- Mixed Permissions ---");
+
+    let bash = Bash::builder()
+        // Readonly system files
+        .readonly_text("/etc/hostname", "sandbox-host")
+        .readonly_text("/etc/os-release", "NAME=\"BashKit\"\nVERSION=\"1.0\"\n")
+        // Writable workspace files
+        .text_file("/workspace/notes.txt", "Initial notes\n")
+        .text_file(
+            "/workspace/data.csv",
+            "id,name,value\n1,foo,100\n2,bar,200\n",
+        )
+        .build();
+
+    let mut bash = bash;
+
+    // Read system info
+    println!("Hostname:");
+    let result = bash.exec("cat /etc/hostname").await?;
+    println!("{}", result.stdout);
+
+    // Process CSV data
+    println!("CSV data:");
+    let result = bash.exec("cat /workspace/data.csv | head -2").await?;
+    print!("{}", result.stdout);
+
+    // Modify workspace file
+    bash.exec("echo '3,baz,300' >> /workspace/data.csv").await?;
+    println!("\nAfter adding row:");
+    let result = bash.exec("cat /workspace/data.csv").await?;
+    print!("{}", result.stdout);
+
+    Ok(())
+}

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -447,6 +447,13 @@ impl Bash {
 ///     .builtin("mycommand", Box::new(MyCommand))
 ///     .build();
 /// ```
+/// A text file to be added during builder construction.
+struct PendingTextFile {
+    path: PathBuf,
+    content: String,
+    mode: u32,
+}
+
 #[derive(Default)]
 pub struct BashBuilder {
     fs: Option<Arc<dyn FileSystem>>,
@@ -456,6 +463,8 @@ pub struct BashBuilder {
     username: Option<String>,
     hostname: Option<String>,
     custom_builtins: HashMap<String, Box<dyn Builtin>>,
+    /// Text files to add to the default InMemoryFs
+    text_files: Vec<PendingTextFile>,
     /// Network allowlist for curl/wget builtins
     #[cfg(feature = "http_client")]
     network_allowlist: Option<NetworkAllowlist>,
@@ -581,9 +590,98 @@ impl BashBuilder {
         self
     }
 
+    /// Add a text file to the virtual filesystem.
+    ///
+    /// This creates a regular file (mode `0o644`) with the specified content at
+    /// the given path. Parent directories are created automatically.
+    ///
+    /// This method only works when using the default [`InMemoryFs`]. If you call
+    /// [`.fs()`](Self::fs) to set a custom filesystem, text files are ignored.
+    /// Use the filesystem's async methods directly for custom filesystems.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::Bash;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let mut bash = Bash::builder()
+    ///     .text_file("/config/app.conf", "debug=true\nport=8080\n")
+    ///     .text_file("/data/users.json", r#"["alice", "bob"]"#)
+    ///     .build();
+    ///
+    /// let result = bash.exec("cat /config/app.conf").await?;
+    /// assert_eq!(result.stdout, "debug=true\nport=8080\n");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn text_file(mut self, path: impl Into<PathBuf>, content: impl Into<String>) -> Self {
+        self.text_files.push(PendingTextFile {
+            path: path.into(),
+            content: content.into(),
+            mode: 0o644,
+        });
+        self
+    }
+
+    /// Add a readonly text file to the virtual filesystem.
+    ///
+    /// This creates a readonly file (mode `0o444`) with the specified content.
+    /// Parent directories are created automatically.
+    ///
+    /// Readonly files are useful for:
+    /// - Configuration that shouldn't be modified by scripts
+    /// - Reference data that should remain immutable
+    /// - Simulating system files like `/etc/passwd`
+    ///
+    /// This method only works when using the default [`InMemoryFs`]. If you call
+    /// [`.fs()`](Self::fs) to set a custom filesystem, text files are ignored.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::Bash;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let mut bash = Bash::builder()
+    ///     .readonly_text("/etc/version", "1.2.3")
+    ///     .readonly_text("/etc/app.conf", "production=true\n")
+    ///     .build();
+    ///
+    /// // Can read the file
+    /// let result = bash.exec("cat /etc/version").await?;
+    /// assert_eq!(result.stdout, "1.2.3");
+    ///
+    /// // File has readonly permissions
+    /// let stat = bash.fs().stat(std::path::Path::new("/etc/version")).await?;
+    /// assert_eq!(stat.mode, 0o444);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn readonly_text(mut self, path: impl Into<PathBuf>, content: impl Into<String>) -> Self {
+        self.text_files.push(PendingTextFile {
+            path: path.into(),
+            content: content.into(),
+            mode: 0o444,
+        });
+        self
+    }
+
     /// Build the Bash instance.
     pub fn build(self) -> Bash {
-        let fs = self.fs.unwrap_or_else(|| Arc::new(InMemoryFs::new()));
+        let fs = match self.fs {
+            Some(custom_fs) => custom_fs,
+            None => {
+                let mem_fs = InMemoryFs::new();
+                // Add text files to the default InMemoryFs
+                for tf in &self.text_files {
+                    mem_fs.add_file(&tf.path, &tf.content, tf.mode);
+                }
+                Arc::new(mem_fs)
+            }
+        };
         let mut interpreter = Interpreter::with_config(
             Arc::clone(&fs),
             self.username.clone(),
@@ -2854,5 +2952,133 @@ mod tests {
         let mut bash = Bash::new();
         let result = bash.exec("arr=(); echo \"${!arr[@]}\"").await.unwrap();
         assert_eq!(result.stdout, "\n");
+    }
+
+    // ============================================================
+    // Text file builder methods
+    // ============================================================
+
+    #[tokio::test]
+    async fn test_text_file_basic() {
+        let mut bash = Bash::builder()
+            .text_file("/config/app.conf", "debug=true\nport=8080\n")
+            .build();
+
+        let result = bash.exec("cat /config/app.conf").await.unwrap();
+        assert_eq!(result.stdout, "debug=true\nport=8080\n");
+    }
+
+    #[tokio::test]
+    async fn test_text_file_multiple() {
+        let mut bash = Bash::builder()
+            .text_file("/data/file1.txt", "content one")
+            .text_file("/data/file2.txt", "content two")
+            .text_file("/other/file3.txt", "content three")
+            .build();
+
+        let result = bash.exec("cat /data/file1.txt").await.unwrap();
+        assert_eq!(result.stdout, "content one");
+
+        let result = bash.exec("cat /data/file2.txt").await.unwrap();
+        assert_eq!(result.stdout, "content two");
+
+        let result = bash.exec("cat /other/file3.txt").await.unwrap();
+        assert_eq!(result.stdout, "content three");
+    }
+
+    #[tokio::test]
+    async fn test_text_file_nested_directory() {
+        // Parent directories should be created automatically
+        let mut bash = Bash::builder()
+            .text_file("/a/b/c/d/file.txt", "nested content")
+            .build();
+
+        let result = bash.exec("cat /a/b/c/d/file.txt").await.unwrap();
+        assert_eq!(result.stdout, "nested content");
+    }
+
+    #[tokio::test]
+    async fn test_text_file_mode() {
+        let bash = Bash::builder()
+            .text_file("/tmp/writable.txt", "content")
+            .build();
+
+        let stat = bash
+            .fs()
+            .stat(std::path::Path::new("/tmp/writable.txt"))
+            .await
+            .unwrap();
+        assert_eq!(stat.mode, 0o644);
+    }
+
+    #[tokio::test]
+    async fn test_readonly_text_basic() {
+        let mut bash = Bash::builder()
+            .readonly_text("/etc/version", "1.2.3")
+            .build();
+
+        let result = bash.exec("cat /etc/version").await.unwrap();
+        assert_eq!(result.stdout, "1.2.3");
+    }
+
+    #[tokio::test]
+    async fn test_readonly_text_mode() {
+        let bash = Bash::builder()
+            .readonly_text("/etc/readonly.conf", "immutable")
+            .build();
+
+        let stat = bash
+            .fs()
+            .stat(std::path::Path::new("/etc/readonly.conf"))
+            .await
+            .unwrap();
+        assert_eq!(stat.mode, 0o444);
+    }
+
+    #[tokio::test]
+    async fn test_text_file_mixed_readonly_writable() {
+        let bash = Bash::builder()
+            .text_file("/data/writable.txt", "can edit")
+            .readonly_text("/data/readonly.txt", "cannot edit")
+            .build();
+
+        let writable_stat = bash
+            .fs()
+            .stat(std::path::Path::new("/data/writable.txt"))
+            .await
+            .unwrap();
+        let readonly_stat = bash
+            .fs()
+            .stat(std::path::Path::new("/data/readonly.txt"))
+            .await
+            .unwrap();
+
+        assert_eq!(writable_stat.mode, 0o644);
+        assert_eq!(readonly_stat.mode, 0o444);
+    }
+
+    #[tokio::test]
+    async fn test_text_file_with_env() {
+        // text_file should work alongside other builder methods
+        let mut bash = Bash::builder()
+            .env("APP_NAME", "testapp")
+            .text_file("/config/app.conf", "name=${APP_NAME}")
+            .build();
+
+        let result = bash.exec("echo $APP_NAME").await.unwrap();
+        assert_eq!(result.stdout, "testapp\n");
+
+        let result = bash.exec("cat /config/app.conf").await.unwrap();
+        assert_eq!(result.stdout, "name=${APP_NAME}");
+    }
+
+    #[tokio::test]
+    async fn test_text_file_json() {
+        let mut bash = Bash::builder()
+            .text_file("/data/users.json", r#"["alice", "bob", "charlie"]"#)
+            .build();
+
+        let result = bash.exec("cat /data/users.json | jq '.[0]'").await.unwrap();
+        assert_eq!(result.stdout, "\"alice\"\n");
     }
 }

--- a/specs/003-vfs.md
+++ b/specs/003-vfs.md
@@ -84,6 +84,33 @@ pub struct DirEntry {
 - Initial directories: `/`, `/tmp`, `/home`, `/home/user`, `/dev`
 - Special handling for `/dev/null`
 - No persistence - state lost on drop
+- Synchronous `add_file()` method for pre-population during construction
+
+##### Pre-populating Files with BashBuilder
+
+The `BashBuilder` provides convenience methods to pre-populate the default `InMemoryFs`:
+
+```rust
+let mut bash = Bash::builder()
+    // Writable file (mode 0o644)
+    .text_file("/config/app.conf", "debug=true\nport=8080\n")
+    // Readonly file (mode 0o444)
+    .readonly_text("/etc/version", "1.2.3")
+    .build();
+```
+
+- `text_file(path, content)` - Creates writable file (mode `0o644`)
+- `readonly_text(path, content)` - Creates readonly file (mode `0o444`)
+- Parent directories are created automatically
+- Only works with default InMemoryFs (ignored when `.fs()` is called)
+
+Use cases:
+- Configuration files for scripts to read
+- Reference data that shouldn't be modified
+- Pre-seeding test fixtures
+- Simulating system files like `/etc/passwd`
+
+See `examples/text_files.rs` for comprehensive examples.
 
 #### OverlayFs (Implemented)
 - Copy-on-write layer over another FileSystem


### PR DESCRIPTION
## Summary
- Add `text_file(path, content)` and `readonly_text(path, content)` convenience methods to `BashBuilder`
- Add `InMemoryFs::add_file()` for synchronous file creation during setup with automatic parent directory creation
- Update VFS spec (003-vfs.md) with documentation for the new feature

## Details

These methods make it easy to pre-populate the virtual filesystem during Bash construction without needing async code:

```rust
let mut bash = Bash::builder()
    .text_file("/config/app.conf", "debug=true\nport=8080\n")
    .readonly_text("/etc/version", "1.2.3")
    .build();
```

**Use cases:**
- Configuration files for scripts to read
- Reference data that shouldn't be modified
- Pre-seeding test fixtures
- Simulating system files like `/etc/passwd`

## Test plan
- [x] 12 new unit tests covering all functionality
- [x] Tests verify file creation, permissions (0o644 vs 0o444), parent directory creation
- [x] All 541 existing tests continue to pass
- [x] New example `text_files.rs` demonstrates usage patterns

https://claude.ai/code/session_019zbW5sGDfV1uSjRp9RRRSR