### PR TITLE
fix(parser): handle heredoc pipe ordering and edge cases

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/heredoc-edge.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/heredoc-edge.test.sh
@@ -28,7 +28,6 @@ $var $(echo nope) $((1+2))
 
 ### heredoc_partial_quote_delimiter
 # Partial quote in delimiter still prevents expansion
-### skip: TODO partial quoting in heredoc delimiter not implemented
 cat <<'EOF'"2"
 one
 two
@@ -40,7 +39,6 @@ two
 
 ### heredoc_pipe_first_line
 # Here doc with pipe on first line
-### skip: TODO heredoc piped to sort - pipe ordering issue
 cat <<EOF | sort
 c
 a
@@ -54,7 +52,6 @@ c
 
 ### heredoc_pipe_last_line
 # Here doc with pipe continued on last line
-### skip: TODO heredoc pipe continuation - pipe ordering issue
 cat <<EOF |
 c
 a
@@ -94,7 +91,6 @@ X 3
 
 ### heredoc_in_while_condition
 # Here doc in while condition and body
-### skip: TODO multiple heredocs in while condition not parsed
 while cat <<E1 && cat <<E2; do cat <<E3; break; done
 1
 E1
@@ -110,7 +106,6 @@ E3
 
 ### heredoc_multiline_condition
 # Here doc in while condition on multiple lines
-### skip: TODO multiple heredocs in while condition not parsed
 while cat <<E1 && cat <<E2
 1
 E1
@@ -130,7 +125,6 @@ done
 
 ### heredoc_with_multiline_dquote
 # Here doc with multiline double quoted string
-### skip: TODO heredoc followed by multiline dquote on same line not parsed correctly
 cat <<EOF; echo "two
 three"
 one


### PR DESCRIPTION
## Summary
- Fix heredoc pipe ordering: `cat <<EOF | sort` now correctly pipes heredoc content to the next command in the pipeline
- Fix pipe continuation: `cat <<EOF |\nsort` works via rest-of-line re-injection
- Handle partial quote delimiters: `<<'EOF'"2"` correctly combines to delimiter `EOF2` with quoting preventing expansion
- Fix multiple heredocs on one line: `while cat <<E1 && cat <<E2; do ... done` parses and executes correctly
- Fix heredoc followed by multiline dquote: `cat <<EOF; echo "two\nthree"` handles quoted strings spanning lines
- Capture while/until condition stdout so heredocs in loop conditions produce visible output

All 6 previously-skipped heredoc-edge spec tests are now enabled and passing.

## Approach
**Lexer**: Added a `VecDeque<char>` re-injection buffer. `read_heredoc` saves the rest of the command line (after the heredoc delimiter token) instead of discarding it, then re-injects it after reading the heredoc body. `peek_char`/`advance` check the buffer first.

**Lexer**: `read_continuation_into` concatenates adjacent quoted/unquoted segments after a single-quoted string, enabling partial-quote heredoc delimiters.

**Interpreter**: `execute_while` and `execute_until` now capture and emit condition command stdout/stderr.

## Test plan
- [x] All 6 heredoc-edge skipped tests enabled and passing
- [x] 2 new parser unit tests (heredoc pipe, multiple heredocs)
- [x] Full spec test suite passes (1305 tests, 1192 passed, 0 failed, 113 skipped)
- [x] bash_comparison_tests pass (identical output to real bash)
- [x] All 1017 lib unit tests pass
- [x] `cargo fmt --check` clean
- [x] No new clippy warnings (pre-existing `resolve_redirect_url` dead_code only)

Closes #359