### PR TITLE
feat(interpreter): implement extglob patterns (@, ?, *, +, !)

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -548,6 +548,32 @@ impl<'a> Lexer<'a> {
                         _ => {}
                     }
                 }
+            } else if ch == '(' && word.ends_with(['@', '?', '*', '+', '!']) {
+                // Extglob: @(...), ?(...), *(...), +(...), !(...)
+                // Consume through matching ) including nested parens
+                word.push(ch);
+                self.advance();
+                let mut depth = 1;
+                while let Some(c) = self.peek_char() {
+                    word.push(c);
+                    self.advance();
+                    match c {
+                        '(' => depth += 1,
+                        ')' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                break;
+                            }
+                        }
+                        '\\' => {
+                            if let Some(esc) = self.peek_char() {
+                                word.push(esc);
+                                self.advance();
+                            }
+                        }
+                        _ => {}
+                    }
+                }
             } else if self.is_word_char(ch) {
                 word.push(ch);
                 self.advance();

--- a/crates/bashkit/tests/spec_cases/bash/extglob.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/extglob.test.sh
@@ -1,0 +1,118 @@
+### extglob_at_basic
+# @(a|b) matches exactly one alternative
+shopt -s extglob
+case "foo" in @(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_at_no_match
+# @(a|b) doesn't match non-alternatives
+shopt -s extglob
+case "baz" in @(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+no
+### end
+
+### extglob_question_zero
+# ?(a|b) matches zero occurrences
+shopt -s extglob
+case "" in ?(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_question_one
+# ?(a|b) matches one occurrence
+shopt -s extglob
+case "foo" in ?(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_question_no_two
+# ?(a|b) does NOT match two occurrences
+shopt -s extglob
+case "foobar" in ?(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+no
+### end
+
+### extglob_plus_one
+# +(a|b) matches one occurrence
+shopt -s extglob
+case "foo" in +(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_plus_multiple
+# +(a|b) matches multiple occurrences
+shopt -s extglob
+case "foobar" in +(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_plus_no_zero
+# +(a|b) does NOT match zero
+shopt -s extglob
+case "" in +(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+no
+### end
+
+### extglob_star_zero
+# *(a|b) matches zero occurrences
+shopt -s extglob
+case "" in *(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_star_multiple
+# *(a|b) matches multiple occurrences
+shopt -s extglob
+case "foobarfoo" in *(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_not_basic
+# !(a|b) matches anything except alternatives
+shopt -s extglob
+case "baz" in !(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+match
+### end
+
+### extglob_not_reject
+# !(a|b) rejects exact matches
+shopt -s extglob
+case "foo" in !(foo|bar)) echo "match";; *) echo "no";; esac
+### expect
+no
+### end
+
+### extglob_conditional
+# extglob in [[ == ]]
+shopt -s extglob
+[[ "hello" == @(hello|world) ]] && echo "yes" || echo "no"
+### expect
+yes
+### end
+
+### extglob_conditional_no
+# extglob in [[ != ]]
+shopt -s extglob
+[[ "xyz" == @(hello|world) ]] && echo "yes" || echo "no"
+### expect
+no
+### end
+
+### extglob_off_literal
+# Without extglob, @(...) is literal
+case "@(foo)" in '@(foo)') echo "literal";; *) echo "no";; esac
+### expect
+literal
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -103,17 +103,17 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 
 ## Spec Test Coverage
 
-**Total spec test cases:** 1437 (1432 pass, 5 skip)
+**Total spec test cases:** 1452 (1447 pass, 5 skip)
 
 | Category | Cases | In CI | Pass | Skip | Notes |
 |----------|-------|-------|------|------|-------|
-| Bash (core) | 1019 | Yes | 1014 | 5 | `bash_spec_tests` in CI |
+| Bash (core) | 1034 | Yes | 1029 | 5 | `bash_spec_tests` in CI |
 | AWK | 96 | Yes | 96 | 0 | loops, arrays, -v, ternary, field assign, getline, %.6g |
 | Grep | 76 | Yes | 76 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect |
 | Sed | 75 | Yes | 75 | 0 | hold space, change, regex ranges, -E |
 | JQ | 114 | Yes | 114 | 0 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
 | Python | 57 | Yes | 57 | 0 | embedded Python (Monty) |
-| **Total** | **1437** | **Yes** | **1432** | **5** | |
+| **Total** | **1452** | **Yes** | **1447** | **5** | |
 
 ### Bash Spec Tests Breakdown
 
@@ -172,6 +172,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | string-ops.test.sh | 14 | string replacement (prefix/suffix anchored), `${var:?}`, case conversion |
 | read-builtin.test.sh | 10 | `read` builtin, IFS splitting, `-r`, `-a` (array), `-n` (nchars), here-string |
 | expr.test.sh | 13 | `expr` arithmetic, string ops, pattern matching, exit codes |
+| extglob.test.sh | 15 | `@()`, `?()`, `*()`, `+()`, `!()` extended globs |
 | dirstack.test.sh | 12 | `pushd`, `popd`, `dirs` directory stack operations |
 
 ## Shell Features
@@ -183,7 +184,7 @@ Features that may be added in the future (not intentionally excluded):
 | Feature | Priority | Notes |
 |---------|----------|-------|
 | Coprocesses `coproc` | Low | Rarely used |
-| Extended globs `@()` `!()` | Medium | Requires `shopt -s extglob` |
+| ~~Extended globs `@()` `!()` `?()` `*()` `+()`~~ | ~~Medium~~ | Implemented: all five extglob operators |
 | ~~Associative arrays `declare -A`~~ | ~~Medium~~ | Implemented: key-value access, iteration, unset, `${!m[@]}` |
 | ~~`[[ =~ ]]` regex matching~~ | ~~Medium~~ | Implemented: `[[ ]]` conditionals with `=~` and BASH_REMATCH |
 | ~~`getopts`~~ | ~~Medium~~ | Implemented: POSIX option parsing |


### PR DESCRIPTION
## Summary

- Implements all five extended glob operators gated on `shopt -s extglob`
- `@(pat|pat)` — exactly one alternative
- `?(pat|pat)` — zero or one
- `*(pat|pat)` — zero or more (recursive backtracking)
- `+(pat|pat)` — one or more (recursive backtracking)
- `!(pat|pat)` — anything except the alternatives
- Lexer updated to consume `OP(...)` as single word tokens
- Works in `case` statements and `[[ == ]]` conditionals
- Nested extglob patterns supported via recursive parsing

## Test plan

- [x] 15 new spec tests covering all five operators
- [x] All 1452 spec tests pass (1447 pass, 5 skip)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Existing glob/case tests still pass