### PR TITLE
feat(interpreter): implement declare -n nameref variables

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/declare.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/declare.test.sh
@@ -81,3 +81,65 @@ echo "$myvar"
 ### expect
 hello
 ### end
+
+### nameref_basic
+# declare -n creates a name reference
+x=hello
+declare -n ref=x
+echo "$ref"
+### expect
+hello
+### end
+
+### nameref_assign_through
+# Assigning to nameref assigns to target variable
+x=old
+declare -n ref=x
+ref=new
+echo "$x"
+### expect
+new
+### end
+
+### nameref_chain
+# Nameref can chain through another nameref
+a=value
+declare -n b=a
+declare -n c=b
+echo "$c"
+### expect
+value
+### end
+
+### nameref_in_function
+# Nameref used to pass variable names to functions
+set_via_ref() {
+  declare -n ref=$1
+  ref="set_by_function"
+}
+result=""
+set_via_ref result
+echo "$result"
+### expect
+set_by_function
+### end
+
+### nameref_read_unset
+# Reading through nameref to unset variable returns empty
+declare -n ref=nonexistent_var
+echo "[$ref]"
+### expect
+[]
+### end
+
+### nameref_reassign_target
+# Changing the target variable reflects through the nameref
+x=first
+declare -n ref=x
+echo "$ref"
+x=second
+echo "$ref"
+### expect
+first
+second
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -107,13 +107,13 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 887 | Yes | 882 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 893 | Yes | 888 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1305** | **Yes** | **1300** | **5** | |
+| **Total** | **1311** | **Yes** | **1306** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -160,7 +160,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | variables.test.sh | 86 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace, `shopt` builtin, nullglob |
 | wc.test.sh | 35 | word count (5 skipped) |
 | type.test.sh | 15 | `type`, `which`, `hash` builtins |
-| declare.test.sh | 10 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p` |
+| declare.test.sh | 16 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p`, `-n` nameref |
 | ln.test.sh | 5 | `ln -s`, `-f`, symlink creation |
 | eval-bugs.test.sh | 4 | regression tests for eval/script bugs |
 | script-exec.test.sh | 10 | script execution by path, $PATH search, exit codes |


### PR DESCRIPTION
## Summary
- Implement `declare -n` nameref variables that act as aliases for other variable names
- Add `resolve_nameref()` with chain following (max 10 levels) to prevent infinite loops
- Integrate nameref resolution into variable expansion and assignment paths

## Changes
- `crates/bashkit/src/interpreter/mod.rs`: Parse `-n` flag, store `_NAMEREF_<name>` markers, add `resolve_nameref()`, integrate into `expand_variable()` and `set_variable()`
- `crates/bashkit/tests/spec_cases/bash/declare.test.sh`: 6 new spec tests (basic, assign-through, chain, function param, read-unset, reassign-target)
- `specs/009-implementation-status.md`: Update test counts (declare 10→16, Bash 887→893, Total 1305→1311)

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] All 6 nameref spec tests pass
- [x] Existing declare tests still pass (no regressions)