### PR TITLE
chore: add ignored-test review step to process-issues

### DIFF
--- a/.claude/commands/process-issues.md
+++ b/.claude/commands/process-issues.md
@@ -52,6 +52,16 @@ For each open issue (`gh issue list --state open`), in order by issue number:
 - Add resolution comment on the issue if helpful
 - Move to next issue
 
+### 10. Review ignored tests
+After all issues are processed, scan for `#[ignore]` tests across the codebase:
+- `grep -rn '#\[ignore\]' crates/` to find all ignored tests
+- For each ignored test, determine why it was ignored (read surrounding comments, git blame)
+- Classify into: (a) can un-ignore now — underlying issue fixed, (b) blocked — still needs work, create/link issue, (c) intentionally ignored — e.g. slow, requires external resource
+- Un-ignore tests in category (a), run them, verify they pass
+- For category (b), ensure a tracking issue exists
+- Commit any un-ignored tests as `test: un-ignore {test_name}, now passing`
+- Create a single PR for all un-ignored tests (separate from issue PRs)
+
 ## Rules
 - One issue = one PR. Do not bundle.
 - If an issue is unclear or not reproducible, comment asking for clarification and skip to next.


### PR DESCRIPTION
## Summary
- Adds step 10 to the `process-issues` command: after all issues are processed, scan for `#[ignore]` tests, classify them, and un-ignore any that now pass
- Ensures blocked tests have tracking issues and intentionally-ignored tests are left alone

## Test plan
- [ ] Verify `.claude/commands/process-issues.md` contains the new step 10
- [ ] Confirm existing steps 0-9 are unchanged

https://claude.ai/code/session_016LwixojZhcz6rcxvw41Ajv