### PR TITLE
feat(js): add async execute API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,6 @@ pyo3 = { version = "0.28.2", features = ["extension-module", "generate-import-li
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 
 # JavaScript/Node.js bindings (NAPI-RS)
-napi = { version = "3.0.0", default-features = false, features = ["napi6", "compat-mode"] }
+napi = { version = "3.0.0", default-features = false, features = ["napi6", "compat-mode", "tokio_rt"] }
 napi-derive = "3.0.0"
 napi-build = "2"

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -113,6 +113,27 @@ impl Bash {
         })
     }
 
+    /// Execute bash commands asynchronously, returning a Promise.
+    #[napi]
+    pub async fn execute(&self, commands: String) -> napi::Result<ExecResult> {
+        let inner = self.inner.clone();
+        let mut bash = inner.lock().await;
+        match bash.exec(&commands).await {
+            Ok(result) => Ok(ExecResult {
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exit_code: result.exit_code,
+                error: None,
+            }),
+            Err(e) => Ok(ExecResult {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: 1,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
     /// Reset interpreter to fresh state, preserving configuration.
     #[napi]
     pub fn reset(&self) -> napi::Result<()> {
@@ -230,6 +251,27 @@ impl BashTool {
                 }),
             }
         })
+    }
+
+    /// Execute bash commands asynchronously, returning a Promise.
+    #[napi]
+    pub async fn execute(&self, commands: String) -> napi::Result<ExecResult> {
+        let inner = self.inner.clone();
+        let mut bash = inner.lock().await;
+        match bash.exec(&commands).await {
+            Ok(result) => Ok(ExecResult {
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exit_code: result.exit_code,
+                error: None,
+            }),
+            Err(e) => Ok(ExecResult {
+                stdout: String::new(),
+                stderr: String::new(),
+                exit_code: 1,
+                error: Some(e.to_string()),
+            }),
+        }
     }
 
     /// Reset interpreter to fresh state, preserving configuration.

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -64,10 +64,36 @@ export class Bash {
   }
 
   /**
+   * Execute bash commands asynchronously, returning a Promise.
+   *
+   * Non-blocking for the Node.js event loop.
+   *
+   * @example
+   * ```typescript
+   * const result = await bash.execute('echo hello');
+   * console.log(result.stdout); // hello\n
+   * ```
+   */
+  async execute(commands: string): Promise<ExecResult> {
+    return this.native.execute(commands);
+  }
+
+  /**
    * Execute bash commands synchronously. Throws `BashError` on non-zero exit.
    */
   executeSyncOrThrow(commands: string): ExecResult {
     const result = this.native.executeSync(commands);
+    if (result.exitCode !== 0) {
+      throw new BashError(result);
+    }
+    return result;
+  }
+
+  /**
+   * Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
+   */
+  async executeOrThrow(commands: string): Promise<ExecResult> {
+    const result = await this.native.execute(commands);
     if (result.exitCode !== 0) {
       throw new BashError(result);
     }
@@ -115,10 +141,28 @@ export class BashTool {
   }
 
   /**
+   * Execute bash commands asynchronously, returning a Promise.
+   */
+  async execute(commands: string): Promise<ExecResult> {
+    return this.native.execute(commands);
+  }
+
+  /**
    * Execute bash commands synchronously. Throws `BashError` on non-zero exit.
    */
   executeSyncOrThrow(commands: string): ExecResult {
     const result = this.native.executeSync(commands);
+    if (result.exitCode !== 0) {
+      throw new BashError(result);
+    }
+    return result;
+  }
+
+  /**
+   * Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
+   */
+  async executeOrThrow(commands: string): Promise<ExecResult> {
+    const result = await this.native.execute(commands);
     if (result.exitCode !== 0) {
       throw new BashError(result);
     }


### PR DESCRIPTION
## Summary
- Add `execute(commands): Promise<ExecResult>` to both `Bash` and `BashTool` classes
- Add `executeOrThrow(commands): Promise<ExecResult>` convenience methods in TypeScript wrapper
- Enable napi `tokio_rt` feature for non-blocking async support
- Keep `executeSync` for backwards compatibility

## Test plan
- [x] `cargo build -p bashkit-js` compiles cleanly
- [x] `cargo clippy -p bashkit-js` passes
- [ ] JS tests via `npm test` (requires native build environment)

Closes #539