### PR TITLE
feat(sed): enable -i in-place editing flag

### DIFF
--- a/crates/bashkit/tests/spec_cases/sed/sed.test.sh
+++ b/crates/bashkit/tests/spec_cases/sed/sed.test.sh
@@ -175,7 +175,7 @@ hi there
 ### end
 
 ### sed_inplace
-### skip: -i flag not implemented
+# In-place editing
 echo 'test' > /tmp/sedtest.txt && sed -i 's/test/done/' /tmp/sedtest.txt && cat /tmp/sedtest.txt
 ### expect
 done

--- a/specs/005-builtins.md
+++ b/specs/005-builtins.md
@@ -65,7 +65,7 @@ in a sandboxed environment. All builtins operate on the virtual filesystem.
 - `cat` - Concatenate files
 - `head`, `tail` - First/last N lines
 - `grep` - Pattern matching (`-i`, `-v`, `-c`, `-n`, `-o`, `-l`, `-w`, `-E`, `-F`, `-q`, `-m`, `-x`, `-A`, `-B`, `-C`, `-e`)
-- `sed` - Stream editing (s/pat/repl/, d, p, a, i; `-E`, `-e`, `-n`; nth occurrence, `!` negation)
+- `sed` - Stream editing (s/pat/repl/, d, p, a, i; `-E`, `-e`, `-i`, `-n`; nth occurrence, `!` negation)
 - `awk` - Text processing (print, -F, variables)
 - `jq` - JSON processing
 - `sort` - Sort lines (`-r`, `-n`, `-u`)


### PR DESCRIPTION
## Summary
- Un-skip `sed_inplace` test (implementation already existed in sed.rs)
- Update spec to document `-i` flag support

## Test plan
- [x] `sed_inplace` test passes
- [x] All sed spec tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes

https://claude.ai/code/session_01QKMmxB7SYmUa5EGbKsMLqY