### PR TITLE
docs: update READMEs and lib.rs with latest features

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -5,7 +5,7 @@ Python bindings for [Bashkit](https://github.com/everruns/bashkit) - a sandboxed
 ## Features
 
 - **Sandboxed execution**: All commands run in isolation with a virtual filesystem
-- **66+ built-in commands**: echo, cat, grep, sed, awk, jq, curl, find, and more
+- **68+ built-in commands**: echo, cat, grep, sed, awk, jq, curl, find, and more
 - **Full bash syntax**: Variables, pipelines, redirects, loops, functions, arrays
 - **Resource limits**: Protect against infinite loops and runaway scripts
 - **LangChain integration**: Ready-to-use tool for LangChain agents


### PR DESCRIPTION
## Summary

- Add experimental Git support and Python/Monty support sections to README and lib.rs rustdoc
- Update builtin count from 66 to 68+ (adds bash, sh, eval, :, history categories)
- Add Shell and Experimental rows to the commands table
- Add Python bindings section to main README
- Add git_workflow and python_scripts examples to lib.rs doc examples list
- Add python_guide and compatibility_scorecard to Guides section in lib.rs
- Update bashkit-python README builtin count (66+ → 68+)

## Test plan

- [x] `cargo check -p bashkit` passes
- [x] `cargo doc --no-deps -p bashkit` builds with zero warnings
- [ ] CI green