### PR TITLE
fix(test): trim whitespace in parse_int for integer comparisons

### DIFF
--- a/crates/bashkit/src/builtins/test.rs
+++ b/crates/bashkit/src/builtins/test.rs
@@ -248,5 +248,5 @@ async fn evaluate_binary(left: &str, op: &str, right: &str, fs: &Arc<dyn FileSys
 }
 
 fn parse_int(s: &str) -> i64 {
-    s.parse().unwrap_or(0)
+    s.trim().parse().unwrap_or(0)
 }

--- a/crates/bashkit/tests/issue_276_test.rs
+++ b/crates/bashkit/tests/issue_276_test.rs
@@ -1,0 +1,24 @@
+//! Regression test for #276: parse_int doesn't trim whitespace
+
+use bashkit::Bash;
+
+#[tokio::test]
+async fn issue_276_parse_int_trims_whitespace() {
+    let mut bash = Bash::new();
+    // wc pads output with spaces; integer comparison must still work
+    let r = bash
+        .exec(r#"[ "  3  " -ge 2 ] && echo yes || echo no"#)
+        .await
+        .unwrap();
+    assert_eq!(r.stdout.trim(), "yes");
+}
+
+#[tokio::test]
+async fn issue_276_wc_output_in_comparison() {
+    let mut bash = Bash::new();
+    let r = bash
+        .exec(r#"count=$(echo -e "a\nb\nc" | wc -l); [ "$count" -ge 2 ] && echo has || echo no"#)
+        .await
+        .unwrap();
+    assert_eq!(r.stdout.trim(), "has");
+}


### PR DESCRIPTION
## Summary
- `parse_int` in the test/`[` builtin now calls `.trim()` before parsing, matching real bash behavior
- Fixes `wc` output (space-padded numbers) breaking `[ "$count" -ge N ]` comparisons

## Test plan
- [x] `issue_276_parse_int_trims_whitespace` — verifies `[ "  3  " -ge 2 ]` works
- [x] `issue_276_wc_output_in_comparison` — verifies wc pipeline output in comparison

Closes #276