### PR TITLE
fix(ci): pass commit message via env to avoid backtick injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,17 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             # Manual trigger: read version from Cargo.toml
             VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           else
-            # Push trigger: extract from commit message
-            COMMIT_MSG="${{ github.event.head_commit.message }}"
-            VERSION=$(echo "$COMMIT_MSG" | sed -n 's/.*prepare v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
+            # Push trigger: extract from first line of commit message
+            FIRST_LINE=$(echo "$COMMIT_MSG" | head -1)
+            VERSION=$(echo "$FIRST_LINE" | sed -n 's/.*prepare v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
           fi
           if [ -z "$VERSION" ]; then
             echo "Error: Could not determine version"


### PR DESCRIPTION
## Summary

- Fix release.yml workflow failure caused by backtick command substitution
- The squash-merged commit message contained backtick-quoted names (e.g. `let`, `pushd`, `seq`) which bash interpreted as command substitution when interpolated via `${{ }}`
- Pass the commit message through an environment variable instead, and extract version from first line only

## Test plan

- [x] Verified the workflow YAML is valid
- [ ] Re-trigger release workflow after merge to verify fix