### PR TITLE
fix(jq): fix argument parsing, add test coverage, update docs

### DIFF
--- a/crates/bashkit/docs/compatibility.md
+++ b/crates/bashkit/docs/compatibility.md
@@ -72,7 +72,7 @@ for sandbox security reasons. See the compliance spec for details.
 | `grep` | `-i`, `-v`, `-c`, `-n`, `-E`, `-q` | Pattern matching |
 | `sed` | `s///[g]`, `d`, `p`, `q`, `a`, `i`, `c`, `h/H/g/G/x`, `-E`, `-n`, `!` | Stream editing |
 | `awk` | `'{print}'`, `-F`, `-v`, loops, arrays, increment, ternary | Text processing |
-| `jq` | `.field`, `.[n]`, pipes, file args | JSON processing |
+| `jq` | `.field`, `.[n]`, pipes, file args, `-r`, `-c`, `-n`, `-s`, `-S`, `-e`, `-j`, `--tab`, `--arg`, `--argjson`, `-V`, combined flags | JSON processing |
 | `sleep` | `N`, `N.N` | Pause execution (max 60s) |
 | `head` | `-n N`, `-N` | First N lines (default 10) |
 | `tail` | `-n N`, `-N` | Last N lines (default 10) |

--- a/crates/bashkit/tests/spec_cases/jq/jq.test.sh
+++ b/crates/bashkit/tests/spec_cases/jq/jq.test.sh
@@ -482,14 +482,14 @@ echo '5' | jq 'if . > 3 then "big" else "small" end'
 ### end
 
 ### jq_alternative
-### skip: alternative operator (//) not implemented
+### skip: jaq errors on .foo applied to null instead of returning null for //
 echo 'null' | jq '.foo // "default"'
 ### expect
 "default"
 ### end
 
 ### jq_try
-### skip: try operator not implemented
+# Try-catch handles runtime errors gracefully
 echo 'null' | jq 'try .foo catch "error"'
 ### expect
 "error"
@@ -512,7 +512,7 @@ echo '{"a":{"b":1}}' | jq 'getpath(["a","b"])'
 ### end
 
 ### jq_setpath
-### skip: setpath not implemented
+### skip: setpath not available in jaq standard library
 echo '{"a":1}' | jq 'setpath(["b"];2)'
 ### expect
 {"a":1,"b":2}
@@ -577,7 +577,7 @@ echo '{"a":{"b":1}}' | jq '[paths]'
 ### end
 
 ### jq_leaf_paths
-### skip: leaf_paths not implemented
+### skip: leaf_paths not available in jaq standard library
 echo '{"a":{"b":1}}' | jq '[leaf_paths]'
 ### expect
 [["a","b"]]
@@ -628,28 +628,28 @@ echo '1' | jq '[while(. < 5; . + 1)]'
 ### end
 
 ### jq_input
-### skip: input not implemented
+### skip: inputs iterator not wired to remaining stdin values
 printf '1\n2\n' | jq 'input'
 ### expect
 2
 ### end
 
 ### jq_inputs
-### skip: inputs not implemented
+### skip: inputs iterator not wired to remaining stdin values
 printf '1\n2\n3\n' | jq '[inputs]'
 ### expect
 [2,3]
 ### end
 
 ### jq_debug
-### skip: debug not implemented
+# Debug passes value through (stderr output not captured)
 echo '1' | jq 'debug'
 ### expect
 1
 ### end
 
 ### jq_env
-### skip: env not implemented
+### skip: shell env vars not propagated to jaq runtime
 FOO=bar jq -n 'env.FOO'
 ### expect
 "bar"
@@ -730,14 +730,14 @@ true
 ### end
 
 ### jq_match
-### skip: match not implemented
+### skip: jaq omits capture name field (real jq includes "name":null)
 echo '"hello"' | jq 'match("e(ll)o")'
 ### expect
 {"offset":1,"length":4,"string":"ello","captures":[{"offset":2,"length":2,"string":"ll","name":null}]}
 ### end
 
 ### jq_scan
-### skip: scan not implemented
+### skip: jaq scan requires explicit "g" flag for global match
 echo '"hello hello"' | jq '[scan("hel")]'
 ### expect
 ["hel","hel"]
@@ -866,4 +866,55 @@ jq -n --arg greeting hello '"say \($greeting)"'
 jq -n --argjson count 5 '$count + 1'
 ### expect
 6
+### end
+
+### jq_empty_input
+# Empty input with no flags produces no output
+echo '' | jq '.'
+### expect
+### end
+
+### jq_ndjson
+# Multiple JSON values (NDJSON) are each processed separately
+printf '{"a":1}\n{"a":2}\n' | jq '.a'
+### expect
+1
+2
+### end
+
+### jq_multiple_arg_bindings
+# Multiple --arg flags each bind a separate variable
+jq -n --arg x hello --arg y world '"[\($x)] [\($y)]"'
+### expect
+"[hello] [world]"
+### end
+
+### jq_argjson_object
+# --argjson with a JSON object value
+jq -n --argjson obj '{"a":1}' '$obj.a'
+### expect
+1
+### end
+
+### jq_combined_flags_snr
+# Three combined short flags -snr
+jq -snr '"hello"'
+### expect
+hello
+### end
+
+### jq_exit_status_false
+# Exit status mode sets exit code 1 for false output
+echo 'false' | jq -e '.'
+### exit_code: 1
+### expect
+false
+### end
+
+### jq_exit_status_truthy
+# Exit status mode sets exit code 0 for truthy output
+echo '42' | jq -e '.'
+### exit_code: 0
+### expect
+42
 ### end

--- a/specs/005-builtins.md
+++ b/specs/005-builtins.md
@@ -68,7 +68,7 @@ in a virtual environment. All builtins operate on the virtual filesystem.
 - `grep` - Pattern matching (`-i`, `-v`, `-c`, `-n`, `-o`, `-l`, `-w`, `-E`, `-F`, `-P`, `-q`, `-m`, `-x`, `-A`, `-B`, `-C`, `-e`, `-f`, `-H`, `-h`, `-b`, `-a`, `-z`, `-r`)
 - `sed` - Stream editing (s/pat/repl/, d, p, a, i; `-E`, `-e`, `-i`, `-n`; nth occurrence, `!` negation)
 - `awk` - Text processing (print, -F, variables)
-- `jq` - JSON processing (file arguments, `-s`, `-r`, `-c`, `-n`, `-S`, `-e`, `--tab`, `-j`)
+- `jq` - JSON processing (file arguments, `-s`, `-r`, `-c`, `-n`, `-S`, `-e`, `--tab`, `-j`, `--arg`, `--argjson`, `-V`/`--version`, combined short flags)
 - `sort` - Sort lines (`-r`, `-n`, `-u`)
 - `uniq` - Filter duplicates (`-c`, `-d`, `-u`)
 - `cut` - Extract fields (`-d`, `-f`)

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -107,7 +107,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1030
+**Total spec test cases:** 1038
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
@@ -115,9 +115,9 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | AWK | 90 | Yes | 73 | 17 | loops, arrays, -v, ternary, field assign |
 | Grep | 81 | Yes | 76 | 5 | now with -z, -r, -a, -b, -H, -h, -f, -P |
 | Sed | 65 | Yes | 53 | 12 | hold space, change, regex ranges, -E |
-| JQ | 100 | Yes | 90 | 10 | reduce, walk, regex funcs |
+| JQ | 108 | Yes | 100 | 8 | reduce, walk, regex funcs, --arg/--argjson, combined flags |
 | Python | 58 | Yes | 50 | 8 | **Experimental.** VFS bridging, pathlib, env vars |
-| **Total** | **1030** | **Yes** | **918** | **112** | |
+| **Total** | **1038** | **Yes** | **928** | **110** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -310,15 +310,21 @@ Features that may be added in the future (not intentionally excluded):
 
 ### JQ Limitations
 
-**Skipped Tests (10):**
+**Skipped Tests (8):**
 
 | Feature | Count | Notes |
 |---------|-------|-------|
-| Alternative `//` | 1 | Null coalescing operator |
-| Try-catch | 1 | `try` expression |
-| Path functions | 2 | `setpath`, `leaf_paths` |
-| I/O functions | 4 | `input`, `inputs`, `debug`, `env` |
-| Regex functions | 2 | `match`, `scan` |
+| Alternative `//` | 1 | jaq errors on `.foo` applied to null instead of returning null |
+| Path functions | 2 | `setpath`, `leaf_paths` not in jaq standard library |
+| I/O functions | 3 | `input`, `inputs` (iterator not wired), `env` (shell vars not propagated) |
+| Regex functions | 2 | `match` (jaq omits capture `name` field), `scan` (jaq needs explicit `"g"` flag) |
+
+**Recently Fixed:**
+- `try`/`catch` expressions now work (jaq handles runtime errors)
+- `debug` passes through values correctly (stderr not captured)
+- Combined short flags (`-rn`, `-sc`, `-snr`)
+- `--arg name value` and `--argjson name value` variable bindings
+- `--indent N` flag no longer eats the filter argument
 
 ### Curl Limitations
 


### PR DESCRIPTION
## Summary
- Fix jq argument parsing: combined short flags (`-rn`, `-sc`, `-snr`), `--arg name value`, `--argjson name value`, `--indent N`, and `--` separator now work correctly
- Add comprehensive positive and negative test coverage (10 new unit tests, 8 new spec tests, 2 unskipped spec tests)
- Update specs (009-implementation-status, 005-builtins) and compatibility docs with full jq flag documentation

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (all 37 jq unit tests, 100/108 spec tests pass, 8 skipped)
- [x] Negative tests cover: invalid JSON input, invalid filter syntax, invalid --argjson value, empty/whitespace input
- [x] Positive tests cover: NDJSON, multiple --arg bindings, --argjson with objects, combined flags, exit status for null/false/truthy