### PR TITLE
test(jq): enable jq_del test that already passes

### DIFF
--- a/crates/bashkit/tests/spec_cases/jq/jq.test.sh
+++ b/crates/bashkit/tests/spec_cases/jq/jq.test.sh
@@ -495,10 +495,12 @@ echo '{"a":1}' | jq 'setpath(["b"];2)'
 ### end
 
 ### jq_del
-### skip: del not implemented
+# Delete a key from an object
 echo '{"a":1,"b":2}' | jq 'del(.a)'
 ### expect
-{"b":2}
+{
+  "b": 2
+}
 ### end
 
 ### jq_to_entries

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -74,8 +74,8 @@ crates/bashkit/tests/
 | AWK | 89 | Yes | 48 | 41 |
 | Grep | 70 | Yes | 56 | 14 |
 | Sed | 65 | Yes | 50 | 15 |
-| JQ | 95 | Yes | 75 | 20 |
-| **Total** | **790** | **790** | 596 | 194 |
+| JQ | 95 | Yes | 76 | 19 |
+| **Total** | **790** | **790** | 597 | 193 |
 
 ### Test File Format
 
@@ -152,8 +152,8 @@ The coverage workflow runs on every PR and push to main. Reports are uploaded
 to Codecov and available as CI artifacts.
 
 ### Current Status
-- All spec tests: 75% pass rate (596/790 running in CI, 194 skipped)
-- Text processing tools: 72% pass rate (229/319 running, 90 skipped)
+- All spec tests: 76% pass rate (597/790 running in CI, 193 skipped)
+- Text processing tools: 72% pass rate (230/319 running, 89 skipped)
 - Core bash specs: 78% pass rate (367/471 running, 104 skipped)
 
 ## TODO: Testing Gaps
@@ -164,12 +164,12 @@ The following items need attention:
 - [x] **Add bash_comparison_tests to CI** - Done! 309 tests compared against real bash
 - [x] **Fix control-flow.test.sh** - Enabled! 31 tests now running
 - [x] **Add coverage tooling** - cargo-tarpaulin + Codecov via `.github/workflows/coverage.yml`
-- [ ] **Fix skipped spec tests** (194 total):
+- [ ] **Fix skipped spec tests** (193 total):
   - Bash: 104 skipped (various implementation gaps)
   - AWK: 41 skipped (operators, control flow, functions)
   - Grep: 14 skipped (flags, features)
   - Sed: 15 skipped (features)
-  - JQ: 20 skipped (functions, flags)
+  - JQ: 19 skipped (functions, flags)
 - [ ] **Fix bash_diff tests** (21 total):
   - wc: 14 tests (output formatting differs)
   - background: 2 tests (non-deterministic order)


### PR DESCRIPTION
## Summary
- Enable the jq_del test case that was skipped but already works via jaq_std
- The del() function is provided by the jaq standard library
- Updated spec test counts in documentation

## Test plan
- [x] `cargo test --test spec_tests -- jq_spec_tests` passes (76/95 passing)
- [x] CI should pass with all existing tests