### PR TITLE
chore: add docs/ folder to maintenance checklist

### DIFF
--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -28,7 +28,7 @@ Key tools: `just test`, `just check-bash-compat`
 
 ### 4. Documentation matches reality
 
-All docs (rustdoc, guides, Python, README, CONTRIBUTING, CHANGELOG) accurately reflect current code. Command counts, feature lists, API signatures, and examples are correct.
+All docs (rustdoc, guides, public docs in `docs/`, Python, README, CONTRIBUTING, CHANGELOG) accurately reflect current code. Command counts, feature lists, CLI flags, security boundaries, API signatures, and examples are correct.
 
 Fix any drift — update the docs, not the code (unless the code is wrong).
 

--- a/specs/012-maintenance.md
+++ b/specs/012-maintenance.md
@@ -50,6 +50,7 @@ dependency rot, or security gaps ship in a release.
 - Python docs (`crates/bashkit-python/README.md`) match current bindings and exports
 - Python docstrings match behavior
 - `README.md` feature list matches implemented builtins
+- Public docs (`docs/`) match current code: CLI flags, security boundaries, feature descriptions, test counts, and examples all reflect reality
 - `CONTRIBUTING.md` instructions accurate
 - `CHANGELOG.md` has entries for all changes since last release
 


### PR DESCRIPTION
## Summary

- Adds public `docs/` folder validation to the pre-release maintenance spec (`specs/012-maintenance.md`)
- Updates the `/maintain` skill to explicitly include `docs/` in the documentation review scope
- Ensures CLI flags, security boundaries, feature descriptions, test counts, and examples in `docs/` are checked for accuracy during maintenance

## Test plan

- [x] Verify `specs/012-maintenance.md` has the new docs/ entry in the Documentation section
- [x] Verify `.claude/commands/maintain.md` references `docs/` in section 4