### PR TITLE
feat(jq): upgrade jaq crates to latest stable versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # JSON processing (jq) - verified embeddable
-jaq-core = "2"
-jaq-std = "2"
-jaq-json = { version = "1", features = ["serde_json"] }
+jaq-core = "2.2"
+jaq-std = "2.1"
+jaq-json = { version = "1.1", features = ["serde_json"] }
 
 # Text search (grep) - verified supports search_slice() for in-memory
 grep = "0.3"

--- a/crates/bashkit/src/builtins/jq.rs
+++ b/crates/bashkit/src/builtins/jq.rs
@@ -1385,4 +1385,29 @@ mod tests {
             "-1"
         );
     }
+
+    #[tokio::test]
+    async fn test_jq_paths_with_filter() {
+        // jaq 2.x: paths/1 returns paths matching a filter
+        let result = run_jq("[paths(numbers)]", r#"{"a":1,"b":{"c":2},"d":"x"}"#)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result.trim()).unwrap();
+        let arr = parsed.as_array().unwrap();
+        // Should contain ["a"] and ["b","c"]
+        assert!(arr.iter().any(|v| v == &serde_json::json!(["a"])));
+        assert!(arr.iter().any(|v| v == &serde_json::json!(["b", "c"])));
+    }
+
+    #[tokio::test]
+    async fn test_jq_getpath() {
+        // jaq 2.x: getpath/1
+        assert_eq!(
+            run_jq(r#"getpath(["a","b"])"#, r#"{"a":{"b":42}}"#)
+                .await
+                .unwrap()
+                .trim(),
+            "42"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Bump jaq-core to 2.2, jaq-std to 2.1, jaq-json to 1.1 (latest stable releases)
- Picks up jaq security audit improvements and performance fixes
- Add tests for `paths/1` and `getpath/1` filters available in jaq 2.x

## Test plan
- [x] All 54 jq unit tests pass
- [x] Full test suite passes (`cargo test --all-features`)
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

Closes #616