### PR TITLE
feat(interpreter): implement caller builtin

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/functions.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/functions.test.sh
@@ -203,3 +203,39 @@ echo "out: ${#FUNCNAME[@]}"
 in: f
 out: 0
 ### end
+
+### func_caller_in_function
+# caller reports calling context
+### bash_diff
+f() { caller 0; }
+f
+### expect
+1 main main
+### end
+
+### func_caller_nested
+# caller 0 reports immediate caller
+### bash_diff
+inner() { caller 0; }
+outer() { inner; }
+outer
+### expect
+1 outer main
+### end
+
+### func_caller_outside
+# caller outside function returns error
+caller 0
+echo "exit:$?"
+### expect
+exit:1
+### end
+
+### func_caller_no_args
+# caller with no args works same as caller 0
+### bash_diff
+f() { caller; }
+f
+### expect
+1 main main
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1365 (1360 pass, 5 skip)
+**Total spec test cases:** 1369 (1364 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 947 | Yes | 942 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 951 | Yes | 946 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1365** | **Yes** | **1360** | **5** | |
+| **Total** | **1369** | **Yes** | **1364** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -137,7 +137,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | errexit.test.sh | 8 | set -e tests |
 | fileops.test.sh | 28 | `mktemp`, `-d`, `-p`, template |
 | find.test.sh | 10 | file search |
-| functions.test.sh | 22 | local dynamic scoping, nested writes, FUNCNAME call stack |
+| functions.test.sh | 26 | local dynamic scoping, nested writes, FUNCNAME call stack, `caller` builtin |
 | getopts.test.sh | 9 | POSIX option parsing, combined flags, silent mode |
 | globs.test.sh | 12 | for-loop glob expansion, recursive `**` |
 | headtail.test.sh | 14 | |


### PR DESCRIPTION
## Summary
- Implement `caller` builtin for call stack introspection
- `caller 0`: reports immediate caller context (line, function, source)
- `caller N`: walks up N frames in the call stack
- Returns exit code 1 when called outside a function
- 4 spec tests covering: in-function, nested, outside-function, no-args

## Test plan
- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Spec counts updated (Bash 947→951, Total 1365→1369)