### PR TITLE
fix(ci): strip git-only monty dep before crates.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,19 @@ jobs:
             echo "Manual dispatch - skipping tag verification"
           fi
 
+      - name: Strip git-only dependencies for publishing
+        # monty is a git dep (not yet on crates.io) — remove before publish
+        run: |
+          TOML=crates/bashkit/Cargo.toml
+          # Remove monty dependency line
+          sed -i '/^monty = .*/d' "$TOML"
+          # Remove python feature that references monty
+          sed -i '/^python = \["dep:monty"\]/d' "$TOML"
+          # Remove python_scripts example block (requires python feature)
+          sed -i '/^\[\[example\]\]/{N;N;/python_scripts/d}' "$TOML"
+          echo "--- Cargo.toml after stripping ---"
+          cat "$TOML"
+
       - name: Publish bashkit to crates.io
         run: cargo publish -p bashkit
         env:


### PR DESCRIPTION
## Summary

- v0.1.5 publish to crates.io failed because `monty ^0.0.6` doesn't exist on the registry (only `0.0.0`)
- `cargo publish` validates all deps (including optional) against crates.io, so the python feature blocks publishing
- Fix: strip monty dependency, python feature, and python_scripts example from Cargo.toml before `cargo publish`
- The python feature was already documented as unavailable from registry (line 81 of crates/bashkit/Cargo.toml)

## Test plan

- [ ] Re-run the Publish workflow via `workflow_dispatch` after merge
- [ ] Verify `cargo publish -p bashkit` succeeds with stripped Cargo.toml
- [ ] Verify `bashkit-cli` publishes successfully (no monty dependency)