### PR TITLE
fix(parser): support quoted heredoc delimiters

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -444,7 +444,7 @@ impl<'a> Lexer<'a> {
             }
         }
 
-        Some(Token::Word(content))
+        Some(Token::QuotedWord(content))
     }
 
     /// Check if the content starting with { looks like a brace expansion
@@ -704,7 +704,7 @@ mod tests {
         assert_eq!(lexer.next_token(), Some(Token::Word("echo".to_string())));
         assert_eq!(
             lexer.next_token(),
-            Some(Token::Word("hello world".to_string()))
+            Some(Token::QuotedWord("hello world".to_string()))
         );
         assert_eq!(lexer.next_token(), None);
     }

--- a/crates/bashkit/src/parser/tokens.rs
+++ b/crates/bashkit/src/parser/tokens.rs
@@ -13,6 +13,10 @@ pub enum Token {
     /// A literal word (single-quoted) - no variable expansion
     LiteralWord(String),
 
+    /// A double-quoted word - may contain variable expansions inside,
+    /// but is marked as quoted (affects heredoc delimiter semantics)
+    QuotedWord(String),
+
     /// Newline character
     Newline,
 

--- a/crates/bashkit/tests/spec_cases/bash/pipes-redirects.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/pipes-redirects.test.sh
@@ -114,3 +114,41 @@ echo err1 2>/tmp/err_append.txt; echo err2 2>>/tmp/err_append.txt; cat /tmp/err_
 err1
 err2
 ### end
+
+### heredoc_single_quoted_delimiter
+# Heredoc with single-quoted delimiter disables variable expansion
+NAME=world; cat <<'EOF'
+hello $NAME
+EOF
+### expect
+hello $NAME
+### end
+
+### heredoc_double_quoted_delimiter
+# Heredoc with double-quoted delimiter also disables expansion
+NAME=world; cat <<"EOF"
+hello $NAME
+EOF
+### expect
+hello $NAME
+### end
+
+### heredoc_quoted_with_special_chars
+# Single-quoted heredoc preserves special characters
+cat <<'PY'
+price = 100
+print(f"${price}")
+PY
+### expect
+price = 100
+print(f"${price}")
+### end
+
+### heredoc_unquoted_expands
+# Unquoted delimiter allows variable expansion (control test)
+VAR=expanded; cat <<END
+value is $VAR
+END
+### expect
+value is expanded
+### end


### PR DESCRIPTION
## Summary

- Fix parsing of heredocs with single-quoted (`<<'EOF'`) and double-quoted (`<<"EOF"`) delimiters
- Per POSIX/bash, quoted delimiters disable variable expansion in heredoc content
- Common use case: embedding code in other languages where `$` has different meaning

## Changes

- Add `Token::QuotedWord` for double-quoted strings to distinguish from unquoted words
- Parser now accepts `LiteralWord` and `QuotedWord` as heredoc delimiters
- Quoted delimiters produce literal heredoc content (no `$var` expansion)

## Test plan

- [x] Add test `heredoc_single_quoted_delimiter` - single-quoted delimiter disables expansion
- [x] Add test `heredoc_double_quoted_delimiter` - double-quoted delimiter disables expansion  
- [x] Add test `heredoc_quoted_with_special_chars` - Python code with `${price}` preserved
- [x] Add test `heredoc_unquoted_expands` - control test showing unquoted still expands
- [x] All 313 spec tests pass
- [x] 570 library tests pass
- [x] cargo clippy and fmt pass