### PR TITLE
chore(specs): document file size reporting requirements

### DIFF
--- a/specs/003-vfs.md
+++ b/specs/003-vfs.md
@@ -109,6 +109,21 @@ pub struct DirEntry {
 }
 ```
 
+#### File Size Reporting
+
+The `size` field in `Metadata` must be set correctly for builtins like `ls -l`, `stat`, and `test -s` to work:
+
+| Entry Type | Expected `size` Value |
+|------------|----------------------|
+| Regular file | Actual content length in bytes |
+| Empty file | `0` |
+| Directory | `0` (not the size of contents) |
+| Symlink | `0` or length of target path |
+
+**Critical for custom implementations**: Both `stat()` and `read_dir()` must return consistent, accurate sizes. The `DirEntry.metadata.size` returned by `read_dir()` is used directly by `ls -l` without additional `stat()` calls.
+
+**Common pitfall**: When implementing `read_dir()`, ensure directory entries report size `0`, not the size of files within them. See `tests/custom_fs_tests.rs` for reference implementation.
+
 ### Implementations
 
 #### InMemoryFs (Implemented)
@@ -230,6 +245,15 @@ let mut bash = Bash::builder().fs(fs).build();
 ```
 
 See `examples/custom_backend.rs` for a complete working example.
+
+#### Size Reporting Checklist
+
+When implementing a custom filesystem, verify:
+
+1. **`stat()` returns correct size** - File size matches content length
+2. **`read_dir()` entries have correct sizes** - Each `DirEntry.metadata.size` is accurate
+3. **Directories always report size 0** - Never inherit child file sizes
+4. **Sizes are consistent** - `stat(path).size == read_dir(parent).find(name).metadata.size`
 
 #### Option 2: FileSystem Directly
 
@@ -392,4 +416,33 @@ async fn test_custom_filesystem_integration() {
     let result = bash.exec("echo test > /tmp/file && cat /tmp/file").await.unwrap();
     assert_eq!(result.stdout, "test\n");
 }
+
+#[tokio::test]
+async fn test_file_size_reporting() {
+    // File sizes must be correctly reported by stat() and read_dir()
+    let fs = InMemoryFs::new();
+    fs.write_file(Path::new("/tmp/file.txt"), b"hello").await.unwrap();
+    fs.mkdir(Path::new("/tmp/subdir"), false).await.unwrap();
+
+    // stat() returns correct sizes
+    let file_meta = fs.stat(Path::new("/tmp/file.txt")).await.unwrap();
+    assert_eq!(file_meta.size, 5); // "hello" = 5 bytes
+
+    let dir_meta = fs.stat(Path::new("/tmp/subdir")).await.unwrap();
+    assert_eq!(dir_meta.size, 0); // Directories always 0
+
+    // read_dir() entries have correct sizes
+    let entries = fs.read_dir(Path::new("/tmp")).await.unwrap();
+    let file_entry = entries.iter().find(|e| e.name == "file.txt").unwrap();
+    assert_eq!(file_entry.metadata.size, 5);
+
+    let dir_entry = entries.iter().find(|e| e.name == "subdir").unwrap();
+    assert_eq!(dir_entry.metadata.size, 0);
+}
 ```
+
+### Test Coverage
+
+File size reporting is verified by:
+- `crates/bashkit/src/builtins/ls.rs` - `test_ls_long_format_*` tests
+- `crates/bashkit/tests/custom_fs_tests.rs` - `test_custom_fs_*_size*` tests


### PR DESCRIPTION
## Summary
- Add file size reporting documentation to `specs/003-vfs.md`
- Document expected `Metadata.size` values for files, directories, symlinks
- Add Size Reporting Checklist for custom filesystem implementers
- Add test examples and test coverage references

Supersedes #151 (rebased, code changes already merged in #150).

## Test plan
- [x] No code changes — spec documentation only
- [x] Existing tests already cover the documented behavior