### PR TITLE
fix(ci): gate python behind feature flag for crates.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,11 +70,13 @@ jobs:
       - name: Wait for crates.io index update
         run: sleep 30
 
-      - name: Strip python feature from bashkit-cli dependency
+      - name: Strip python feature from bashkit-cli
         # python feature is stripped from bashkit during publish (monty is git-only)
         run: |
           TOML=crates/bashkit-cli/Cargo.toml
-          sed -i 's/features = \["http_client", "git", "python"\]/features = ["http_client", "git"]/' "$TOML"
+          # Remove python feature and default that references it
+          sed -i '/^python = \["bashkit\/python"\]/d' "$TOML"
+          sed -i 's/default = \["python"\]/default = []/' "$TOML"
           echo "--- bashkit-cli Cargo.toml after stripping ---"
           cat "$TOML"
 

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -18,8 +18,12 @@ name = "bashkit"
 path = "src/main.rs"
 doc = false  # Disable to avoid collision with bashkit library docs
 
+[features]
+default = ["python"]
+python = ["bashkit/python"]
+
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.1.9", features = ["http_client", "git", "python"] }
+bashkit = { path = "../bashkit", version = "0.1.9", features = ["http_client", "git"] }
 tokio.workspace = true
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -41,7 +41,8 @@ struct Args {
     no_git: bool,
 
     /// Disable python builtin (monty backend)
-    #[arg(long)]
+    #[cfg_attr(not(feature = "python"), arg(long, hide = true))]
+    #[cfg_attr(feature = "python", arg(long))]
     no_python: bool,
 
     #[command(subcommand)]
@@ -65,6 +66,7 @@ fn build_bash(args: &Args) -> bashkit::Bash {
         builder = builder.git(bashkit::GitConfig::new());
     }
 
+    #[cfg(feature = "python")]
     if !args.no_python {
         builder = builder.python();
     }
@@ -143,6 +145,7 @@ mod tests {
         assert!(!args.no_python);
     }
 
+    #[cfg(feature = "python")]
     #[tokio::test]
     async fn python_enabled_by_default() {
         let args = Args::parse_from(["bashkit", "-c", "python --version"]);
@@ -151,6 +154,7 @@ mod tests {
         assert_ne!(result.stderr, "python: command not found\n");
     }
 
+    #[cfg(feature = "python")]
     #[tokio::test]
     async fn python_can_be_disabled() {
         let args = Args::parse_from(["bashkit", "--no-python", "-c", "python --version"]);


### PR DESCRIPTION
## Summary

- Fix `bashkit-cli` v0.1.9 publish to crates.io that failed because `builder.python()` doesn't exist when bashkit's `python` feature is stripped (monty is git-only)
- Move `python` from hardcoded dependency feature to a bashkit-cli feature flag (`default = ["python"]`)
- Gate python code with `#[cfg(feature = "python")]` so it compiles without the feature
- Update publish workflow to strip the python feature from bashkit-cli before publishing

## Test plan

- [x] `cargo build -p bashkit-cli` (with python) passes
- [x] `cargo build -p bashkit-cli --no-default-features` (without python) passes
- [x] `cargo test -p bashkit-cli --all-features` — 9 tests pass
- [x] `cargo test -p bashkit-cli --no-default-features` — 7 tests pass (python tests skipped)
- [x] `cargo clippy --all-targets --all-features` passes
- [ ] CI green
- [ ] After merge, re-trigger Publish workflow to publish bashkit-cli v0.1.9