### PR TITLE
docs(examples): use bashkit from PyPI instead of local build

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,8 @@
 # Bashkit Examples
 
+All examples use [PEP 723](https://peps.python.org/pep-0723/) inline script metadata.
+`uv run` resolves dependencies automatically — bashkit installs from PyPI as a pre-built wheel (no Rust toolchain needed).
+
 ## treasure_hunt_agent.py
 
 LangChain agent with Bashkit sandbox.

--- a/examples/deepagent_coding_agent.py
+++ b/examples/deepagent_coding_agent.py
@@ -2,17 +2,18 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "deepagents>=0.3.11",
+#     "bashkit[deepagents]>=0.1.4",
 #     "langchain-anthropic>=0.3",
 # ]
 # ///
-# Note: Install bashkit first: cd crates/bashkit-python && maturin develop
 """
 Deep Agent with Bashkit Virtual Filesystem
 
 Run:
     export ANTHROPIC_API_KEY=your_key
     uv run examples/deepagent_coding_agent.py
+
+uv automatically installs bashkit from PyPI (pre-built wheels, no Rust needed).
 """
 
 import asyncio
@@ -21,11 +22,7 @@ import sys
 
 from deepagents import create_deep_agent
 
-try:
-    from bashkit.deepagents import BashkitBackend
-except ImportError:
-    print("bashkit not found. Install: cd crates/bashkit-python && maturin develop")
-    sys.exit(1)
+from bashkit.deepagents import BashkitBackend
 
 
 SYSTEM_PROMPT = """You are a coding assistant with a sandboxed bash environment.

--- a/examples/treasure_hunt_agent.py
+++ b/examples/treasure_hunt_agent.py
@@ -2,11 +2,11 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
+#     "bashkit[langchain]>=0.1.4",
 #     "langchain>=1.0",
 #     "langchain-anthropic>=0.3",
 # ]
 # ///
-# Note: Install bashkit first: cd crates/bashkit-python && maturin develop
 """
 Treasure Hunt Agent - A fun demonstration of LangChain + Bashkit
 
@@ -24,6 +24,8 @@ Demonstrates multiple agentic loop iterations as the agent:
 Run with:
     export ANTHROPIC_API_KEY=your_key
     uv run examples/treasure_hunt_agent.py
+
+uv automatically installs bashkit from PyPI (pre-built wheels, no Rust needed).
 """
 
 import asyncio
@@ -32,12 +34,7 @@ import sys
 
 from langchain.agents import create_agent
 
-# Try to import from installed package
-try:
-    from bashkit.langchain import create_bash_tool
-except ImportError:
-    print("bashkit not found. Install with: cd crates/bashkit-python && maturin develop")
-    sys.exit(1)
+from bashkit.langchain import create_bash_tool
 
 
 # The treasure hunt setup script - creates clues in the virtual filesystem


### PR DESCRIPTION
## Summary
- Examples now declare `bashkit` as a PEP 723 inline dependency so `uv run` installs pre-built wheels from PyPI automatically
- Removed `maturin develop` prerequisite and try/except ImportError guards
- Updated README noting zero-setup experience (no Rust toolchain needed)

## Test plan
- [x] `uv run examples/treasure_hunt_agent.py` — confirmed uv downloads 2.6 MiB pre-built wheel, no compilation
- [x] `uv run examples/deepagent_coding_agent.py` — same, 53 packages installed in ~1s