### PR TITLE
chore: add rebase hint to process-issues step 9

### DIFF
--- a/.claude/commands/process-issues.md
+++ b/.claude/commands/process-issues.md
@@ -50,6 +50,7 @@ For each open issue (`gh issue list --state open`), in order by issue number:
 ### 9. Merge & close
 - Squash-merge the PR (`gh pr merge --squash --delete-branch`)
 - Add resolution comment on the issue if helpful
+- Rebase on latest main before starting next issue: `git checkout main && git pull origin main`
 - Move to next issue
 
 ### 10. Review ignored tests


### PR DESCRIPTION
## Summary
- Add explicit rebase-on-main instruction to step 9 (Merge & close) of the process-issues workflow
- Ensures the next issue starts from latest main after a PR is merged

## Test plan
- [ ] Verify `.claude/commands/process-issues.md` step 9 includes rebase hint