### PR TITLE
fix(builtins): make xargs execute commands instead of echoing

### DIFF
--- a/crates/bashkit/src/builtins/pipeline.rs
+++ b/crates/bashkit/src/builtins/pipeline.rs
@@ -16,8 +16,8 @@ use crate::interpreter::ExecResult;
 ///   -d DELIM     Use DELIM as delimiter instead of whitespace
 ///   -0           Use NUL as delimiter (same as -d '\0')
 ///
-/// Note: In virtual mode, xargs outputs the commands that would be run
-/// instead of executing them, unless the command is a builtin.
+/// Note: xargs is intercepted at the interpreter level for actual command
+/// execution. This builtin fallback only handles option parsing/validation.
 pub struct Xargs;
 
 #[async_trait]


### PR DESCRIPTION
## Summary

- Fix xargs to execute commands through the interpreter instead of echoing them as text
- Intercept `xargs` at the interpreter level (alongside `timeout`, `eval`, `source`) and dispatch constructed `SimpleCommand`s via `execute_command()`
- Add 5 integration tests covering: basic execution, default echo, newline splitting, `-n 1` per-item execution, and `-I {}` replacement

Closes #346

## Test plan

- [x] `test_xargs_executes_command` - verifies `echo file.txt | xargs cat` reads file contents
- [x] `test_xargs_default_echo` - verifies `echo 'a b c' | xargs` defaults to echo
- [x] `test_xargs_splits_newlines` - verifies multi-line input is split into separate args
- [x] `test_xargs_n1_executes_per_item` - verifies `-n 1` executes once per argument
- [x] `test_xargs_replace_str` - verifies `-I {}` substitution with actual execution
- [x] All existing xargs unit tests still pass (option parsing, `-d`, `-0`, etc.)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p bashkit --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p bashkit --lib --all-features` - 1109 tests pass
- [x] `cargo test -p bashkit --all-features --tests` - 118 integration tests pass