### PR TITLE
feat(interpreter): implement recursive variable deref and array access in arithmetic

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/arith-dynamic.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arith-dynamic.test.sh
@@ -12,7 +12,6 @@ echo $(( x + 2 * 3 ))
 
 ### arith_dyn_var_expression
 # Variable containing expression is re-evaluated
-### skip: TODO arithmetic variable re-evaluation of expressions not implemented
 x='1 + 2'
 echo $(( x * 3 ))
 ### expect
@@ -29,7 +28,6 @@ echo $(( $x * 3 ))
 
 ### arith_dyn_quoted_substitution
 # "$x" in arithmetic
-### skip: TODO double-quoted substitution in arithmetic not implemented
 x='1 + 2'
 echo $(( "$x" * 3 ))
 ### expect
@@ -38,7 +36,6 @@ echo $(( "$x" * 3 ))
 
 ### arith_dyn_nested_var
 # Nested variable reference in arithmetic
-### skip: TODO recursive variable dereferencing in arithmetic not implemented
 a=3
 b=a
 echo $(( b + 1 ))
@@ -48,7 +45,6 @@ echo $(( b + 1 ))
 
 ### arith_dyn_array_index
 # Dynamic array index
-### skip: TODO array access in arithmetic expressions not implemented
 arr=(10 20 30 40)
 i=2
 echo $(( arr[i] ))
@@ -58,7 +54,6 @@ echo $(( arr[i] ))
 
 ### arith_dyn_array_index_expr
 # Expression as array index
-### skip: TODO array access in arithmetic expressions not implemented
 arr=(10 20 30 40)
 echo $(( arr[1+1] ))
 ### expect


### PR DESCRIPTION
## Summary
- Implement recursive variable dereferencing in arithmetic context: bare variable names are recursively resolved until a numeric value is found (e.g. `b=a; a=3; $((b+1))` yields `4`)
- Add expression re-evaluation: variable values containing arithmetic expressions are evaluated as sub-expressions with proper grouping (e.g. `x='1+2'; $((x*3))` yields `9`)
- Add array element access in arithmetic: `arr[expr]` evaluates the index expression and looks up the array element
- Handle double-quoted substitution in arithmetic context by stripping quotes

Closes #361

## Test plan
- [x] Enabled 5 previously-skipped spec tests in `arith-dynamic.test.sh`
- [x] All 1015 library unit tests pass
- [x] All bash spec tests pass (1184 passed, 0 failed)
- [x] Bash comparison tests pass (vs real bash)
- [x] `cargo fmt --check` clean
- [x] Pre-existing clippy warning unrelated to this change (`resolve_redirect_url` dead code)