### PR TITLE
chore(release): prepare v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.7] - 2026-02-26
 
 ### Highlights
 
@@ -59,7 +59,7 @@
 * chore(deps): upgrade monty to latest main (87f8f31) ([#226](https://github.com/everruns/bashkit/pull/226))
 * fix(ci): repair nightly CI and add fuzz compile guard ([#225](https://github.com/everruns/bashkit/pull/225))
 
-**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.1.6...HEAD
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.1.6...v0.1.7
 
 ## [0.1.6] - 2026-02-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 authors = ["Everruns"]


### PR DESCRIPTION
## Summary

- Bump workspace version from 0.1.6 to 0.1.7
- Update CHANGELOG.md with release date (2026-02-26)

## Changelog excerpt

### Highlights

- 20+ new builtins: `declare`/`typeset`, `let`, `getopts`, `trap`, `caller`, `shopt`, `pushd`/`popd`/`dirs`, `seq`, `tac`, `rev`, `yes`, `expr`, `mktemp`, `realpath`, and more
- Glob options: `dotglob`, `nocaseglob`, `failglob`, `noglob`, `globstar`
- Shell flags: `bash -e/-x/-u/-f/-o`, `set -x` xtrace debugging
- `select` construct, `case ;;&` fallthrough, `FUNCNAME` variable
- Nameref variables (`declare -n`), case conversion (`declare -l/-u`)
- 10+ bug fixes for quoting, arrays, globs, and redirections

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes
- [x] `cargo test --all-features` — 1762 tests pass, 0 failures