### PR TITLE
feat(grep): add --include/--exclude glob patterns

### DIFF
--- a/crates/bashkit/tests/spec_cases/grep/grep.test.sh
+++ b/crates/bashkit/tests/spec_cases/grep/grep.test.sh
@@ -336,17 +336,25 @@ foo
 ### end
 
 ### grep_include_pattern
-### skip: --include not implemented
-grep --include='*.txt' pattern /some/dir
-### exit_code: 1
+# Include only .txt files in recursive search
+mkdir -p /tmp/grepdir && printf 'hello\n' > /tmp/grepdir/a.txt && printf 'hello\n' > /tmp/grepdir/b.log && grep -r --include='*.txt' hello /tmp/grepdir
 ### expect
+/tmp/grepdir/a.txt:hello
 ### end
 
 ### grep_exclude_pattern
-### skip: --exclude not implemented
-grep --exclude='*.log' pattern /some/dir
-### exit_code: 1
+# Exclude .log files in recursive search
+mkdir -p /tmp/grepdir2 && printf 'hello\n' > /tmp/grepdir2/a.txt && printf 'hello\n' > /tmp/grepdir2/b.log && grep -r --exclude='*.log' hello /tmp/grepdir2
 ### expect
+/tmp/grepdir2/a.txt:hello
+### end
+
+### grep_include_no_match
+# Include pattern that matches no files
+mkdir -p /tmp/grepdir3 && printf 'hello\n' > /tmp/grepdir3/a.log && grep -r --include='*.txt' hello /tmp/grepdir3
+echo $?
+### expect
+1
 ### end
 
 ### grep_line_buffered

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -107,17 +107,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1042
+**Total spec test cases:** 1043
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
 | Bash (core) | 640 | Yes | 592 | 48 | `bash_spec_tests` in CI |
 | AWK | 90 | Yes | 73 | 17 | loops, arrays, -v, ternary, field assign |
-| Grep | 81 | Yes | 76 | 5 | now with -z, -r, -a, -b, -H, -h, -f, -P |
+| Grep | 82 | Yes | 79 | 3 | now with -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude |
 | Sed | 65 | Yes | 53 | 12 | hold space, change, regex ranges, -E |
 | JQ | 108 | Yes | 100 | 8 | reduce, walk, regex funcs, --arg/--argjson, combined flags |
 | Python | 58 | Yes | 50 | 8 | **Experimental.** VFS bridging, pathlib, env vars |
-| **Total** | **1042** | **Yes** | **944** | **98** | |
+| **Total** | **1043** | **Yes** | **948** | **95** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -277,19 +277,19 @@ Features that may be added in the future (not intentionally excluded):
 
 ### Grep Limitations
 
-**Skipped Tests (5):**
+**Skipped Tests (3):**
 
 | Feature | Count | Notes |
 |---------|-------|-------|
 | Recursive test | 1 | Test needs VFS setup with files |
 | Pattern file `-f` | 1 | Requires file redirection support |
-| Include/exclude | 2 | `--include`, `--exclude` patterns |
 | Binary detection | 1 | Auto-detect binary files |
 
 **Implemented Features:**
 - Basic flags: `-i`, `-v`, `-c`, `-n`, `-o`, `-l`, `-w`, `-E`, `-F`, `-q`, `-m`, `-x`
 - Context: `-A`, `-B`, `-C` (after/before/context lines)
 - Multiple patterns: `-e`
+- Include/exclude: `--include=GLOB`, `--exclude=GLOB` for recursive search
 - Pattern file: `-f` (requires file to exist in VFS)
 - Filename control: `-H` (always show), `-h` (never show)
 - Byte offset: `-b`


### PR DESCRIPTION
## Summary

- Add `--include=GLOB` and `--exclude=GLOB` options for `grep -r` recursive search
- Fix recursive grep to always show filenames (matching real grep behavior)
- Fix multi-file filename display to use actual input count instead of CLI arg count
- Add `strip_quotes` helper for `=` option values
- Add `glob_matches` and `should_include_file` helper functions

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all tests pass
- [x] 17 grep unit tests pass (including 2 new recursive include/exclude)
- [x] grep spec tests pass — 2 previously-skipped tests now active, 1 new test added