### PR TITLE
feat(bash): auto-populate shell variables (PWD, HOME, USER, etc.)

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/variables.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/variables.test.sh
@@ -448,3 +448,90 @@ echo "hello\tworld"
 ### expect
 hello\tworld
 ### end
+
+### var_pwd_set
+# $PWD is set to current directory
+### bash_diff
+echo "$PWD" | grep -q "/" && echo "has_slash"
+### expect
+has_slash
+### end
+
+### var_home_set
+# $HOME is set
+### bash_diff
+test -n "$HOME" && echo "home_set"
+### expect
+home_set
+### end
+
+### var_user_set
+# $USER is set
+### bash_diff
+test -n "$USER" && echo "user_set"
+### expect
+user_set
+### end
+
+### var_hostname_set
+# $HOSTNAME is set
+### bash_diff
+test -n "$HOSTNAME" && echo "hostname_set"
+### expect
+hostname_set
+### end
+
+### var_bash_version
+# BASH_VERSION is set
+### bash_diff
+test -n "$BASH_VERSION" && echo "version_set"
+### expect
+version_set
+### end
+
+### var_bash_versinfo_array
+# BASH_VERSINFO is an array with version parts
+### bash_diff
+echo "${#BASH_VERSINFO[@]}"
+test -n "${BASH_VERSINFO[0]}" && echo "major_set"
+### expect
+6
+major_set
+### end
+
+### var_uid_set
+# $UID is set
+### bash_diff
+test -n "$UID" && echo "uid_set"
+### expect
+uid_set
+### end
+
+### var_seconds
+# $SECONDS is set (always 0 in bashkit)
+### bash_diff
+test -n "$SECONDS" && echo "seconds_set"
+### expect
+seconds_set
+### end
+
+### var_pwd_updates_with_cd
+# $PWD updates after cd
+### bash_diff
+mkdir -p /tmp/test_pwd_cd
+cd /tmp/test_pwd_cd
+echo "$PWD"
+### expect
+/tmp/test_pwd_cd
+### end
+
+### var_oldpwd_set_after_cd
+# $OLDPWD is set after cd
+### bash_diff
+mkdir -p /tmp/test_oldpwd_cd
+old="$PWD"
+cd /tmp/test_oldpwd_cd
+echo "$OLDPWD" | grep -q "/" && echo "oldpwd_set"
+### expect
+oldpwd_set
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1282 (1277 pass, 5 skip)
+**Total spec test cases:** 1292 (1287 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 864 | Yes | 859 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 874 | Yes | 869 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1282** | **Yes** | **1277** | **5** | |
+| **Total** | **1292** | **Yes** | **1287** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -157,7 +157,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | test-operators.test.sh | 17 | file/string tests |
 | time.test.sh | 11 | Wall-clock only (user/sys always 0) |
 | timeout.test.sh | 17 | |
-| variables.test.sh | 63 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation |
+| variables.test.sh | 73 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS |
 | wc.test.sh | 35 | word count (5 skipped) |
 | type.test.sh | 15 | `type`, `which`, `hash` builtins |
 | declare.test.sh | 10 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p` |


### PR DESCRIPTION
## Summary
- Initialize shell variables at startup: HOME, USER, UID, EUID from configured username
- Add HOSTNAME, BASH_VERSINFO array
- Add dynamic expansion for PWD (from cwd), BASH_VERSION, SECONDS, HOSTNAME, OLDPWD
- cd builtin now sets OLDPWD on directory change
- Builder env() calls also set shell variables so they override defaults

## Test plan
- [x] `cargo test --all-features` passes (all 1020+ unit tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean
- [x] `bash_comparison_tests` 789/789 match real bash
- [x] 10 new spec tests for shell variable auto-population
- [x] All 874 bash spec tests pass