### PR TITLE
docs: refresh lib.rs to match README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-## Built-in Commands (60+)
+## Built-in Commands (66)
 
 | Category | Commands |
 |----------|----------|

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1,17 +1,47 @@
 //! BashKit - Sandboxed bash interpreter for multi-tenant environments
 //!
-//! BashKit provides a fully sandboxed bash interpreter with a virtual filesystem,
-//! making it safe to execute untrusted scripts in multi-tenant environments like
-//! AI agents, CI/CD pipelines, and code sandboxes.
+//! Sandboxed bash interpreter for AI agents, CI/CD pipelines, and code sandboxes.
+//! Written in Rust.
 //!
 //! # Features
 //!
-//! - **Virtual Filesystem**: All file operations happen in memory by default
-//! - **Resource Limits**: Control command count, loop iterations, and function depth
-//! - **Sandboxed Identity**: Customizable username/hostname for `whoami`, `hostname`, etc.
-//! - **Custom Builtins**: Extend with domain-specific commands (psql, kubectl, etc.)
-//! - **66 Built-in Commands**: Shell builtins, text processing, file operations, and networking
-//! - **Full Bash Syntax**: Variables, pipelines, redirects, loops, functions, arrays
+//! - **POSIX compliant** - Substantial IEEE 1003.1-2024 Shell Command Language compliance
+//! - **Sandboxed execution** - No real filesystem access by default
+//! - **Virtual filesystem** - [`InMemoryFs`], [`OverlayFs`], [`MountableFs`]
+//! - **Resource limits** - Command count, loop iterations, function depth
+//! - **Network allowlist** - Control HTTP access per-domain
+//! - **Custom builtins** - Extend with domain-specific commands
+//! - **Async-first** - Built on tokio
+//!
+//! # Built-in Commands (66)
+//!
+//! | Category | Commands |
+//! |----------|----------|
+//! | Core | `echo`, `printf`, `cat`, `read` |
+//! | Navigation | `cd`, `pwd`, `ls`, `find` |
+//! | Flow control | `true`, `false`, `exit`, `return`, `break`, `continue`, `test`, `[` |
+//! | Variables | `export`, `set`, `unset`, `local`, `shift`, `source`, `.` |
+//! | Text processing | `grep`, `sed`, `awk`, `jq`, `head`, `tail`, `sort`, `uniq`, `cut`, `tr`, `wc` |
+//! | File operations | `mkdir`, `rm`, `cp`, `mv`, `touch`, `chmod`, `rmdir` |
+//! | File inspection | `file`, `stat`, `less` |
+//! | Archives | `tar`, `gzip`, `gunzip` |
+//! | Utilities | `sleep`, `date`, `basename`, `dirname`, `timeout`, `wait`, `xargs`, `tee` |
+//! | System info | `whoami`, `hostname`, `uname`, `id`, `env`, `printenv`, `history` |
+//! | Network | `curl`, `wget` (requires [`NetworkAllowlist`])
+//!
+//! # Shell Features
+//!
+//! - Variables and parameter expansion (`$VAR`, `${VAR:-default}`, `${#VAR}`)
+//! - Command substitution (`$(cmd)`)
+//! - Arithmetic expansion (`$((1 + 2))`)
+//! - Pipelines and redirections (`|`, `>`, `>>`, `<`, `<<<`, `2>&1`)
+//! - Control flow (`if`/`elif`/`else`, `for`, `while`, `case`)
+//! - Functions (POSIX and bash-style)
+//! - Arrays (`arr=(a b c)`, `${arr[@]}`, `${#arr[@]}`)
+//! - Glob expansion (`*`, `?`)
+//! - Here documents (`<<EOF`)
+//!
+//! - [`compatibility_scorecard`] - Full compatibility status
 //!
 //! # Quick Start
 //!
@@ -247,10 +277,6 @@
 //! # Guides
 //!
 //! - [`custom_builtins_guide`] - Creating custom builtins
-//!
-//! # References
-//!
-//! - [`compatibility_reference`] - Bash compatibility scorecard
 
 // Stricter panic prevention - prefer proper error handling over unwrap()
 #![warn(clippy::unwrap_used)]
@@ -647,21 +673,21 @@ impl BashBuilder {
 /// - Working with arguments, environment, and filesystem
 /// - Best practices and examples
 ///
-/// **Related:** [`BashBuilder::builtin`], [`compatibility_reference`]
+/// **Related:** [`BashBuilder::builtin`], [`compatibility_scorecard`]
 #[doc = include_str!("../docs/custom_builtins.md")]
 pub mod custom_builtins_guide {}
 
-/// Bash compatibility scorecard - tracks feature parity with real bash.
+/// Bash compatibility scorecard.
 ///
-/// This reference provides:
-/// - Quick status of implemented features vs bash
-/// - Detailed compatibility tables for builtins, syntax, expansions
+/// Tracks feature parity with real bash:
+/// - Implemented vs missing features
+/// - Builtins, syntax, expansions
 /// - POSIX compliance status
-/// - Resource limits and security boundaries
+/// - Resource limits
 ///
 /// **Related:** [`custom_builtins_guide`]
 #[doc = include_str!("../docs/compatibility.md")]
-pub mod compatibility_reference {}
+pub mod compatibility_scorecard {}
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/specs/008-documentation.md
+++ b/specs/008-documentation.md
@@ -16,20 +16,15 @@ Use `include_str!` macro to embed external markdown files into rustdoc as docume
 ```
 crates/bashkit/
 ├── docs/
-│   ├── compatibility.md      # Bash compatibility scorecard (reference)
+│   ├── compatibility.md      # Bash compatibility scorecard
 │   ├── custom_builtins.md    # Guide for extending BashKit
 │   └── (future docs...)
 └── src/
     └── lib.rs
-        ├── //! crate docs with links to guides and references
-        └── pub mod custom_builtins_guide {}      # Tutorial-style guide
-            pub mod compatibility_reference {}    # Dense reference/scorecard
+        ├── //! crate docs with links to guides
+        └── pub mod custom_builtins_guide {}
+            pub mod compatibility_scorecard {}
 ```
-
-### Guides vs References
-
-- **Guides** (`*_guide`): Tutorial-style docs with examples, step-by-step instructions
-- **References** (`*_reference`): Dense lookup tables, compatibility scorecards, quick status
 
 Note: Docs live inside `crates/bashkit/docs/` to ensure they are included in
 the published crate package. This allows `include_str!` to work correctly
@@ -61,16 +56,19 @@ Add "See also" section at top of each markdown file:
 
 ### Crate Docs
 
-Add "Guides" and "References" sections to main crate documentation:
+Add "Guides" section and link to scorecard in main crate documentation:
 
 ```rust
+//! # Shell Features
+//! ...
+//! - [`compatibility_scorecard`] - Full compatibility status
+//!
+//! # Quick Start
+//! ...
+//!
 //! # Guides
 //!
 //! - [`custom_builtins_guide`] - Creating custom builtins
-//!
-//! # References
-//!
-//! - [`compatibility_reference`] - Bash compatibility scorecard
 ```
 
 ## Adding New Guides


### PR DESCRIPTION
## Summary

- Align features list with README (POSIX compliant, async-first, etc.)
- Add built-in commands table by category (66 commands)
- Add Shell Features section matching README
- Remove separate "References" section, keep single "Guides" section
- Fix README command count (60+ -> 66)
- Update spec 008-documentation to remove guides vs references distinction

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] `cargo doc` builds successfully

https://claude.ai/code/session_012byxqB5Z2D2n35ch697637