### PR TITLE
fix(fs): flush RealFs append to prevent data loss race

### DIFF
--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -293,6 +293,7 @@ impl FsBackend for RealFs {
             .open(&real)
             .await?;
         file.write_all(content).await?;
+        file.flush().await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Adds `file.flush().await?` after `write_all` in `RealFs::append` to ensure data is persisted before the file handle is dropped
- Fixes flaky `readwrite_mount_modifies_host` test that fails in CI due to tokio's internal buffering — `write_all` returns `Ready` before the blocking write completes, so without flush the data can be lost on drop

## Test plan
- [x] `cargo test --features realfs -p bashkit --test realfs_tests readwrite_mount_modifies_host` passes
- [x] `cargo test --all-features --tests` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] CI green