### PR TITLE
feat(builtins): implement file comparison test operators

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1227,6 +1227,35 @@ impl Interpreter {
                                 >= args[2].parse::<i64>().unwrap_or(0)
                         }
                         "=~" => self.regex_match(&args[0], &args[2]),
+                        "-nt" => {
+                            let lm = self.fs.stat(std::path::Path::new(&args[0])).await;
+                            let rm = self.fs.stat(std::path::Path::new(&args[2])).await;
+                            match (lm, rm) {
+                                (Ok(l), Ok(r)) => l.modified > r.modified,
+                                (Ok(_), Err(_)) => true,
+                                _ => false,
+                            }
+                        }
+                        "-ot" => {
+                            let lm = self.fs.stat(std::path::Path::new(&args[0])).await;
+                            let rm = self.fs.stat(std::path::Path::new(&args[2])).await;
+                            match (lm, rm) {
+                                (Ok(l), Ok(r)) => l.modified < r.modified,
+                                (Err(_), Ok(_)) => true,
+                                _ => false,
+                            }
+                        }
+                        "-ef" => {
+                            let lp = crate::builtins::resolve_path(
+                                &std::path::PathBuf::from("/"),
+                                &args[0],
+                            );
+                            let rp = crate::builtins::resolve_path(
+                                &std::path::PathBuf::from("/"),
+                                &args[2],
+                            );
+                            lp == rp
+                        }
                         _ => false,
                     }
                 }

--- a/crates/bashkit/tests/spec_cases/bash/test-operators.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/test-operators.test.sh
@@ -123,3 +123,95 @@ both true
 ### expect
 one true
 ### end
+
+### test_file_newer_than
+# Test -nt (file1 newer than file2)
+### bash_diff
+echo "old" > /tmp/old.txt
+sleep 0.01
+echo "new" > /tmp/new.txt
+[ /tmp/new.txt -nt /tmp/old.txt ] && echo "newer"
+### expect
+newer
+### end
+
+### test_file_older_than
+# Test -ot (file1 older than file2)
+### bash_diff
+echo "first" > /tmp/first.txt
+sleep 0.01
+echo "second" > /tmp/second.txt
+[ /tmp/first.txt -ot /tmp/second.txt ] && echo "older"
+### expect
+older
+### end
+
+### test_file_nt_nonexistent
+# -nt returns true if left exists and right doesn't
+echo "exists" > /tmp/exists_nt.txt
+[ /tmp/exists_nt.txt -nt /tmp/nonexistent_nt ] && echo "newer"
+### expect
+newer
+### end
+
+### test_file_ot_nonexistent
+# -ot returns true if left doesn't exist and right does
+echo "exists" > /tmp/exists_ot.txt
+[ /tmp/nonexistent_ot -ot /tmp/exists_ot.txt ] && echo "older"
+### expect
+older
+### end
+
+### test_file_ef_same_path
+# -ef returns true for same file
+echo "data" > /tmp/ef_test.txt
+[ /tmp/ef_test.txt -ef /tmp/ef_test.txt ] && echo "same"
+### expect
+same
+### end
+
+### test_file_ef_different_path
+# -ef returns false for different files
+echo "a" > /tmp/ef_a.txt
+echo "b" > /tmp/ef_b.txt
+[ /tmp/ef_a.txt -ef /tmp/ef_b.txt ] || echo "different"
+### expect
+different
+### end
+
+### test_file_nt_both_nonexistent
+# -nt returns false if both don't exist
+[ /tmp/no1 -nt /tmp/no2 ] || echo "false"
+### expect
+false
+### end
+
+### test_cond_nt
+# [[ ]] also supports -nt
+### bash_diff
+echo "old" > /tmp/c_old.txt
+sleep 0.01
+echo "new" > /tmp/c_new.txt
+[[ /tmp/c_new.txt -nt /tmp/c_old.txt ]] && echo "newer"
+### expect
+newer
+### end
+
+### test_cond_ot
+# [[ ]] also supports -ot
+### bash_diff
+echo "first" > /tmp/c_first.txt
+sleep 0.01
+echo "second" > /tmp/c_second.txt
+[[ /tmp/c_first.txt -ot /tmp/c_second.txt ]] && echo "older"
+### expect
+older
+### end
+
+### test_cond_ef
+# [[ ]] also supports -ef
+echo "data" > /tmp/c_ef.txt
+[[ /tmp/c_ef.txt -ef /tmp/c_ef.txt ]] && echo "same"
+### expect
+same
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1389 (1384 pass, 5 skip)
+**Total spec test cases:** 1399 (1394 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 971 | Yes | 966 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 981 | Yes | 976 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1389** | **Yes** | **1384** | **5** | |
+| **Total** | **1399** | **Yes** | **1394** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -154,7 +154,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | sleep.test.sh | 6 | |
 | sortuniq.test.sh | 32 | sort and uniq, `-z` zero-terminated, `-m` merge |
 | source.test.sh | 21 | source/., function loading, PATH search, positional params |
-| test-operators.test.sh | 17 | file/string tests |
+| test-operators.test.sh | 27 | file/string tests, `-nt`/`-ot`/`-ef` file comparisons |
 | time.test.sh | 11 | Wall-clock only (user/sys always 0) |
 | timeout.test.sh | 17 | |
 | variables.test.sh | 97 | includes special vars, prefix env, PIPESTATUS, trap EXIT, `${var@Q}`, `\<newline>` line continuation, PWD/HOME/USER/HOSTNAME/BASH_VERSION/SECONDS, `set -x` xtrace, `shopt` builtin, nullglob, `set -o`/`set +o` display, `trap -p` |


### PR DESCRIPTION
## Summary
- Implement `-nt` (newer than), `-ot` (older than), and `-ef` (same file) test operators
- Works in both `[ ]` test command and `[[ ]]` conditionals
- Uses VFS metadata timestamps for `-nt`/`-ot`, canonical path comparison for `-ef`
- Handles edge cases: nonexistent files, both nonexistent, same path

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features --test spec_tests bash_spec_tests` passes
- [x] 10 new spec tests (Bash 981, Total 1399)
- [x] Tests marked `bash_diff` where timing-dependent