### PR TITLE
fix(builtins): correct -a/-o operator precedence in test/[ builtin

### DIFF
--- a/crates/bashkit/src/builtins/test.rs
+++ b/crates/bashkit/src/builtins/test.rs
@@ -95,19 +95,18 @@ fn evaluate_expression<'a>(
             return evaluate_expression(&args[1..args.len() - 1], fs, cwd).await;
         }
 
-        // Look for binary operators
+        // Look for logical operators: -o has lowest precedence, then -a.
+        // Scan for -o first (split at lowest precedence first).
         for (i, arg) in args.iter().enumerate() {
-            match arg.as_str() {
-                // Logical operators (lowest precedence)
-                "-a" if i > 0 => {
-                    return evaluate_expression(&args[..i], fs, cwd).await
-                        && evaluate_expression(&args[i + 1..], fs, cwd).await;
-                }
-                "-o" if i > 0 => {
-                    return evaluate_expression(&args[..i], fs, cwd).await
-                        || evaluate_expression(&args[i + 1..], fs, cwd).await;
-                }
-                _ => {}
+            if arg == "-o" && i > 0 {
+                return evaluate_expression(&args[..i], fs, cwd).await
+                    || evaluate_expression(&args[i + 1..], fs, cwd).await;
+            }
+        }
+        for (i, arg) in args.iter().enumerate() {
+            if arg == "-a" && i > 0 {
+                return evaluate_expression(&args[..i], fs, cwd).await
+                    && evaluate_expression(&args[i + 1..], fs, cwd).await;
             }
         }
 
@@ -787,6 +786,34 @@ mod tests {
         let ctx = Context::new_for_test(&args, &env, &mut variables, &mut cwd, fs.clone(), None);
         let result = Bracket.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 0);
+    }
+
+    // ==================== operator precedence ====================
+
+    #[tokio::test]
+    async fn test_or_and_precedence() {
+        // [ true -o false -a false ] should be true (-a binds tighter than -o)
+        let (fs, mut cwd, mut variables) = setup().await;
+        let env = HashMap::new();
+        let args = vec![
+            "1".to_string(),
+            "-eq".to_string(),
+            "1".to_string(),
+            "-o".to_string(),
+            "1".to_string(),
+            "-eq".to_string(),
+            "2".to_string(),
+            "-a".to_string(),
+            "1".to_string(),
+            "-eq".to_string(),
+            "2".to_string(),
+        ];
+        let ctx = Context::new_for_test(&args, &env, &mut variables, &mut cwd, fs.clone(), None);
+        let result = Test.execute(ctx).await.unwrap();
+        assert_eq!(
+            result.exit_code, 0,
+            "-a should have higher precedence than -o"
+        );
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/bash/test-operators.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/test-operators.test.sh
@@ -186,6 +186,20 @@ different
 false
 ### end
 
+### test_or_and_precedence
+# -a has higher precedence than -o: [ true -o false -a false ] => true
+[ 1 -eq 1 -o 1 -eq 2 -a 1 -eq 2 ] && echo "correct" || echo "wrong"
+### expect
+correct
+### end
+
+### test_or_and_precedence_reverse
+# -a binds tighter: [ false -a false -o true ] => true
+[ 1 -eq 2 -a 1 -eq 2 -o 1 -eq 1 ] && echo "correct" || echo "wrong"
+### expect
+correct
+### end
+
 ### test_cond_nt
 # [[ ]] also supports -nt
 ### bash_diff


### PR DESCRIPTION
## Summary

- Fix `-a`/`-o` operator precedence in `test`/`[` builtin: `-a` (AND) now correctly has higher precedence than `-o` (OR) per POSIX
- Previous code iterated left-to-right treating both operators at equal precedence
- Fix scans for `-o` first (lowest precedence), then `-a` within each segment

## Test plan

- [x] Added spec tests for mixed `-a`/`-o` precedence (`test_or_and_precedence`, `test_or_and_precedence_reverse`)
- [x] Added unit test `test_or_and_precedence`
- [x] All existing test-operators spec tests still pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean

Closes #614