### PR TITLE
fix(ci): trigger Python publish workflow on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,9 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Trigger publish workflow
-        run: gh workflow run publish.yml
+      - name: Trigger publish workflows
+        run: |
+          gh workflow run publish.yml
+          gh workflow run publish-python.yml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The release workflow only triggered `publish.yml` (crates.io) but not `publish-python.yml` (PyPI)
- GitHub Actions events created by `GITHUB_TOKEN` don't trigger other workflows, so the `release` event never reached `publish-python.yml`
- This left PyPI stuck at 0.1.4 while crates.io advanced to 0.1.7
- Fix: explicitly call `gh workflow run publish-python.yml` alongside the existing `gh workflow run publish.yml`

## Test plan
- [ ] CI passes on this PR
- [ ] Next release triggers both publish.yml and publish-python.yml