### PR TITLE
fix(builtins): add jq -R raw input and awk printf parens

### DIFF
--- a/crates/bashkit/tests/spec_cases/awk/awk.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/awk.test.sh
@@ -650,3 +650,17 @@ printf '10\n2\n' | awk '{if ($1 > 5) print $1}'
 ### expect
 10
 ### end
+
+### awk_printf_parens
+# printf with parenthesized form
+printf 'x\n' | awk '{printf("[%s]", $1); print ""}'
+### expect
+[x]
+### end
+
+### awk_printf_parens_begin
+# printf with parens in BEGIN block
+echo x | awk 'BEGIN{printf("["); printf("%s", "hi"); printf("]"); print ""}'
+### expect
+[hi]
+### end

--- a/crates/bashkit/tests/spec_cases/jq/jq.test.sh
+++ b/crates/bashkit/tests/spec_cases/jq/jq.test.sh
@@ -954,3 +954,21 @@ echo '42' | jq -e '.'
 ### expect
 42
 ### end
+
+### jq_raw_input
+# -R flag: each line treated as string
+printf 'hello\nworld\n' | jq -R '.'
+### expect
+"hello"
+"world"
+### end
+
+### jq_raw_input_slurp
+# -Rs flag: entire input as one string, then split
+printf 'a,b\n1,2\n' | jq -Rs 'split("\n") | map(select(length>0))'
+### expect
+[
+  "a,b",
+  "1,2"
+]
+### end


### PR DESCRIPTION
## Summary

- **jq**: Implement `-R`/`--raw-input` flag — treats each input line as a JSON string instead of parsing as JSON. Also supports `-Rs` (slurp entire input as single string). Unblocks CSV processing patterns like `jq -Rs 'split("\n")'`.
- **awk**: Support `printf("format", args)` parenthesized syntax in addition to existing `printf "format", args`. Common in awk scripts for JSON generation.

## Root cause

- Issue #368: `complex_markdown_toc` eval failures were caused by awk `printf("format")` syntax not being supported, not tr character classes as initially suspected
- Issue #369: `data_csv_to_json` eval failures were caused by missing `jq -R` raw input mode, preventing CSV-to-JSON conversion patterns

## Test plan

- [x] Added unit tests for `jq -R`, `jq -Rs`, and `jq -Rs` with split
- [x] Added unit tests for awk `printf("format", args)` and CSV-to-JSON pattern
- [x] Added spec tests: `jq_raw_input`, `jq_raw_input_slurp`, `awk_printf_parens`, `awk_printf_parens_begin`
- [x] All existing tests pass (AWK: 98, JQ: 115, Bash: 1214)
- [x] `cargo clippy` clean, `cargo fmt` clean

Closes #368
Closes #369