### PR TITLE
chore: add tokio-macros 2.6.1 to cargo-vet exemptions

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1274,6 +1274,10 @@ criteria = "safe-to-deploy"
 version = "2.6.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.tokio-macros]]
+version = "2.6.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.tokio-rustls]]
 version = "0.26.4"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary
- Add tokio-macros 2.6.1 exemption (patch bump from already-exempted 2.6.0)
- Fixes CI Audit failure blocking all PRs