### PR TITLE
feat(interpreter): implement glob options (dotglob, nocaseglob, failglob, noglob, globstar)

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/glob-options.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/glob-options.test.sh
@@ -1,0 +1,146 @@
+### dotglob_off_default
+# By default, * does not match dotfiles
+mkdir -p /tmp/dg_test
+cd /tmp/dg_test
+touch a b .hidden
+echo *
+### expect
+a b
+### end
+
+### dotglob_on
+# With dotglob, * matches dotfiles
+### bash_diff
+mkdir -p /tmp/dg_on
+cd /tmp/dg_on
+touch a b .hidden
+shopt -s dotglob
+echo *
+### expect
+.hidden a b
+### end
+
+### dotglob_explicit_dot
+# Pattern starting with . always matches dotfiles regardless of dotglob
+mkdir -p /tmp/dg_dot
+cd /tmp/dg_dot
+touch .foo .bar visible
+echo .*
+### expect
+.bar .foo
+### end
+
+### nocaseglob_off
+# Without nocaseglob, glob is case-sensitive
+mkdir -p /tmp/ncg_off
+cd /tmp/ncg_off
+touch ABC abc
+echo [a]*
+### expect
+abc
+### end
+
+### nocaseglob_on
+# With nocaseglob, glob is case-insensitive
+### bash_diff
+mkdir -p /tmp/ncg_on
+cd /tmp/ncg_on
+touch ABC abc
+shopt -s nocaseglob
+echo [a]*
+### expect
+ABC abc
+### end
+
+### nullglob_off
+# Without nullglob, unmatched glob stays literal
+mkdir -p /tmp/ng_off
+cd /tmp/ng_off
+echo *.nonexistent
+### expect
+*.nonexistent
+### end
+
+### nullglob_on
+# With nullglob, unmatched glob expands to nothing
+mkdir -p /tmp/ng_on
+cd /tmp/ng_on
+shopt -s nullglob
+for f in *.nonexistent; do echo "got: $f"; done
+echo "done"
+### expect
+done
+### end
+
+### failglob_on
+# With failglob, unmatched glob is an error
+### bash_diff
+mkdir -p /tmp/fg_on
+cd /tmp/fg_on
+shopt -s failglob
+echo *.nonexistent 2>/dev/null
+echo "exit:$?"
+### expect
+exit:1
+### end
+
+### noglob_set_f
+# set -f disables glob expansion
+mkdir -p /tmp/ng_setf
+cd /tmp/ng_setf
+touch a b c
+set -f
+echo *
+### expect
+*
+### end
+
+### noglob_restored
+# set +f re-enables glob expansion
+mkdir -p /tmp/ng_restore
+cd /tmp/ng_restore
+touch x y z
+set -f
+echo *
+set +f
+echo *
+### expect
+*
+x y z
+### end
+
+### dotglob_toggle
+# dotglob can be toggled off
+### bash_diff
+mkdir -p /tmp/dg_toggle
+cd /tmp/dg_toggle
+touch a .hidden
+shopt -s dotglob
+echo *
+shopt -u dotglob
+echo *
+### expect
+.hidden a
+a
+### end
+
+### globstar_off_default
+# Without globstar, ** is treated as regular *
+mkdir -p /tmp/gs_off/sub
+touch /tmp/gs_off/top.txt /tmp/gs_off/sub/deep.txt
+cd /tmp/gs_off
+echo **
+### expect
+sub top.txt
+### end
+
+### globstar_on
+# With globstar, ** matches recursively
+### bash_diff
+mkdir -p /tmp/gs_on/sub
+touch /tmp/gs_on/top.txt /tmp/gs_on/sub/deep.txt
+shopt -s globstar
+echo /tmp/gs_on/**/*.txt
+### expect
+/tmp/gs_on/sub/deep.txt /tmp/gs_on/top.txt
+### end

--- a/crates/bashkit/tests/spec_cases/bash/globs.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/globs.test.sh
@@ -37,7 +37,8 @@ echo a > /x1.txt; echo b > /x2.txt; echo /x[12].txt
 
 ### glob_recursive
 ### bash_diff: Bashkit VFS has files, real bash CI filesystem does not
-# Recursive glob with **
+# Recursive glob with ** (requires globstar)
+shopt -s globstar
 mkdir -p /recur/sub1/deep
 mkdir -p /recur/sub2
 echo a > /recur/f1.txt

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1411 (1406 pass, 5 skip)
+**Total spec test cases:** 1424 (1419 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 993 | Yes | 988 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 1006 | Yes | 1001 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1411** | **Yes** | **1406** | **5** | |
+| **Total** | **1424** | **Yes** | **1419** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -139,6 +139,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | find.test.sh | 10 | file search |
 | functions.test.sh | 26 | local dynamic scoping, nested writes, FUNCNAME call stack, `caller` builtin |
 | getopts.test.sh | 9 | POSIX option parsing, combined flags, silent mode |
+| glob-options.test.sh | 13 | dotglob, nocaseglob, failglob, nullglob, noglob, globstar |
 | globs.test.sh | 12 | for-loop glob expansion, recursive `**` |
 | headtail.test.sh | 14 | |
 | herestring.test.sh | 8 | 1 skipped |


### PR DESCRIPTION
## Summary

- Enforces shopt glob options during glob expansion: `dotglob`, `nocaseglob`, `failglob`, `noglob` (`set -f`), `globstar`
- Adds case-insensitive matching to `glob_match` and `match_bracket_expr`
- Gates `**` recursive glob on `shopt -s globstar` (bash-compatible behavior)
- Refactors three glob expansion call sites into shared `expand_glob_item` helper
- Adds 13 spec tests covering all glob options

## Test plan

- [x] All 1424 spec tests pass (1419 pass, 5 skip)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Existing `glob_recursive` test updated to use `shopt -s globstar`