### PR TITLE
fix(lexer): handle backslash-escaped metacharacters

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -418,6 +418,21 @@ impl<'a> Lexer<'a> {
                         }
                     }
                 }
+            } else if ch == '\\' {
+                self.advance();
+                if let Some(next) = self.peek_char() {
+                    if next == '\n' {
+                        // Line continuation: skip backslash + newline
+                        self.advance();
+                    } else {
+                        // Escaped character: backslash quotes the next char
+                        // (quote removal — only the literal char survives)
+                        word.push(next);
+                        self.advance();
+                    }
+                } else {
+                    word.push('\\');
+                }
             } else if self.is_word_char(ch) {
                 word.push(ch);
                 self.advance();

--- a/crates/bashkit/tests/spec_cases/bash/negative-tests.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/negative-tests.test.sh
@@ -51,7 +51,6 @@ echo $((0 || 0))
 ### end
 
 ### neg_string_compare_equal
-### skip: test string comparison with \< not fully implemented
 # Equal strings not less/greater
 [ "abc" \< "abc" ] && echo "less" || echo "not less"
 ### expect

--- a/crates/bashkit/tests/spec_cases/bash/test-operators.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/test-operators.test.sh
@@ -62,7 +62,6 @@ empty
 ### end
 
 ### test_string_lt
-### skip: test string comparison with \< not fully implemented
 # String less than comparison
 [ "apple" \< "banana" ] && echo "less"
 ### expect
@@ -70,7 +69,6 @@ less
 ### end
 
 ### test_string_gt
-### skip: test string comparison with \> not fully implemented
 # String greater than comparison
 [ "zoo" \> "apple" ] && echo "greater"
 ### expect

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -107,7 +107,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1043
+**Total spec test cases:** 1043 (951 pass, 92 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
@@ -144,7 +144,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | headtail.test.sh | 14 | |
 | herestring.test.sh | 8 | 1 skipped |
 | hextools.test.sh | 5 | od/xxd/hexdump (3 skipped) |
-| negative-tests.test.sh | 16 | error conditions (4 skipped) |
+| negative-tests.test.sh | 16 | error conditions (3 skipped) |
 | nl.test.sh | 14 | line numbering |
 | paste.test.sh | 4 | line merging (2 skipped) |
 | path.test.sh | 14 | |
@@ -154,7 +154,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | sleep.test.sh | 6 | |
 | sortuniq.test.sh | 32 | sort and uniq (2 skipped) |
 | source.test.sh | 21 | source/., function loading, PATH search, positional params |
-| test-operators.test.sh | 17 | file/string tests (2 skipped) |
+| test-operators.test.sh | 17 | file/string tests |
 | time.test.sh | 11 | Wall-clock only (user/sys always 0) |
 | timeout.test.sh | 17 | |
 | variables.test.sh | 44 | includes special vars, prefix env assignments |


### PR DESCRIPTION
## Summary
- Fix lexer to perform quote removal on backslash-escaped characters outside quotes
- `\<` and `\>` now correctly produce literal `<` and `>` tokens, enabling string comparison in `[` test commands
- Removes 3 skip markers from spec tests (test_string_lt, test_string_gt, neg_string_compare_equal)

## Test plan
- [x] Existing spec tests for `test_string_lt`, `test_string_gt`, `neg_string_compare_equal` now pass
- [x] Full test suite passes (`cargo test --all-features`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean