### PR TITLE
feat(tool): add language warnings and rename llmtext to help

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -101,7 +101,7 @@ print(result.stdout)
 - `execute(commands: str) -> ExecResult`: Execute commands asynchronously
 - `execute_sync(commands: str) -> ExecResult`: Execute commands synchronously
 - `description() -> str`: Get tool description
-- `llmtext() -> str`: Get LLM documentation
+- `help() -> str`: Get LLM documentation
 - `input_schema() -> str`: Get JSON input schema
 - `output_schema() -> str`: Get JSON output schema
 

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -76,7 +76,7 @@ class BashTool:
         """Get the full description."""
         ...
 
-    def llmtext(self) -> str:
+    def help(self) -> str:
         """Get LLM documentation."""
         ...
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -236,9 +236,9 @@ impl BashTool {
     }
 
     /// Get LLM documentation
-    fn llmtext(&self) -> PyResult<String> {
+    fn help(&self) -> PyResult<String> {
         let tool = RustBashTool::default();
-        Ok(tool.llmtext())
+        Ok(tool.help())
     }
 
     /// Get system prompt for LLMs

--- a/crates/bashkit/docs/python.md
+++ b/crates/bashkit/docs/python.md
@@ -154,8 +154,8 @@ let tool = BashTool::builder()
     .python()
     .build();
 
-// llmtext() and system_prompt() automatically document Python limitations
-let llmtext = tool.llmtext();  // Includes NOTES section with Python hints
+// help() and system_prompt() automatically document Python limitations
+let help = tool.help();  // Includes NOTES section with Python hints
 ```
 
 The builtin's `llm_hint()` is automatically included in the tool's documentation,

--- a/crates/bashkit/examples/show_tool_output.rs
+++ b/crates/bashkit/examples/show_tool_output.rs
@@ -15,8 +15,8 @@ fn main() {
     println!("\n=== system_prompt() ===");
     println!("{}", tool.system_prompt());
 
-    println!("\n=== llmtext() ===");
-    println!("{}", tool.llmtext());
+    println!("\n=== help() ===");
+    println!("{}", tool.help());
 
     println!("\n=== version() ===");
     println!("{}", tool.version());

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -317,7 +317,7 @@ impl<'a> Context<'a> {
 /// # LLM Hints
 ///
 /// Builtins can provide short hints for LLM system prompts via [`llm_hint`](Builtin::llm_hint).
-/// These appear in the tool's `llmtext()` and `system_prompt()` output so LLMs know
+/// These appear in the tool's `help()` and `system_prompt()` output so LLMs know
 /// about capabilities and limitations.
 ///
 /// # Return Values
@@ -341,7 +341,7 @@ pub trait Builtin: Send + Sync {
     /// Optional short hint for LLM system prompts.
     ///
     /// Return a concise one-line description of capabilities and limitations.
-    /// These hints are included in `llmtext()` and `system_prompt()` output
+    /// These hints are included in `help()` and `system_prompt()` output
     /// when the builtin is registered.
     ///
     /// # Example

--- a/specs/001-architecture.md
+++ b/specs/001-architecture.md
@@ -87,7 +87,7 @@ pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
     fn short_description(&self) -> &str;
     fn description(&self) -> String;          // Dynamic, includes custom builtins
-    fn llmtext(&self) -> String;              // Full docs for LLMs
+    fn help(&self) -> String;              // Full docs for LLMs
     fn system_prompt(&self) -> String;        // Token-efficient for sysprompt
     fn input_schema(&self) -> serde_json::Value;
     fn output_schema(&self) -> serde_json::Value;

--- a/specs/009-tool-contract.md
+++ b/specs/009-tool-contract.md
@@ -17,7 +17,7 @@ pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
     fn short_description(&self) -> &str;
     fn description(&self) -> String;
-    fn llmtext(&self) -> String;
+    fn help(&self) -> String;
     fn system_prompt(&self) -> String;
     fn input_schema(&self) -> serde_json::Value;
     fn output_schema(&self) -> serde_json::Value;
@@ -38,7 +38,7 @@ pub trait Tool: Send + Sync {
 | `name()` | Tool identifier for registries | No |
 | `short_description()` | One-liner for tool listings | No |
 | `description()` | Full description with supported tools | Yes |
-| `llmtext()` | Man-page style docs for LLMs | Yes |
+| `help()` | Man-page style docs for LLMs | Yes |
 | `system_prompt()` | Structured prompt header | Yes |
 | `input_schema()` | JSON Schema for validation | No |
 | `output_schema()` | JSON Schema for output | No |
@@ -84,7 +84,7 @@ Input: {"commands": "<bash commands>"}
 Output: {stdout, stderr, exit_code}
 ```
 
-#### `llmtext()` (man-page format)
+#### `help()` (man-page format)
 ```
 BASH(1)                          User Commands                         BASH(1)
 
@@ -192,7 +192,7 @@ When configured, outputs automatically include:
 
 - `description()`: Appends custom builtin names to supported tools
 - `system_prompt()`: Adds `Home: /home/<username>` if username set
-- `llmtext()`: Adds CONFIGURATION section with user, host, limits, env vars
+- `help()`: Adds CONFIGURATION section with user, host, limits, env vars
 
 ## Design Rationale
 
@@ -208,15 +208,15 @@ Aligns with `bash -c "commands"` semantics. Clearer that it's inline commands, n
 
 Use `timeout` builtin in commands: `timeout 5 long_running_cmd`. Keeps the API simple.
 
-### Why man-page format for `llmtext()`?
+### Why man-page format for `help()`?
 
 - Universal format familiar to developers
 - Structured sections (NAME, SYNOPSIS, DESCRIPTION, EXAMPLES)
 - Works well with LLM context windows
 
-### Why `system_prompt()` separate from `llmtext()`?
+### Why `system_prompt()` separate from `help()`?
 
-- `llmtext()`: Full docs with examples, for tool discovery and help
+- `help()`: Full docs with examples, for tool discovery and help
 - `system_prompt()`: Minimal tokens, for embedding in system prompts
 
 ## Verification

--- a/specs/011-eval.md
+++ b/specs/011-eval.md
@@ -16,7 +16,7 @@ JSONL Dataset → Runner → Agent Loop (per task) → Scorer → Report
 
 ### Key Design Decisions
 
-1. **`Bash` directly, not `BashTool`** — `BashTool::execute()` creates a fresh interpreter per call (no VFS persistence). Agent loop needs persistent VFS across turns. `BashTool::default()` used only for `input_schema()`, `system_prompt()`, `llmtext()` introspection.
+1. **`Bash` directly, not `BashTool`** — `BashTool::execute()` creates a fresh interpreter per call (no VFS persistence). Agent loop needs persistent VFS across turns. `BashTool::default()` used only for `input_schema()`, `system_prompt()`, `help()` introspection.
 
 2. **One `Bash` per task** — Each dataset task gets a fresh `Bash` instance. VFS persists across all tool calls within that task. Scorer inspects final VFS state. Instance dropped after scoring.
 

--- a/specs/011-python-builtin.md
+++ b/specs/011-python-builtin.md
@@ -265,7 +265,7 @@ Relative paths are resolved against the shell's cwd. Path traversal via
 ### LLM Hints
 
 When Python is registered via `BashToolBuilder::python()`, the builtin contributes
-a hint to `llmtext()` and `system_prompt()` documenting its limitations:
+a hint to `help()` and `system_prompt()` documenting its limitations:
 
 > python/python3: Embedded Python (Monty). File I/O via pathlib.Path only (no open()). No HTTP/network. No classes. No third-party imports.
 


### PR DESCRIPTION
## Summary
- Add warning to `system_prompt()` and `help()` when `perl` and/or `python/python3` are not registered as builtins (e.g. `Warning: perl, python/python3 not available.`)
- Rename `llmtext()` → `help()` across trait, impl, Python bindings, eval agent, examples, specs, and docs

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 15 tool unit tests pass (3 new: default warning, suppressed, partial)
- [x] Doc-tests pass

https://claude.ai/code/session_01FiKE63cmVsdfro4UKs3ZSK