### PR TITLE
fix: close 5 critical bashkit gaps blocking LLM-generated scripts

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -1647,6 +1647,19 @@ impl AwkInterpreter {
                 if args.is_empty() {
                     AwkValue::Number(self.state.get_field(0).as_string().len() as f64)
                 } else {
+                    // Check if the argument is an array name - if so, return element count
+                    if let AwkExpr::Variable(ref arr_name) = args[0] {
+                        let prefix = format!("{}[", arr_name);
+                        let count = self
+                            .state
+                            .variables
+                            .keys()
+                            .filter(|k| k.starts_with(&prefix))
+                            .count();
+                        if count > 0 {
+                            return AwkValue::Number(count as f64);
+                        }
+                    }
                     AwkValue::Number(self.eval_expr(&args[0]).as_string().len() as f64)
                 }
             }

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -1385,6 +1385,10 @@ impl<'a> Parser<'a> {
                         kind: RedirectKind::HereDoc,
                         target,
                     });
+
+                    // Heredoc body consumed subsequent lines from input.
+                    // Stop parsing this command - next tokens belong to new commands.
+                    break;
                 }
                 Some(tokens::Token::ProcessSubIn) | Some(tokens::Token::ProcessSubOut) => {
                     // Process substitution as argument


### PR DESCRIPTION
## Summary

Fixes 5 shell feature gaps that are the most common patterns LLMs emit, all of which were silently broken:

- **Heredoc file writes**: `cat > file <<'EOF'` now writes to file instead of printing to stdout. Parser broke out of command parsing after heredoc body consumption.
- **Compound pipelines**: `cmd | while read line; do ... done` now works. Pipeline executor handles compound commands with progressive stdin consumption.
- **Source loading functions**: `source lib.sh` now executes sourced scripts in the current shell context, properly registering functions and variables. Moved source/eval handling from builtins to interpreter level.
- **chmod symbolic mode**: `chmod +x`, `chmod u+x`, `chmod go-w`, `chmod a=rx` etc. all work alongside existing octal mode support.
- **Awk array length**: `length(arr)` returns element count when argument is an array name.

## Test plan

- [x] 15 new tests covering all 5 fixes (heredoc redirect, pipe-to-while-read, source-loads-functions, source-loads-variables, chmod symbolic modes, awk array length/split/word-count)
- [x] All 1250+ existing tests pass (cargo test --all-features)
- [x] cargo clippy --all-targets --all-features -- -D warnings clean
- [x] cargo fmt --check clean

https://claude.ai/code/session_01ExGoos6WacNAfS1sYTykNm