### PR TITLE
refactor(vfs): rename to mount_text/mount_readonly_text with custom fs support

### DIFF
--- a/crates/bashkit/examples/text_files.rs
+++ b/crates/bashkit/examples/text_files.rs
@@ -1,6 +1,6 @@
 //! Text file pre-population example
 //!
-//! Demonstrates using `text_file()` and `readonly_text()` builder methods
+//! Demonstrates using `mount_text()` and `mount_readonly_text()` builder methods
 //! to pre-populate the virtual filesystem before running scripts.
 //!
 //! Run with: cargo run --example text_files
@@ -31,11 +31,11 @@ async fn basic_text_files() -> anyhow::Result<()> {
 
     // Pre-populate files using the builder
     let mut bash = Bash::builder()
-        .text_file(
+        .mount_text(
             "/config/app.conf",
             "debug=true\nport=8080\nhost=localhost\n",
         )
-        .text_file("/data/greeting.txt", "Hello from pre-populated file!")
+        .mount_text("/data/greeting.txt", "Hello from pre-populated file!")
         .build();
 
     // Scripts can read the pre-populated files
@@ -63,8 +63,8 @@ async fn readonly_config_files() -> anyhow::Result<()> {
 
     // Use readonly_text for files that shouldn't be modified
     let bash = Bash::builder()
-        .readonly_text("/etc/version", "1.2.3")
-        .readonly_text(
+        .mount_readonly_text("/etc/version", "1.2.3")
+        .mount_readonly_text(
             "/etc/system.conf",
             "# System configuration (readonly)\nmode=production\n",
         )
@@ -91,11 +91,11 @@ async fn json_data_files() -> anyhow::Result<()> {
     println!("--- JSON Data Files ---");
 
     let mut bash = Bash::builder()
-        .text_file(
+        .mount_text(
             "/data/users.json",
             r#"[{"name": "alice", "role": "admin"}, {"name": "bob", "role": "user"}]"#,
         )
-        .text_file(
+        .mount_text(
             "/data/config.json",
             r#"{"api_url": "https://api.example.com", "timeout": 30}"#,
         )
@@ -119,11 +119,11 @@ async fn mixed_permissions() -> anyhow::Result<()> {
 
     let bash = Bash::builder()
         // Readonly system files
-        .readonly_text("/etc/hostname", "sandbox-host")
-        .readonly_text("/etc/os-release", "NAME=\"BashKit\"\nVERSION=\"1.0\"\n")
+        .mount_readonly_text("/etc/hostname", "sandbox-host")
+        .mount_readonly_text("/etc/os-release", "NAME=\"BashKit\"\nVERSION=\"1.0\"\n")
         // Writable workspace files
-        .text_file("/workspace/notes.txt", "Initial notes\n")
-        .text_file(
+        .mount_text("/workspace/notes.txt", "Initial notes\n")
+        .mount_text(
             "/workspace/data.csv",
             "id,name,value\n1,foo,100\n2,bar,200\n",
         )

--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -221,6 +221,27 @@ impl OverlayFs {
         }
     }
 
+    /// Access the upper (writable) filesystem layer.
+    ///
+    /// This provides direct access to the [`InMemoryFs`] that stores all writes.
+    /// Useful for pre-populating files during construction.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{InMemoryFs, OverlayFs};
+    /// use std::sync::Arc;
+    ///
+    /// let base = Arc::new(InMemoryFs::new());
+    /// let overlay = OverlayFs::new(base);
+    ///
+    /// // Add files directly to upper layer
+    /// overlay.upper().add_file("/config/app.conf", "debug=true\n", 0o644);
+    /// ```
+    pub fn upper(&self) -> &InMemoryFs {
+        &self.upper
+    }
+
     /// Compute combined usage (upper + visible lower).
     fn compute_usage(&self) -> FsUsage {
         // Get upper layer usage

--- a/specs/003-vfs.md
+++ b/specs/003-vfs.md
@@ -86,23 +86,29 @@ pub struct DirEntry {
 - No persistence - state lost on drop
 - Synchronous `add_file()` method for pre-population during construction
 
-##### Pre-populating Files with BashBuilder
+##### Mounting Files with BashBuilder
 
-The `BashBuilder` provides convenience methods to pre-populate the default `InMemoryFs`:
+The `BashBuilder` provides convenience methods to mount files in the virtual filesystem:
 
 ```rust
 let mut bash = Bash::builder()
     // Writable file (mode 0o644)
-    .text_file("/config/app.conf", "debug=true\nport=8080\n")
+    .mount_text("/config/app.conf", "debug=true\nport=8080\n")
     // Readonly file (mode 0o444)
-    .readonly_text("/etc/version", "1.2.3")
+    .mount_readonly_text("/etc/version", "1.2.3")
     .build();
 ```
 
-- `text_file(path, content)` - Creates writable file (mode `0o644`)
-- `readonly_text(path, content)` - Creates readonly file (mode `0o444`)
+- `mount_text(path, content)` - Creates writable file (mode `0o644`)
+- `mount_readonly_text(path, content)` - Creates readonly file (mode `0o444`)
 - Parent directories are created automatically
-- Only works with default InMemoryFs (ignored when `.fs()` is called)
+- Works with any filesystem - mounted files are added via an OverlayFs layer
+
+When mounted files are specified, they're added to an OverlayFs layer on top of
+the base filesystem. This means:
+- The base filesystem remains unchanged
+- Mounted files take precedence over base filesystem files
+- Works with both default InMemoryFs and custom filesystems
 
 Use cases:
 - Configuration files for scripts to read


### PR DESCRIPTION
## Summary
- Renamed methods for better semantics: `text_file()` -> `mount_text()`, `readonly_text()` -> `mount_readonly_text()`
- Added support for custom filesystems via OverlayFs layering
- Added `OverlayFs::upper()` method to access the writable layer

## Details

### Method Rename
The new names better convey the "mounting" semantics:
- `mount_text(path, content)` - Creates writable file (mode `0o644`)
- `mount_readonly_text(path, content)` - Creates readonly file (mode `0o444`)

### Custom Filesystem Support
Mounted files now work with any filesystem via OverlayFs:
```rust
let custom_fs = Arc::new(InMemoryFs::new());
let mut bash = Bash::builder()
    .fs(custom_fs)
    .mount_text("/config/app.conf", "debug=true\n")
    .mount_readonly_text("/etc/version", "1.0.0")
    .build();
```

**How it works:**
- Mounted files are added to an OverlayFs layer on top of the base filesystem
- Base filesystem remains unchanged
- Mounted files take precedence over base filesystem files

## Test plan
- [x] 2 new tests for custom filesystem mounting
- [x] All 543 existing tests pass
- [x] Example `text_files.rs` works correctly

https://claude.ai/code/session_019zbW5sGDfV1uSjRp9RRRSR