### PR TITLE
feat(builtins): implement mktemp builtin

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -81,7 +81,7 @@ pub use disk::{Df, Du};
 pub use echo::Echo;
 pub use environ::{Env, History, Printenv};
 pub use export::Export;
-pub use fileops::{Chmod, Chown, Cp, Kill, Ln, Mkdir, Mv, Rm, Touch};
+pub use fileops::{Chmod, Chown, Cp, Kill, Ln, Mkdir, Mktemp, Mv, Rm, Touch};
 pub use flow::{Break, Colon, Continue, Exit, False, Return, True};
 pub use grep::Grep;
 pub use headtail::{Head, Tail};

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -238,6 +238,7 @@ impl Interpreter {
         builtins.insert("basename".to_string(), Box::new(builtins::Basename));
         builtins.insert("dirname".to_string(), Box::new(builtins::Dirname));
         builtins.insert("mkdir".to_string(), Box::new(builtins::Mkdir));
+        builtins.insert("mktemp".to_string(), Box::new(builtins::Mktemp));
         builtins.insert("rm".to_string(), Box::new(builtins::Rm));
         builtins.insert("cp".to_string(), Box::new(builtins::Cp));
         builtins.insert("mv".to_string(), Box::new(builtins::Mv));

--- a/crates/bashkit/tests/spec_cases/bash/fileops.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/fileops.test.sh
@@ -177,3 +177,68 @@ echo $?
 ### expect
 0
 ### end
+
+### mktemp_creates_file
+# mktemp creates a temp file and prints its path
+f=$(mktemp)
+[ -f "$f" ] && echo "ok"
+### expect
+ok
+### end
+
+### mktemp_in_tmp
+# mktemp creates file under /tmp
+f=$(mktemp)
+echo "$f" | grep -q "^/tmp/" && echo "in_tmp"
+### expect
+in_tmp
+### end
+
+### mktemp_directory
+# mktemp -d creates a directory
+d=$(mktemp -d)
+[ -d "$d" ] && echo "ok"
+### expect
+ok
+### end
+
+### mktemp_template
+# mktemp with template replaces XXXXXX
+f=$(mktemp /tmp/myapp.XXXXXX)
+echo "$f" | grep -q "^/tmp/myapp\." && echo "matched"
+[ -f "$f" ] && echo "exists"
+### expect
+matched
+exists
+### end
+
+### mktemp_dir_template
+# mktemp -d with template
+d=$(mktemp -d /tmp/mydir.XXXXXX)
+echo "$d" | grep -q "^/tmp/mydir\." && echo "matched"
+[ -d "$d" ] && echo "exists"
+### expect
+matched
+exists
+### end
+
+### mktemp_unique
+# mktemp creates unique names
+f1=$(mktemp)
+f2=$(mktemp)
+[ "$f1" != "$f2" ] && echo "unique"
+### expect
+unique
+### end
+
+### mktemp_p_flag
+# mktemp -p uses specified directory
+### bash_diff
+mkdir -p /tmp/custom
+f=$(mktemp -p /tmp/custom)
+echo "$f" | grep -q "^/tmp/custom/" && echo "in_custom"
+[ -f "$f" ] && echo "exists"
+### expect
+in_custom
+exists
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1329 (1324 pass, 5 skip)
+**Total spec test cases:** 1336 (1331 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 911 | Yes | 906 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 918 | Yes | 913 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1329** | **Yes** | **1324** | **5** | |
+| **Total** | **1336** | **Yes** | **1331** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -135,7 +135,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | diff.test.sh | 4 | line diffs |
 | echo.test.sh | 24 | escape sequences |
 | errexit.test.sh | 8 | set -e tests |
-| fileops.test.sh | 21 | |
+| fileops.test.sh | 28 | `mktemp`, `-d`, `-p`, template |
 | find.test.sh | 10 | file search |
 | functions.test.sh | 22 | local dynamic scoping, nested writes, FUNCNAME call stack |
 | getopts.test.sh | 9 | POSIX option parsing, combined flags, silent mode |


### PR DESCRIPTION
## Summary
- Implement `mktemp` builtin for creating temporary files and directories in the virtual filesystem
- Supports `-d` (create directory), `-p DIR` (custom prefix directory), `-t` (use tmpdir), and `TEMPLATE` with `XXXXXX` placeholder
- 7 spec tests covering: basic file creation, `/tmp` path, directory mode, template substitution, uniqueness, and `-p` flag

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Bash comparison tests pass
- [x] Spec counts updated (Bash 911→918, Total 1329→1336)