### PR TITLE
fix(jq): return ExecResult::err instead of Error::Execution for stderr suppression

### DIFF
--- a/crates/bashkit/tests/issue_277_test.rs
+++ b/crates/bashkit/tests/issue_277_test.rs
@@ -1,0 +1,23 @@
+//! Regression test for #277: jq stderr output cannot be suppressed via 2>/dev/null
+
+use bashkit::Bash;
+
+#[tokio::test]
+async fn issue_277_jq_stderr_suppressed() {
+    let mut bash = Bash::new();
+    let r = bash
+        .exec(r#"echo "not json" | jq '.foo' 2>/dev/null; echo "exit=$?""#)
+        .await
+        .unwrap();
+    // stderr should be suppressed by 2>/dev/null; stdout should only contain exit code line
+    assert!(
+        !r.stdout.contains("error"),
+        "jq error should be suppressed, stdout={:?}",
+        r.stdout
+    );
+    assert!(
+        r.stdout.contains("exit="),
+        "should see exit code echo, stdout={:?}",
+        r.stdout
+    );
+}


### PR DESCRIPTION
## Summary
- jq builtin returned `Err(Error::Execution(...))` for parse/runtime errors
- This bypassed `apply_redirections`, so `2>/dev/null` couldn't suppress errors
- Changed all error paths to return `Ok(ExecResult::err(...))` with non-zero exit code
- Errors now flow through normal redirect handling

## Test plan
- [x] `issue_277_jq_stderr_suppressed` — `jq '.foo' 2>/dev/null` suppresses error
- [x] All 41 existing jq unit tests pass (updated 5 that expected `is_err()`)

Closes #277