### PR TITLE
feat(builtins): implement shopt builtin with nullglob enforcement

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -104,7 +104,7 @@ pub use strings::Strings;
 pub use system::{Hostname, Id, Uname, Whoami, DEFAULT_HOSTNAME, DEFAULT_USERNAME};
 pub use test::{Bracket, Test};
 pub use timeout::Timeout;
-pub use vars::{Eval, Local, Readonly, Set, Shift, Times, Unset};
+pub use vars::{Eval, Local, Readonly, Set, Shift, Shopt, Times, Unset};
 pub use wait::Wait;
 pub use wc::Wc;
 

--- a/crates/bashkit/tests/spec_cases/bash/variables.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/variables.test.sh
@@ -580,3 +580,95 @@ echo hello
 ### expect
 hello
 ### end
+
+### shopt_set_and_query
+# shopt -s sets option, -q queries it
+shopt -s nullglob
+shopt -q nullglob && echo "on" || echo "off"
+shopt -u nullglob
+shopt -q nullglob && echo "on" || echo "off"
+### expect
+on
+off
+### end
+
+### shopt_print_format
+# shopt -p prints in reusable format
+### bash_diff
+shopt -s extglob
+shopt -p extglob
+shopt -u extglob
+shopt -p extglob
+### expect
+shopt -s extglob
+shopt -u extglob
+### end
+
+### shopt_invalid_option
+# shopt rejects invalid option names
+shopt -s nonexistent_option
+echo "exit:$?"
+### expect
+exit:1
+### end
+### exit_code: 1
+
+### shopt_show_specific
+# shopt shows status of named option
+### bash_diff
+shopt nullglob
+shopt -s nullglob
+shopt nullglob
+### expect
+nullglob                        off
+nullglob                        on
+### end
+
+### shopt_nullglob_no_matches
+# shopt -s nullglob: unmatched globs expand to nothing
+### bash_diff
+shopt -s nullglob
+for f in /tmp/nonexistent_pattern_xyz_*.txt; do
+  echo "found: $f"
+done
+echo "done"
+### expect
+done
+### end
+
+### shopt_nullglob_off_keeps_pattern
+# Without nullglob, unmatched globs keep the pattern
+for f in /tmp/nonexistent_pattern_xyz_*.txt; do
+  echo "found: $f"
+done
+echo "done"
+### expect
+found: /tmp/nonexistent_pattern_xyz_*.txt
+done
+### end
+
+### shopt_nullglob_with_matches
+# nullglob doesn't affect globs that have matches
+### bash_diff
+echo "test" > /tmp/shopt_test1.txt
+echo "test" > /tmp/shopt_test2.txt
+shopt -s nullglob
+count=0
+for f in /tmp/shopt_test*.txt; do
+  count=$((count + 1))
+done
+echo "count:$count"
+### expect
+count:2
+### end
+
+### shopt_multiple_options
+# shopt -s can set multiple options
+### bash_diff
+shopt -s nullglob extglob
+shopt -q nullglob && echo "null:on" || echo "null:off"
+shopt -q extglob && echo "ext:on" || echo "ext:off"
+### expect
+null:on
+ext:on
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1297 (1292 pass, 5 skip)
+**Total spec test cases:** 1305 (1300 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 879 | Yes | 874 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 887 | Yes | 882 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1297** | **Yes** | **1292** | **5** | |
+| **Total** | **1305** | **Yes** | **1300** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -157,7 +157,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | test-operators.test.sh | 17 | file/string tests |
 | time.test.sh | 11 | Wall-clock only (user/sys always 0) |
 | timeout.test.sh | 17 | |
-| variables.test.sh | 78 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace |
+| variables.test.sh | 86 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace, `shopt` builtin, nullglob |
 | wc.test.sh | 35 | word count (5 skipped) |
 | type.test.sh | 15 | `type`, `which`, `hash` builtins |
 | declare.test.sh | 10 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p` |
@@ -207,7 +207,7 @@ Features that may be added in the future (not intentionally excluded):
 
 ### Implemented
 
-**93 core builtins + 3 feature-gated = 96 total**
+**94 core builtins + 3 feature-gated = 97 total**
 
 `echo`, `printf`, `cat`, `nl`, `cd`, `pwd`, `true`, `false`, `exit`, `test`, `[`,
 `export`, `set`, `unset`, `local`, `source`, `.`, `read`, `shift`, `break`,
@@ -215,7 +215,7 @@ Features that may be added in the future (not intentionally excluded):
 `basename`, `dirname`, `mkdir`, `rm`, `cp`, `mv`, `touch`, `chmod`, `chown`, `ln`, `wc`,
 `sort`, `uniq`, `cut`, `tr`, `paste`, `column`, `diff`, `comm`, `date`,
 `wait`, `curl`, `wget`, `timeout`, `command`, `getopts`,
-`type`, `which`, `hash`, `declare`, `typeset`, `let`, `kill`,
+`type`, `which`, `hash`, `declare`, `typeset`, `let`, `kill`, `shopt`,
 `time` (keyword), `whoami`, `hostname`, `uname`, `id`, `ls`, `rmdir`, `find`, `xargs`, `tee`,
 `:` (colon), `eval`, `readonly`, `times`, `bash`, `sh`,
 `od`, `xxd`, `hexdump`, `strings`,


### PR DESCRIPTION
## Summary
- Add `shopt` builtin for bash-specific shell options (`-s`, `-u`, `-q`, `-p` flags)
- All standard bash shopt option names recognized (extglob, nullglob, globstar, etc.)
- Enforce `nullglob` behavior: unmatched globs expand to nothing when enabled
- nullglob applied in command args, for loops, and select loops

## Test plan
- [x] 8 spec tests covering set/unset/query/print/invalid options/nullglob behavior
- [x] All existing tests pass
- [x] `cargo clippy` clean, `cargo fmt` clean