### PR TITLE
test(find,ls): add comprehensive subdirectory recursion tests

### DIFF
--- a/crates/bashkit/src/builtins/ls.rs
+++ b/crates/bashkit/src/builtins/ls.rs
@@ -1072,6 +1072,311 @@ mod tests {
         assert!(result.stderr.contains("unknown type"));
     }
 
+    #[tokio::test]
+    async fn test_find_deep_recursion() {
+        // Test that find without maxdepth descends into all subdirectory levels
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Create a deep directory structure: a/b/c/d/deep.txt
+        fs.mkdir(&cwd.join("a"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/b"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/b/c"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/b/c/d"), false).await.unwrap();
+        fs.write_file(&cwd.join("a/b/c/d/deep.txt"), b"deep content")
+            .await
+            .unwrap();
+
+        // Also add files at each level
+        fs.write_file(&cwd.join("a/file1.txt"), b"level1")
+            .await
+            .unwrap();
+        fs.write_file(&cwd.join("a/b/file2.txt"), b"level2")
+            .await
+            .unwrap();
+        fs.write_file(&cwd.join("a/b/c/file3.txt"), b"level3")
+            .await
+            .unwrap();
+
+        let args: Vec<String> = vec![];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Find.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        // Should find the root
+        assert!(result.stdout.contains("."), "Should contain current dir");
+
+        // Should find all directories at all levels
+        assert!(result.stdout.contains("./a"), "Should contain ./a");
+        assert!(result.stdout.contains("./a/b"), "Should contain ./a/b");
+        assert!(result.stdout.contains("./a/b/c"), "Should contain ./a/b/c");
+        assert!(
+            result.stdout.contains("./a/b/c/d"),
+            "Should contain ./a/b/c/d"
+        );
+
+        // Should find all files at all levels
+        assert!(
+            result.stdout.contains("file1.txt"),
+            "Should contain file1.txt at level 1"
+        );
+        assert!(
+            result.stdout.contains("file2.txt"),
+            "Should contain file2.txt at level 2"
+        );
+        assert!(
+            result.stdout.contains("file3.txt"),
+            "Should contain file3.txt at level 3"
+        );
+        assert!(
+            result.stdout.contains("deep.txt"),
+            "Should contain deep.txt at level 4"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ls_recursive_deep() {
+        // Test that ls -R descends into all subdirectory levels
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Create a deep directory structure: a/b/c/deep.txt
+        fs.mkdir(&cwd.join("a"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/b"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/b/c"), false).await.unwrap();
+        fs.write_file(&cwd.join("a/b/c/deep.txt"), b"deep content")
+            .await
+            .unwrap();
+
+        let args = vec!["-R".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Ls.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        // Should list all directories and their contents
+        assert!(result.stdout.contains("a"), "Should list dir a");
+        assert!(result.stdout.contains("b"), "Should list dir b under a");
+        assert!(result.stdout.contains("c"), "Should list dir c under a/b");
+        assert!(
+            result.stdout.contains("deep.txt"),
+            "Should list deep.txt under a/b/c"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_very_deep_nesting() {
+        // Test 10 levels of nesting to ensure no recursion limits
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Create 10 levels deep
+        let mut path = cwd.clone();
+        for i in 0..10 {
+            path = path.join(format!("level{}", i));
+            fs.mkdir(&path, false).await.unwrap();
+            fs.write_file(
+                &path.join(format!("file{}.txt", i)),
+                format!("content{}", i).as_bytes(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let args: Vec<String> = vec![];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Find.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        // Verify all 10 levels are found
+        for i in 0..10 {
+            assert!(
+                result.stdout.contains(&format!("level{}", i)),
+                "Should find level{} directory",
+                i
+            );
+            assert!(
+                result.stdout.contains(&format!("file{}.txt", i)),
+                "Should find file{}.txt",
+                i
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_find_and_ls_consistency() {
+        // Ensure find and ls -R find the same nested structure
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Create test structure
+        fs.mkdir(&cwd.join("top"), false).await.unwrap();
+        fs.mkdir(&cwd.join("top/middle"), false).await.unwrap();
+        fs.mkdir(&cwd.join("top/middle/bottom"), false)
+            .await
+            .unwrap();
+        fs.write_file(&cwd.join("top/a.txt"), b"a").await.unwrap();
+        fs.write_file(&cwd.join("top/middle/b.txt"), b"b")
+            .await
+            .unwrap();
+        fs.write_file(&cwd.join("top/middle/bottom/c.txt"), b"c")
+            .await
+            .unwrap();
+
+        // Run find
+        let args_find: Vec<String> = vec![];
+        let ctx_find = Context {
+            args: &args_find,
+            env: &env,
+            variables: &mut variables.clone(),
+            cwd: &mut cwd.clone(),
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let find_result = Find.execute(ctx_find).await.unwrap();
+
+        // Run ls -R
+        let args_ls = vec!["-R".to_string()];
+        let ctx_ls = Context {
+            args: &args_ls,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let ls_result = Ls.execute(ctx_ls).await.unwrap();
+
+        // Both should find all the nested content
+        assert!(find_result.stdout.contains("top"));
+        assert!(find_result.stdout.contains("middle"));
+        assert!(find_result.stdout.contains("bottom"));
+        assert!(find_result.stdout.contains("a.txt"));
+        assert!(find_result.stdout.contains("b.txt"));
+        assert!(find_result.stdout.contains("c.txt"));
+
+        assert!(ls_result.stdout.contains("top"));
+        assert!(ls_result.stdout.contains("middle"));
+        assert!(ls_result.stdout.contains("bottom"));
+        assert!(ls_result.stdout.contains("a.txt"));
+        assert!(ls_result.stdout.contains("b.txt"));
+        assert!(ls_result.stdout.contains("c.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_find_with_empty_subdirs() {
+        // Ensure empty subdirectories are still traversed
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Create structure with some empty dirs in the path
+        fs.mkdir(&cwd.join("a"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/empty1"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/empty2"), false).await.unwrap();
+        fs.mkdir(&cwd.join("a/empty1/deep"), false).await.unwrap();
+        fs.write_file(&cwd.join("a/empty1/deep/file.txt"), b"found")
+            .await
+            .unwrap();
+
+        let args: Vec<String> = vec![];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Find.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        // Should find the file through the empty directories
+        assert!(result.stdout.contains("file.txt"));
+        assert!(result.stdout.contains("empty1"));
+        assert!(result.stdout.contains("empty2"));
+        assert!(result.stdout.contains("deep"));
+    }
+
+    #[tokio::test]
+    async fn test_find_from_specific_path() {
+        // Test finding from a specific starting path (not cwd)
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Create nested structure
+        fs.mkdir(&cwd.join("start"), false).await.unwrap();
+        fs.mkdir(&cwd.join("start/sub1"), false).await.unwrap();
+        fs.mkdir(&cwd.join("start/sub1/sub2"), false).await.unwrap();
+        fs.write_file(&cwd.join("start/sub1/sub2/target.txt"), b"target")
+            .await
+            .unwrap();
+
+        // Find from a specific starting path
+        let args = vec!["start".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Find.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        assert!(
+            result.stdout.contains("start"),
+            "Should contain starting path"
+        );
+        assert!(result.stdout.contains("sub1"), "Should descend into sub1");
+        assert!(result.stdout.contains("sub2"), "Should descend into sub2");
+        assert!(
+            result.stdout.contains("target.txt"),
+            "Should find target.txt"
+        );
+    }
+
     // ==================== rmdir tests ====================
 
     #[tokio::test]
@@ -1219,6 +1524,302 @@ mod tests {
         let result = Rmdir.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("missing operand"));
+    }
+
+    // ==================== Custom filesystem tests ====================
+
+    #[tokio::test]
+    async fn test_find_with_overlay_fs() {
+        use crate::fs::OverlayFs;
+
+        // Create base filesystem with nested structure
+        let base = Arc::new(InMemoryFs::new());
+        base.mkdir(Path::new("/home/user"), true).await.unwrap();
+        base.mkdir(Path::new("/home/user/base"), false)
+            .await
+            .unwrap();
+        base.mkdir(Path::new("/home/user/base/sub1"), false)
+            .await
+            .unwrap();
+        base.mkdir(Path::new("/home/user/base/sub1/sub2"), false)
+            .await
+            .unwrap();
+        base.write_file(Path::new("/home/user/base/file1.txt"), b"base1")
+            .await
+            .unwrap();
+        base.write_file(Path::new("/home/user/base/sub1/file2.txt"), b"base2")
+            .await
+            .unwrap();
+        base.write_file(Path::new("/home/user/base/sub1/sub2/file3.txt"), b"base3")
+            .await
+            .unwrap();
+
+        // Create overlay
+        let overlay: Arc<dyn FileSystem> = Arc::new(OverlayFs::new(base));
+
+        // Add a file in the overlay layer (use recursive to ensure parent exists in upper)
+        overlay
+            .mkdir(Path::new("/home/user/base/overlay_dir"), true)
+            .await
+            .unwrap();
+        overlay
+            .write_file(
+                Path::new("/home/user/base/overlay_dir/overlay_file.txt"),
+                b"overlay",
+            )
+            .await
+            .unwrap();
+
+        let mut cwd = PathBuf::from("/home/user");
+        let mut variables = HashMap::new();
+        let env = HashMap::new();
+
+        // Run find on the overlay filesystem
+        let args = vec!["base".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: overlay.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Find.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        // Should find files from base layer
+        assert!(
+            result.stdout.contains("file1.txt"),
+            "Should find file1.txt from base"
+        );
+        assert!(
+            result.stdout.contains("file2.txt"),
+            "Should find file2.txt from base/sub1"
+        );
+        assert!(
+            result.stdout.contains("file3.txt"),
+            "Should find file3.txt from base/sub1/sub2"
+        );
+
+        // Should find files from overlay layer
+        assert!(
+            result.stdout.contains("overlay_dir"),
+            "Should find overlay_dir"
+        );
+        assert!(
+            result.stdout.contains("overlay_file.txt"),
+            "Should find overlay_file.txt"
+        );
+
+        // Should descend into all subdirectories
+        assert!(result.stdout.contains("sub1"), "Should find sub1");
+        assert!(result.stdout.contains("sub2"), "Should find sub2");
+    }
+
+    #[tokio::test]
+    async fn test_find_with_mountable_fs() {
+        use crate::fs::MountableFs;
+
+        // Create root filesystem
+        let root = Arc::new(InMemoryFs::new());
+        root.mkdir(Path::new("/home/user"), true).await.unwrap();
+        root.write_file(Path::new("/home/user/root_file.txt"), b"root")
+            .await
+            .unwrap();
+
+        // Create a nested filesystem to mount
+        let nested = Arc::new(InMemoryFs::new());
+        nested.mkdir(Path::new("/level1"), false).await.unwrap();
+        nested
+            .mkdir(Path::new("/level1/level2"), false)
+            .await
+            .unwrap();
+        nested
+            .mkdir(Path::new("/level1/level2/level3"), false)
+            .await
+            .unwrap();
+        nested
+            .write_file(Path::new("/level1/nested1.txt"), b"n1")
+            .await
+            .unwrap();
+        nested
+            .write_file(Path::new("/level1/level2/nested2.txt"), b"n2")
+            .await
+            .unwrap();
+        nested
+            .write_file(Path::new("/level1/level2/level3/nested3.txt"), b"n3")
+            .await
+            .unwrap();
+
+        // Create mountable filesystem and mount nested at /home/user/mounted
+        let mountable = MountableFs::new(root.clone());
+        mountable
+            .mount("/home/user/mounted", nested.clone())
+            .unwrap();
+
+        let fs: Arc<dyn FileSystem> = Arc::new(mountable);
+        let mut cwd = PathBuf::from("/home/user");
+        let mut variables = HashMap::new();
+        let env = HashMap::new();
+
+        // Run find from cwd - should find both root files and mounted files
+        let args: Vec<String> = vec![];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Find.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        // Should find root file
+        assert!(
+            result.stdout.contains("root_file.txt"),
+            "Should find root_file.txt"
+        );
+
+        // Should find mount point
+        assert!(
+            result.stdout.contains("mounted"),
+            "Should find mounted directory"
+        );
+
+        // Should descend into mounted filesystem
+        assert!(
+            result.stdout.contains("level1"),
+            "Should find level1 in mounted fs"
+        );
+        assert!(
+            result.stdout.contains("level2"),
+            "Should find level2 in mounted fs"
+        );
+        assert!(
+            result.stdout.contains("level3"),
+            "Should find level3 in mounted fs"
+        );
+
+        // Should find files deep in mounted filesystem
+        assert!(
+            result.stdout.contains("nested1.txt"),
+            "Should find nested1.txt"
+        );
+        assert!(
+            result.stdout.contains("nested2.txt"),
+            "Should find nested2.txt"
+        );
+        assert!(
+            result.stdout.contains("nested3.txt"),
+            "Should find nested3.txt"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ls_recursive_with_overlay_fs() {
+        use crate::fs::OverlayFs;
+
+        // Create base filesystem with nested structure
+        let base = Arc::new(InMemoryFs::new());
+        base.mkdir(Path::new("/home/user"), true).await.unwrap();
+        base.mkdir(Path::new("/home/user/dir"), false)
+            .await
+            .unwrap();
+        base.mkdir(Path::new("/home/user/dir/subdir"), false)
+            .await
+            .unwrap();
+        base.write_file(Path::new("/home/user/dir/base.txt"), b"base")
+            .await
+            .unwrap();
+        base.write_file(Path::new("/home/user/dir/subdir/deep.txt"), b"deep")
+            .await
+            .unwrap();
+
+        let overlay: Arc<dyn FileSystem> = Arc::new(OverlayFs::new(base));
+
+        let mut cwd = PathBuf::from("/home/user");
+        let mut variables = HashMap::new();
+        let env = HashMap::new();
+
+        let args = vec!["-R".to_string(), "dir".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: overlay,
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Ls.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        assert!(result.stdout.contains("base.txt"), "Should list base.txt");
+        assert!(result.stdout.contains("subdir"), "Should list subdir");
+        assert!(result.stdout.contains("deep.txt"), "Should list deep.txt");
+    }
+
+    #[tokio::test]
+    async fn test_ls_recursive_with_mountable_fs() {
+        use crate::fs::MountableFs;
+
+        let root = Arc::new(InMemoryFs::new());
+        root.mkdir(Path::new("/home/user"), true).await.unwrap();
+
+        let mounted = Arc::new(InMemoryFs::new());
+        mounted.mkdir(Path::new("/a"), false).await.unwrap();
+        mounted.mkdir(Path::new("/a/b"), false).await.unwrap();
+        mounted
+            .write_file(Path::new("/a/file_a.txt"), b"a")
+            .await
+            .unwrap();
+        mounted
+            .write_file(Path::new("/a/b/file_b.txt"), b"b")
+            .await
+            .unwrap();
+
+        let mountable = MountableFs::new(root);
+        mountable.mount("/home/user/mnt", mounted.clone()).unwrap();
+
+        let fs: Arc<dyn FileSystem> = Arc::new(mountable);
+        let mut cwd = PathBuf::from("/home/user");
+        let mut variables = HashMap::new();
+        let env = HashMap::new();
+
+        let args = vec!["-R".to_string(), "mnt".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+        };
+
+        let result = Ls.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        assert!(result.stdout.contains("a"), "Should list directory a");
+        assert!(result.stdout.contains("b"), "Should list directory b");
+        assert!(
+            result.stdout.contains("file_a.txt"),
+            "Should list file_a.txt"
+        );
+        assert!(
+            result.stdout.contains("file_b.txt"),
+            "Should list file_b.txt"
+        );
     }
 
     // ==================== glob_match tests ====================

--- a/crates/bashkit/tests/spec_cases/bash/find.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/find.test.sh
@@ -1,0 +1,96 @@
+### find_basic
+### bash_diff: Virtual filesystem vs real filesystem produces different output
+# Find should list current directory
+find .
+### expect
+.
+### end
+
+### find_with_path
+### bash_diff: Virtual /tmp vs real /tmp may have different state
+# Find in /tmp
+touch /tmp/testfile.txt
+find /tmp -name "testfile.txt"
+### expect
+/tmp/testfile.txt
+### end
+
+### find_type_file
+# Find only files
+mkdir -p /tmp/findtest
+touch /tmp/findtest/file.txt
+mkdir /tmp/findtest/subdir
+find /tmp/findtest -type f
+### expect
+/tmp/findtest/file.txt
+### end
+
+### find_type_directory
+# Find only directories (sorted for deterministic output)
+mkdir -p /tmp/findtest2
+touch /tmp/findtest2/file.txt
+mkdir /tmp/findtest2/subdir
+find /tmp/findtest2 -type d | sort
+### expect
+/tmp/findtest2
+/tmp/findtest2/subdir
+### end
+
+### find_deep_recursion
+# Find should descend into nested directories
+mkdir -p /tmp/deep/a/b/c/d
+touch /tmp/deep/a/b/c/d/deep.txt
+touch /tmp/deep/a/file1.txt
+touch /tmp/deep/a/b/file2.txt
+touch /tmp/deep/a/b/c/file3.txt
+find /tmp/deep -name "*.txt" | sort
+### expect
+/tmp/deep/a/b/c/d/deep.txt
+/tmp/deep/a/b/c/file3.txt
+/tmp/deep/a/b/file2.txt
+/tmp/deep/a/file1.txt
+### end
+
+### find_maxdepth
+# Find with maxdepth should limit recursion depth
+mkdir -p /tmp/depth/a/b/c
+touch /tmp/depth/level0.txt
+touch /tmp/depth/a/level1.txt
+touch /tmp/depth/a/b/level2.txt
+touch /tmp/depth/a/b/c/level3.txt
+find /tmp/depth -maxdepth 1 -name "*.txt"
+### expect
+/tmp/depth/level0.txt
+### end
+
+### find_name_glob
+# Find with name pattern using wildcards
+mkdir -p /tmp/glob
+touch /tmp/glob/test.txt
+touch /tmp/glob/test.md
+touch /tmp/glob/other.txt
+find /tmp/glob -name "test.*" | sort
+### expect
+/tmp/glob/test.md
+/tmp/glob/test.txt
+### end
+
+### ls_recursive
+# ls -R should list nested directories
+mkdir -p /tmp/lsrec/a/b
+touch /tmp/lsrec/file.txt
+touch /tmp/lsrec/a/nested.txt
+touch /tmp/lsrec/a/b/deep.txt
+ls -R /tmp/lsrec
+### expect
+/tmp/lsrec:
+a
+file.txt
+
+/tmp/lsrec/a:
+b
+nested.txt
+
+/tmp/lsrec/a/b:
+deep.txt
+### end

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -226,12 +226,20 @@ criteria = "safe-to-run"
 version = "0.8.1"
 criteria = "safe-to-run"
 
+[[exemptions.criterion]]
+version = "0.8.2"
+criteria = "safe-to-run"
+
 [[exemptions.criterion-plot]]
 version = "0.5.0"
 criteria = "safe-to-run"
 
 [[exemptions.criterion-plot]]
 version = "0.8.1"
+criteria = "safe-to-run"
+
+[[exemptions.criterion-plot]]
+version = "0.8.2"
 criteria = "safe-to-run"
 
 [[exemptions.crossbeam-deque]]


### PR DESCRIPTION
## Summary
- Add extensive test coverage for `find` and `ls -R` subdirectory recursion
- Tests verify correct behavior at any nesting depth (up to 10 levels)
- Tests cover all filesystem implementations: InMemoryFs, OverlayFs, MountableFs
- Add integration spec tests via the bash interpreter

## Test plan
- [x] All 611 library tests pass
- [x] `test_find_deep_recursion` - 4+ levels of nesting
- [x] `test_find_very_deep_nesting` - 10 levels of nesting
- [x] `test_find_and_ls_consistency` - Both commands find same content
- [x] `test_find_with_overlay_fs` - OverlayFs traversal
- [x] `test_find_with_mountable_fs` - MountableFs traversal
- [x] `test_ls_recursive_with_overlay_fs` - ls -R with OverlayFs
- [x] `test_ls_recursive_with_mountable_fs` - ls -R with MountableFs
- [x] Spec tests pass (479 bash spec tests, 100% pass rate)

https://claude.ai/code/session_0182XS7bKVWA5xRWFD4AjHMK