### PR TITLE
fix(security): mitigate path validation and nested loop threats

### DIFF
--- a/crates/bashkit-monty-worker/Cargo.toml
+++ b/crates/bashkit-monty-worker/Cargo.toml
@@ -20,6 +20,6 @@ name = "bashkit-monty-worker"
 path = "src/main.rs"
 
 [dependencies]
-monty = { git = "https://github.com/pydantic/monty", version = "0.0.3" }
+monty = { git = "https://github.com/pydantic/monty", version = "0.0.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -60,7 +60,7 @@ base64 = { workspace = true, optional = true }
 # Logging/tracing (optional)
 tracing = { workspace = true, optional = true }
 # Embedded Python interpreter (pydantic/monty) - optional
-monty = { git = "https://github.com/pydantic/monty", version = "0.0.3", optional = true }
+monty = { git = "https://github.com/pydantic/monty", version = "0.0.4", optional = true }
 # Monty subprocess worker protocol (for crash-isolated execution)
 bashkit-monty-worker = { path = "../bashkit-monty-worker", optional = true }
 

--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -492,6 +492,11 @@ impl InMemoryFs {
 #[async_trait]
 impl FileSystem for InMemoryFs {
     async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         // Fail point: simulate read failures
         #[cfg(feature = "failpoints")]
         fail_point!("fs::read_file", |action| {
@@ -528,6 +533,11 @@ impl FileSystem for InMemoryFs {
     }
 
     async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         // Fail point: simulate write failures
         #[cfg(feature = "failpoints")]
         fail_point!("fs::write_file", |action| {
@@ -595,6 +605,11 @@ impl FileSystem for InMemoryFs {
     }
 
     async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         let path = Self::normalize_path(path);
 
         // Special handling for /dev/null - discard all writes
@@ -672,6 +687,11 @@ impl FileSystem for InMemoryFs {
     }
 
     async fn mkdir(&self, path: &Path, recursive: bool) -> Result<()> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         let path = Self::normalize_path(path);
         let mut entries = self.entries.write().unwrap();
 

--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -362,6 +362,11 @@ impl FileSystem for OverlayFs {
     }
 
     async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         let path = Self::normalize_path(path);
 
         // Check limits before writing
@@ -389,6 +394,11 @@ impl FileSystem for OverlayFs {
     }
 
     async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         let path = Self::normalize_path(path);
 
         // Check for whiteout
@@ -429,6 +439,11 @@ impl FileSystem for OverlayFs {
     }
 
     async fn mkdir(&self, path: &Path, recursive: bool) -> Result<()> {
+        // THREAT[TM-DOS-012, TM-DOS-013, TM-DOS-015]: Validate path before use
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+
         let path = Self::normalize_path(path);
 
         // Remove any whiteout for this path


### PR DESCRIPTION
## Summary

- **TM-DOS-012**: Add `max_path_depth` (100) to `FsLimits` — prevents deep directory nesting from exhausting stack/memory
- **TM-DOS-013**: Add `max_filename_length` (255) and `max_path_length` (4096) to `FsLimits` — prevents long filenames/paths from exhausting memory
- **TM-DOS-015**: Add `validate_path()` to `FsLimits` — rejects ASCII control chars, C1 controls, and Unicode bidi override characters in path components
- **TM-DOS-018**: Add `max_total_loop_iterations` (1M) to `ExecutionLimits` — global counter that never resets across nested loops, preventing the 10K^depth multiplication attack

Path validation enforced in both `InMemoryFs` and `OverlayFs` at all write entry points. Also bumps monty dep from 0.0.3 to 0.0.4 to fix build.

## Test plan

- [x] 8 new path validation security tests (depth, filename length, path length, control chars, bidi overrides, unicode, e2e script)
- [x] 2 new nested loop security tests (multiplication blocked, sequential within budget)
- [x] All 86 threat model tests pass
- [x] Full unit test suite passes (724+ tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean