### PR TITLE
fix(ci): strip python feature from bashkit-cli before crates.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,15 @@ jobs:
       - name: Wait for crates.io index update
         run: sleep 30
 
+      - name: Strip python feature from bashkit-cli dependency
+        # python feature is stripped from bashkit during publish (monty is git-only)
+        run: |
+          TOML=crates/bashkit-cli/Cargo.toml
+          sed -i 's/features = \["http_client", "git", "python"\]/features = ["http_client", "git"]/' "$TOML"
+          echo "--- bashkit-cli Cargo.toml after stripping ---"
+          cat "$TOML"
+
       - name: Publish bashkit-cli to crates.io
-        run: cargo publish -p bashkit-cli
+        run: cargo publish -p bashkit-cli --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix bashkit-cli publish to crates.io that failed during v0.1.9 release
- The `python` feature is stripped from `bashkit` during publish (monty is git-only), so `bashkit-cli` must also drop this feature reference before publishing

## Test plan

- [ ] CI green
- [ ] After merge, manually re-trigger Publish workflow to publish bashkit-cli v0.1.9