### PR TITLE
feat(interpreter): implement declare -l/-u case conversion attributes

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/declare.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/declare.test.sh
@@ -143,3 +143,68 @@ echo "$ref"
 first
 second
 ### end
+
+### declare_lowercase
+# declare -l converts value to lowercase
+declare -l x=HELLO
+echo "$x"
+### expect
+hello
+### end
+
+### declare_uppercase
+# declare -u converts value to uppercase
+declare -u x=hello
+echo "$x"
+### expect
+HELLO
+### end
+
+### declare_lowercase_subsequent
+# declare -l applies to subsequent assignments
+declare -l x
+x=WORLD
+echo "$x"
+### expect
+world
+### end
+
+### declare_uppercase_subsequent
+# declare -u applies to subsequent assignments
+declare -u x
+x=world
+echo "$x"
+### expect
+WORLD
+### end
+
+### declare_lowercase_mixed
+# declare -l handles mixed case
+declare -l x=HeLLo_WoRLd
+echo "$x"
+### expect
+hello_world
+### end
+
+### declare_uppercase_overrides_lowercase
+# declare -u after -l overrides to uppercase
+declare -l x=Hello
+echo "$x"
+declare -u x
+x=Hello
+echo "$x"
+### expect
+hello
+HELLO
+### end
+
+### declare_case_in_function
+# declare -l works in functions
+toupper() {
+  declare -u result="$1"
+  echo "$result"
+}
+toupper "hello world"
+### expect
+HELLO WORLD
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1305 (1300 pass, 5 skip)
+**Total spec test cases:** 1318 (1313 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 893 | Yes | 888 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 900 | Yes | 895 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1311** | **Yes** | **1306** | **5** | |
+| **Total** | **1318** | **Yes** | **1313** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -160,7 +160,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | variables.test.sh | 86 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace, `shopt` builtin, nullglob |
 | wc.test.sh | 35 | word count (5 skipped) |
 | type.test.sh | 15 | `type`, `which`, `hash` builtins |
-| declare.test.sh | 16 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p`, `-n` nameref |
+| declare.test.sh | 23 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p`, `-n` nameref, `-l`/`-u` case conversion |
 | ln.test.sh | 5 | `ln -s`, `-f`, symlink creation |
 | eval-bugs.test.sh | 4 | regression tests for eval/script bugs |
 | script-exec.test.sh | 10 | script execution by path, $PATH search, exit codes |
@@ -183,7 +183,7 @@ Features that may be added in the future (not intentionally excluded):
 | ~~`getopts`~~ | ~~Medium~~ | Implemented: POSIX option parsing |
 | ~~`command` builtin~~ | ~~Medium~~ | Implemented: `-v`, `-V`, bypass functions |
 | ~~`type`/`which` builtins~~ | ~~Medium~~ | Implemented: `-t`, `-a`, `-p` flags |
-| ~~`declare` builtin~~ | ~~Medium~~ | Implemented: `-i`, `-r`, `-x`, `-a`, `-p` |
+| ~~`declare` builtin~~ | ~~Medium~~ | Implemented: `-i`, `-r`, `-x`, `-a`, `-p`, `-n`, `-l`, `-u` |
 | ~~`ln` builtin~~ | ~~Medium~~ | Implemented: symbolic links (`-s`, `-f`) |
 | `alias` | Low | Interactive feature |
 | History expansion | Out of scope | Interactive only |

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -610,6 +610,10 @@ criteria = "safe-to-deploy"
 version = "0.3.89"
 criteria = "safe-to-deploy"
 
+[[exemptions.js-sys]]
+version = "0.3.90"
+criteria = "safe-to-deploy"
+
 [[exemptions.leb128fmt]]
 version = "0.1.0"
 criteria = "safe-to-deploy"
@@ -1386,20 +1390,40 @@ criteria = "safe-to-run"
 version = "0.2.112"
 criteria = "safe-to-deploy"
 
+[[exemptions.wasm-bindgen]]
+version = "0.2.113"
+criteria = "safe-to-deploy"
+
 [[exemptions.wasm-bindgen-futures]]
 version = "0.4.62"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-futures]]
+version = "0.4.63"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
 version = "0.2.112"
 criteria = "safe-to-deploy"
 
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.113"
+criteria = "safe-to-deploy"
+
 [[exemptions.wasm-bindgen-macro-support]]
 version = "0.2.112"
 criteria = "safe-to-deploy"
 
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.113"
+criteria = "safe-to-deploy"
+
 [[exemptions.wasm-bindgen-shared]]
 version = "0.2.112"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.113"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-encoder]]
@@ -1420,6 +1444,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
 version = "0.3.89"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-sys]]
+version = "0.3.90"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]


### PR DESCRIPTION
## Summary
- Implement `declare -l` (lowercase) and `declare -u` (uppercase) variable attributes
- Attribute persists across assignments, converting values on each `set_variable()` call
- Store attributes as `_LOWER_<name>` / `_UPPER_<name>` marker variables (consistent with existing `_READONLY_*`, `_NAMEREF_*` patterns)

## Changes
- `crates/bashkit/src/interpreter/mod.rs`: Parse `-l`/`-u` flags, apply case conversion in declare and `set_variable()`
- `crates/bashkit/tests/spec_cases/bash/declare.test.sh`: 7 new spec tests covering basic, subsequent assignment, mixed case, override, and function usage
- `specs/009-implementation-status.md`: Update test counts (declare 16→23, Bash 893→900, Total 1311→1318)

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] All 7 new declare spec tests pass
- [x] Verified against real bash behavior