### PR TITLE
fix(bash): nested double quotes inside $() in double-quoted strings

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/command-subst.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/command-subst.test.sh
@@ -96,3 +96,59 @@ VAR=$(printf 'hello\n\n\n'); echo "x${VAR}y"
 ### expect
 xhelloy
 ### end
+
+### subst_nested_quotes
+# Nested double quotes inside $() inside double quotes
+echo "$(echo "hello world")"
+### expect
+hello world
+### end
+
+### subst_nested_quotes_var
+# Variable expansion in nested quoted $()
+x="John"; echo "Hello, $(echo "$x")!"
+### expect
+Hello, John!
+### end
+
+### subst_deeply_nested_quotes
+# Deeply nested $() with quotes
+echo "nested: $(echo "$(echo "deep")")"
+### expect
+nested: deep
+### end
+
+### subst_nested_single_quotes
+# Single quotes inside $() inside double quotes
+echo "$(echo 'single quoted')"
+### expect
+single quoted
+### end
+
+### subst_nested_quotes_no_expand
+# Nested quotes without variable (literal string)
+echo "result=$(echo "done")"
+### expect
+result=done
+### end
+
+### subst_nested_quotes_empty
+# Nested quotes with empty inner string
+echo "x$(echo "")y"
+### expect
+xy
+### end
+
+### subst_nested_quotes_multiple
+# Multiple nested $() in same double-quoted string
+echo "$(echo "a") and $(echo "b")"
+### expect
+a and b
+### end
+
+### subst_nested_quotes_escape
+# Escaped characters inside nested $()
+echo "$(echo "hello\"world")"
+### expect
+hello"world
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,16 +103,16 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1186 (1181 pass, 5 skip)
+**Total spec test cases:** 1194 (1189 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 825 | Yes | 820 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 833 | Yes | 828 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
-| **Total** | **1186** | **Yes** | **1181** | **5** | |
+| **Total** | **1194** | **Yes** | **1189** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -127,7 +127,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | command.test.sh | 9 | `command -v`, `-V`, function bypass |
 | command-not-found.test.sh | 17 | unknown command handling |
 | conditional.test.sh | 24 | `[[ ]]` conditionals, `=~` regex, BASH_REMATCH, glob `==`/`!=` |
-| command-subst.test.sh | 14 | includes backtick substitution (1 skipped) |
+| command-subst.test.sh | 22 | includes backtick substitution, nested quotes in `$()` (1 skipped) |
 | control-flow.test.sh | 48 | if/elif/else, for, while, case, trap ERR, `[[ =~ ]]` BASH_REMATCH, compound input redirects |
 | cuttr.test.sh | 32 | cut and tr commands, `-z` zero-terminated |
 | date.test.sh | 38 | format specifiers, `-d` relative/compound/epoch, `-R`, `-I`, `%N` (2 skipped) |


### PR DESCRIPTION
## Summary
- Fix lexer to handle nested double quotes inside `$()` command substitutions within double-quoted strings
- `echo "$(echo "$x")"` now correctly expands instead of prematurely closing the outer quotes
- Add `read_command_subst_into()` method that tracks paren depth and handles nested quotes recursively

## Test plan
- [x] 8 new spec tests covering nested quotes, variable expansion, deeply nested `$()`, single quotes, empty strings, multiple substitutions, and escaped characters
- [x] All 1194 spec tests pass (1189 pass, 5 skip)
- [x] `cargo clippy` and `cargo fmt` clean