### PR TITLE
refactor(error): add From<regex::Error> impl for Error

### DIFF
--- a/crates/bashkit/src/error.rs
+++ b/crates/bashkit/src/error.rs
@@ -49,6 +49,10 @@ pub enum Error {
     #[error("network error: {0}")]
     Network(String),
 
+    /// Regex compilation or matching error.
+    #[error("regex error: {0}")]
+    Regex(#[from] regex::Error),
+
     /// Internal error for unexpected failures.
     ///
     /// THREAT[TM-INT-002]: Unexpected internal failures should not crash the interpreter.

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -671,6 +671,7 @@ fn error_kind(e: &Error) -> String {
         Error::CommandNotFound(_) => "command_not_found".to_string(),
         Error::ResourceLimit(_) => "resource_limit".to_string(),
         Error::Network(_) => "network_error".to_string(),
+        Error::Regex(_) => "regex_error".to_string(),
         Error::Internal(_) => "internal_error".to_string(),
     }
 }


### PR DESCRIPTION
## Summary
- Add `Regex` variant to `Error` enum with `#[from] regex::Error`
- Handle new variant in `error_kind()` match in tool.rs

Closes #319

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test --all-features` passes (all 69 tests pass)