### PR TITLE
fix(builtins): handle escape sequences in AWK -F field separator

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -2104,6 +2104,35 @@ impl AwkInterpreter {
     }
 }
 
+impl Awk {
+    /// Process C-style escape sequences in a string (e.g., \t → tab, \n → newline)
+    fn process_escape_sequences(s: &str) -> String {
+        let mut result = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                match chars.next() {
+                    Some('t') => result.push('\t'),
+                    Some('n') => result.push('\n'),
+                    Some('r') => result.push('\r'),
+                    Some('\\') => result.push('\\'),
+                    Some('a') => result.push('\x07'),
+                    Some('b') => result.push('\x08'),
+                    Some('f') => result.push('\x0C'),
+                    Some(other) => {
+                        result.push('\\');
+                        result.push(other);
+                    }
+                    None => result.push('\\'),
+                }
+            } else {
+                result.push(c);
+            }
+        }
+        result
+    }
+}
+
 #[async_trait]
 impl Builtin for Awk {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -2174,7 +2203,7 @@ impl Builtin for Awk {
         let program = parser.parse()?;
 
         let mut interp = AwkInterpreter::new();
-        interp.state.fs = field_sep;
+        interp.state.fs = Self::process_escape_sequences(&field_sep);
 
         // Set pre-assigned variables (-v)
         for (name, value) in &pre_vars {

--- a/crates/bashkit/tests/spec_cases/awk/awk.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/awk.test.sh
@@ -292,7 +292,6 @@ b
 ### end
 
 ### awk_field_sep_tab
-### skip: -F tab delimiter not working
 printf 'a\tb\tc\n' | awk -F'\t' '{print $2}'
 ### expect
 b


### PR DESCRIPTION
## Summary
- Process C-style escape sequences (`\t`, `\n`, `\r`, etc.) in the `-F` flag so `awk -F'\t'` correctly splits on tab characters

## Test plan
- [x] AWK spec tests pass, `awk_field_sep_tab` unskipped and passing
- [x] `cargo check` clean