### PR TITLE
feat(bash): implement let builtin and fix declare -i arithmetic

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/arithmetic.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arithmetic.test.sh
@@ -405,3 +405,91 @@ echo $((5 >= 3)); echo $((5 >= 5)); echo $((4 >= 5))
 1
 0
 ### end
+
+### let_basic
+# let evaluates arithmetic and assigns
+let x=5+3
+echo $x
+### expect
+8
+### end
+
+### let_multiple
+# let evaluates multiple expressions
+let a=2 b=3 c=a+b
+echo $a $b $c
+### expect
+2 3 5
+### end
+
+### let_exit_zero
+# let returns 0 when last expression is non-zero
+let x=5
+echo $?
+### expect
+0
+### end
+
+### let_exit_one
+# let returns 1 when last expression is zero
+let x=0
+echo $?
+### expect
+1
+### end
+
+### let_increment
+# let with increment operators
+x=5; let x++
+echo $x
+### expect
+6
+### end
+
+### let_compound_assign
+# let with compound assignment
+x=10; let x+=5
+echo $x
+### expect
+15
+### end
+
+### let_no_args
+# let with no arguments returns 1
+let 2>/dev/null
+echo $?
+### expect
+1
+### end
+
+### declare_i_basic
+# declare -i evaluates arithmetic on assignment
+declare -i x=5+3
+echo $x
+### expect
+8
+### end
+
+### declare_i_expression
+# declare -i with complex expression
+declare -i x=2*3+4
+echo $x
+### expect
+10
+### end
+
+### declare_i_variable_ref
+# declare -i referencing other variables
+a=5; b=3; declare -i x=a+b
+echo $x
+### expect
+8
+### end
+
+### declare_i_plain_number
+# declare -i with plain number
+declare -i x=42
+echo $x
+### expect
+42
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,22 +103,23 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1214 (1209 pass, 5 skip)
+**Total spec test cases:** 1277 (1272 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 853 | Yes | 848 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 859 | Yes | 854 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
-| **Total** | **1214** | **Yes** | **1209** | **5** | |
+| Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
+| **Total** | **1277** | **Yes** | **1272** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
 | File | Cases | Notes |
 |------|-------|-------|
-| arithmetic.test.sh | 57 | includes logical, bitwise, compound assign, increment/decrement |
+| arithmetic.test.sh | 68 | includes logical, bitwise, compound assign, increment/decrement, `let` builtin, `declare -i` arithmetic |
 | arrays.test.sh | 27 | indices, `${arr[@]}` / `${arr[*]}`, negative indexing `${arr[-1]}` |
 | background.test.sh | 4 | |
 | bash-command.test.sh | 34 | bash/sh re-invocation |
@@ -206,7 +207,7 @@ Features that may be added in the future (not intentionally excluded):
 
 ### Implemented
 
-**92 core builtins + 3 feature-gated = 95 total**
+**93 core builtins + 3 feature-gated = 96 total**
 
 `echo`, `printf`, `cat`, `nl`, `cd`, `pwd`, `true`, `false`, `exit`, `test`, `[`,
 `export`, `set`, `unset`, `local`, `source`, `.`, `read`, `shift`, `break`,
@@ -214,7 +215,7 @@ Features that may be added in the future (not intentionally excluded):
 `basename`, `dirname`, `mkdir`, `rm`, `cp`, `mv`, `touch`, `chmod`, `chown`, `ln`, `wc`,
 `sort`, `uniq`, `cut`, `tr`, `paste`, `column`, `diff`, `comm`, `date`,
 `wait`, `curl`, `wget`, `timeout`, `command`, `getopts`,
-`type`, `which`, `hash`, `declare`, `typeset`, `kill`,
+`type`, `which`, `hash`, `declare`, `typeset`, `let`, `kill`,
 `time` (keyword), `whoami`, `hostname`, `uname`, `id`, `ls`, `rmdir`, `find`, `xargs`, `tee`,
 `:` (colon), `eval`, `readonly`, `times`, `bash`, `sh`,
 `od`, `xxd`, `hexdump`, `strings`,


### PR DESCRIPTION
## Summary
- Implement `let` builtin for evaluating arithmetic expressions with assignment side effects
- Fix `declare -i` to use arithmetic evaluation instead of `parse().unwrap_or(0)`, so `declare -i x=5+3` correctly yields 8
- Add 11 spec tests covering `let` (basic, multiple, exit codes, increment, compound assign, no-args) and `declare -i` (basic, expressions, variable refs, plain numbers)

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] Spec tests verify `let` assignment, exit codes, and `declare -i` arithmetic