### PR TITLE
fix(python): enable PyO3 generate-import-lib for Windows wheels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,5 +83,5 @@ tracing = "0.1"
 serial_test = "3"
 
 # Python bindings
-pyo3 = { version = "0.24", features = ["extension-module"] }
+pyo3 = { version = "0.24", features = ["extension-module", "generate-import-lib"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -958,6 +958,10 @@ criteria = "safe-to-deploy"
 version = "0.24.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.python3-dll-a]]
+version = "0.2.14"
+criteria = "safe-to-deploy"
+
 [[exemptions.quick-error]]
 version = "1.2.3"
 criteria = "safe-to-run"


### PR DESCRIPTION
## Summary

- Enable PyO3 `generate-import-lib` feature in workspace Cargo.toml to fix Windows wheel builds

The `publish-python.yml` workflow failed on Windows because maturin couldn't build wheels for Python versions not installed on the runner (3.9, 3.10, 3.11, 3.13). The `generate-import-lib` feature lets PyO3 generate the import library from bundled sysconfig data, removing the need for each Python interpreter to be installed.

## Test plan

- [ ] CI passes
- [ ] After merge, re-trigger `publish-python.yml` — all 7 platforms should build successfully