### PR TITLE
fix(security): add depth limits to awk/jq builtin parsers (TM-DOS-027)

### DIFF
--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -13,6 +13,7 @@
 //! - **TM-DOS-022**: Parser recursion → `max_ast_depth`
 //! - **TM-DOS-023**: CPU exhaustion → `timeout`
 //! - **TM-DOS-024**: Parser hang → `parser_timeout`, `max_parser_operations`
+//! - **TM-DOS-027**: Builtin parser recursion → `MAX_AWK_PARSER_DEPTH`, `MAX_JQ_JSON_DEPTH` (in builtins)
 //!
 //! # Fail Points (enabled with `failpoints` feature)
 //!


### PR DESCRIPTION
## Summary
- Add `MAX_AWK_PARSER_DEPTH` (100) with push/pop depth tracking in awk recursive descent parser (`parse_expression`, `parse_unary`, `parse_if`) to prevent stack overflow from deeply nested expressions or chained unary operators
- Add `MAX_JQ_JSON_DEPTH` (100) with `check_json_depth` to reject deeply nested JSON input before jaq evaluation (defense-in-depth alongside serde_json's built-in ~128 recursion limit)
- Update TM-DOS-027 status from Partial to MITIGATED in threat model spec and security controls matrix

## Test plan
- [x] Unit tests: awk parser rejects 150-level nested parens and 200-level chained unary ops
- [x] Unit tests: awk parser accepts moderate (10-level) nesting
- [x] Unit tests: jq rejects 150-level nested JSON arrays and objects
- [x] Unit tests: jq accepts moderate (10-level) JSON nesting
- [x] Unit test: `check_json_depth` directly tested
- [x] Threat model integration tests: deep awk/jq nesting via `Bash::exec` pipeline doesn't crash
- [x] Threat model integration tests: moderate nesting still produces correct output
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Full test suite (1142 tests) passes with 0 failures

https://claude.ai/code/session_011GDvpiGXNsxN9Fch6CxZR7