### PR TITLE
fix(interpreter): forward pipeline stdin to user-defined functions

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3087,8 +3087,15 @@ impl Interpreter {
                 .collect();
             let prev_funcname = self.arrays.insert("FUNCNAME".to_string(), funcname_arr);
 
+            // Forward pipeline stdin to function body
+            let prev_pipeline_stdin = self.pipeline_stdin.take();
+            self.pipeline_stdin = stdin;
+
             // Execute function body
             let mut result = self.execute_command(&func_def.body).await?;
+
+            // Restore previous pipeline stdin
+            self.pipeline_stdin = prev_pipeline_stdin;
 
             // Pop call frame and function counter
             self.call_stack.pop();

--- a/crates/bashkit/tests/issue_274_test.rs
+++ b/crates/bashkit/tests/issue_274_test.rs
@@ -1,0 +1,31 @@
+//! Regression test for #274: Pipeline stdin not forwarded to user-defined functions
+
+use bashkit::Bash;
+use std::path::Path;
+
+#[tokio::test]
+async fn issue_274_pipeline_stdin_to_function() {
+    let mut bash = Bash::new();
+    let r = bash
+        .exec("to_upper() { tr '[:lower:]' '[:upper:]'; }\necho hello | to_upper")
+        .await
+        .unwrap();
+    assert_eq!(r.stdout.trim(), "HELLO");
+}
+
+#[tokio::test]
+async fn issue_274_pipeline_stdin_to_sourced_function() {
+    let mut bash = Bash::new();
+    let fs = bash.fs();
+    fs.write_file(
+        Path::new("/lib.sh"),
+        b"to_upper() { tr '[:lower:]' '[:upper:]'; }",
+    )
+    .await
+    .unwrap();
+    let r = bash
+        .exec("source /lib.sh\necho hello world | to_upper")
+        .await
+        .unwrap();
+    assert_eq!(r.stdout.trim(), "HELLO WORLD");
+}


### PR DESCRIPTION
## Summary
- Set `self.pipeline_stdin` before executing function body, restore after
- Same pattern already used for compound commands in pipelines (line ~2583)

## Test plan
- [x] `issue_274_pipeline_stdin_to_function` — `echo hello | to_upper` works
- [x] `issue_274_pipeline_stdin_to_sourced_function` — sourced function receives stdin

Closes #274