### PR TITLE
chore: close verified-not-reproducible issues #279, #282

### DIFF
--- a/crates/bashkit/tests/issue_275_279_282_test.rs
+++ b/crates/bashkit/tests/issue_275_279_282_test.rs
@@ -1,5 +1,9 @@
 //! Regression tests verifying issues #275, #279, #282 are not reproducible.
 //!
+//! - Issue #275: Parser corrupts `\(` in single-quoted strings — works correctly
+//! - Issue #279: `done` cannot be used as a case pattern — works correctly
+//! - Issue #282: `find -type f` doesn't enumerate VFS files — works correctly
+//!
 //! These issues were reported but code review and testing confirm
 //! they work correctly in the current implementation.
 


### PR DESCRIPTION
## Summary
- Adds detailed per-issue documentation to the regression test file header
- Issues #279 and #282 were verified as not reproducible with regression tests in PR #306

Closes #279, closes #282

## Test plan
- [x] Regression tests already passing (merged in PR #306)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean