### PR TITLE
fix(network): redact credentials from allowlist error messages

### DIFF
--- a/crates/bashkit/src/network/allowlist.rs
+++ b/crates/bashkit/src/network/allowlist.rs
@@ -387,7 +387,11 @@ mod tests {
     #[test]
     fn test_redact_url_strips_credentials() {
         let redacted = redact_url("https://user:secret@example.com/path");
-        assert!(!redacted.contains("secret"), "password leaked: {}", redacted);
+        assert!(
+            !redacted.contains("secret"),
+            "password leaked: {}",
+            redacted
+        );
         assert!(!redacted.contains("user"), "username leaked: {}", redacted);
         assert!(redacted.contains("example.com/path"));
     }


### PR DESCRIPTION
## Summary
- Full URL including `user:pass@` was echoed in "not in allowlist" errors
- Added `redact_url()` that strips credentials before including URL in messages

## Test plan
- [x] Unit test: `test_redact_url_strips_credentials`
- [x] Unit test: `test_redact_url_preserves_clean_url`
- [x] Unit test: `test_blocked_message_no_credentials`

Closes #429