### PR TITLE
feat(builtins): implement find -exec command execution

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -99,6 +99,7 @@ pub use headtail::{Head, Tail};
 pub use hextools::{Hexdump, Od, Xxd};
 pub use inspect::{File, Less, Stat};
 pub use jq::Jq;
+pub(crate) use ls::glob_match;
 pub use ls::{Find, Ls, Rmdir};
 pub use navigation::{Cd, Pwd};
 pub use nl::Nl;


### PR DESCRIPTION
## Summary

Closes #320.

- Intercept `find -exec` at interpreter level (same pattern as xargs/timeout) so commands execute through the interpreter instead of silently printing paths
- Support per-file mode (`find -exec cmd {} \;`) and batch mode (`find -exec cmd {} +`) with `{}` placeholder substitution
- Remove WTF comment and dead `has_exec` field; make `glob_match` reusable via `pub(crate)` export

## Test plan

- [x] `test_find_exec_per_file` - executes command for each matched file
- [x] `test_find_exec_batch_mode` - executes command once with all paths
- [x] `test_find_exec_cat_reads_files` - verifies actual command execution (cat reads file contents)
- [x] `test_find_exec_with_type_filter` - respects -type filter with -exec
- [x] `test_find_exec_nonexistent_path` - error handling for missing paths
- [x] `test_find_exec_no_matches` - no execution when nothing matches
- [x] `test_find_exec_multiple_placeholder` - multiple {} in command template
- [x] Full test suite passes (1120+ tests, 0 failures)