### PR TITLE
feat(date): add -R, -I flags and %N format

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/date.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/date.test.sh
@@ -135,14 +135,14 @@ valid
 ### end
 
 ### date_rfc_format
-### skip: date -R flag not implemented
+# RFC 2822 format
 date -R | grep -qE '^[A-Z][a-z]{2},' && echo "valid"
 ### expect
 valid
 ### end
 
 ### date_iso_flag
-### skip: date -I flag not implemented
+# ISO 8601 format
 date -I | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' && echo "valid"
 ### expect
 valid
@@ -188,7 +188,7 @@ valid
 ### end
 
 ### date_nanoseconds
-### skip: %N (nanoseconds) not implemented
+# Nanoseconds format
 date +%N | grep -qE '^[0-9]{9}$' && echo "valid"
 ### expect
 valid

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -107,7 +107,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1043 (951 pass, 92 skip)
+**Total spec test cases:** 1043 (954 pass, 89 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
@@ -133,7 +133,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | command-subst.test.sh | 14 | 2 skipped |
 | control-flow.test.sh | 33 | if/elif/else, for, while, case |
 | cuttr.test.sh | 32 | cut and tr commands (25 skipped) |
-| date.test.sh | 38 | format specifiers, `-d` relative/compound/epoch (6 skipped) |
+| date.test.sh | 38 | format specifiers, `-d` relative/compound/epoch, `-R`, `-I`, `%N` (3 skipped) |
 | diff.test.sh | 4 | line diffs |
 | echo.test.sh | 24 | escape sequences (1 skipped) |
 | errexit.test.sh | 8 | set -e tests |


### PR DESCRIPTION
## Summary
- Add `-R`/`--rfc-2822` flag for RFC 2822 formatted date output
- Add `-I`/`--iso-8601` flag with precision support (date/hours/minutes/seconds)
- Add `%N` format specifier for nanoseconds (9-digit zero-padded)
- Removes 3 skip markers from date spec tests

## Test plan
- [x] Unit tests for `-R`, `-I`, `%N`, and `expand_nanoseconds` helper
- [x] Spec tests `date_rfc_format`, `date_iso_flag`, `date_nanoseconds` now pass
- [x] Full test suite passes (`cargo test --all-features`)
- [x] `cargo clippy` and `cargo fmt` clean