### PR TITLE
chore(deps): update pyo3 requirement from 0.24 to 0.24.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,5 +83,5 @@ tracing = "0.1"
 serial_test = "3"
 
 # Python bindings
-pyo3 = { version = "0.24", features = ["extension-module", "generate-import-lib"] }
+pyo3 = { version = "0.24.2", features = ["extension-module", "generate-import-lib"] }
 pyo3-async-runtimes = { version = "0.24", features = ["tokio-runtime"] }


### PR DESCRIPTION
## Summary
- Updates the minimum pyo3 version requirement from `0.24` to `0.24.2` in workspace Cargo.toml
- Ensures the latest patch release with bug fixes is used as the minimum floor
- pyo3-async-runtimes stays at `0.24` (only 0.24.0 exists in the 0.24.x series)

## Test plan
- [x] `cargo build --all-features` passes
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --check` passes