### PR TITLE
docs: consolidate intentionally unimplemented features documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,9 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 | 006-threat-model | Security threats and mitigations |
 | 007-parallel-execution | Threading model, Arc usage |
 | 008-documentation | Rustdoc guides, embedded markdown |
+| 008-posix-compliance | POSIX design rationale, security exclusions |
 | 008-release-process | Version tagging, crates.io publishing |
+| 009-implementation-status | Feature status, test coverage, limitations |
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ test: add array edge case tests
 2. Add spec tests in `crates/bashkit/tests/spec_cases/`
 3. Implement the feature
 4. Update `crates/bashkit/docs/compatibility.md` if applicable
-5. Update `KNOWN_LIMITATIONS.md` if removing a limitation
+5. Update `specs/009-implementation-status.md` if removing a limitation
 
 ## Spec Test Format
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ BashKit is designed as a sandboxed interpreter. Key security boundaries:
 
 ### Known Limitations
 
-See [KNOWN_LIMITATIONS.md](KNOWN_LIMITATIONS.md) for documented gaps and edge cases.
+See [specs/009-implementation-status.md](specs/009-implementation-status.md) for documented gaps and limitations.
 
 ## Supported Versions
 

--- a/crates/bashkit/docs/compatibility.md
+++ b/crates/bashkit/docs/compatibility.md
@@ -399,9 +399,6 @@ cargo test --test spec_tests -- bash_comparison_tests --ignored
 - [x] String comparison operators (< >) in test
 - [x] Array indices `${!arr[@]}`
 
-### Planned
-- [ ] `trap` signal handling
-
 ### Not Planned
 - Interactive features (history, job control UI)
 - Process spawning (sandboxed environment)
@@ -411,5 +408,5 @@ cargo test --test spec_tests -- bash_comparison_tests --ignored
 
 ## See Also
 
-- [KNOWN_LIMITATIONS.md](../KNOWN_LIMITATIONS.md) - Detailed gap analysis
-- [specs/](../specs/) - Design specifications
+- [specs/009-implementation-status.md](../../../specs/009-implementation-status.md) - Detailed implementation status
+- [specs/](../../../specs/) - Design specifications

--- a/specs/004-testing.md
+++ b/specs/004-testing.md
@@ -184,7 +184,7 @@ The following items need attention:
 3. Run `just check-bash-compat` to verify expected output matches real bash
 4. If test fails due to unimplemented feature, add `### skip: reason`
 5. If BashKit intentionally differs from bash, add `### bash_diff: reason`
-6. Update `KNOWN_LIMITATIONS.md` for skipped tests
+6. Update `specs/009-implementation-status.md` for skipped tests
 
 ### Checking Expected Outputs
 

--- a/specs/008-posix-compliance.md
+++ b/specs/008-posix-compliance.md
@@ -6,199 +6,32 @@ Implemented (substantial compliance)
 ## Summary
 
 BashKit aims for substantial compliance with IEEE Std 1003.1-2024 (POSIX.1-2024)
-Shell Command Language specification. This document tracks compliance status and
-documents intentional deviations for security/sandbox reasons.
+Shell Command Language specification. This document explains our compliance
+approach and security-motivated deviations.
 
-## POSIX Compliance Overview
+For detailed implementation status, see [009-implementation-status.md](009-implementation-status.md).
 
-BashKit implements the core POSIX shell functionality required for portable script
-execution while maintaining its security-first, sandboxed architecture.
+## Design Philosophy
 
-### Compliance Level
+BashKit prioritizes:
+1. **Security over completeness** - exclude features that break sandbox containment
+2. **Stateless execution** - no persistent state between command invocations
+3. **Deterministic behavior** - predictable results for AI agent workflows
 
-| Category | Status | Notes |
-|----------|--------|-------|
-| Reserved Words | Full | All 16 reserved words supported |
-| Special Parameters | Full | All 8 POSIX parameters supported |
-| Special Built-in Utilities | Substantial | 13/15 implemented (2 excluded for security) |
-| Regular Built-in Utilities | Full | Core set implemented |
-| Quoting | Full | All quoting mechanisms supported |
-| Word Expansions | Substantial | Most expansions supported |
-| Redirections | Full | All POSIX redirection operators |
-| Compound Commands | Full | All compound command types |
-| Functions | Full | Both syntax forms supported |
+## Security Exclusions
 
-## POSIX Reserved Words
+Two POSIX special builtins are intentionally excluded:
 
-All 16 POSIX reserved words are recognized:
-
-| Reserved Word | Status | Notes |
-|---------------|--------|-------|
-| `!` | Implemented | Pipeline negation |
-| `{` | Implemented | Brace group start |
-| `}` | Implemented | Brace group end |
-| `case` | Implemented | Case statement |
-| `do` | Implemented | Loop body start |
-| `done` | Implemented | Loop body end |
-| `elif` | Implemented | Else-if clause |
-| `else` | Implemented | Else clause |
-| `esac` | Implemented | Case statement end |
-| `fi` | Implemented | If statement end |
-| `for` | Implemented | For loop |
-| `if` | Implemented | If statement |
-| `in` | Implemented | For/case keyword |
-| `then` | Implemented | Then clause |
-| `until` | Implemented | Until loop |
-| `while` | Implemented | While loop |
-
-## POSIX Special Parameters
-
-All 8 POSIX special parameters are implemented:
-
-| Parameter | Status | Implementation |
-|-----------|--------|----------------|
-| `$@` | Implemented | All positional parameters (separate words in quotes) |
-| `$*` | Implemented | All positional parameters (single word when quoted) |
-| `$#` | Implemented | Count of positional parameters |
-| `$?` | Implemented | Exit status of last pipeline |
-| `$-` | Implemented | Current option flags (e, x, etc.) |
-| `$$` | Implemented | Process ID (uses actual Rust process ID) |
-| `$!` | Implemented | Last background job ID (placeholder in sandbox) |
-| `$0` | Implemented | Script/function name |
-
-## POSIX Special Built-in Utilities
-
-POSIX defines 15 special built-in utilities. BashKit implements 13:
-
-| Utility | Status | Notes |
-|---------|--------|-------|
-| `.` (dot) | Implemented | Execute commands in current environment |
-| `:` (colon) | Implemented | Null utility (no-op, returns success) |
-| `break` | Implemented | Exit from loop with optional level count |
-| `continue` | Implemented | Continue loop with optional level count |
-| `eval` | Implemented | Construct and execute command |
-| `exec` | **Not Implemented** | Security: cannot replace shell process |
-| `exit` | Implemented | Exit shell with status code |
-| `export` | Implemented | Export variables to environment |
-| `readonly` | Implemented | Mark variables as read-only |
-| `return` | Implemented | Return from function with status |
-| `set` | Implemented | Set options and positional parameters |
-| `shift` | Implemented | Shift positional parameters |
-| `times` | Implemented | Display process times (returns zeros in sandbox) |
-| `trap` | **Not Implemented** | Security: signal handling excluded |
-| `unset` | Implemented | Remove variables and functions |
-
-### Security Exclusions
-
-**`exec`**: Cannot be implemented in a sandboxed environment. The POSIX `exec`
-replaces the current shell process, which would break sandbox containment.
-Scripts requiring `exec` should be refactored to use standard command execution.
+**`exec`**: The POSIX `exec` replaces the current shell process, which would
+break sandbox containment. Scripts requiring `exec` should be refactored to
+use standard command execution.
 
 **`trap`**: Signal handlers require persistent state across commands, conflicting
 with BashKit's stateless execution model. Additionally, there are no signal
 sources in the sandbox (no external processes send SIGINT/SIGTERM). Scripts
 should handle errors through exit codes and conditional execution.
 
-## Word Expansions
-
-POSIX defines these expansion types (in order of processing):
-
-| Expansion | Status | Notes |
-|-----------|--------|-------|
-| Tilde Expansion | Implemented | `~` expands to `$HOME` |
-| Parameter Expansion | Implemented | Full `${...}` syntax |
-| Command Substitution | Implemented | `$(...)` and `` `...` `` |
-| Arithmetic Expansion | Implemented | `$((...))` with full operators |
-| Field Splitting | Implemented | IFS-based splitting |
-| Pathname Expansion | Implemented | `*`, `?`, `[...]` globs |
-| Quote Removal | Implemented | Final stage |
-
-### Parameter Expansion Details
-
-| Syntax | Status | Description |
-|--------|--------|-------------|
-| `${parameter}` | Implemented | Basic expansion |
-| `${parameter:-word}` | Implemented | Use default if unset/null |
-| `${parameter:=word}` | Implemented | Assign default if unset/null |
-| `${parameter:?word}` | Implemented | Error if unset/null |
-| `${parameter:+word}` | Implemented | Use alternative if set |
-| `${#parameter}` | Implemented | String length |
-| `${parameter%word}` | Implemented | Remove shortest suffix |
-| `${parameter%%word}` | Implemented | Remove longest suffix |
-| `${parameter#word}` | Implemented | Remove shortest prefix |
-| `${parameter##word}` | Implemented | Remove longest prefix |
-
-## Redirections
-
-All POSIX redirection operators are supported:
-
-| Operator | Status | Description |
-|----------|--------|-------------|
-| `[n]<word` | Implemented | Input redirection |
-| `[n]>word` | Implemented | Output redirection (truncate) |
-| `[n]>>word` | Implemented | Output redirection (append) |
-| `[n]<&digit` | Implemented | Duplicate input fd |
-| `[n]>&digit` | Implemented | Duplicate output fd |
-| `[n]<&-` | Implemented | Close input fd |
-| `[n]>&-` | Implemented | Close output fd |
-| `[n]<>word` | Implemented | Open for read/write |
-| `<<word` | Implemented | Here-document |
-| `<<-word` | Implemented | Here-document with tab strip |
-| `<<<word` | Implemented | Here-string (bash extension) |
-
-## Compound Commands
-
-All POSIX compound commands are supported:
-
-| Command | Status | Syntax |
-|---------|--------|--------|
-| Brace Group | Implemented | `{ list; }` |
-| Subshell | Implemented | `( list )` |
-| For Loop | Implemented | `for name in words; do list; done` |
-| Case | Implemented | `case word in pattern) list;; esac` |
-| If | Implemented | `if list; then list; [elif...] [else...] fi` |
-| While | Implemented | `while list; do list; done` |
-| Until | Implemented | `until list; do list; done` |
-
-## Pipelines and Lists
-
-| Operator | Status | Description |
-|----------|--------|-------------|
-| `\|` | Implemented | Pipeline |
-| `&&` | Implemented | AND list |
-| `\|\|` | Implemented | OR list |
-| `;` | Implemented | Sequential execution |
-| `&` | Partial | Parsed, runs synchronously |
-| `!` | Implemented | Pipeline negation |
-
-## Function Definitions
-
-Both POSIX and bash-style function definitions are supported:
-
-```sh
-# POSIX style
-name() compound-command
-
-# Bash style (also accepted)
-function name { compound-command; }
-function name() { compound-command; }
-```
-
-## Shell Options
-
-Implemented via `set` builtin:
-
-| Option | Flag | Status | Notes |
-|--------|------|--------|-------|
-| errexit | `-e` | Implemented | Exit on error |
-| xtrace | `-x` | Stored | Trace mode (not enforced) |
-| nounset | `-u` | Stored | Error on unset variables |
-| noclobber | `-C` | Stored | Prevent file overwrite |
-
 ## Intentional Deviations
-
-See [KNOWN_LIMITATIONS.md](../KNOWN_LIMITATIONS.md#intentionally-unimplemented-features)
-for the complete list with threat IDs.
 
 ### Security-Motivated
 
@@ -208,52 +41,27 @@ for the complete list with threat IDs.
 4. **Virtual filesystem**: Real FS access requires explicit configuration
 5. **Network allowlist**: HTTP requires URL allowlist configuration
 
-### Simplification
+### Simplification (Stateless Model)
 
-1. **Background execution**: `&` is parsed but runs synchronously (stateless model)
+1. **Background execution**: `&` is parsed but runs synchronously
 2. **Job control**: Not implemented (interactive feature)
 3. **Process times**: `times` returns zeros (no CPU tracking)
 
-## Testing POSIX Compliance
+## Testing Approach
 
-### Testing Approach
+POSIX compliance is verified through:
 
-POSIX compliance is verified through multiple layers of testing:
-
-1. **Unit Tests** (22 POSIX-specific tests in `interpreter/mod.rs`)
-   - Positive tests: Verify correct behavior for valid inputs
-   - Negative tests: Verify correct handling of edge cases and errors
-   - Coverage: All new POSIX special builtins and parameters
-
-2. **Positive Tests** verify:
-   - `:` (colon) returns success with no output
-   - `:` works in common patterns (while loops, if/then, variable defaults)
-   - `readonly` correctly sets and marks variables
-   - `times` outputs correct format (two lines, POSIX time format)
-   - `eval` accepts and stores commands
-   - `$-` reflects current shell options
-   - `$!` is accessible (empty when no background jobs)
-
-3. **Negative/Edge Case Tests** verify:
-   - `:` produces no output even with arguments
-   - `eval` with no arguments succeeds silently
-   - `readonly` handles empty values correctly
-   - `times` ignores extraneous arguments
-   - `$!` is empty when no background jobs have run
-   - `:` resets exit code to 0 after failed command
-
-### Running Tests
+1. **Unit Tests** - 22 POSIX-specific tests for special builtins and parameters
+2. **Spec Tests** - 435 bash spec test cases in CI
+3. **Bash Comparison** - differential testing against real bash
 
 ```bash
-# Run all POSIX compliance tests
+# Run POSIX compliance tests
 cargo test --lib -- interpreter::tests::test_colon
 cargo test --lib -- interpreter::tests::test_readonly
 cargo test --lib -- interpreter::tests::test_times
 cargo test --lib -- interpreter::tests::test_eval
 cargo test --lib -- interpreter::tests::test_special_param
-
-# Run POSIX-focused spec tests
-cargo test --test spec_tests
 
 # Compare with real bash
 cargo test --test spec_tests -- bash_comparison_tests --ignored


### PR DESCRIPTION
## Summary

- Create single source of truth for intentionally unimplemented features
- Move KNOWN_LIMITATIONS.md to specs/009-implementation-status.md
- Slim specs/008-posix-compliance.md to design rationale only
- Fix rationales (trap can't interfere with host, sed -i isn't security)

## Changes

1. **specs/009-implementation-status.md** (new) - consolidated feature status, test coverage, limitations
2. **specs/008-posix-compliance.md** - now focused on design rationale only
3. **docs/compatibility.md** - updated references, removed trap from planned
4. **AGENTS.md** - added new spec to table
5. **Deleted KNOWN_LIMITATIONS.md** - content moved to spec

## Intentionally Unimplemented Features

| Feature | Rationale |
|---------|-----------|
| `exec` | Breaks sandbox containment |
| `trap` | Stateless model - no persistent handlers; no signal sources |
| Background `&` | Stateless model - no persistent processes |
| Job control | Requires process state |
| Symlink following | Prevents loop attacks and sandbox escape |
| Process spawning | Commands run as builtins |
| Raw sockets | HTTP allowlist only |

## Test plan

- [x] All references updated
- [ ] CI passes