### PR TITLE
docs: remove benchmark interpretation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,6 @@ just bench-verbose      # Detailed output
 just bench-list         # List all benchmarks
 ```
 
-Key findings:
-- **~2000x faster startup** - No subprocess overhead (0.004ms vs 9ms)
-- **~200-1000x faster for tools** - grep/sed/awk run in-process
-- **~550x faster recursive functions** - Fibonacci(10): 1ms vs 586ms
-
 See [crates/bashkit-bench/README.md](crates/bashkit-bench/README.md) for methodology and assumptions.
 
 ## Acknowledgments


### PR DESCRIPTION
## Summary
- Remove "Key findings" section with performance claims (e.g., "~2000x faster startup")
- Methodology docs in crates/bashkit-bench/README.md remain for context

## Test plan
- [x] Verify README still renders correctly
- [x] Benchmark methodology docs unchanged

https://claude.ai/code/session_01DcnUj6NbjfaB8UxEP5XDze