### PR TITLE
fix(builtins): make exported variables visible to Python's os.getenv

### DIFF
--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -256,12 +256,17 @@ impl Builtin for Python {
             ));
         };
 
+        // Merge env and variables so exported vars (set via `export`) are visible
+        // to Python's os.getenv(). Variables override env (bash semantics).
+        let mut merged_env = ctx.env.clone();
+        merged_env.extend(ctx.variables.iter().map(|(k, v)| (k.clone(), v.clone())));
+
         run_python(
             &code,
             &filename,
             ctx.fs.clone(),
             ctx.cwd,
-            ctx.env,
+            &merged_env,
             &self.limits,
         )
         .await

--- a/crates/bashkit/tests/spec_cases/python/python.test.sh
+++ b/crates/bashkit/tests/spec_cases/python/python.test.sh
@@ -409,7 +409,6 @@ print(a, b, c)"
 ### end
 
 ### python3_nested_dict_access
-### skip: Monty dict literal in bash quoting needs single-quote support
 # Nested data structures
 python3 -c "data = {'users': [{'name': 'Alice'}]}
 print(data['users'][0]['name'])"
@@ -511,7 +510,6 @@ print(count)"
 ### end
 
 ### python3_vfs_getenv
-### skip: export propagation to ctx.env may not work in spec test runner
 # Read environment variables from Python
 export MY_TEST_VAR=hello_from_env
 python3 -c "import os


### PR DESCRIPTION
## Summary
- Merged `ctx.variables` into env when running Python code so `export VAR=val` is visible to `os.getenv()`
- Unskipped two Python spec tests: `python3_vfs_getenv` and `python3_nested_dict_access`

Closes #316

## Test plan
- [x] python3_vfs_getenv spec test now passes
- [x] python3_nested_dict_access spec test now passes
- [x] All existing Python tests pass