### PR TITLE
fix(scripted_tool): use Display not Debug format in errors

### DIFF
--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -456,8 +456,8 @@ mod tests {
     #[tokio::test]
     async fn test_error_uses_display_not_debug() {
         use super::ScriptedTool;
-        use crate::ToolDef;
         use crate::tool::Tool;
+        use crate::ToolDef;
 
         let mut tool = ScriptedTool::builder("test")
             .short_description("test")


### PR DESCRIPTION
## Summary
- Error responses used `{:?}` (Debug format) which could leak internal details
- Changed to `e.to_string()` (Display format) for consistent, safe messages

## Test plan
- [x] Unit test: `test_error_uses_display_not_debug`

Closes #428