### PR TITLE
fix(parser): support output redirection on compound commands

### DIFF
--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -28,8 +28,8 @@ pub enum Command {
     /// A command list (e.g., `a && b || c`)
     List(CommandList),
 
-    /// A compound command (if, for, while, case, etc.)
-    Compound(CompoundCommand),
+    /// A compound command (if, for, while, case, etc.) with optional redirections
+    Compound(CompoundCommand, Vec<Redirect>),
 
     /// A function definition
     Function(FunctionDef),

--- a/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
@@ -216,6 +216,13 @@ three
 hello
 ### end
 
+### subshell_redirect
+# Subshell with output redirection
+(echo redirected) > /tmp/subshell_out.txt && cat /tmp/subshell_out.txt
+### expect
+redirected
+### end
+
 ### brace_group
 # Brace group
 { echo hello; }


### PR DESCRIPTION
## Summary
- Extend `Command::Compound` AST node to carry `Vec<Redirect>`
- Parse trailing redirections (`>`, `>>`, `2>`, `&>`, etc.) after `)`, `}`, `fi`, `done`
- Apply redirections when executing compound commands
- Enables `(echo foo) > file`, `{ cmd; } 2>/dev/null`, `if ...; fi > out`

## Test plan
- [x] All bash spec tests pass, new `subshell_redirect` test added
- [x] `cargo check` clean