### PR TITLE
feat(builtins): implement set -o / set +o option display

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/variables.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/variables.test.sh
@@ -672,3 +672,50 @@ shopt -q extglob && echo "ext:on" || echo "ext:off"
 null:on
 ext:on
 ### end
+
+### set_dash_o_display
+# set -o shows options in human-readable format with grep
+set -o | grep "^errexit"
+### expect
+errexit        	off
+### end
+
+### set_dash_o_shows_enabled
+# set -o reflects enabled options
+set -e
+set -o | grep "^errexit"
+### expect
+errexit        	on
+### end
+
+### set_plus_o_display
+# set +o shows options in re-executable format
+set +o | grep "errexit"
+### expect
+set +o errexit
+### end
+
+### set_plus_o_shows_enabled
+# set +o reflects enabled options
+set -o pipefail
+set +o | grep "pipefail"
+### expect
+set -o pipefail
+### end
+
+### set_dash_o_noclobber
+# set -o noclobber and display
+set -o noclobber
+set -o | grep "^noclobber"
+### expect
+noclobber      	on
+### end
+
+### set_plus_o_restore
+# set +o output can be used to restore state
+set -o xtrace
+state=$(set +o 2>/dev/null | grep xtrace)
+echo "$state"
+### expect
+set -o xtrace
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1318 (1313 pass, 5 skip)
+**Total spec test cases:** 1324 (1319 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 900 | Yes | 895 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 906 | Yes | 901 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1318** | **Yes** | **1313** | **5** | |
+| **Total** | **1324** | **Yes** | **1319** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -157,7 +157,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | test-operators.test.sh | 17 | file/string tests |
 | time.test.sh | 11 | Wall-clock only (user/sys always 0) |
 | timeout.test.sh | 17 | |
-| variables.test.sh | 86 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace, `shopt` builtin, nullglob |
+| variables.test.sh | 92 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace, `shopt` builtin, nullglob, `set -o`/`set +o` display |
 | wc.test.sh | 35 | word count (5 skipped) |
 | type.test.sh | 15 | `type`, `which`, `hash` builtins |
 | declare.test.sh | 23 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p`, `-n` nameref, `-l`/`-u` case conversion |


### PR DESCRIPTION
## Summary
- Implement `set -o` human-readable option display (name + on/off)
- Implement `set +o` re-executable option display (`set -/+o name`)
- Format matches real bash exactly (15-char padded name, tab separator)

## Changes
- `crates/bashkit/src/builtins/vars.rs`: Add `SET_O_OPTIONS` list, `format_set_dash_o()`, `format_set_plus_o()`, handle bare `-o`/`+o` in Set execute
- `crates/bashkit/tests/spec_cases/bash/variables.test.sh`: 6 new spec tests
- `specs/009-implementation-status.md`: Update test counts (variables 86→92, Bash 900→906, Total 1318→1324)

## Test plan
- [x] `cargo test --all-features` passes (including bash comparison tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Output format verified against real bash byte-for-byte