### PR TITLE
feat(builtins): implement printf %q shell quoting

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/printf.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/printf.test.sh
@@ -197,3 +197,47 @@ printf -v padded "%05d" 42; echo "$padded"
 ### expect
 00042
 ### end
+
+### printf_q_space
+# printf %q escapes spaces
+printf '%q\n' 'hello world'
+### expect
+hello\ world
+### end
+
+### printf_q_simple
+# printf %q leaves safe strings unquoted
+printf '%q\n' 'simple'
+### expect
+simple
+### end
+
+### printf_q_empty
+# printf %q quotes empty string
+printf '%q\n' ''
+### expect
+''
+### end
+
+### printf_q_special_chars
+# printf %q escapes special shell chars
+printf '%q\n' 'a"b'
+### expect
+a\"b
+### end
+
+### printf_q_tab
+# printf %q uses $'...' for control chars
+### bash_diff
+x=$(printf 'hello\tworld')
+printf '%q\n' "$x"
+### expect
+$'hello\tworld'
+### end
+
+### printf_q_single_quote
+# printf %q escapes single quotes
+printf '%q\n' "it's"
+### expect
+it\'s
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1359 (1354 pass, 5 skip)
+**Total spec test cases:** 1365 (1360 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 941 | Yes | 936 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 947 | Yes | 942 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1359** | **Yes** | **1354** | **5** | |
+| **Total** | **1365** | **Yes** | **1360** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -149,7 +149,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | paste.test.sh | 4 | line merging with `-s` serial and `-d` delimiter |
 | path.test.sh | 14 | |
 | pipes-redirects.test.sh | 19 | includes stderr redirects |
-| printf.test.sh | 26 | format specifiers, array expansion, `-v` variable assignment |
+| printf.test.sh | 32 | format specifiers, array expansion, `-v` variable assignment, `%q` shell quoting |
 | procsub.test.sh | 6 | |
 | sleep.test.sh | 6 | |
 | sortuniq.test.sh | 32 | sort and uniq, `-z` zero-terminated, `-m` merge |


### PR DESCRIPTION
## Summary
- Implement `printf %q` format specifier for shell-safe string quoting
- Matches bash behavior: backslash-escapes printable special chars, `$'...'` for control chars
- 6 spec tests covering: spaces, simple strings, empty, special chars, tabs, single quotes

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Spec counts updated (Bash 941→947, Total 1359→1365)