### PR TITLE
chore(release): prepare v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.1.6] - 2026-02-20
+
+### Highlights
+
+- ScriptedTool for composing multi-tool bash orchestration with Python/LangChain bindings
+- Streaming output support for Tool trait
+- Script file execution by path
+- 10 interpreter bug fixes surfaced by eval harness
+
+### What's Changed
+
+* chore: pre-release maintenance checklist ([#223](https://github.com/everruns/bashkit/pull/223)) by @chaliy
+* feat(interpreter): support executing script files by path ([#222](https://github.com/everruns/bashkit/pull/222)) by @chaliy
+* fix(jq): fix argument parsing, add test coverage, update docs ([#221](https://github.com/everruns/bashkit/pull/221)) by @chaliy
+* feat(tool): add streaming output support ([#220](https://github.com/everruns/bashkit/pull/220)) by @chaliy
+* feat(python): ScriptedTool bindings + LangChain integration ([#219](https://github.com/everruns/bashkit/pull/219)) by @chaliy
+* refactor(examples): extract fake tools into separate module ([#218](https://github.com/everruns/bashkit/pull/218)) by @chaliy
+* chore: add small-PR preference to AGENTS.md ([#217](https://github.com/everruns/bashkit/pull/217)) by @chaliy
+* fix(builtins): resolve 10 eval-surfaced interpreter bugs ([#216](https://github.com/everruns/bashkit/pull/216)) by @chaliy
+* fix: address 10 code TODOs across codebase ([#215](https://github.com/everruns/bashkit/pull/215)) by @chaliy
+* test: add skipped tests for eval-surfaced interpreter bugs ([#214](https://github.com/everruns/bashkit/pull/214)) by @chaliy
+* feat(scripted_tool): add ScriptedTool for multi-tool bash composition ([#213](https://github.com/everruns/bashkit/pull/213)) by @chaliy
+* ci(python): add Python bindings CI with ruff and pytest ([#212](https://github.com/everruns/bashkit/pull/212)) by @chaliy
+* fix(interpreter): apply brace/glob expansion in for-loop word list ([#211](https://github.com/everruns/bashkit/pull/211)) by @chaliy
+* feat(python): add PydanticAI integration and example ([#210](https://github.com/everruns/bashkit/pull/210)) by @chaliy
+* fix(ci): add --allow-dirty for cargo publish after stripping monty ([#209](https://github.com/everruns/bashkit/pull/209)) by @chaliy
+* fix(ci): strip git-only monty dep before crates.io publish ([#208](https://github.com/everruns/bashkit/pull/208)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.1.5...v0.1.6
+
 ## [0.1.5] - 2026-02-17
 
 ### Highlights

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 doc = false  # Disable to avoid collision with bashkit library docs
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.1.4" }
+bashkit = { path = "../bashkit", version = "0.1.6" }
 tokio.workspace = true
 clap.workspace = true
 anyhow.workspace = true

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -603,7 +603,7 @@ version = "0.1.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.85"
+version = "0.3.86"
 criteria = "safe-to-deploy"
 
 [[exemptions.leb128fmt]]
@@ -1367,23 +1367,23 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.108"
+version = "0.2.109"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.58"
+version = "0.4.59"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.108"
+version = "0.2.109"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.108"
+version = "0.2.109"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.108"
+version = "0.2.109"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-encoder]]
@@ -1403,7 +1403,7 @@ version = "0.244.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.85"
+version = "0.3.86"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.1.5 to 0.1.6
- Update bashkit-cli dependency pin to 0.1.6
- Add CHANGELOG entry for v0.1.6

### Highlights

- ScriptedTool for composing multi-tool bash orchestration with Python/LangChain bindings
- Streaming output support for Tool trait
- Script file execution by path
- 10 interpreter bug fixes surfaced by eval harness

### What's Changed (since v0.1.5)

16 PRs merged (#208–#223) including new features (ScriptedTool, streaming output, script file execution, PydanticAI integration), bug fixes (jq args, interpreter bugs, for-loop expansion), CI improvements, and maintenance.