### PR TITLE
fix(ci): switch tarpaulin to LLVM engine to fix coverage failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
 
@@ -37,7 +39,8 @@ jobs:
             --exclude-files "crates/bashkit-cli/*" \
             --exclude-files "crates/bashkit-python/*" \
             --timeout 300 \
-            --skip-clean
+            --skip-clean \
+            --engine llvm
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- Switch cargo-tarpaulin from default ptrace engine to `--engine llvm` for reliable coverage collection
- Add `llvm-tools-preview` rustup component required by the LLVM engine
- Fixes Coverage workflow that has been consistently failing since Feb 27 despite all tests passing

## Root cause
Tarpaulin's ptrace engine causes spurious failures:
- CI: `Error: "Test failed during run"` after all 1067 tests pass
- Local: `A segfault occurred while executing tests` during ptrace tracing

The LLVM source-based coverage engine avoids all ptrace-related issues and was verified locally (73.40% coverage, all tests pass).

## Test plan
- [x] Verified `--engine llvm` works locally with full test suite
- [ ] CI Coverage workflow passes on this PR's branch
- [ ] Coverage report uploads to Codecov successfully