### PR TITLE
fix(interpreter): count unicode chars in ${#x} and add printf \u/\U escapes

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4977,7 +4977,7 @@ impl Interpreter {
                     } else {
                         self.expand_variable(name)
                     };
-                    result.push_str(&value.len().to_string());
+                    result.push_str(&value.chars().count().to_string());
                 }
                 WordPart::ParameterExpansion {
                     name,

--- a/crates/bashkit/tests/spec_cases/bash/unicode.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/unicode.test.sh
@@ -41,7 +41,7 @@ echo $'\U000003bc'
 
 ### unicode_printf_u
 # printf \u escape
-### skip: TODO printf \u unicode escape not implemented
+### bash_diff: system bash printf \u requires UTF-8 locale
 printf '\u03bc\n'
 ### expect
 μ
@@ -49,7 +49,7 @@ printf '\u03bc\n'
 
 ### unicode_printf_U
 # printf \U escape
-### skip: TODO printf \U unicode escape not implemented
+### bash_diff: system bash printf \U requires UTF-8 locale
 printf '\U000003bc\n'
 ### expect
 μ
@@ -65,7 +65,7 @@ café
 
 ### unicode_string_length
 # String length of unicode string
-### skip: TODO ${#x} counts bytes instead of characters for unicode
+### bash_diff: system bash ${#x} counts bytes in POSIX locale, chars in UTF-8
 x=café
 echo ${#x}
 ### expect

--- a/crates/bashkit/tests/spec_tests.rs
+++ b/crates/bashkit/tests/spec_tests.rs
@@ -8,7 +8,7 @@
 //! - `### skip: reason` - Skip test entirely (not run in any test)
 //! - `### bash_diff: reason` - Known difference from real bash (runs in spec tests, excluded from comparison)
 //!
-//! ## Skipped Tests (18 total)
+//! ## Skipped Tests (15 total)
 //!
 //! Actual `### skip:` markers across spec test files:
 //!


### PR DESCRIPTION
## Summary
- Fix `${#x}` to count Unicode characters instead of bytes: `x=café; echo ${#x}` now correctly returns `4` instead of `5`
- Add `\uHHHH` (4-digit) and `\UHHHHHHHH` (8-digit) Unicode escape handling to the printf builtin, both in format strings and `%b` argument expansion
- Remove 3 `### skip:` markers from `unicode.test.sh` and replace with `### bash_diff:` markers (system bash behavior differs based on locale)

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] All 1015 unit tests pass
- [x] Bash spec tests: 1184 passed, 0 failed (100% pass rate)
- [x] Bash comparison tests: 1081/1081 match real bash (100%)
- [x] New printf unicode unit tests: `test_unicode_escape_u`, `test_unicode_escape_big_u`, `test_unicode_escape_ascii`, `test_unicode_escape_in_expand`

Closes #362