### PR TITLE
fix(ci): add --allow-dirty for cargo publish after stripping monty

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           cat "$TOML"
 
       - name: Publish bashkit to crates.io
-        run: cargo publish -p bashkit
+        run: cargo publish -p bashkit --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The strip step from #208 modifies Cargo.toml without committing, so `cargo publish` rejects the dirty tree
- Add `--allow-dirty` flag — the modification is intentional (removing git-only monty dep)

## Test plan

- [ ] Re-run Publish workflow after merge