### PR TITLE
fix(test): increase cpu exhaustion timeout bound for coverage

### DIFF
--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -158,8 +158,8 @@ mod resource_exhaustion {
         let elapsed = start.elapsed();
 
         // Should complete quickly due to either timeout or loop limit.
-        // Under ASan the overhead can be ~10x, so use a generous bound.
-        assert!(elapsed < Duration::from_secs(15));
+        // Under ASan/tarpaulin the overhead can be ~20x, so use a generous bound.
+        assert!(elapsed < Duration::from_secs(30));
     }
 }
 


### PR DESCRIPTION
## Summary
- The `threat_cpu_exhaustion_timeout` test was failing in the Coverage CI job (tarpaulin) because the assertion `elapsed < 15s` was too tight — tarpaulin instrumentation overhead caused the test to take 15.22s
- Increased the bound from 15s to 30s to accommodate coverage instrumentation slowdown

## Test plan
- [x] `cargo test threat_cpu_exhaustion_timeout` passes locally
- [ ] Coverage CI job passes on this PR