### PR TITLE
docs(vfs): clarify symlink handling is intentional security decision

### DIFF
--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -520,7 +520,7 @@ impl FileSystem for InMemoryFs {
             Some(FsEntry::File { content, .. }) => Ok(content.clone()),
             Some(FsEntry::Directory { .. }) => Err(IoError::other("is a directory").into()),
             Some(FsEntry::Symlink { .. }) => {
-                // TODO: Follow symlinks
+                // Symlinks are intentionally not followed for security (TM-ESC-002, TM-DOS-011)
                 Err(IoError::new(ErrorKind::NotFound, "file not found").into())
             }
             None => Err(IoError::new(ErrorKind::NotFound, "file not found").into()),

--- a/specs/003-vfs.md
+++ b/specs/003-vfs.md
@@ -228,8 +228,11 @@ fn normalize_path(path: &Path) -> PathBuf {
 
 ### Symlink Handling
 
-Current: Symlinks stored but not followed (TODO comment in code)
-Planned: Follow symlinks with loop detection (max 40 levels like Linux)
+Symlinks are stored but intentionally not followed for security:
+- **TM-ESC-002**: Prevents symlink escape attacks
+- **TM-DOS-011**: Prevents symlink loop DoS attacks
+
+See `specs/006-threat-model.md` for details.
 
 ### Error Handling
 


### PR DESCRIPTION
## Summary
- Update TODO comment in memory.rs to reference threat model IDs
- Update VFS spec to document security rationale for not following symlinks
- Reference TM-ESC-002 (symlink escape) and TM-DOS-011 (symlink loops)

The symlink handling was documented with a TODO suggesting it should be implemented, but the threat model explicitly requires symlinks NOT to be followed for security reasons.

## Test plan
- [x] `cargo build --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes