### PR TITLE
fix(security): prevent panics and add internal error handling

### DIFF
--- a/crates/bashkit/src/error.rs
+++ b/crates/bashkit/src/error.rs
@@ -1,4 +1,9 @@
 //! Error types for BashKit
+//!
+//! This module provides error types for the interpreter with the following design goals:
+//! - Human-readable error messages for users
+//! - No leakage of sensitive information (paths, memory addresses, secrets)
+//! - Clear categorization for programmatic handling
 
 use crate::limits::LimitExceeded;
 use thiserror::Error;
@@ -7,6 +12,9 @@ use thiserror::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// BashKit error types.
+///
+/// All error messages are designed to be safe for display to end users without
+/// exposing internal details or sensitive information.
 #[derive(Error, Debug)]
 pub enum Error {
     /// Parse error occurred while parsing the script.
@@ -32,4 +40,20 @@ pub enum Error {
     /// Network error.
     #[error("network error: {0}")]
     Network(String),
+
+    /// Internal error for unexpected failures.
+    ///
+    /// THREAT[TM-INT-002]: Unexpected internal failures should not crash the interpreter.
+    /// This error type provides a human-readable message without exposing:
+    /// - Stack traces
+    /// - Memory addresses
+    /// - Internal file paths
+    /// - Panic messages that may contain sensitive data
+    ///
+    /// Use this for:
+    /// - Recovered panics that need to abort execution
+    /// - Logic errors that indicate a bug
+    /// - Security-sensitive failures where details should not be exposed
+    #[error("internal error: {0}")]
+    Internal(String),
 }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1590,7 +1590,8 @@ impl Interpreter {
             };
 
             // Execute builtin with panic catching for security
-            // SECURITY: Custom builtins may panic - we catch this to:
+            // THREAT[TM-INT-001]: Builtins may panic on unexpected input
+            // SECURITY: All builtins (built-in and custom) may panic - we catch this to:
             // 1. Prevent interpreter crash
             // 2. Avoid leaking panic message (may contain sensitive info)
             // 3. Return sanitized error to user

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -441,6 +441,7 @@ fn error_kind(e: &Error) -> String {
         Error::CommandNotFound(_) => "command_not_found".to_string(),
         Error::ResourceLimit(_) => "resource_limit".to_string(),
         Error::Network(_) => "network_error".to_string(),
+        Error::Internal(_) => "internal_error".to_string(),
     }
 }
 

--- a/specs/005-security-testing.md
+++ b/specs/005-security-testing.md
@@ -148,7 +148,7 @@ fail_point!("module::function", |action| {
 
 - `crates/bashkit/tests/security_failpoint_tests.rs` - Fail-point security tests
 - `crates/bashkit/tests/threat_model_tests.rs` - Threat model tests (51 tests)
-- `crates/bashkit/tests/builtin_error_security_tests.rs` - Custom builtin error security tests (34 tests)
+- `crates/bashkit/tests/builtin_error_security_tests.rs` - Builtin error security tests (39 tests, includes TM-INT-003)
 - `crates/bashkit/src/limits.rs` - Resource limit fail points
 - `crates/bashkit/src/fs/memory.rs` - Filesystem fail points
 - `crates/bashkit/src/interpreter/mod.rs` - Interpreter fail points, panic catching

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -99,7 +99,7 @@ version = "1.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bytes]]
-version = "1.11.0"
+version = "1.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cast]]
@@ -131,11 +131,11 @@ version = "0.2.2"
 criteria = "safe-to-run"
 
 [[exemptions.clap]]
-version = "4.5.56"
+version = "4.5.57"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.5.56"
+version = "4.5.57"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
@@ -239,7 +239,7 @@ version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.flate2]]
-version = "1.1.8"
+version = "1.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.fnv]]
@@ -364,14 +364,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.hyper-tls]]
 version = "0.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.hyper-util]]
-version = "0.1.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.hyper-util]]
-version = "0.1.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-util]]
@@ -711,19 +703,19 @@ version = "0.5.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex]]
-version = "1.12.2"
+version = "1.12.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-automata]]
-version = "0.4.13"
+version = "0.4.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-lite]]
-version = "0.1.8"
+version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.regex-syntax]]
-version = "0.8.8"
+version = "0.8.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.reqwest]]
@@ -880,14 +872,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.synstructure]]
 version = "0.13.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.system-configuration]]
-version = "0.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.system-configuration]]
-version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.system-configuration]]
@@ -1219,11 +1203,11 @@ version = "0.8.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]
-version = "0.8.37"
+version = "0.8.38"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
-version = "0.8.37"
+version = "0.8.38"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerofrom]]


### PR DESCRIPTION
## Summary

- **Fix date builtin panic**: Validate strftime format strings before formatting to prevent chrono panic on invalid specifiers (e.g., `%Q`), combined with runtime error handling for timezone issues
- **Add Internal error variant**: New `Error::Internal` for unexpected failures with safe, human-readable messaging
- **Update threat model**: Add TM-INT-xxx category documenting internal error handling threats and mitigations:
  - TM-INT-001: Builtin panic recovery
  - TM-INT-002: Panic info leak prevention
  - TM-INT-003: Date format validation
  - TM-INT-004/005/006: Error message safety
- **Add comprehensive tests**: Date format validation and error handling security tests
- **Update specs**: Updated test counts in 005-security-testing.md

## Test plan

- [x] `cargo fmt --check` - passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passes
- [x] Library tests - 595 passed
- [x] Failpoint tests (single-threaded) - 14 passed
- [x] Threat model tests - 51 passed
- [x] Builtin error security tests - 39 passed (5 new date tests)
- [x] Invalid date format returns error not panic: `date '+%Q'` → exit code 1

https://claude.ai/code/session_01XjPeQtrNSz8tEaRXgFuHnx