### PR TITLE
fix(builtins): handle multi-byte UTF-8 in tr expand_char_set()

### DIFF
--- a/crates/bashkit/src/builtins/cuttr.rs
+++ b/crates/bashkit/src/builtins/cuttr.rs
@@ -408,8 +408,16 @@ fn expand_char_set(spec: &str) -> Vec<char> {
     while i < len {
         // Check for POSIX character class [:class:]
         if char_vec[i] == '[' && i + 1 < len && char_vec[i + 1] == ':' {
-            if let Some(end) = spec[spec.char_indices().nth(i + 2).map_or(spec.len(), |(pos, _)| pos)..].find(":]") {
-                let class_start = spec.char_indices().nth(i + 2).map_or(spec.len(), |(pos, _)| pos);
+            if let Some(end) = spec[spec
+                .char_indices()
+                .nth(i + 2)
+                .map_or(spec.len(), |(pos, _)| pos)..]
+                .find(":]")
+            {
+                let class_start = spec
+                    .char_indices()
+                    .nth(i + 2)
+                    .map_or(spec.len(), |(pos, _)| pos);
                 let class_name = &spec[class_start..class_start + end];
                 match class_name {
                     "lower" => chars.extend('a'..='z'),


### PR DESCRIPTION
## Summary
- `expand_char_set()` used `spec.as_bytes()` and `bytes[i] as char` which corrupted multi-byte UTF-8
- Rewrote to use char-based iteration with `Vec<char>` indexing

## Test plan
- [x] Unit test: `test_tr_multibyte_utf8`
- [x] Unit test: `test_tr_multibyte_utf8_range`
- [x] Unit test: `test_cut_multibyte_utf8_chars`
- [x] Unit test: `test_expand_char_set_multibyte`

Closes #436