### PR TITLE
feat(jq): add -S, -s, -e, --tab, -j flags

### DIFF
--- a/crates/bashkit/tests/spec_cases/jq/jq.test.sh
+++ b/crates/bashkit/tests/spec_cases/jq/jq.test.sh
@@ -206,17 +206,24 @@ echo '{"a": 1, "b": 2}' | jq -c '.'
 ### end
 
 ### jq_sort_keys
-### skip: -S flag not implemented
+# Sort keys mode outputs objects with keys in sorted order
 echo '{"z":1,"a":2}' | jq -S '.'
 ### expect
-{"a":2,"z":1}
+{
+  "a": 2,
+  "z": 1
+}
 ### end
 
 ### jq_slurp
-### skip: -s slurp flag not implemented
+# Slurp mode reads all inputs into a single array
 printf '1\n2\n3\n' | jq -s '.'
 ### expect
-[1,2,3]
+[
+  1,
+  2,
+  3
+]
 ### end
 
 ### jq_has
@@ -768,7 +775,7 @@ jq -n '1 + 1'
 ### end
 
 ### jq_exit_status
-### skip: -e flag not implemented
+# Exit status mode sets exit code 1 for null/false output
 echo 'null' | jq -e '.'
 ### exit_code: 1
 ### expect
@@ -776,7 +783,7 @@ null
 ### end
 
 ### jq_tab_indent
-### skip: --tab flag not implemented
+# Tab indent mode uses tabs instead of spaces for indentation
 echo '{"a":1}' | jq --tab '.'
 ### expect
 {
@@ -785,7 +792,7 @@ echo '{"a":1}' | jq --tab '.'
 ### end
 
 ### jq_join_output
-### skip: -j flag not implemented
+# Join output mode suppresses newlines between outputs
 echo '["a","b"]' | jq -j '.[]'
 ### expect
 ab


### PR DESCRIPTION
## Summary
- Implement `-S`/`--sort-keys` flag: Sort object keys alphabetically in output
- Implement `-s`/`--slurp` flag: Read all inputs into an array before processing  
- Implement `-e`/`--exit-status` flag: Set exit code 1 for null/false output
- Implement `--tab` flag: Use tabs for indentation instead of spaces
- Implement `-j`/`--join-output` flag: Suppress newlines between outputs

## Test plan
- [x] Enable and update existing skipped tests for these flags
- [x] Verify jq_sort_keys test passes with proper pretty-print output
- [x] Verify jq_slurp test passes with array collection
- [x] Verify jq_exit_status test passes with exit code 1 for null
- [x] Verify jq_tab_indent test passes with tab indentation
- [x] Verify jq_join_output test passes with joined string output
- [x] All 606 library unit tests pass
- [x] All spec tests pass including jq_spec_tests

https://claude.ai/code/session_01L4dXuz3hkG1sJgxNP7XSaK