### PR TITLE
feat(sed): grouped commands, branching, Q quit, step/zero addresses

### DIFF
--- a/crates/bashkit/tests/spec_cases/sed/sed.test.sh
+++ b/crates/bashkit/tests/spec_cases/sed/sed.test.sh
@@ -210,7 +210,7 @@ bird
 ### end
 
 ### sed_hold_h
-### skip: hold space with grouped commands not implemented
+# Hold space with grouped commands
 printf 'a\nb\n' | sed '1h; 2{x;p;x}'
 ### expect
 a
@@ -219,7 +219,7 @@ b
 ### end
 
 ### sed_hold_H
-### skip: hold space (H) command not implemented
+# Hold space H append with multi-command pipeline
 printf 'a\nb\nc\n' | sed 'H; $!d; x; s/\n/ /g'
 ### expect
  a b c
@@ -241,21 +241,21 @@ three
 ### end
 
 ### sed_quit_Q
-### skip: quit (Q) command not implemented
+# Q (quiet quit) exits without printing current line
 printf 'a\nb\nc\n' | sed '2Q'
 ### expect
 a
 ### end
 
 ### sed_branch_t
-### skip: branch (t) command not implemented
+# Branch on substitution with label
 printf 'abc\n' | sed ':loop; s/a/X/; t loop'
 ### expect
 Xbc
 ### end
 
 ### sed_grouped_commands
-### skip: grouped commands not implemented
+# Grouped commands with address
 printf 'a\nb\nc\n' | sed '2{s/b/X/;p}'
 ### expect
 a
@@ -462,7 +462,7 @@ printf 'hello\n' | sed 's/hello/\&/'
 ### end
 
 ### sed_step_address
-### skip: step addresses (first~step) not implemented
+# Step address: delete every 2nd line
 printf 'a\nb\nc\nd\ne\nf\n' | sed '0~2d'
 ### expect
 a
@@ -471,7 +471,7 @@ e
 ### end
 
 ### sed_zero_address
-### skip: 0,/pattern/ addressing not implemented
+# 0,/pattern/ addressing: substitute only first match
 printf 'no\nyes\nyes\n' | sed '0,/yes/s/yes/FIRST/'
 ### expect
 no
@@ -484,4 +484,71 @@ printf 'a\nstart\nb\nend\nc\n' | sed '/start/,/end/d'
 ### expect
 a
 c
+### end
+
+### sed_group_delete
+# Grouped commands: address with delete
+printf 'a\nb\nc\n' | sed '2{d}'
+### expect
+a
+c
+### end
+
+### sed_group_nested_hold
+# Grouped commands with hold space operations
+printf 'x\ny\n' | sed '1{h;d}; 2{x;p;x}'
+### expect
+x
+y
+### end
+
+### sed_branch_b_unconditional
+# Unconditional branch to end
+printf 'a\nb\nc\n' | sed '2b; s/./X/'
+### expect
+X
+b
+X
+### end
+
+### sed_branch_t_no_match
+# t does NOT branch when substitution fails
+printf 'abc\n' | sed ':top; s/z/Z/; t top; s/a/X/'
+### expect
+Xbc
+### end
+
+### sed_Q_first_line
+# Q on first line prints nothing
+printf 'a\nb\n' | sed '1Q'
+### expect
+### end
+
+### sed_step_address_1_2
+# Step address: every 2nd line starting at line 1
+printf 'a\nb\nc\nd\n' | sed '1~2s/.*/X/'
+### expect
+X
+b
+X
+d
+### end
+
+### sed_zero_address_first_line_match
+# 0,/pattern/ where first line matches
+printf 'yes\nyes\nno\n' | sed '0,/yes/s/yes/FIRST/'
+### expect
+FIRST
+yes
+no
+### end
+
+### sed_group_with_regex_addr
+# Grouped commands with regex address
+printf 'foo\nbar\nbaz\n' | sed '/bar/{s/bar/BAR/;p}'
+### expect
+foo
+BAR
+BAR
+baz
 ### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -259,32 +259,21 @@ Features that may be added in the future (not intentionally excluded):
 
 ### Sed Limitations
 
-**Skipped Tests (13):**
-
-| Feature | Count | Notes |
-|---------|-------|-------|
-| Hold space (h/H) | 2 | `h` copy, `H` append to hold (multi-cmd interaction) |
-| Pattern ranges | 3 | `/start/,/end/d`, `/pattern/,$d` address range delete |
-| Branching | 2 | `b`, `t`, `:label` commands, `Q` quiet quit |
-| Grouped commands | 1 | `{cmd1;cmd2}` blocks |
-| Special addresses | 2 | `0~2` step, `0,/pattern/` first match |
-| Replacement escapes | 2 | `\n` newline, `&` with adjacent chars |
-| Ampersand | 1 | `&` in replacement refers to matched text |
+**Skipped Tests: 0** (all previously-skipped sed tests now pass)
 
 **Recently Implemented:**
+- Grouped commands: `{cmd1;cmd2}` blocks with address support
+- Branching: `b` (unconditional), `t` (on substitution), `:label`
+- `Q` (quiet quit) — exits without printing current line
+- Step addresses: `0~2` (every Nth line)
+- `0,/pattern/` addressing (first match only)
+- Hold space with grouped commands: `h`, `H` in `{...}` blocks
 - Hold space commands: `h` (copy), `H` (append), `g` (get), `G` (get-append), `x` (exchange)
 - Change command: `c\text` line replacement
 - Regex range addressing: `/start/,/end/` with stateful tracking
 - Numeric-regex range: `N,/pattern/`
 - Extended regex (`-E`), nth occurrence, address negation (`!`)
-
-<!-- Known SED gaps for LLM compatibility (tracked in docs/compatibility.md) -->
-<!-- - Ampersand (&) in replacement - very commonly used by LLMs -->
-<!-- - \n literal newline in replacement - used in line splitting -->
-<!-- - Grouped commands {cmd1;cmd2} - used in complex transforms -->
-<!-- - Branch/label (b/t/:label) - used in advanced scripts -->
-<!-- - 0~2 step addressing - used for even/odd line processing -->
-<!-- - Q (quiet quit) command -->
+- Ampersand `&` in replacement, `\n` literal newline in replacement
 
 ### Grep Limitations
 


### PR DESCRIPTION
## Summary
- Implement `{cmd1;cmd2}` grouped command blocks with address support
- Add `Q` (quiet quit), `b`/`t`/`:label` branching, step addresses (`0~2`), `0,/pattern/` addressing
- Refactor execution loop with `LineState` struct and `exec_sed_cmd` helper
- Remove all 7 sed skip markers — **all sed spec tests now pass (75/75)**
- Add 9 new spec tests covering positive and negative cases

## Test plan
- [x] All 75 sed spec tests pass (0 skipped, was 7 skipped)
- [x] Full test suite passes (`cargo test --all-features`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean