### PR TITLE
fix(ls): add -t option for sorting by modification time

### DIFF
--- a/specs/005-builtins.md
+++ b/specs/005-builtins.md
@@ -98,7 +98,7 @@ Bash::builder()
 ```
 
 #### Directory Listing and Search
-- `ls` - List directory contents (`-l`, `-a`, `-h`, `-1`, `-R`)
+- `ls` - List directory contents (`-l`, `-a`, `-h`, `-1`, `-R`, `-t`)
 - `find` - Search for files (`-name PATTERN`, `-type f|d|l`, `-maxdepth N`, `-print`)
 - `rmdir` - Remove empty directories (`-p` for parents)
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -226,12 +226,20 @@ criteria = "safe-to-run"
 version = "0.8.1"
 criteria = "safe-to-run"
 
+[[exemptions.criterion]]
+version = "0.8.2"
+criteria = "safe-to-run"
+
 [[exemptions.criterion-plot]]
 version = "0.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.criterion-plot]]
 version = "0.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.criterion-plot]]
+version = "0.8.2"
 criteria = "safe-to-run"
 
 [[exemptions.crossbeam-deque]]


### PR DESCRIPTION
## Summary
- Add missing `-t` flag to the `ls` builtin command
- Sorts directory listings by modification time (newest first) instead of alphabetically
- Update specs documentation to include the new option

Fixes error: `ls: invalid option -- 't'`

## Test plan
- [x] Add test `test_ls_sort_by_time` that verifies `-t` option is accepted
- [x] Run `cargo test --package bashkit test_ls` - all 9 tests pass
- [x] Run `cargo fmt --check` and `cargo clippy` - no issues

https://claude.ai/code/session_01GTyExJZBcMgHxmkijbUNcw