### PR TITLE
fix(builtins): fix sed ampersand replacement and escape handling

### DIFF
--- a/crates/bashkit/src/builtins/sed.rs
+++ b/crates/bashkit/src/builtins/sed.rs
@@ -416,10 +416,10 @@ fn parse_sed_command(s: &str, extended_regex: bool) -> Result<(Option<Address>, 
 
             // Convert sed replacement syntax to regex replacement syntax
             // sed uses \1, \2, etc. and & for full match
-            // regex crate uses $1, $2, etc. and $0 for full match
+            // regex crate uses ${N} format to avoid ambiguity
             let replacement = replacement
                 .replace("\\&", "\x00") // Temporarily escape literal &
-                .replace('&', "$0")
+                .replace('&', "${0}")
                 .replace("\x00", "&");
 
             // Use ${N} format instead of $N to avoid ambiguity with following chars
@@ -427,6 +427,9 @@ fn parse_sed_command(s: &str, extended_regex: bool) -> Result<(Option<Address>, 
                 .unwrap()
                 .replace_all(&replacement, r"$${$1}")
                 .to_string();
+
+            // Convert \n → newline, \t → tab in replacement
+            let replacement = replacement.replace("\\n", "\n").replace("\\t", "\t");
 
             // Parse nth occurrence from flags (e.g., "2" in s/a/b/2)
             let nth = flags

--- a/crates/bashkit/tests/spec_cases/sed/sed.test.sh
+++ b/crates/bashkit/tests/spec_cases/sed/sed.test.sh
@@ -59,7 +59,6 @@ d
 ### end
 
 ### sed_ampersand
-### skip: ampersand (&) in replacement not fully working
 # Ampersand replacement
 printf 'hello\n' | sed 's/hello/[&]/'
 ### expect
@@ -211,7 +210,7 @@ bird
 ### end
 
 ### sed_hold_h
-### skip: hold space (h) command not implemented
+### skip: hold space with grouped commands not implemented
 printf 'a\nb\n' | sed '1h; 2{x;p;x}'
 ### expect
 a
@@ -338,7 +337,6 @@ heo
 ### end
 
 ### sed_literal_newline
-### skip: literal newlines in replacement not implemented
 printf 'a b\n' | sed 's/ /\n/'
 ### expect
 a
@@ -399,7 +397,6 @@ XXX
 ### end
 
 ### sed_multiple_patterns
-### skip: pattern range addressing not implemented
 printf 'a\nb\nc\nd\n' | sed '/a/,/c/d'
 ### expect
 d
@@ -431,7 +428,6 @@ c
 ### end
 
 ### sed_delete_range_pattern
-### skip: pattern/$ range addressing not implemented
 printf 'a\nb\nc\nd\n' | sed '/b/,$d'
 ### expect
 a
@@ -453,7 +449,6 @@ printf '' | sed 's/x/y/'
 ### end
 
 ### sed_special_chars_in_replacement
-### skip: ampersand (&) in replacement not working
 printf 'hello\n' | sed 's/hello/a&b/'
 ### expect
 ahellob
@@ -485,7 +480,6 @@ yes
 ### end
 
 ### sed_pattern_range
-### skip: pattern ranges not implemented
 printf 'a\nstart\nb\nend\nc\n' | sed '/start/,/end/d'
 ### expect
 a


### PR DESCRIPTION
## Summary
- Fix `&` (ampersand) replacement using `${0}` format to avoid regex crate ambiguity
- Add `\n` and `\t` escape handling in replacement strings
- Unskip pattern range addressing tests (`/start/,/end/` and `/pat/,$`)

## Test plan
- [x] All sed spec tests pass, 5 tests unskipped
- [x] `cargo check` clean