### PR TITLE
feat(cli): enable http/git/python defaults with opt-out flags

### DIFF
--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -1,4 +1,4 @@
-# Bashkit CLI - Command line interface for bashkit
+bashkit = { path = "../bashkit", version = "0.1.0", features = ["http_client", "git"] }
 # Run bash scripts in a sandboxed environment
 
 [package]

--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -1,4 +1,72 @@
-//! Bashkit CLI - Command line interface for sandboxed bash execution
+mod python;
+    /// Disable HTTP builtins (curl/wget)
+    #[arg(long)]
+    no_http: bool,
+
+    /// Disable git builtin
+    #[arg(long)]
+    no_git: bool,
+
+    /// Disable python builtin (monty backend)
+    #[arg(long)]
+    no_python: bool,
+
+fn build_bash(args: &Args) -> bashkit::Bash {
+    let mut builder = bashkit::Bash::builder();
+
+    if !args.no_http {
+        builder = builder.network(bashkit::NetworkAllowlist::allow_all());
+    }
+
+    if !args.no_git {
+        builder = builder.git(bashkit::GitConfig::new());
+    }
+
+    if !args.no_python {
+        builder = builder.builtin("python", Box::new(python::PythonBuiltin::new()));
+    }
+
+    builder.build()
+}
+
+    let mut bash = build_bash(&args);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn parse_disable_flags() {
+        let args = Args::parse_from([
+            "bashkit",
+            "--no-http",
+            "--no-git",
+            "--no-python",
+            "-c",
+            "echo hi",
+        ]);
+        assert!(args.no_http);
+        assert!(args.no_git);
+        assert!(args.no_python);
+    }
+
+    #[tokio::test]
+    async fn python_enabled_by_default() {
+        let args = Args::parse_from(["bashkit", "-c", "python --version"]);
+        let mut bash = build_bash(&args);
+        let result = bash.exec("python --version").await.expect("exec");
+        assert_ne!(result.stderr, "python: command not found\n");
+    }
+
+    #[tokio::test]
+    async fn python_can_be_disabled() {
+        let args = Args::parse_from(["bashkit", "--no-python", "-c", "python --version"]);
+        let mut bash = build_bash(&args);
+        let result = bash.exec("python --version").await.expect("exec");
+        assert!(result.stderr.contains("python: command not found"));
+    }
+}
 //!
 //! Usage:
 //!   bashkit -c 'echo hello'        # Execute a command string

--- a/crates/bashkit-cli/src/python.rs
+++ b/crates/bashkit-cli/src/python.rs
@@ -1,0 +1,62 @@
+// Decision: expose `python` command in CLI via host command execution.
+// Prefer `monty` backend when available to match product requirement.
+// Fallback to `python3` to keep CLI usable where monty isn't installed.
+
+use bashkit::{async_trait, Builtin, BuiltinContext, ExecResult};
+use std::env;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+pub struct PythonBuiltin;
+
+impl PythonBuiltin {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Builtin for PythonBuiltin {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let (program, mut args) = if command_exists("monty") {
+            ("monty", vec!["python".to_string()])
+        } else {
+            ("python3", Vec::new())
+        };
+
+        args.extend(ctx.args.iter().cloned());
+
+        let output = match Command::new(program).args(&args).output() {
+            Ok(output) => output,
+            Err(err) => {
+                return Ok(ExecResult::err(
+                    format!("python: failed to start {program}: {err}\n"),
+                    1,
+                ));
+            }
+        };
+
+        Ok(ExecResult {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: output.status.code().unwrap_or(1),
+            ..Default::default()
+        })
+    }
+}
+
+fn command_exists(cmd: &str) -> bool {
+    let Some(path) = env::var_os("PATH") else {
+        return false;
+    };
+
+    env::split_paths(&path).any(|dir| is_executable_file(dir.join(cmd)))
+}
+
+fn is_executable_file(path: PathBuf) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    metadata.is_file() && (metadata.permissions().mode() & 0o111 != 0)
+}

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,0 +1,71 @@
+# bashkit-cli
+
+Quick CLI for running BashKit scripts in a sandboxed virtual filesystem.
+
+## Defaults
+
+`bashkit-cli` enables these by default:
+
+- HTTP builtins (`curl`, `wget`)
+- Git builtin (`git`)
+- Python command (`python`) via `monty python` when `monty` exists, else `python3`
+
+Disable any default per run:
+
+- `--no-http`
+- `--no-git`
+- `--no-python`
+
+## Quick install
+
+From source:
+
+```bash
+git clone https://github.com/everruns/bashkit
+cd bashkit
+cargo install --path crates/bashkit-cli
+```
+
+Run:
+
+```bash
+bashkit --version
+```
+
+## Examples
+
+Works everywhere (no network):
+
+```bash
+bashkit -c 'echo "hello" | tr a-z A-Z'
+```
+
+Python enabled by default:
+
+```bash
+bashkit -c 'python -c "print(2 + 2)"'
+```
+
+Disable python:
+
+```bash
+bashkit --no-python -c 'python --version'
+```
+
+Git enabled by default:
+
+```bash
+bashkit -c 'git init /repo && cd /repo && git status'
+```
+
+HTTP enabled by default:
+
+```bash
+bashkit -c 'curl -s https://example.com | head -n 1'
+```
+
+Disable HTTP:
+
+```bash
+bashkit --no-http -c 'curl -s https://example.com'
+```


### PR DESCRIPTION
### Motivation

- Make `bashkit-cli` usable out-of-the-box with common builtins (HTTP, git, Python) so examples and agent workflows run without extra build flags. 
- Provide explicit per-run opt-out switches for environments that must disable network/git/python for security or testing.

### Description

- Enable `http_client` and `git` features for the CLI by default in `crates/bashkit-cli/Cargo.toml` so the binary builds with HTTP and git support. 
- Add CLI flags `--no-http`, `--no-git`, and `--no-python` and wire them into a new `build_bash` helper in `crates/bashkit-cli/src/main.rs` to opt out of the defaults at runtime. 
- Register a `python` builtin for the CLI in `crates/bashkit-cli/src/python.rs` that prefers `monty python` when `monty` is present and falls back to `python3`, returning captured stdout/stderr/exit code. 
- Add `doc/cli.md` with a short description, quick install steps, and runnable examples that reflect the default-enabled and opt-out behaviors. 
- Add unit tests validating flag parsing and python default/disable behavior in `crates/bashkit-cli/src/main.rs` tests.

### Testing

- Ran `cargo fmt` and `cargo clippy -p bashkit-cli -- -D warnings` with no failures. 
- Ran unit tests with `cargo test -p bashkit-cli` and all tests passed. 
- Performed smoke runs with `cargo run -p bashkit-cli -- -c 'echo "hello" | tr a-z A-Z'`, `cargo run -p bashkit-cli -- -c 'python -c "print(2 + 2)"'`, `cargo run -p bashkit-cli -- --no-python -c 'python --version'`, `cargo run -p bashkit-cli -- -c 'git init /repo && cd /repo && git status'`, and `cargo run -p bashkit-cli -- -c 'curl -s https://example.com | head -n 1'`; the expected behaviors (enabled by default and disabled when requested) were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7821d0230832ba0fec864227aa3c6)