### PR TITLE
feat(history): persistent searchable history across Bash instances

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -36,6 +36,21 @@ use crate::error::Result;
 use crate::fs::FileSystem;
 use crate::limits::{ExecutionCounters, ExecutionLimits};
 
+/// A single command history entry.
+#[derive(Debug, Clone)]
+pub struct HistoryEntry {
+    /// The command line as entered
+    pub command: String,
+    /// Unix timestamp when the command was executed
+    pub timestamp: i64,
+    /// Working directory at execution time
+    pub cwd: String,
+    /// Exit code of the command
+    pub exit_code: i32,
+    /// Duration in milliseconds
+    pub duration_ms: u64,
+}
+
 /// Callback for streaming output chunks as they are produced.
 ///
 /// Arguments: `(stdout_chunk, stderr_chunk)`. Called after each loop iteration
@@ -304,6 +319,12 @@ pub struct Interpreter {
     /// Aliases currently being expanded (prevents infinite recursion).
     /// When alias `foo` expands to `foo bar`, the inner `foo` is not re-expanded.
     expanding_aliases: HashSet<String>,
+    /// Command history entries for the current session.
+    history: Vec<HistoryEntry>,
+    /// Optional VFS path for persisting history between sessions.
+    history_file: Option<PathBuf>,
+    /// Whether history has been loaded from VFS (to avoid re-loading on each exec).
+    history_loaded: bool,
 }
 
 impl Interpreter {
@@ -560,6 +581,9 @@ impl Interpreter {
             pipestatus: Vec::new(),
             aliases: HashMap::new(),
             expanding_aliases: HashSet::new(),
+            history: Vec::new(),
+            history_file: None,
+            history_loaded: false,
         }
     }
 
@@ -615,6 +639,104 @@ impl Interpreter {
     /// Set the current working directory.
     pub fn set_cwd(&mut self, cwd: PathBuf) {
         self.cwd = cwd;
+    }
+
+    /// Get the current working directory.
+    pub fn cwd(&self) -> &Path {
+        &self.cwd
+    }
+
+    /// Record a history entry for the current session.
+    pub fn record_history(
+        &mut self,
+        command: String,
+        timestamp: i64,
+        cwd: String,
+        exit_code: i32,
+        duration_ms: u64,
+    ) {
+        self.history.push(HistoryEntry {
+            command,
+            timestamp,
+            cwd,
+            exit_code,
+            duration_ms,
+        });
+    }
+
+    /// Set the VFS path for persisting history.
+    pub fn set_history_file(&mut self, path: PathBuf) {
+        self.history_file = Some(path);
+    }
+
+    /// Get a reference to the history entries.
+    #[allow(dead_code)]
+    pub fn history(&self) -> &[HistoryEntry] {
+        &self.history
+    }
+
+    /// Clear all history entries.
+    #[allow(dead_code)]
+    pub fn clear_history(&mut self) {
+        self.history.clear();
+    }
+
+    /// Load history from the VFS history file (if configured). No-op after first call.
+    pub async fn load_history(&mut self) {
+        if self.history_loaded {
+            return;
+        }
+        self.history_loaded = true;
+        let path = match &self.history_file {
+            Some(p) => p.clone(),
+            None => return,
+        };
+        let bytes = match self.fs.read_file(&path).await {
+            Ok(b) => b,
+            Err(_) => return, // File doesn't exist yet
+        };
+        let content = String::from_utf8_lossy(&bytes);
+        for line in content.lines() {
+            // Format: timestamp|exit_code|duration_ms|cwd|command
+            let parts: Vec<&str> = line.splitn(5, '|').collect();
+            if parts.len() == 5
+                && let (Ok(ts), Ok(ec), Ok(dur)) = (
+                    parts[0].parse::<i64>(),
+                    parts[1].parse::<i32>(),
+                    parts[2].parse::<u64>(),
+                )
+            {
+                self.history.push(HistoryEntry {
+                    timestamp: ts,
+                    exit_code: ec,
+                    duration_ms: dur,
+                    cwd: parts[3].to_string(),
+                    command: parts[4].to_string(),
+                });
+            }
+        }
+    }
+
+    /// Save history to the VFS history file (if configured).
+    pub async fn save_history(&self) {
+        let path = match &self.history_file {
+            Some(p) => p.clone(),
+            None => return,
+        };
+        let mut content = String::new();
+        for entry in &self.history {
+            use std::fmt::Write;
+            let _ = writeln!(
+                content,
+                "{}|{}|{}|{}|{}",
+                entry.timestamp, entry.exit_code, entry.duration_ms, entry.cwd, entry.command
+            );
+        }
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            let _ = self.fs.mkdir(parent, true).await;
+        }
+        let _ = self.fs.write_file(&path, content.as_bytes()).await;
     }
 
     /// Capture the current shell state (variables, env, cwd, options).
@@ -4017,6 +4139,11 @@ impl Interpreter {
             return self.execute_local_builtin(&args, &command.redirects).await;
         }
 
+        // Handle `history` at interpreter level - needs access to history entries
+        if name == "history" {
+            return self.execute_history(&args, &command.redirects).await;
+        }
+
         // Handle `timeout` specially - needs interpreter-level command execution
         if name == "timeout" {
             return self.execute_timeout(&args, stdin, &command.redirects).await;
@@ -4737,6 +4864,182 @@ impl Interpreter {
             }
         }
         Ok(ExecResult::ok(String::new()))
+    }
+
+    /// Execute the `history` builtin with query modes.
+    ///
+    /// Supported syntax:
+    /// - `history` — show all entries
+    /// - `history N` — show last N entries
+    /// - `history -c` — clear history (and VFS file)
+    /// - `history --grep PATTERN` — filter by command substring
+    /// - `history --cwd PATH` — filter by working directory
+    /// - `history --failed` — show only non-zero exit codes
+    /// - `history --since DURATION` — entries newer than duration (e.g. 2d, 1h, 30m)
+    async fn execute_history(
+        &mut self,
+        args: &[String],
+        redirects: &[Redirect],
+    ) -> Result<ExecResult> {
+        let mut clear = false;
+        let mut count: Option<usize> = None;
+        let mut grep_pattern: Option<String> = None;
+        let mut cwd_filter: Option<String> = None;
+        let mut failed_only = false;
+        let mut since_secs: Option<i64> = None;
+
+        let mut i = 0;
+        while i < args.len() {
+            let arg = &args[i];
+            match arg.as_str() {
+                "-c" => clear = true,
+                "--grep" => {
+                    i += 1;
+                    if i < args.len() {
+                        grep_pattern = Some(args[i].clone());
+                    } else {
+                        let result = ExecResult::err(
+                            "history: --grep requires an argument\n".to_string(),
+                            1,
+                        );
+                        return self.apply_redirections(result, redirects).await;
+                    }
+                }
+                "--cwd" => {
+                    i += 1;
+                    if i < args.len() {
+                        cwd_filter = Some(args[i].clone());
+                    } else {
+                        let result =
+                            ExecResult::err("history: --cwd requires an argument\n".to_string(), 1);
+                        return self.apply_redirections(result, redirects).await;
+                    }
+                }
+                "--failed" => failed_only = true,
+                "--since" => {
+                    i += 1;
+                    if i < args.len() {
+                        match Self::parse_duration_to_secs(&args[i]) {
+                            Some(secs) => since_secs = Some(secs),
+                            None => {
+                                let result = ExecResult::err(
+                                    format!(
+                                        "history: invalid duration '{}' (use e.g. 2d, 1h, 30m, 60s)\n",
+                                        args[i]
+                                    ),
+                                    1,
+                                );
+                                return self.apply_redirections(result, redirects).await;
+                            }
+                        }
+                    } else {
+                        let result = ExecResult::err(
+                            "history: --since requires an argument\n".to_string(),
+                            1,
+                        );
+                        return self.apply_redirections(result, redirects).await;
+                    }
+                }
+                _ => {
+                    if let Some(opt) = arg.strip_prefix("--") {
+                        let result = ExecResult::err(
+                            format!("history: unrecognized option '--{}'\n", opt),
+                            1,
+                        );
+                        return self.apply_redirections(result, redirects).await;
+                    } else if let Some(opt) = arg.strip_prefix('-') {
+                        // Allow -c, reject others
+                        if opt != "c" {
+                            let result = ExecResult::err(
+                                format!("history: invalid option -- '{}'\n", opt),
+                                1,
+                            );
+                            return self.apply_redirections(result, redirects).await;
+                        }
+                    } else if let Ok(n) = arg.parse::<usize>() {
+                        count = Some(n);
+                    }
+                }
+            }
+            i += 1;
+        }
+
+        if clear {
+            self.history.clear();
+            self.save_history().await;
+            let result = ExecResult::ok(String::new());
+            return self.apply_redirections(result, redirects).await;
+        }
+
+        let now = chrono::Utc::now().timestamp();
+
+        // Apply filters
+        let filtered: Vec<(usize, &HistoryEntry)> = self
+            .history
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                if let Some(ref pat) = grep_pattern
+                    && !entry.command.contains(pat.as_str())
+                {
+                    return false;
+                }
+                if let Some(ref cwd) = cwd_filter
+                    && !entry.cwd.starts_with(cwd.as_str())
+                {
+                    return false;
+                }
+                if failed_only && entry.exit_code == 0 {
+                    return false;
+                }
+                if let Some(secs) = since_secs
+                    && now - entry.timestamp > secs
+                {
+                    return false;
+                }
+                true
+            })
+            .collect();
+
+        // Apply count limit (last N entries)
+        let entries: &[(usize, &HistoryEntry)] = if let Some(n) = count {
+            let start = filtered.len().saturating_sub(n);
+            &filtered[start..]
+        } else {
+            &filtered
+        };
+
+        // Format output: bash-style numbered listing
+        let mut output = String::new();
+        for (idx, entry) in entries {
+            use std::fmt::Write;
+            // 1-indexed like bash
+            let _ = writeln!(output, "  {}  {}", idx + 1, entry.command);
+        }
+
+        let result = ExecResult::ok(output);
+        self.apply_redirections(result, redirects).await
+    }
+
+    /// Parse a human-readable duration string to seconds (e.g. "2d", "1h", "30m", "60s").
+    fn parse_duration_to_secs(s: &str) -> Option<i64> {
+        let s = s.trim();
+        if s.is_empty() {
+            return None;
+        }
+        let (num_str, multiplier) = if let Some(n) = s.strip_suffix('d') {
+            (n, 86400)
+        } else if let Some(n) = s.strip_suffix('h') {
+            (n, 3600)
+        } else if let Some(n) = s.strip_suffix('m') {
+            (n, 60)
+        } else if let Some(n) = s.strip_suffix('s') {
+            (n, 1)
+        } else {
+            (s, 1)
+        };
+        let n: i64 = num_str.parse().ok()?;
+        Some(n * multiplier)
     }
 
     /// Execute the `trap` builtin — register/list signal handlers.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -420,7 +420,7 @@ pub use fs::{
 #[cfg(feature = "realfs")]
 pub use fs::{RealFs, RealFsMode};
 pub use git::GitConfig;
-pub use interpreter::{ControlFlow, ExecResult, OutputCallback, ShellState};
+pub use interpreter::{ControlFlow, ExecResult, HistoryEntry, OutputCallback, ShellState};
 pub use limits::{ExecutionCounters, ExecutionLimits, LimitExceeded};
 pub use network::NetworkAllowlist;
 pub use tool::BashToolBuilder as ToolBuilder;
@@ -613,7 +613,32 @@ impl Bash {
         #[cfg(feature = "logging")]
         tracing::debug!(target: "bashkit::interpreter", "Starting interpretation");
 
+        // Load persisted history on first exec (no-op if already loaded)
+        self.interpreter.load_history().await;
+
+        let exec_start = std::time::Instant::now();
         let result = self.interpreter.execute(&ast).await;
+        let duration_ms = exec_start.elapsed().as_millis() as u64;
+
+        // Record history entry for each line of the script
+        if let Ok(ref exec_result) = result {
+            let cwd = self.interpreter.cwd().to_string_lossy().to_string();
+            let timestamp = chrono::Utc::now().timestamp();
+            for line in script.lines() {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                    self.interpreter.record_history(
+                        trimmed.to_string(),
+                        timestamp,
+                        cwd.clone(),
+                        exec_result.exit_code,
+                        duration_ms,
+                    );
+                }
+            }
+            // Persist history to VFS if configured
+            self.interpreter.save_history().await;
+        }
 
         #[cfg(feature = "logging")]
         match &result {
@@ -831,6 +856,8 @@ pub struct BashBuilder {
     /// Real host directories to mount in the VFS
     #[cfg(feature = "realfs")]
     real_mounts: Vec<MountedRealDir>,
+    /// Optional VFS path for persistent history
+    history_file: Option<PathBuf>,
 }
 
 impl BashBuilder {
@@ -881,6 +908,15 @@ impl BashBuilder {
     /// When set, `date` returns this fixed time instead of the real clock.
     pub fn fixed_epoch(mut self, epoch: i64) -> Self {
         self.fixed_epoch = Some(epoch);
+        self
+    }
+
+    /// Enable persistent history stored at the given VFS path.
+    ///
+    /// History entries are loaded from this file at startup and saved after each
+    /// `exec()` call. The file is stored in the virtual filesystem.
+    pub fn history_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.history_file = Some(path.into());
         self
     }
 
@@ -1367,6 +1403,7 @@ impl BashBuilder {
             self.cwd,
             self.limits,
             self.custom_builtins,
+            self.history_file,
             #[cfg(feature = "http_client")]
             self.network_allowlist,
             #[cfg(feature = "logging")]
@@ -1447,6 +1484,7 @@ impl BashBuilder {
         cwd: Option<PathBuf>,
         limits: ExecutionLimits,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
+        history_file: Option<PathBuf>,
         #[cfg(feature = "http_client")] network_allowlist: Option<NetworkAllowlist>,
         #[cfg(feature = "logging")] log_config: Option<logging::LogConfig>,
         #[cfg(feature = "git")] git_config: Option<GitConfig>,
@@ -1501,6 +1539,11 @@ impl BashBuilder {
         if let Some(config) = git_config {
             let client = git::GitClient::new(config);
             interpreter.set_git_client(client);
+        }
+
+        // Configure persistent history file
+        if let Some(hf) = history_file {
+            interpreter.set_history_file(hf);
         }
 
         let parser_timeout = limits.parser_timeout;

--- a/crates/bashkit/tests/history_tests.rs
+++ b/crates/bashkit/tests/history_tests.rs
@@ -1,0 +1,217 @@
+// Integration tests for persistent searchable history (issue #578)
+
+use bashkit::{Bash, FileSystem};
+
+async fn run(script: &str) -> bashkit::ExecResult {
+    let mut bash = Bash::new();
+    bash.exec(script).await.unwrap()
+}
+
+#[tokio::test]
+async fn history_shows_previous_commands() {
+    let mut bash = Bash::new();
+    bash.exec("echo hello").await.unwrap();
+    bash.exec("echo world").await.unwrap();
+    let result = bash.exec("history").await.unwrap();
+    assert!(
+        result.stdout.contains("echo hello"),
+        "should contain first command"
+    );
+    assert!(
+        result.stdout.contains("echo world"),
+        "should contain second command"
+    );
+}
+
+#[tokio::test]
+async fn history_n_limits_output() {
+    let mut bash = Bash::new();
+    bash.exec("echo a").await.unwrap();
+    bash.exec("echo b").await.unwrap();
+    bash.exec("echo c").await.unwrap();
+    let result = bash.exec("history 2").await.unwrap();
+    // Should show last 2 entries (echo c and history 2 itself won't be in history yet
+    // because history is recorded after exec, and history builtin runs during exec)
+    // Actually: echo a, echo b, echo c are recorded. history 2 shows last 2.
+    assert!(
+        !result.stdout.contains("echo a"),
+        "should not contain first command"
+    );
+    assert!(result.stdout.contains("echo b") || result.stdout.contains("echo c"));
+}
+
+#[tokio::test]
+async fn history_clear() {
+    let mut bash = Bash::new();
+    bash.exec("echo hello").await.unwrap();
+    bash.exec("history -c").await.unwrap();
+    let result = bash.exec("history").await.unwrap();
+    // After clear, only the "history -c" line may be gone, and "history" itself hasn't been recorded yet
+    // The history -c command itself is recorded AFTER exec, but clear happens DURING exec.
+    // So: echo hello -> recorded after exec. history -c -> clears during exec, then records "history -c" after exec.
+    // Then history -> shows "history -c" only.
+    assert!(
+        !result.stdout.contains("echo hello"),
+        "history should be cleared"
+    );
+}
+
+#[tokio::test]
+async fn history_grep() {
+    let mut bash = Bash::new();
+    bash.exec("echo hello").await.unwrap();
+    bash.exec("ls /tmp").await.unwrap();
+    bash.exec("echo world").await.unwrap();
+    let result = bash.exec("history --grep echo").await.unwrap();
+    assert!(result.stdout.contains("echo hello"));
+    assert!(result.stdout.contains("echo world"));
+    assert!(!result.stdout.contains("ls /tmp"));
+}
+
+#[tokio::test]
+async fn history_failed() {
+    let mut bash = Bash::new();
+    bash.exec("true").await.unwrap();
+    bash.exec("false").await.unwrap();
+    let result = bash.exec("history --failed").await.unwrap();
+    assert!(
+        result.stdout.contains("false"),
+        "should show failed command"
+    );
+    assert!(
+        !result.stdout.contains("true"),
+        "should not show successful command"
+    );
+}
+
+#[tokio::test]
+async fn history_cwd_filter() {
+    let mut bash = Bash::new();
+    bash.exec("echo in-home").await.unwrap();
+    bash.exec("cd /tmp && echo in-tmp").await.unwrap();
+    let result = bash.exec("history --cwd /tmp").await.unwrap();
+    // Commands executed while cwd was /tmp
+    // Note: cd /tmp && echo in-tmp is recorded with the cwd at exec time.
+    // Since cwd changes during the script, the recorded cwd is whatever it was at the start of exec.
+    // Actually, the cwd is captured in lib.rs AFTER execution, so it will be /tmp for that script.
+    assert!(result.stdout.contains("echo in-tmp") || result.stdout.contains("cd /tmp"));
+}
+
+#[tokio::test]
+async fn history_invalid_option() {
+    let result = run("history --invalid").await;
+    assert_eq!(result.exit_code, 1);
+    assert!(result.stderr.contains("unrecognized option"));
+}
+
+#[tokio::test]
+async fn history_grep_missing_arg() {
+    let result = run("history --grep").await;
+    assert_eq!(result.exit_code, 1);
+    assert!(result.stderr.contains("requires an argument"));
+}
+
+#[tokio::test]
+async fn history_since_filter() {
+    let mut bash = Bash::new();
+    bash.exec("echo recent").await.unwrap();
+    let result = bash.exec("history --since 1h").await.unwrap();
+    assert!(
+        result.stdout.contains("echo recent"),
+        "recent entry should appear"
+    );
+}
+
+#[tokio::test]
+async fn history_since_invalid_duration() {
+    let result = run("history --since xyz").await;
+    assert_eq!(result.exit_code, 1);
+    assert!(result.stderr.contains("invalid duration"));
+}
+
+#[tokio::test]
+async fn history_numbered_output() {
+    let mut bash = Bash::new();
+    bash.exec("echo test").await.unwrap();
+    let result = bash.exec("history").await.unwrap();
+    // Should have bash-style numbered output like "  1  echo test"
+    assert!(
+        result.stdout.contains("  1  echo test"),
+        "output should be numbered: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn history_persists_to_vfs() {
+    let mut bash = Bash::builder()
+        .history_file("/home/user/.bash_history")
+        .build();
+    bash.exec("echo persisted").await.unwrap();
+
+    // Create a new Bash instance with same history file and VFS
+    // Since they share the same VFS through builder, history should persist
+    // For this test, we verify the file was written
+    let result = bash.exec("cat /home/user/.bash_history").await.unwrap();
+    assert!(
+        result.stdout.contains("echo persisted"),
+        "history file should contain command: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn history_loads_from_vfs() {
+    use std::sync::Arc;
+
+    let fs = Arc::new(bashkit::InMemoryFs::new());
+    // Pre-populate a history file
+    let history_content = "1700000000|0|10|/home/user|echo preloaded\n";
+    fs.mkdir(std::path::Path::new("/home/user"), true)
+        .await
+        .unwrap();
+    fs.write_file(
+        std::path::Path::new("/home/user/.bash_history"),
+        history_content.as_bytes(),
+    )
+    .await
+    .unwrap();
+
+    let mut bash = Bash::builder()
+        .fs(fs)
+        .history_file("/home/user/.bash_history")
+        .build();
+    let result = bash.exec("history").await.unwrap();
+    assert!(
+        result.stdout.contains("echo preloaded"),
+        "should load preexisting history: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn history_empty_when_no_commands() {
+    let result = run("history").await;
+    assert_eq!(result.stdout, "");
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn history_does_not_record_comments() {
+    let mut bash = Bash::new();
+    bash.exec("# this is a comment").await.unwrap();
+    bash.exec("echo visible").await.unwrap();
+    let result = bash.exec("history").await.unwrap();
+    assert!(!result.stdout.contains("comment"));
+    assert!(result.stdout.contains("echo visible"));
+}
+
+#[tokio::test]
+async fn history_does_not_record_blank_lines() {
+    let mut bash = Bash::new();
+    bash.exec("   ").await.unwrap();
+    bash.exec("echo visible").await.unwrap();
+    let result = bash.exec("history").await.unwrap();
+    let lines: Vec<&str> = result.stdout.lines().collect();
+    assert_eq!(lines.len(), 1, "should only have one entry: {:?}", lines);
+}


### PR DESCRIPTION
## Summary
- Add persistent, searchable command history with opt-in VFS persistence via `BashBuilder::history_file()`
- Intercept `history` builtin at interpreter level with query modes: `history N`, `--grep`, `--cwd`, `--failed`, `--since`
- Record each executed command with timestamp, cwd, exit code, and duration

## Test plan
- [x] 16 integration tests covering all query modes, VFS persistence, edge cases
- [x] Existing 1766 lib tests pass
- [x] clippy clean, cargo fmt clean

Closes #578