### PR TITLE
ci(coverage): add cargo-tarpaulin coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,64 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-coverage-
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked
+
+      - name: Generate coverage report
+        run: |
+          cargo tarpaulin --features http_client \
+            --workspace \
+            --out xml \
+            --out html \
+            --output-dir coverage \
+            --exclude-files "crates/bashkit-bench/*" \
+            --exclude-files "crates/bashkit-cli/*" \
+            --timeout 300 \
+            --skip-clean
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/cobertura.xml
+          flags: unittests
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ local*
 
 # OS
 .DS_Store
+
+# Coverage reports
+coverage/

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -138,8 +138,18 @@ cargo test --test spec_tests -- compatibility_report --ignored --nocapture
 
 ## Coverage
 
-**Note:** No formal coverage tooling (codecov, tarpaulin) is currently configured.
-Coverage is tracked manually via spec test pass rates.
+Coverage is tracked with cargo-tarpaulin and uploaded to Codecov.
+
+```bash
+# Generate local coverage report
+cargo tarpaulin --features http_client --out html --output-dir coverage
+
+# View coverage report
+open coverage/tarpaulin-report.html
+```
+
+The coverage workflow runs on every PR and push to main. Reports are uploaded
+to Codecov and available as CI artifacts.
 
 ### Current Status
 - All spec tests: 75% pass rate (324/434 running in CI, 110 skipped)
@@ -153,7 +163,7 @@ The following items need attention:
 - [x] **Enable bash_spec_tests in CI** - Done! 325/435 tests running
 - [x] **Add bash_comparison_tests to CI** - Done! 304 tests compared against real bash
 - [x] **Fix control-flow.test.sh** - Enabled! 31 tests now running
-- [ ] **Add coverage tooling** - Consider cargo-tarpaulin or codecov
+- [x] **Add coverage tooling** - cargo-tarpaulin + Codecov via `.github/workflows/coverage.yml`
 - [ ] **Fix skipped spec tests** (110 total):
   - Bash: 108 skipped (various implementation gaps)
   - AWK: 2 skipped (blocked by multi-statement action parsing bug)


### PR DESCRIPTION
## Summary
- Add coverage tracking with cargo-tarpaulin and Codecov
- New workflow in `.github/workflows/coverage.yml`
- Runs on PRs and pushes to main
- Generates HTML and XML reports, uploads to Codecov
- Add `coverage/` to `.gitignore` for local generation

## Test plan
- [x] Workflow syntax validated
- [x] Testing spec updated with coverage instructions
- [x] `.gitignore` updated

https://claude.ai/code/session_014PwJPpXSYYYszKvRD16Npx