### PR TITLE
docs(network): remove outdated 'stub' references for curl/wget

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
 | Utilities | `sleep`, `date`, `basename`, `dirname`, `timeout`, `wait` |
 | Pipeline | `xargs`, `tee` |
 | System info | `whoami`, `hostname`, `uname`, `id`, `env`, `printenv` |
-| Network | `curl`, `wget` (stub, requires allowlist) |
+| Network | `curl`, `wget` (requires allowlist) |
 
 ## Shell Features
 

--- a/specs/001-architecture.md
+++ b/specs/001-architecture.md
@@ -55,7 +55,7 @@ src/
     ├── date.rs          # date
     ├── sleep.rs         # sleep
     ├── wait.rs          # wait
-    ├── curl.rs          # curl, wget (stubs)
+    ├── curl.rs          # curl, wget
     └── ...              # grep, sed, awk, jq, etc.
 ```
 


### PR DESCRIPTION
## Summary
- Remove "stub" from README.md network section - curl/wget are fully implemented
- Remove "(stubs)" comment from specs/001-architecture.md

curl and wget have full HTTP implementation with security controls (allowlist, size limits, timeouts).

## Test plan
- [x] Documentation-only change, no code changes

https://claude.ai/code/session_01FY8TuCpBJd4vJD6D9S2d7q