### PR TITLE
feat(bash): implement select construct

### DIFF
--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -100,6 +100,8 @@ pub enum CompoundCommand {
     Until(UntilCommand),
     /// Case statement
     Case(CaseCommand),
+    /// Select loop
+    Select(SelectCommand),
     /// Subshell (commands in parentheses)
     Subshell(Vec<Command>),
     /// Brace group
@@ -143,6 +145,16 @@ pub struct IfCommand {
 pub struct ForCommand {
     pub variable: String,
     pub words: Option<Vec<Word>>,
+    pub body: Vec<Command>,
+    /// Source span of this command
+    pub span: Span,
+}
+
+/// Select loop.
+#[derive(Debug, Clone)]
+pub struct SelectCommand {
+    pub variable: String,
+    pub words: Vec<Word>,
     pub body: Vec<Command>,
     /// Source span of this command
     pub span: Span,

--- a/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
@@ -429,3 +429,42 @@ fi
 ### expect
 line 42
 ### end
+
+### select_basic
+# select reads from stdin and sets variable
+echo "2" | select item in alpha beta gamma; do echo "got: $item"; break; done
+### expect
+got: beta
+### end
+
+### select_reply
+# select sets REPLY to raw input
+echo "1" | select x in one two three; do echo "REPLY=$REPLY x=$x"; break; done
+### expect
+REPLY=1 x=one
+### end
+
+### select_invalid
+# select with invalid number sets variable to empty
+echo "9" | select x in a b c; do echo "x='$x' REPLY=$REPLY"; break; done
+### expect
+x='' REPLY=9
+### end
+
+### select_multiple_iterations
+# select loops until break
+printf "1\n2\n3\n" | select x in a b c; do echo "$x"; if [ "$REPLY" = "3" ]; then break; fi; done
+### expect
+a
+b
+c
+### end
+
+### select_eof_exits
+# select exits on EOF (prints newline, exit code 1)
+echo "1" | select x in a b; do echo "$x"; done
+### exit_code: 1
+### expect
+a
+
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1277 (1272 pass, 5 skip)
+**Total spec test cases:** 1282 (1277 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 859 | Yes | 854 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 864 | Yes | 859 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1277** | **Yes** | **1272** | **5** | |
+| **Total** | **1282** | **Yes** | **1277** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -129,7 +129,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | command-not-found.test.sh | 17 | unknown command handling |
 | conditional.test.sh | 24 | `[[ ]]` conditionals, `=~` regex, BASH_REMATCH, glob `==`/`!=` |
 | command-subst.test.sh | 22 | includes backtick substitution, nested quotes in `$()` (1 skipped) |
-| control-flow.test.sh | 53 | if/elif/else, for, while, case `;;`/`;&`/`;;&`, trap ERR, `[[ =~ ]]` BASH_REMATCH, compound input redirects |
+| control-flow.test.sh | 58 | if/elif/else, for, while, case `;;`/`;&`/`;;&`, select, trap ERR, `[[ =~ ]]` BASH_REMATCH, compound input redirects |
 | cuttr.test.sh | 32 | cut and tr commands, `-z` zero-terminated |
 | date.test.sh | 38 | format specifiers, `-d` relative/compound/epoch, `-R`, `-I`, `%N` (2 skipped) |
 | diff.test.sh | 4 | line diffs |


### PR DESCRIPTION
## Summary
- Implement `select var in list; do body; done` construct
- Parse into `SelectCommand` AST node (similar to `ForCommand`)
- Execute by reading from `pipeline_stdin`, printing numbered menu to stderr
- Sets variable to selected item, `REPLY` to raw input
- Matches bash EOF behavior: prints newline to stdout and exits with code 1
- 5 spec tests: basic selection, REPLY variable, invalid input, multiple iterations, EOF exit

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] `bash_comparison_tests` 789/789 match real bash
- [x] All 864 bash spec tests pass (859 pass + 5 skip)