### PR TITLE
fix(bash): glob pattern matching in [[ == ]] and [[ != ]]

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -959,8 +959,8 @@ impl Interpreter {
                 3 => {
                     // Binary operators
                     match args[1].as_str() {
-                        "=" | "==" => args[0] == args[2],
-                        "!=" => args[0] != args[2],
+                        "=" | "==" => self.pattern_matches(&args[0], &args[2]),
+                        "!=" => !self.pattern_matches(&args[0], &args[2]),
                         "<" => args[0] < args[2],
                         ">" => args[0] > args[2],
                         "-eq" => {

--- a/crates/bashkit/tests/spec_cases/bash/conditional.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/conditional.test.sh
@@ -118,3 +118,52 @@ echo $?
 ### expect
 1
 ### end
+
+### cond_glob_star
+# [[ == ]] with * glob pattern
+[[ "hello.txt" == *.txt ]] && echo match || echo no
+### expect
+match
+### end
+
+### cond_glob_star_no_match
+# [[ == ]] glob * doesn't match wrong extension
+[[ "hello.txt" == *.log ]] && echo match || echo no
+### expect
+no
+### end
+
+### cond_glob_question
+# [[ == ]] with ? single-char glob
+[[ "abc" == ?b? ]] && echo match || echo no
+### expect
+match
+### end
+
+### cond_glob_prefix
+# [[ == ]] with prefix glob
+[[ "hello_world" == hello* ]] && echo match || echo no
+### expect
+match
+### end
+
+### cond_glob_suffix
+# [[ == ]] with suffix glob
+[[ "test_file" == *_file ]] && echo match || echo no
+### expect
+match
+### end
+
+### cond_glob_not_equal
+# [[ != ]] with glob pattern
+[[ "hello.txt" != *.log ]] && echo diff || echo same
+### expect
+diff
+### end
+
+### cond_exact_match_no_glob
+# [[ == ]] exact match with no glob chars
+[[ "hello" == "hello" ]] && echo yes || echo no
+### expect
+yes
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,16 +103,16 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1174 (1169 pass, 5 skip)
+**Total spec test cases:** 1181 (1176 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 813 | Yes | 808 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 820 | Yes | 815 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
-| **Total** | **1174** | **Yes** | **1169** | **5** | |
+| **Total** | **1181** | **Yes** | **1176** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -126,7 +126,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | column.test.sh | 10 | column alignment |
 | command.test.sh | 9 | `command -v`, `-V`, function bypass |
 | command-not-found.test.sh | 17 | unknown command handling |
-| conditional.test.sh | 17 | `[[ ]]` conditionals, `=~` regex, BASH_REMATCH |
+| conditional.test.sh | 24 | `[[ ]]` conditionals, `=~` regex, BASH_REMATCH, glob `==`/`!=` |
 | command-subst.test.sh | 14 | includes backtick substitution (1 skipped) |
 | control-flow.test.sh | 43 | if/elif/else, for, while, case, trap ERR, `[[ =~ ]]` BASH_REMATCH |
 | cuttr.test.sh | 32 | cut and tr commands, `-z` zero-terminated |


### PR DESCRIPTION
## Summary
- `[[ ]]` conditional now uses glob matching (*, ?, [...]) for `==` and `!=` operators
- Previously did exact string comparison, causing `[[ "hello.txt" == *.txt ]]` to fail
- Leverages existing `pattern_matches()` method

## Test plan
- [x] 7 new tests: star, question, prefix, suffix, negation, no-match, exact
- [x] `cargo test --all-features` passes
- [x] `cargo clippy` and `cargo fmt` clean