### PR TITLE
chore: clarify commit type for specs and AGENTS.md updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ just pre-pr       # Pre-PR checks
 
 Types: feat, fix, docs, refactor, test, chore
 
+- Updates to `specs/` and `AGENTS.md`: use `chore` type
+
 ### PRs
 
 Squash and Merge. Use PR template if exists.


### PR DESCRIPTION
## Summary

- Adds guidance that updates to `specs/` and `AGENTS.md` should use the `chore` commit type

## Test plan

- [x] Documentation-only change, no tests needed

https://claude.ai/code/session_01RcBuHQKo5ifgV2PFtE4mPt