### PR TITLE
feat(builtins): add grep -L, --exclude-dir, -s, -Z flags

### DIFF
--- a/crates/bashkit/tests/spec_cases/grep/grep.test.sh
+++ b/crates/bashkit/tests/spec_cases/grep/grep.test.sh
@@ -571,3 +571,46 @@ printf 'foo\nfoo\n' | grep -m 0 foo
 ### exit_code: 1
 ### expect
 ### end
+
+### grep_files_without_match
+# -L prints files that have no matches
+printf 'foo\n' > /tmp/grep_l_a.txt && printf 'bar\n' > /tmp/grep_l_b.txt && grep -L foo /tmp/grep_l_a.txt /tmp/grep_l_b.txt
+### expect
+/tmp/grep_l_b.txt
+### end
+
+### grep_files_without_match_no_output
+# -L does not print files that match
+printf 'foo\n' > /tmp/grep_l2_a.txt && grep -L foo /tmp/grep_l2_a.txt
+### exit_code: 1
+### expect
+### end
+
+### grep_exclude_dir
+# --exclude-dir skips directories during recursive search
+mkdir -p /tmp/grepexd/src /tmp/grepexd/vendor && printf 'match\n' > /tmp/grepexd/src/a.txt && printf 'match\n' > /tmp/grepexd/vendor/b.txt && grep -r --exclude-dir=vendor match /tmp/grepexd
+### expect
+/tmp/grepexd/src/a.txt:match
+### end
+
+### grep_suppress_errors
+# -s suppresses error messages for nonexistent files
+grep -s foo /tmp/nonexistent_grep_file_xyz
+echo $?
+### expect
+1
+### end
+
+### grep_null_filename_l
+# -Z with -l uses null byte after filename
+printf 'foo\n' > /tmp/grep_z_a.txt && grep -lZ foo /tmp/grep_z_a.txt | tr '\0' '\n'
+### expect
+/tmp/grep_z_a.txt
+### end
+
+### grep_null_filename_big_l
+# -Z with -L uses null byte after filename
+printf 'bar\n' > /tmp/grep_zl_a.txt && grep -LZ foo /tmp/grep_zl_a.txt | tr '\0' '\n'
+### expect
+/tmp/grep_zl_a.txt
+### end


### PR DESCRIPTION
## Summary

- Add `-L`/`--files-without-match` flag: print filenames that have zero matches (inverse of `-l`) - Closes #380
- Add `--exclude-dir=GLOB` flag: skip entire directories during recursive grep - Closes #381
- Add `-s`/`--no-messages` flag: suppress error messages about nonexistent/unreadable files - Closes #382
- Add `-Z`/`--null` flag: print `\0` after filenames instead of `:` or `\n` (for `-l`/`-L` output and filename prefixes) - Closes #383

## Test plan

- [x] Unit tests for each flag (positive and negative cases)
- [x] Spec tests for each flag in `grep.test.sh`
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features -p bashkit --lib` passes (1126 tests)
- [x] `cargo test --all-features -p bashkit --test spec_tests -- grep` passes (82 spec tests)