### PR TITLE
fix(builtins): resolve 10 eval-surfaced interpreter bugs

### DIFF
--- a/crates/bashkit/tests/spec_cases/awk/eval-bugs.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/eval-bugs.test.sh
@@ -1,22 +1,18 @@
 ### awk_field_multiply_accumulate
-### skip: eval-surfaced bug — awk field multiplication with += accumulation returns wrong result
 # Bug: awk -F',' '{total += $2 * $3} END {print total}' computes wrong sum
 # Expected: 10*5 + 25*3 + 7*12 + 15*8 = 50+75+84+120 = 329
 # Affected eval tasks: text_csv_revenue (fails 2/4 models)
-# Root cause: compound expression $2 * $3 inside += accumulator evaluates incorrectly;
-#   simple += with single field works (see awk_variables test), but multiplication
-#   of two fields before accumulation produces wrong intermediate values
+# Root cause: compound expression $2 * $3 inside += accumulator evaluated incorrectly
 printf 'widget,10,5\ngadget,25,3\ndoohickey,7,12\nsprocket,15,8\n' | awk -F',' '{total += $2 * $3} END {print total}'
 ### expect
 329
 ### end
 
 ### awk_match_capture_array
-### skip: eval-surfaced bug — awk match() with 3rd argument (capture array) unsupported
 # Bug: GNU awk match(string, /regex/, array) stores captures in array — bashkit errors
 # Affected eval tasks: complex_release_notes, complex_markdown_toc (fails multiple models)
-# Root cause: match() builtin only accepts 2 args (string, regex); 3rd arg for
-#   capture group extraction is a gawk extension that isn't implemented
+# Root cause: match() builtin only accepted 2 args; 3rd arg for capture group
+#   extraction (gawk extension) is now implemented
 printf 'feat(auth): add OAuth2\n' | awk 'match($0, /^([a-z]+)\(([^)]+)\): (.*)/, arr) {print arr[1], arr[2], arr[3]}'
 ### expect
 feat auth add OAuth2

--- a/crates/bashkit/tests/spec_cases/bash/eval-bugs.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/eval-bugs.test.sh
@@ -1,16 +1,13 @@
 ### tr_class_upper_from_pipe
-### skip: eval-surfaced bug — tr '[:lower:]' '[:upper:]' produces empty output from pipe input
 # Bug: echo "hello world" | tr '[:lower:]' '[:upper:]' should produce HELLO WORLD
 # Affected eval tasks: script_function_lib (fails all 4 models)
-# Root cause: tr POSIX character class translation ([:lower:], [:upper:]) not implemented;
-#   pipe input compounds the issue producing empty output instead of passthrough
+# Root cause: tr POSIX character class translation ([:lower:], [:upper:]) was not implemented
 echo "hello world" | tr '[:lower:]' '[:upper:]'
 ### expect
 HELLO WORLD
 ### end
 
 ### while_read_pipe_vars
-### skip: eval-surfaced bug — variables empty inside while-read loop fed by pipe
 # Bug: printf "a\nb\n" | while read line; do echo "$line"; done — $line is empty
 # Affected eval tasks: complex_markdown_toc (fails all 4 models)
 # Root cause: pipe creates subshell for while-read; variable propagation from
@@ -25,10 +22,9 @@ got: line3
 ### end
 
 ### tail_plus_n_offset
-### skip: eval-surfaced bug — tail -n +N returns wrong content (only last lines instead of from line N)
 # Bug: tail -n +2 should skip first line and return all remaining lines
 # Affected eval tasks: complex_markdown_toc, text_csv_revenue
-# Root cause: tail interprets +N as "last N" instead of "starting from line N"
+# Root cause: tail interpreted +N as "last N" instead of "starting from line N"
 printf 'header\nline1\nline2\nline3\n' | tail -n +2
 ### expect
 line1
@@ -37,11 +33,10 @@ line3
 ### end
 
 ### script_chmod_exec_by_path
-### skip: eval-surfaced bug — executing script via chmod +x then /path/script.sh fails
 # Bug: after chmod +x, running script by absolute path gives "command not found"
 # Workaround: bash /path/script.sh works, but direct execution doesn't
 # Affected eval tasks: complex_release_notes
-# Root cause: VFS executable lookup doesn't check file's execute permission bit
+# Root cause: VFS executable lookup didn't check file's execute permission bit
 echo '#!/bin/bash
 echo "script ran"' > /tmp/test_exec.sh
 chmod +x /tmp/test_exec.sh

--- a/crates/bashkit/tests/spec_cases/grep/eval-bugs.test.sh
+++ b/crates/bashkit/tests/spec_cases/grep/eval-bugs.test.sh
@@ -1,17 +1,14 @@
 ### grep_bre_literal_paren
-### skip: eval-surfaced bug — grep treats ( as ERE group metachar in default BRE mode
 # Bug: grep 'feat(' should match literal parenthesis — in BRE, ( is literal
-# Only \( starts a group in BRE. Bashkit incorrectly treats ( as a group metachar.
+# Only \( starts a group in BRE. Bashkit incorrectly treated ( as a group metachar.
 # Affected eval tasks: complex_release_notes (fails 3/4 models)
-# Root cause: regex engine doesn't distinguish BRE vs ERE metachar rules;
-#   BRE: ( is literal, \( is group; ERE (grep -E): ( is group, \( is literal
+# Root cause: regex engine didn't distinguish BRE vs ERE metachar rules
 printf 'feat(auth): add OAuth2\nfix(api): handle null\nchore: update\n' | grep 'feat('
 ### expect
 feat(auth): add OAuth2
 ### end
 
 ### grep_bre_literal_paren_pattern
-### skip: eval-surfaced bug — grep BRE pattern with literal parens and content extraction
 # Generalized: filtering conventional commit lines by type prefix with parens
 printf 'feat(auth): OAuth2\nfeat(ui): dark mode\nfix(api): null body\n' | grep '^feat('
 ### expect

--- a/crates/bashkit/tests/spec_cases/sed/eval-bugs.test.sh
+++ b/crates/bashkit/tests/spec_cases/sed/eval-bugs.test.sh
@@ -1,18 +1,15 @@
 ### sed_capture_group_complex_bre
-### skip: eval-surfaced bug — sed BRE capture groups with complex pattern produce no substitution
 # Bug: sed 's/^[a-z]*(\([^)]*\)): \(.*\)/- \1: \2/' silently produces no change
 # Simple capture group swap works (see sed_regex_group), but multi-group extraction
-#   from complex patterns with literal chars between groups fails
+#   from complex patterns with literal chars between groups failed
 # Affected eval tasks: complex_release_notes (fails 3/4 models)
-# Root cause: capture group matching interacts badly with literal ( ) in BRE patterns;
-#   the ( before \([^)]*\) confuses the parser since ( is literal in BRE
+# Root cause: BRE-to-ERE conversion didn't escape literal ( ) in BRE patterns
 printf 'feat(auth): add OAuth2\n' | sed 's/^[a-z]*(\([^)]*\)): \(.*\)/- \1: \2/'
 ### expect
 - auth: add OAuth2
 ### end
 
 ### sed_ere_capture_group_extract
-### skip: eval-surfaced bug — sed -E capture group extraction from structured text fails
 # Same class of bug with ERE syntax: ( ) are group metachars in -E mode
 # Pattern: extract scope and description from conventional commit format
 # Affected eval tasks: complex_release_notes

--- a/crates/bashkit/tests/spec_tests.rs
+++ b/crates/bashkit/tests/spec_tests.rs
@@ -8,7 +8,7 @@
 //! - `### skip: reason` - Skip test entirely (not run in any test)
 //! - `### bash_diff: reason` - Known difference from real bash (runs in spec tests, excluded from comparison)
 //!
-//! ## Skipped Tests TODO (76 total)
+//! ## Skipped Tests TODO (66 total)
 //!
 //! The following tests are skipped and need fixes:
 //!


### PR DESCRIPTION
## Summary

- Fix 7 bugs across tail, tr, grep, sed, awk, and the interpreter, unignoring all 10 eval-surfaced test cases from #214
- Add BRE (Basic Regular Expression) support to grep and sed — literal `(` `)` are now correctly distinguished from group metacharacters `\(` `\)`
- Implement VFS script execution by absolute path after `chmod +x`

## Changes

| Bug | Fix | Files |
|-----|-----|-------|
| `tail -n +N` returns wrong lines | Parse `+N` prefix, add `take_from_line()` | `headtail.rs` |
| `tr '[:lower:]' '[:upper:]'` garbled | Implement POSIX character class expansion | `cuttr.rs` |
| `grep 'feat('` crashes (unclosed group) | Add `bre_to_ere()` conversion in default mode | `grep.rs` |
| `sed` BRE capture groups fail with literal `()` | Add `bre_to_ere()` conversion for BRE patterns | `sed.rs` |
| `awk match($0, /re/, arr)` produces no output | Support 3rd-arg capture array (gawk extension) | `awk.rs` |
| `/tmp/script.sh` after `chmod +x` → command not found | Check VFS execute permission, parse and run script | `mod.rs` |
| `awk '{total += $2 * $3}'` wrong result | Already worked — test was incorrectly skipped | — |
| `while read` in pipe empty vars | Already worked — test was incorrectly skipped | — |
| `sed -E` ERE capture groups | Already worked — test was incorrectly skipped | — |

Skipped test count: 87 → 77 (bash comparison: 488 → 492 matching real bash)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all pass
- [x] All 10 previously-skipped spec tests now pass
- [x] Bash comparison tests: 492/492 match real bash (100%)