### PR TITLE
feat(tool): add per-tool-call timeout_ms to ToolRequest

### DIFF
--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -491,7 +491,12 @@ impl ScriptedTool {
     fn execute<'py>(&self, py: Python<'py>, commands: String) -> PyResult<Bound<'py, PyAny>> {
         let mut tool = self.build_rust_tool();
         future_into_py(py, async move {
-            let resp = tool.execute(ToolRequest { commands }).await;
+            let resp = tool
+                .execute(ToolRequest {
+                    commands,
+                    timeout_ms: None,
+                })
+                .await;
             Ok(ExecResult {
                 stdout: resp.stdout,
                 stderr: resp.stderr,
@@ -507,7 +512,13 @@ impl ScriptedTool {
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to create runtime: {}", e)))?;
 
-        let resp = rt.block_on(async move { tool.execute(ToolRequest { commands }).await });
+        let resp = rt.block_on(async move {
+            tool.execute(ToolRequest {
+                commands,
+                timeout_ms: None,
+            })
+            .await
+        });
         Ok(ExecResult {
             stdout: resp.stdout,
             stderr: resp.stderr,

--- a/crates/bashkit/examples/scripted_tool.rs
+++ b/crates/bashkit/examples/scripted_tool.rs
@@ -37,6 +37,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = tool
         .execute(ToolRequest {
             commands: "get_user --id 1".to_string(),
+            timeout_ms: None,
         })
         .await;
     println!("$ get_user --id 1");
@@ -47,6 +48,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = tool
         .execute(ToolRequest {
             commands: "get_user --id 1 | jq -r '.name'".to_string(),
+            timeout_ms: None,
         })
         .await;
     println!("$ get_user --id 1 | jq -r '.name'");
@@ -67,6 +69,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = tool
         .execute(ToolRequest {
             commands: script.to_string(),
+            timeout_ms: None,
         })
         .await;
     println!("$ <multi-step script>");
@@ -91,6 +94,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = tool
         .execute(ToolRequest {
             commands: script.to_string(),
+            timeout_ms: None,
         })
         .await;
     println!("$ <loop with conditional>");
@@ -113,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = tool
         .execute(ToolRequest {
             commands: script.to_string(),
+            timeout_ms: None,
         })
         .await;
     println!("$ <inventory check>");
@@ -133,6 +138,7 @@ async fn main() -> anyhow::Result<()> {
     let resp = tool
         .execute(ToolRequest {
             commands: script.to_string(),
+            timeout_ms: None,
         })
         .await;
     println!("$ <aggregate report>");

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -42,6 +42,7 @@
 //!
 //! let resp = tool.execute(ToolRequest {
 //!     commands: "greet --name Alice".to_string(),
+//!     timeout_ms: None,
 //! }).await;
 //!
 //! assert_eq!(resp.stdout.trim(), "hello Alice");
@@ -415,6 +416,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: String::new(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -427,6 +429,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "get_user --id 42".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -440,6 +443,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "get_user --id=42".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -452,6 +456,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "get_user --id 42 | jq -r '.name'".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -471,6 +476,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: script.to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -483,6 +489,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "fail_tool".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_ne!(resp.exit_code, 0);
@@ -495,6 +502,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "fail_tool || echo 'fallback'".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -507,6 +515,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "echo hello | from_stdin".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -524,6 +533,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: script.to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -545,6 +555,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: script.to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -563,6 +574,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "echo $API_BASE".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -581,6 +593,7 @@ mod tests {
             .execute_with_status(
                 ToolRequest {
                     commands: "get_user --id 1".to_string(),
+                    timeout_ms: None,
                 },
                 Box::new(move |status| {
                     phases_clone
@@ -605,6 +618,7 @@ mod tests {
         let resp1 = tool
             .execute(ToolRequest {
                 commands: "get_user --id 1 | jq -r '.name'".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp1.stdout.trim(), "Alice");
@@ -612,6 +626,7 @@ mod tests {
         let resp2 = tool
             .execute(ToolRequest {
                 commands: "get_orders --user_id 1 | jq 'length'".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp2.stdout.trim(), "2");
@@ -639,6 +654,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "search --verbose --query hello".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);
@@ -657,6 +673,7 @@ mod tests {
         let resp = tool
             .execute(ToolRequest {
                 commands: "echo_args --name Alice --count 3".to_string(),
+                timeout_ms: None,
             })
             .await;
         assert_eq!(resp.exit_code, 0);

--- a/specs/009-tool-contract.md
+++ b/specs/009-tool-contract.md
@@ -157,7 +157,8 @@ CONFIGURATION
 
 ```rust
 pub struct ToolRequest {
-    pub commands: String,  // Like bash -c "commands"
+    pub commands: String,           // Like bash -c "commands"
+    pub timeout_ms: Option<u64>,    // Per-call timeout (exit 124 on expiry)
 }
 
 pub struct ToolResponse {
@@ -183,6 +184,7 @@ let mut tool = BashTool::builder()
 
 let response = tool.execute(ToolRequest {
     commands: "echo hello".to_string(),
+    timeout_ms: None,
 }).await;
 ```
 
@@ -254,9 +256,9 @@ Allows multiple tool implementations to share the same interface. Future tools (
 
 Aligns with `bash -c "commands"` semantics. Clearer that it's inline commands, not a script file.
 
-### Why no `timeout_ms`?
+### Why `timeout_ms` on `ToolRequest`?
 
-Use `timeout` builtin in commands: `timeout 5 long_running_cmd`. Keeps the API simple.
+Per-call timeouts let orchestrating systems (LangChain, CrewAI) enforce limits without wrapping every command in `timeout`. Returns exit code 124 (matching bash `timeout` convention). The `timeout` builtin still works for per-command granularity.
 
 ### Why man-page format for `help()`?
 


### PR DESCRIPTION
## Summary
- Add optional `timeout_ms` field to `ToolRequest` for per-call execution timeouts
- Returns exit code 124 on timeout (matching bash `timeout` convention)
- Both `execute` and `execute_with_status` respect the timeout
- Backward compatible: field uses `#[serde(default)]` so existing JSON without it still works

## Test plan
- [x] Unit test: timeout triggers on `sleep 10` with 100ms timeout (exit 124)
- [x] Unit test: fast command completes within generous timeout (exit 0)
- [x] Unit test: `ToolRequest::new()` convenience constructor
- [x] Unit test: JSON deserialization with and without `timeout_ms`
- [x] All existing tool tests pass (49 tests)
- [ ] CI green

Closes #337