### PR TITLE
fix(ci): make Publish workflow idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           cat "$TOML"
 
       - name: Publish bashkit to crates.io
-        run: cargo publish -p bashkit --allow-dirty
+        run: cargo publish -p bashkit --allow-dirty 2>&1 || echo "::warning::bashkit publish failed (may already exist)"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Allow re-triggering the Publish workflow when `bashkit` is already on crates.io but `bashkit-cli` still needs publishing
- Without this, a re-trigger after partial failure exits early on `bashkit` and never reaches `bashkit-cli`

## Test plan

- [ ] CI green
- [ ] After merge, re-trigger Publish workflow to publish `bashkit-cli` v0.1.9