### PR TITLE
fix(interpreter): correct &&/|| operator precedence in [[ ]] conditional

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1566,17 +1566,18 @@ impl Interpreter {
                 return self.evaluate_conditional(&args[1..args.len() - 1]).await;
             }
 
-            // Look for logical operators (lowest precedence, right to left)
-            for i in (0..args.len()).rev() {
-                if args[i] == "&&" && i > 0 {
-                    return self.evaluate_conditional(&args[..i]).await
-                        && self.evaluate_conditional(&args[i + 1..]).await;
-                }
-            }
+            // Look for logical operators: || has lowest precedence, then &&.
+            // Scan for || first (split at lowest precedence first).
             for i in (0..args.len()).rev() {
                 if args[i] == "||" && i > 0 {
                     return self.evaluate_conditional(&args[..i]).await
                         || self.evaluate_conditional(&args[i + 1..]).await;
+                }
+            }
+            for i in (0..args.len()).rev() {
+                if args[i] == "&&" && i > 0 {
+                    return self.evaluate_conditional(&args[..i]).await
+                        && self.evaluate_conditional(&args[i + 1..]).await;
                 }
             }
 

--- a/crates/bashkit/tests/spec_cases/bash/conditional.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/conditional.test.sh
@@ -161,6 +161,20 @@ match
 diff
 ### end
 
+### cond_or_and_precedence
+# && has higher precedence than || in [[: [[ true || false && false ]] => true
+[[ -n "a" || -z "b" && -z "c" ]] && echo "correct" || echo "wrong"
+### expect
+correct
+### end
+
+### cond_or_and_precedence_reverse
+# && binds tighter: [[ false && false || true ]] => true
+[[ -z "a" && -z "b" || -n "c" ]] && echo "correct" || echo "wrong"
+### expect
+correct
+### end
+
 ### cond_exact_match_no_glob
 # [[ == ]] exact match with no glob chars
 [[ "hello" == "hello" ]] && echo yes || echo no


### PR DESCRIPTION
## Summary

- Fix `&&`/`||` operator precedence in `[[ ]]` conditional: `&&` now correctly has higher precedence than `||`
- Previous code searched for `&&` before `||`, inverting the precedence
- Fix swaps the loop order: scan for `||` first (lowest precedence)

## Test plan

- [x] Added spec tests `cond_or_and_precedence` and `cond_or_and_precedence_reverse`
- [x] All existing conditional spec tests still pass
- [x] Full test suite passes (1955+ tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean

Closes #615