### PR TITLE
fix(bindings): surface pre-exec failures in stderr for Python/JS

### DIFF
--- a/crates/bashkit-js/__test__/error-handling.spec.ts
+++ b/crates/bashkit-js/__test__/error-handling.spec.ts
@@ -194,3 +194,25 @@ test("unclosed quote returns non-zero or handles gracefully", (t) => {
   // Should either error or handle gracefully
   t.is(typeof r.exitCode, "number");
 });
+
+// ============================================================================
+// Pre-exec failure stderr surfacing (issue #606)
+// ============================================================================
+
+test("pre-exec parse error surfaces in stderr (Bash)", (t) => {
+  const bash = new Bash();
+  const r = bash.executeSync("echo $(");
+  t.not(r.exitCode, 0);
+  t.truthy(r.error, "error field should contain the parse error");
+  t.truthy(r.stderr, "stderr must not be empty on pre-exec failure");
+  t.true(r.stderr.includes(r.error!), "stderr should contain the error message");
+});
+
+test("pre-exec parse error surfaces in stderr (BashTool)", (t) => {
+  const tool = new BashTool();
+  const r = tool.executeSync("echo $(");
+  t.not(r.exitCode, 0);
+  t.truthy(r.error, "error field should contain the parse error");
+  t.truthy(r.stderr, "stderr must not be empty on pre-exec failure");
+  t.true(r.stderr.includes(r.error!), "stderr should contain the error message");
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -118,12 +118,15 @@ impl Bash {
                     exit_code: result.exit_code,
                     error: None,
                 }),
-                Err(e) => Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    exit_code: 1,
-                    error: Some(e.to_string()),
-                }),
+                Err(e) => {
+                    let msg = e.to_string();
+                    Ok(ExecResult {
+                        stdout: String::new(),
+                        stderr: msg.clone(),
+                        exit_code: 1,
+                        error: Some(msg),
+                    })
+                }
             }
         })
     }
@@ -140,12 +143,15 @@ impl Bash {
                 exit_code: result.exit_code,
                 error: None,
             }),
-            Err(e) => Ok(ExecResult {
-                stdout: String::new(),
-                stderr: String::new(),
-                exit_code: 1,
-                error: Some(e.to_string()),
-            }),
+            Err(e) => {
+                let msg = e.to_string();
+                Ok(ExecResult {
+                    stdout: String::new(),
+                    stderr: msg.clone(),
+                    exit_code: 1,
+                    error: Some(msg),
+                })
+            }
         }
     }
 
@@ -269,12 +275,15 @@ impl BashTool {
                     exit_code: result.exit_code,
                     error: None,
                 }),
-                Err(e) => Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    exit_code: 1,
-                    error: Some(e.to_string()),
-                }),
+                Err(e) => {
+                    let msg = e.to_string();
+                    Ok(ExecResult {
+                        stdout: String::new(),
+                        stderr: msg.clone(),
+                        exit_code: 1,
+                        error: Some(msg),
+                    })
+                }
             }
         })
     }
@@ -291,12 +300,15 @@ impl BashTool {
                 exit_code: result.exit_code,
                 error: None,
             }),
-            Err(e) => Ok(ExecResult {
-                stdout: String::new(),
-                stderr: String::new(),
-                exit_code: 1,
-                error: Some(e.to_string()),
-            }),
+            Err(e) => {
+                let msg = e.to_string();
+                Ok(ExecResult {
+                    stdout: String::new(),
+                    stderr: msg.clone(),
+                    exit_code: 1,
+                    error: Some(msg),
+                })
+            }
         }
     }
 

--- a/crates/bashkit-python/bashkit/deepagents.py
+++ b/crates/bashkit-python/bashkit/deepagents.py
@@ -71,6 +71,8 @@ def _make_bash_tool(bash_instance: NativeBashTool):
     def bashkit(command: str) -> str:
         result = bash_instance.execute_sync(command)
         output = result.stdout
+        if result.error:
+            output += f"\nError: {result.error}"
         if result.stderr:
             output += f"\n{result.stderr}"
         if result.exit_code != 0:
@@ -134,7 +136,10 @@ if DEEPAGENTS_AVAILABLE:
         def execute_sync(self, command: str) -> str:
             """Execute command synchronously (for setup scripts)."""
             result = self._bash.execute_sync(command)
-            return result.stdout + (result.stderr or "")
+            output = result.stdout + (result.stderr or "")
+            if result.error and result.error not in output:
+                output += f"\nError: {result.error}"
+            return output
 
         def reset(self) -> None:
             """Reset VFS to initial state."""
@@ -189,6 +194,8 @@ if DEEPAGENTS_AVAILABLE:
         def execute(self, command: str) -> ExecuteResponse:
             result = self._bash.execute_sync(command)
             output = result.stdout + (result.stderr or "")
+            if result.error and result.error not in output:
+                output += f"\nError: {result.error}"
             return ExecuteResponse(output=output, exit_code=result.exit_code, truncated=False)
 
         async def aexecute(self, command: str) -> ExecuteResponse:
@@ -344,7 +351,10 @@ if DEEPAGENTS_AVAILABLE:
         def setup(self, script: str) -> str:
             """Execute setup script."""
             result = self._bash.execute_sync(script)
-            return result.stdout + (result.stderr or "")
+            output = result.stdout + (result.stderr or "")
+            if result.error and result.error not in output:
+                output += f"\nError: {result.error}"
+            return output
 
         def reset(self) -> None:
             """Reset VFS."""

--- a/crates/bashkit-python/bashkit/pydantic_ai.py
+++ b/crates/bashkit-python/bashkit/pydantic_ai.py
@@ -73,6 +73,8 @@ def create_bash_tool(
         result = await native.execute(commands)
 
         output = result.stdout
+        if result.error:
+            output += f"\nError: {result.error}"
         if result.stderr:
             output += f"\nSTDERR: {result.stderr}"
         if result.exit_code != 0:

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -268,12 +268,15 @@ impl PyBash {
                     exit_code: result.exit_code,
                     error: None,
                 }),
-                Err(e) => Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    exit_code: 1,
-                    error: Some(e.to_string()),
-                }),
+                Err(e) => {
+                    let msg = e.to_string();
+                    Ok(ExecResult {
+                        stdout: String::new(),
+                        stderr: msg.clone(),
+                        exit_code: 1,
+                        error: Some(msg),
+                    })
+                }
             }
         })
     }
@@ -476,12 +479,15 @@ impl BashTool {
                     exit_code: result.exit_code,
                     error: None,
                 }),
-                Err(e) => Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    exit_code: 1,
-                    error: Some(e.to_string()),
-                }),
+                Err(e) => {
+                    let msg = e.to_string();
+                    Ok(ExecResult {
+                        stdout: String::new(),
+                        stderr: msg.clone(),
+                        exit_code: 1,
+                        error: Some(msg),
+                    })
+                }
             }
         })
     }

--- a/crates/bashkit-python/tests/test_bashkit.py
+++ b/crates/bashkit-python/tests/test_bashkit.py
@@ -954,3 +954,41 @@ def test_deeply_nested_schema_rejected():
     tool = ScriptedTool("deep")
     with pytest.raises(ValueError, match="nesting depth"):
         tool.add_tool("deep", "Deep", callback=lambda p, s=None: "", schema=nested)
+
+
+# ===========================================================================
+# Pre-exec failure stderr surfacing (issue #606)
+# ===========================================================================
+
+
+def test_bash_pre_exec_error_in_stderr():
+    """Pre-exec failures (parse errors) must appear in stderr, not only error field."""
+    bash = Bash()
+    # Unclosed subshell triggers parse error -> Err path in bindings
+    r = bash.execute_sync("echo $(")
+    assert r.exit_code != 0
+    assert r.error is not None
+    # Bug #606: stderr was empty even though error had the message
+    assert r.stderr != "", "stderr must contain the error message, not be empty"
+    assert r.error in r.stderr
+
+
+def test_bashtool_pre_exec_error_in_stderr():
+    """BashTool pre-exec failures must also surface in stderr."""
+    tool = BashTool()
+    r = tool.execute_sync("echo $(")
+    assert r.exit_code != 0
+    assert r.error is not None
+    assert r.stderr != "", "stderr must contain the error message, not be empty"
+    assert r.error in r.stderr
+
+
+@pytest.mark.asyncio
+async def test_bash_pre_exec_error_in_stderr_async():
+    """Async path should also surface pre-exec errors in stderr."""
+    bash = Bash()
+    r = await bash.execute("echo $(")
+    assert r.exit_code != 0
+    assert r.error is not None
+    assert r.stderr != "", "stderr must contain the error message, not be empty"
+    assert r.error in r.stderr


### PR DESCRIPTION
## Summary
- Pre-exec failures (parse errors, resource limits) only populated `error` field, leaving `stderr` empty
- Agent integrations only read `stdout`/`stderr`, so errors were silently lost
- Fix: copy error message into `stderr` in both Python and JS Rust bindings
- Update `deepagents.py` and `pydantic_ai.py` to surface `result.error`

## Test plan
- [x] 3 new Python tests confirming pre-exec errors appear in stderr
- [x] 2 new JS tests confirming pre-exec errors appear in stderr
- [x] `cargo clippy`, `cargo fmt` clean
- [x] `ruff check`, `ruff format` clean

Closes #606