### PR TITLE
feat(python): add PydanticAI integration and example

### DIFF
--- a/crates/bashkit-python/bashkit/__init__.py
+++ b/crates/bashkit-python/bashkit/__init__.py
@@ -17,6 +17,10 @@ For LangChain integration:
 For Deep Agents integration:
     >>> from bashkit.deepagents import create_bash_middleware
     >>> middleware = create_bash_middleware()
+
+For PydanticAI integration:
+    >>> from bashkit.pydantic_ai import create_bash_tool
+    >>> tool = create_bash_tool()
 """
 
 from bashkit._bashkit import (

--- a/crates/bashkit-python/bashkit/pydantic_ai.py
+++ b/crates/bashkit-python/bashkit/pydantic_ai.py
@@ -1,0 +1,89 @@
+"""
+PydanticAI integration for Bashkit.
+
+Provides a Tool that wraps BashTool for use with PydanticAI agents.
+
+Example:
+    >>> from bashkit.pydantic_ai import create_bash_tool
+    >>> from pydantic_ai import Agent
+    >>>
+    >>> tool = create_bash_tool()
+    >>> agent = Agent('anthropic:claude-sonnet-4-20250514', tools=[tool])
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:
+    from pydantic_ai import Tool
+
+    PYDANTIC_AI_AVAILABLE = True
+except ImportError:
+    PYDANTIC_AI_AVAILABLE = False
+
+from bashkit import BashTool as NativeBashTool
+
+
+def create_bash_tool(
+    username: Optional[str] = None,
+    hostname: Optional[str] = None,
+    max_commands: Optional[int] = None,
+    max_loop_iterations: Optional[int] = None,
+) -> "Tool":
+    """Create a PydanticAI Tool wrapping Bashkit.
+
+    Args:
+        username: Custom username for sandbox
+        hostname: Custom hostname for sandbox
+        max_commands: Max commands to execute
+        max_loop_iterations: Max loop iterations
+
+    Returns:
+        Tool for use with ``Agent(tools=[...])``
+
+    Raises:
+        ImportError: If pydantic-ai is not installed
+
+    Example:
+        >>> from bashkit.pydantic_ai import create_bash_tool
+        >>> tool = create_bash_tool()
+        >>> from pydantic_ai import Agent
+        >>> agent = Agent('anthropic:claude-sonnet-4-20250514', tools=[tool])
+    """
+    if not PYDANTIC_AI_AVAILABLE:
+        raise ImportError(
+            "pydantic-ai is required for PydanticAI integration. "
+            "Install with: pip install 'bashkit[pydantic-ai]'"
+        )
+
+    native = NativeBashTool(
+        username=username,
+        hostname=hostname,
+        max_commands=max_commands,
+        max_loop_iterations=max_loop_iterations,
+    )
+
+    async def bash(commands: str) -> str:
+        """Execute bash commands in a sandboxed virtual environment.
+
+        Runs commands like ``bash -c "commands"``. All file operations happen
+        in a virtual filesystem — nothing touches the real host.
+
+        Args:
+            commands: Bash commands to execute
+        """
+        result = await native.execute(commands)
+
+        output = result.stdout
+        if result.stderr:
+            output += f"\nSTDERR: {result.stderr}"
+        if result.exit_code != 0:
+            output += f"\n[Exit code: {result.exit_code}]"
+
+        return output if output else "[No output]"
+
+    return Tool(bash, takes_ctx=False, name="bash")
+
+
+__all__ = ["create_bash_tool"]

--- a/crates/bashkit-python/pyproject.toml
+++ b/crates/bashkit-python/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.3", "langchain-anthropic>=0.3"]
 deepagents = ["deepagents>=0.3.11", "langchain-anthropic>=0.3"]
+pydantic-ai = ["pydantic-ai>=1.0"]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23"]
 
 [tool.maturin]

--- a/examples/pydantic_ai_bash_agent.py
+++ b/examples/pydantic_ai_bash_agent.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "bashkit[pydantic-ai]>=0.1.4",
+# ]
+# ///
+"""
+PydanticAI Agent with Bashkit Virtual Filesystem
+
+A coding agent that writes and tests a bash script entirely
+inside Bashkit's sandboxed virtual filesystem.
+
+Run:
+    export ANTHROPIC_API_KEY=your_key
+    uv run examples/pydantic_ai_bash_agent.py
+
+uv automatically installs bashkit from PyPI (pre-built wheels, no Rust needed).
+"""
+
+import asyncio
+import os
+import sys
+
+from pydantic_ai import Agent
+
+from bashkit.pydantic_ai import create_bash_tool
+
+
+SYSTEM_PROMPT = """\
+You are a coding assistant with a sandboxed bash environment.
+
+You can run any bash command: echo, cat, grep, sed, awk, mkdir, etc.
+All commands execute in a virtual filesystem — nothing touches the real host.
+
+When asked to build something, create the files, then verify your work."""
+
+
+async def main():
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("Set ANTHROPIC_API_KEY")
+        sys.exit(1)
+
+    print("=" * 60)
+    print("  PydanticAI + Bashkit")
+    print("=" * 60)
+
+    bash_tool = create_bash_tool(username="agent", hostname="sandbox")
+
+    agent = Agent(
+        "anthropic:claude-sonnet-4-20250514",
+        system_prompt=SYSTEM_PROMPT,
+        tools=[bash_tool],
+    )
+
+    task = (
+        "Create a FizzBuzz bash script:\n"
+        "1. mkdir -p /home/agent/project\n"
+        "2. Write a bash script /home/agent/project/fizzbuzz.sh that prints "
+        "FizzBuzz for numbers 1 to 20 using a for loop\n"
+        "3. Show the file with cat\n"
+        "4. Run it with: source /home/agent/project/fizzbuzz.sh\n"
+    )
+
+    print(f"\nTask: {task}")
+    print("-" * 60)
+
+    result = await agent.run(task)
+    print("\n" + "-" * 60)
+    print("Agent output:")
+    print(result.data)
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/specs/013-python-package.md
+++ b/specs/013-python-package.md
@@ -17,7 +17,8 @@ crates/bashkit-python/
 │   ├── _bashkit.pyi         # Type stubs (PEP 561)
 │   ├── py.typed             # Marker for typed package
 │   ├── langchain.py         # LangChain integration
-│   └── deepagents.py        # Deep Agents integration
+│   ├── deepagents.py        # Deep Agents integration
+│   └── pydantic_ai.py       # PydanticAI integration
 ```
 
 ## Build System
@@ -146,6 +147,7 @@ Returns dict with `name`, `description`, `args_schema` for LangChain integration
 ```
 pip install bashkit[langchain]     # + langchain-core, langchain-anthropic
 pip install bashkit[deepagents]    # + deepagents, langchain-anthropic
+pip install bashkit[pydantic-ai]   # + pydantic-ai
 pip install bashkit[dev]           # + pytest, pytest-asyncio
 ```
 


### PR DESCRIPTION
## Summary
- Add `bashkit.pydantic_ai` module with `create_bash_tool()` wrapping `BashTool` as a PydanticAI `Tool`
- Add `examples/pydantic_ai_bash_agent.py` demonstrating a FizzBuzz coding agent
- Add `pydantic-ai` optional dependency group (`pip install bashkit[pydantic-ai]`)

## Test plan
- [x] Built Python bindings and verified `create_bash_tool()` returns a valid PydanticAI `Tool`
- [x] Ran `examples/pydantic_ai_bash_agent.py` end-to-end with Anthropic API
- [x] `cargo fmt --check` passes (no Rust changes)