### PR TITLE
refactor(test): drop 'new_' prefix from curl/wget flag test modules

### DIFF
--- a/crates/bashkit/tests/network_security_tests.rs
+++ b/crates/bashkit/tests/network_security_tests.rs
@@ -415,10 +415,10 @@ mod allowlist_unit {
 }
 
 // =============================================================================
-// 8. NEW FLAG TESTS
+// 8. EXTENDED FLAG TESTS
 // =============================================================================
 
-mod new_curl_flags {
+mod curl_flags {
     use super::*;
 
     /// Test curl --compressed flag parsing
@@ -674,7 +674,7 @@ mod new_curl_flags {
     }
 }
 
-mod new_wget_flags {
+mod wget_flags {
     use super::*;
 
     /// Test wget --header flag parsing


### PR DESCRIPTION
## Summary
- Renamed `new_curl_flags` → `curl_flags` and `new_wget_flags` → `wget_flags` test modules
- Updated section header from "NEW FLAG TESTS" to "EXTENDED FLAG TESTS"
- The "new_" prefix was a leftover from when these tests were first added; no longer meaningful

## Test plan
- [x] All 53 network security tests pass (`cargo test --test network_security_tests --features http_client`)

https://claude.ai/code/session_01GJqgXnAnZitNj6FP1XzF17