### PR TITLE
docs: add Everruns ecosystem reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ See [crates/bashkit-bench/README.md](crates/bashkit-bench/README.md) for methodo
 
 This project was inspired by [just-bash](https://github.com/vercel-labs/just-bash) from Vercel Labs. Huge kudos to the Vercel team for pioneering the idea of a sandboxed bash interpreter for AI-powered environments. Their work laid the conceptual foundation that made BashKit possible.
 
+## Ecosystem
+
+BashKit is part of the [Everruns](https://everruns.com) ecosystem.
+
 ## License
 
 MIT

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -281,6 +281,10 @@
 //! # Resources
 //!
 //! - [`threat_model`] - Security threats and mitigations
+//!
+//! # Ecosystem
+//!
+//! BashKit is part of the [Everruns](https://everruns.com) ecosystem.
 
 // Stricter panic prevention - prefer proper error handling over unwrap()
 #![warn(clippy::unwrap_used)]


### PR DESCRIPTION
## Summary
- Add "Ecosystem" section to README referencing https://everruns.com
- Add same reference to crate-level rustdoc in lib.rs

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

https://claude.ai/code/session_01UWcx3X44aa8UHrGhgrmmWJ