### PR TITLE
fix(interpreter): apply brace/glob expansion in for-loop word list

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/arrays.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arrays.test.sh
@@ -142,3 +142,15 @@ printf "(%s)\n" ${arr[@]}
 (y)
 (z)
 ### end
+
+### array_for_loop_with_brace
+# Array and brace expansion mixed in for-loop word list
+arr=(a b)
+for x in "${arr[@]}" {1..3}; do echo $x; done
+### expect
+a
+b
+1
+2
+3
+### end

--- a/crates/bashkit/tests/spec_cases/bash/brace-expansion.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/brace-expansion.test.sh
@@ -75,3 +75,86 @@ echo {5..1}
 ### expect
 5 4 3 2 1
 ### end
+
+### brace_in_for_numeric_range
+# Numeric range brace expansion in for-loop word list
+for i in {1..5}; do echo $i; done
+### expect
+1
+2
+3
+4
+5
+### end
+
+### brace_in_for_comma
+# Comma brace expansion in for-loop
+for x in {a,b,c}; do echo $x; done
+### expect
+a
+b
+c
+### end
+
+### brace_in_for_with_prefix
+# Brace expansion with prefix in for-loop
+for f in file{1..3}.txt; do echo $f; done
+### expect
+file1.txt
+file2.txt
+file3.txt
+### end
+
+### brace_in_for_nested
+# Nested brace expansion in for-loop
+for x in {a,b}{1,2}; do echo $x; done
+### expect
+a1
+a2
+b1
+b2
+### end
+
+### brace_in_for_reverse_range
+# Reverse range in for-loop
+for i in {3..1}; do echo $i; done
+### expect
+3
+2
+1
+### end
+
+### brace_in_for_mixed_words
+# Mix of plain words and brace expansion in for-loop
+for x in hello {1..3} world; do echo $x; done
+### expect
+hello
+1
+2
+3
+world
+### end
+
+### brace_in_for_alpha_range
+# Alpha range in for-loop
+for c in {a..d}; do echo $c; done
+### expect
+a
+b
+c
+d
+### end
+
+### brace_in_for_quoted_skip
+# Quoted braces should NOT expand in for-loop
+for x in "{1..3}"; do echo "$x"; done
+### expect
+{1..3}
+### end
+
+### brace_in_for_single_no_expand
+# Single item braces don't expand in for-loop
+for x in {only}; do echo $x; done
+### expect
+{only}
+### end

--- a/crates/bashkit/tests/spec_cases/bash/globs.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/globs.test.sh
@@ -46,3 +46,20 @@ echo file.{txt,log}
 ### expect
 file.txt file.log
 ### end
+
+### glob_in_for_loop
+### bash_diff: Bashkit VFS has files, real bash CI filesystem does not - glob expands differently
+# Glob expansion in for-loop word list
+echo a > /g1.txt; echo b > /g2.txt
+for f in /g*.txt; do echo $f; done
+### expect
+/g1.txt
+/g2.txt
+### end
+
+### glob_in_for_no_match
+# Glob with no matches in for-loop keeps literal pattern
+for f in /nonexistent_dir/*.xyz; do echo $f; done
+### expect
+/nonexistent_dir/*.xyz
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -124,10 +124,10 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | File | Cases | Notes |
 |------|-------|-------|
 | arithmetic.test.sh | 29 | includes logical operators |
-| arrays.test.sh | 19 | includes indices, `${arr[@]}` / `${arr[*]}` expansion |
+| arrays.test.sh | 20 | includes indices, `${arr[@]}` / `${arr[*]}` expansion |
 | background.test.sh | 4 | |
 | bash-command.test.sh | 34 | bash/sh re-invocation |
-| brace-expansion.test.sh | 12 | {a,b,c}, {1..5} |
+| brace-expansion.test.sh | 21 | {a,b,c}, {1..5}, for-loop brace expansion |
 | column.test.sh | 10 | column alignment |
 | command-not-found.test.sh | 17 | unknown command handling |
 | command-subst.test.sh | 14 | 2 skipped |
@@ -140,7 +140,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | fileops.test.sh | 21 | |
 | find.test.sh | 10 | file search |
 | functions.test.sh | 14 | |
-| globs.test.sh | 10 | 1 skipped |
+| globs.test.sh | 12 | for-loop glob expansion, 1 skipped |
 | headtail.test.sh | 14 | |
 | herestring.test.sh | 8 | 1 skipped |
 | hextools.test.sh | 5 | od/xxd/hexdump (3 skipped) |


### PR DESCRIPTION
## Summary
- `execute_for` now applies `expand_braces` and `expand_glob` to each word in the for-loop word list, matching `execute_dispatched_command` behavior
- Quoted words correctly skip brace/glob expansion
- Fixes `for i in {1..5}` iterating once with literal `{1..5}` instead of expanding to `1 2 3 4 5`

## Test plan
- [x] 9 new brace-expansion-in-for-loop tests (numeric range, comma, prefix, nested, reverse, alpha, mixed words, quoted skip, single-no-expand)
- [x] 2 new glob-in-for-loop tests (match + no-match keeps literal)
- [x] 1 new array+brace mixed for-loop test
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — all 14 test suites pass (594 spec cases, 99.8%+ pass rate)

Closes #204