### PR TITLE
fix(bash): input redirections on compound commands

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
@@ -329,6 +329,54 @@ before: 2
 after: 0
 ### end
 
+### while_read_input_redirect
+# while read ... done < file
+printf "a\nb\nc\n" > /tmp/wr_test
+while read -r line; do echo "got: $line"; done < /tmp/wr_test
+### expect
+got: a
+got: b
+got: c
+### end
+
+### while_read_herestring
+# while read ... done <<< string
+while read -r line; do echo "line: $line"; done <<< "hello"
+### expect
+line: hello
+### end
+
+### while_read_heredoc
+# while read ... done << EOF
+while read -r line; do echo "$line"; done << EOF
+alpha
+beta
+EOF
+### expect
+alpha
+beta
+### end
+
+### while_read_sum
+# Sum numbers from file redirect
+printf "10\n20\n30\n" > /tmp/wr_sum
+total=0
+while read -r n; do total=$((total + n)); done < /tmp/wr_sum
+echo $total
+### expect
+60
+### end
+
+### for_output_redirect
+# for loop with output redirect
+for i in a b c; do echo $i; done > /tmp/for_out
+cat /tmp/for_out
+### expect
+a
+b
+c
+### end
+
 ### regex_match_in_conditional
 # Regex match used in && chain
 x="error: line 42"

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,16 +103,16 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1181 (1176 pass, 5 skip)
+**Total spec test cases:** 1186 (1181 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 820 | Yes | 815 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 825 | Yes | 820 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
-| **Total** | **1181** | **Yes** | **1176** | **5** | |
+| **Total** | **1186** | **Yes** | **1181** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -128,7 +128,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | command-not-found.test.sh | 17 | unknown command handling |
 | conditional.test.sh | 24 | `[[ ]]` conditionals, `=~` regex, BASH_REMATCH, glob `==`/`!=` |
 | command-subst.test.sh | 14 | includes backtick substitution (1 skipped) |
-| control-flow.test.sh | 43 | if/elif/else, for, while, case, trap ERR, `[[ =~ ]]` BASH_REMATCH |
+| control-flow.test.sh | 48 | if/elif/else, for, while, case, trap ERR, `[[ =~ ]]` BASH_REMATCH, compound input redirects |
 | cuttr.test.sh | 32 | cut and tr commands, `-z` zero-terminated |
 | date.test.sh | 38 | format specifiers, `-d` relative/compound/epoch, `-R`, `-I`, `%N` (2 skipped) |
 | diff.test.sh | 4 | line diffs |


### PR DESCRIPTION
## Summary
- `while read ... done < file` and `done <<< string` and `done << EOF` now work
- Parser's `parse_trailing_redirects` handles HereString/HereDoc/HereDocStrip tokens
- Interpreter processes input redirects before compound execution, setting `pipeline_stdin`
- Preserves existing pipe-based `pipeline_stdin` when no input redirects present

## Test plan
- [x] 5 new tests: while read < file, herestring, heredoc, sum, for output redirect
- [x] Existing pipe-to-while tests still pass (regression check)
- [x] `cargo test --all-features` passes
- [x] `cargo clippy` and `cargo fmt` clean