### PR TITLE
test(security): add session isolation tests (TM-ISO-007 to TM-ISO-020)

### DIFF
--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -486,17 +486,17 @@ mod network_security {
 }
 
 // =============================================================================
-// 6. MULTI-TENANT ISOLATION TESTS
+// 6. SESSION ISOLATION TESTS
 // =============================================================================
 
-mod multi_tenant {
+mod session_isolation {
     use super::*;
     use bashkit::InMemoryFs;
     use std::sync::Arc;
 
     /// Test that separate instances have isolated filesystems
     #[tokio::test]
-    async fn threat_tenant_fs_isolation() {
+    async fn threat_isolation_fs_isolation() {
         let fs_a = Arc::new(InMemoryFs::new());
         let fs_b = Arc::new(InMemoryFs::new());
 
@@ -517,7 +517,7 @@ mod multi_tenant {
 
     /// Test that separate instances have isolated variables
     #[tokio::test]
-    async fn threat_tenant_variable_isolation() {
+    async fn threat_isolation_variable_isolation() {
         let mut tenant_a = Bash::new();
         let mut tenant_b = Bash::new();
 
@@ -529,7 +529,7 @@ mod multi_tenant {
 
     /// Test that separate instances have isolated functions
     #[tokio::test]
-    async fn threat_tenant_function_isolation() {
+    async fn threat_isolation_function_isolation() {
         let mut tenant_a = Bash::new();
         let mut tenant_b = Bash::new();
 
@@ -545,7 +545,7 @@ mod multi_tenant {
 
     /// Test that limits are per-instance
     #[tokio::test]
-    async fn threat_tenant_limits_isolation() {
+    async fn threat_isolation_limits_isolation() {
         let limits_strict = ExecutionLimits::new().max_commands(5);
         let limits_relaxed = ExecutionLimits::new().max_commands(100);
 
@@ -563,6 +563,318 @@ mod multi_tenant {
             .exec("true; true; true; true; true; true; true")
             .await;
         assert!(result.is_ok());
+    }
+
+    /// TM-ISO-019: Aliases defined in one session must not leak to another
+    #[tokio::test]
+    async fn threat_isolation_alias_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a
+            .exec("alias secret_cmd='echo LEAKED'")
+            .await
+            .unwrap();
+
+        // Tenant B should not have tenant A's alias
+        let result = tenant_b.exec("secret_cmd").await.unwrap();
+        assert_eq!(result.exit_code, 127);
+        assert!(!result.stdout.contains("LEAKED"));
+    }
+
+    /// TM-ISO-020: Trap handlers in one session must not fire in another
+    #[tokio::test]
+    async fn threat_isolation_trap_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a.exec("trap 'echo TRAP_LEAKED' EXIT").await.unwrap();
+
+        // Tenant B's EXIT trap should not produce tenant A's output
+        let result = tenant_b.exec("true").await.unwrap();
+        assert!(!result.stdout.contains("TRAP_LEAKED"));
+    }
+
+    /// TM-ISO-019: Shell options (set -e, set -o pipefail, etc.) must not leak
+    #[tokio::test]
+    async fn threat_isolation_shell_options_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a.exec("set -e").await.unwrap();
+        tenant_a.exec("set -o pipefail").await.unwrap();
+
+        // Tenant B should still have default options (errexit off)
+        // If errexit leaked, `false` would abort and we'd get an error
+        let result = tenant_b.exec("false; echo STILL_RUNNING").await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("STILL_RUNNING"));
+    }
+
+    /// TM-ISO-020: Exported environment variables must not cross sessions
+    #[tokio::test]
+    async fn threat_isolation_export_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a.exec("export DB_PASSWORD=s3cret").await.unwrap();
+
+        // Tenant B must not see tenant A's exported var
+        let result = tenant_b.exec("echo \"[$DB_PASSWORD]\"").await.unwrap();
+        assert_eq!(result.stdout.trim(), "[]");
+    }
+
+    /// TM-ISO-019: Indexed and associative arrays must not leak between sessions
+    #[tokio::test]
+    async fn threat_isolation_array_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a
+            .exec("SECRET_ARR=(one two three); declare -A SECRET_MAP; SECRET_MAP[key]=val")
+            .await
+            .unwrap();
+
+        // Tenant B must not see tenant A's arrays
+        let result = tenant_b
+            .exec("echo \"${SECRET_ARR[0]}\" \"${SECRET_MAP[key]}\"")
+            .await
+            .unwrap();
+        assert_eq!(result.stdout.trim(), "");
+    }
+
+    /// TM-ISO-020: Working directory changes must not leak between sessions
+    #[tokio::test]
+    async fn threat_isolation_cwd_isolation() {
+        let fs_a = Arc::new(InMemoryFs::new());
+        let mut tenant_a = Bash::builder().fs(fs_a).build();
+        let mut tenant_b = Bash::new();
+
+        tenant_a
+            .exec("mkdir -p /opt/secret && cd /opt/secret")
+            .await
+            .unwrap();
+
+        // Tenant B should still be at default cwd, not /opt/secret
+        let result = tenant_b.exec("pwd").await.unwrap();
+        assert!(!result.stdout.contains("/opt/secret"));
+    }
+
+    /// TM-ISO-019: Exit codes from one session must not affect another
+    #[tokio::test]
+    async fn threat_isolation_exit_code_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        // Tenant A ends with failure
+        tenant_a.exec("false").await.unwrap();
+
+        // Tenant B should start with clean exit code (0)
+        let result = tenant_b.exec("echo $?").await.unwrap();
+        assert_eq!(result.stdout.trim(), "0");
+    }
+
+    /// TM-ISO-020: Concurrent sessions must not interfere with each other
+    #[tokio::test]
+    async fn threat_isolation_concurrent_isolation() {
+        use tokio::task::JoinSet;
+
+        let mut tasks = JoinSet::new();
+
+        for i in 0..10 {
+            tasks.spawn(async move {
+                let mut bash = Bash::new();
+                let secret = format!("TENANT_{}_SECRET", i);
+                bash.exec(&format!("MY_SECRET={}", secret)).await.unwrap();
+
+                // Each session should only see its own variable
+                let result = bash.exec("echo $MY_SECRET").await.unwrap();
+                assert_eq!(result.stdout.trim(), secret);
+
+                // Try to probe for other tenants' variables
+                for j in 0..10 {
+                    if j != i {
+                        let other = format!("TENANT_{}_SECRET", j);
+                        let probe = bash.exec("echo $MY_SECRET").await.unwrap();
+                        assert!(!probe.stdout.contains(&other));
+                    }
+                }
+            });
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            result.unwrap();
+        }
+    }
+
+    /// TM-ISO-019: Concurrent filesystem writes must not cross-contaminate
+    #[tokio::test]
+    async fn threat_isolation_concurrent_fs_isolation() {
+        use tokio::task::JoinSet;
+
+        let mut tasks = JoinSet::new();
+
+        for i in 0..10 {
+            tasks.spawn(async move {
+                let fs = Arc::new(InMemoryFs::new());
+                let mut bash = Bash::builder().fs(fs).build();
+
+                let secret = format!("FS_SECRET_{}", i);
+                bash.exec(&format!("echo '{}' > /tmp/data.txt", secret))
+                    .await
+                    .unwrap();
+
+                let result = bash.exec("cat /tmp/data.txt").await.unwrap();
+                assert!(
+                    result.stdout.contains(&secret),
+                    "Tenant {} should see its own secret",
+                    i
+                );
+
+                // Verify no other tenant's data leaked in
+                for j in 0..10 {
+                    if j != i {
+                        let other_secret = format!("FS_SECRET_{}", j);
+                        assert!(
+                            !result.stdout.contains(&other_secret),
+                            "Tenant {} saw tenant {}'s data!",
+                            i,
+                            j
+                        );
+                    }
+                }
+            });
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            result.unwrap();
+        }
+    }
+
+    /// TM-ISO-020: Session state snapshot/restore must not affect other sessions
+    #[tokio::test]
+    async fn threat_isolation_snapshot_isolation() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a.exec("SNAPSHOT_SECRET=before").await.unwrap();
+        let snapshot = tenant_a.shell_state();
+
+        // Mutate tenant_a
+        tenant_a.exec("SNAPSHOT_SECRET=after").await.unwrap();
+
+        // Restore snapshot on tenant_a
+        tenant_a.restore_shell_state(&snapshot);
+
+        // Tenant B should be unaffected by any of this
+        let result = tenant_b.exec("echo \"[$SNAPSHOT_SECRET]\"").await.unwrap();
+        assert_eq!(result.stdout.trim(), "[]");
+    }
+
+    /// TM-ISO-019: Adversarial probing — script tries to discover other sessions
+    /// by iterating common paths and variable names
+    #[tokio::test]
+    async fn threat_isolation_adversarial_probing() {
+        let mut victim = Bash::new();
+        victim.exec("API_KEY=sk-live-12345").await.unwrap();
+        victim
+            .exec("export DATABASE_URL=postgres://secret@db/prod")
+            .await
+            .unwrap();
+
+        let mut attacker = Bash::new();
+
+        // Try common secret variable names
+        let probe_script = r#"
+echo "$API_KEY"
+echo "$DATABASE_URL"
+echo "$AWS_SECRET_ACCESS_KEY"
+echo "$GITHUB_TOKEN"
+echo "$PASSWORD"
+echo "$SECRET"
+echo "$PRIVATE_KEY"
+"#;
+        let result = attacker.exec(probe_script).await.unwrap();
+        assert!(!result.stdout.contains("sk-live"));
+        assert!(!result.stdout.contains("postgres://"));
+
+        // Try to enumerate env via env/printenv/set
+        let result = attacker
+            .exec("env 2>/dev/null; printenv 2>/dev/null")
+            .await
+            .unwrap();
+        assert!(!result.stdout.contains("sk-live"));
+        assert!(!result.stdout.contains("postgres://"));
+    }
+
+    /// TM-ISO-020: Adversarial script tries to read /proc, /sys, /dev for leaks
+    #[tokio::test]
+    async fn threat_isolation_proc_probing() {
+        let mut bash = Bash::new();
+
+        // These should not expose host information
+        let probes = vec![
+            "cat /proc/self/environ 2>/dev/null",
+            "cat /proc/self/cmdline 2>/dev/null",
+            "cat /proc/1/environ 2>/dev/null",
+            "ls /proc 2>/dev/null",
+            "cat /etc/passwd 2>/dev/null",
+            "cat /etc/shadow 2>/dev/null",
+        ];
+
+        for probe in probes {
+            let result = bash.exec(probe).await.unwrap();
+            // VFS shouldn't have real /proc or /etc content
+            assert!(
+                result.stdout.trim().is_empty() || result.exit_code != 0,
+                "Probe '{}' returned unexpected data: {}",
+                probe,
+                result.stdout
+            );
+        }
+    }
+
+    /// TM-ISO-019: jq env isolation — jq in one session must not see
+    /// environment variables from another concurrent session
+    #[tokio::test]
+    async fn threat_isolation_jq_env_cross_session() {
+        let mut tenant_a = Bash::new();
+        let mut tenant_b = Bash::new();
+
+        tenant_a
+            .exec("export JQ_SECRET=tenant_a_secret")
+            .await
+            .unwrap();
+
+        // Tenant B's jq should not see tenant A's env
+        let result = tenant_b
+            .exec("jq -n 'env.JQ_SECRET // \"none\"'")
+            .await
+            .unwrap();
+        assert!(
+            !result.stdout.contains("tenant_a_secret"),
+            "jq leaked cross-session env: {}",
+            result.stdout
+        );
+    }
+
+    /// TM-ISO-020: Subshell isolation — mutations in subshell must not
+    /// leak to parent, and parent state must not leak to sibling sessions
+    #[tokio::test]
+    async fn threat_isolation_subshell_isolation() {
+        let mut bash = Bash::new();
+
+        bash.exec("OUTER=original").await.unwrap();
+        bash.exec("(OUTER=mutated; INNER=leaked)").await.unwrap();
+
+        // Parent should not see subshell mutations
+        let result = bash.exec("echo $OUTER $INNER").await.unwrap();
+        assert_eq!(result.stdout.trim(), "original");
+
+        // Separate session should see neither
+        let mut other = Bash::new();
+        let result = other.exec("echo \"[$OUTER][$INNER]\"").await.unwrap();
+        assert_eq!(result.stdout.trim(), "[][]");
     }
 }
 

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -752,15 +752,30 @@ Only exact domain matches are allowed (TM-NET-017).
 
 ### 6. Multi-Tenant Isolation
 
-#### 6.1 Cross-Tenant Access
+#### 6.1 Cross-Session Access
 
 | ID | Threat | Attack Vector | Mitigation | Status |
 |----|--------|--------------|------------|--------|
-| TM-ISO-001 | Shared filesystem | Access other tenant files | Separate Bash instances | **MITIGATED** |
-| TM-ISO-002 | Shared memory | Read other tenant data | Rust memory safety | **MITIGATED** |
-| TM-ISO-003 | Resource starvation | One tenant exhausts limits | Per-instance limits | **MITIGATED** |
+| TM-ISO-001 | Shared filesystem | Access other session's files | Separate Bash instances with separate FS | **MITIGATED** |
+| TM-ISO-002 | Shared memory | Read other session's data | Rust memory safety, per-instance state | **MITIGATED** |
+| TM-ISO-003 | Resource starvation | One session exhausts limits | Per-instance limits | **MITIGATED** |
+| TM-ISO-004 | Cross-session env pollution via jq | `std::env::set_var()` in jq | Custom jaq global variable (`$__bashkit_env__`) | **MITIGATED** |
+| TM-ISO-007 | Alias leakage | Aliases defined in session A visible in session B | Per-instance alias HashMap | **MITIGATED** |
+| TM-ISO-008 | Trap handler leakage | Trap from session A fires in session B | Per-instance trap HashMap | **MITIGATED** |
+| TM-ISO-009 | Shell option leakage | `set -e` in session A affects session B | Per-instance ShellOptions | **MITIGATED** |
+| TM-ISO-010 | Exported env var leakage | `export` in session A visible in session B | Per-instance env HashMap | **MITIGATED** |
+| TM-ISO-011 | Array leakage | Indexed/associative arrays cross sessions | Per-instance array HashMaps | **MITIGATED** |
+| TM-ISO-012 | Working directory leakage | `cd` in session A changes session B's cwd | Per-instance `cwd: PathBuf` | **MITIGATED** |
+| TM-ISO-013 | Exit code leakage | `$?` from session A visible in session B | Per-instance `last_exit_code` | **MITIGATED** |
+| TM-ISO-014 | Concurrent variable leakage | Race condition leaks vars between parallel sessions | Per-instance state, no shared mutables | **MITIGATED** |
+| TM-ISO-015 | Concurrent FS leakage | Race condition leaks files between parallel sessions | Separate `Arc<FileSystem>` per instance | **MITIGATED** |
+| TM-ISO-016 | Snapshot/restore side effects | `restore_shell_state()` affects other sessions | Snapshot is per-instance, no shared state | **MITIGATED** |
+| TM-ISO-017 | Adversarial variable probing | Script enumerates common secret var names | Default-empty env, no host env inheritance | **MITIGATED** |
+| TM-ISO-018 | /proc /sys probing | Script reads `/proc/self/environ` etc. | VFS has no real /proc or /etc | **MITIGATED** |
+| TM-ISO-019 | jq cross-session env | `jq 'env.X'` sees other session's vars | jaq reads from injected global, not `std::env` | **MITIGATED** |
+| TM-ISO-020 | Subshell mutation leakage | Subshell vars leak to parent or sibling sessions | Snapshot/restore in subshell + per-instance state | **MITIGATED** |
 
-| TM-ISO-004 | Cross-tenant env pollution via jq | `std::env::set_var()` in jq modifies process-wide env, visible to concurrent tenants | Custom `$__bashkit_env__` jaq context variable replaces `std::env` access | **FIXED** |
+| TM-ISO-004 | Cross-session env pollution via jq | `std::env::set_var()` in jq modifies process-wide env, visible to concurrent sessions | Custom `$__bashkit_env__` jaq context variable replaces `std::env` access | **FIXED** |
 | TM-ISO-005 | Session-level cumulative counter bypass | Repeated `exec()` calls each reset `ExecutionCounters`, giving unbounded aggregate resources | — | **OPEN** |
 | TM-ISO-006 | No per-instance variable/memory budget | Unbounded `HashMap` growth in variables, arrays, functions exhausts process memory | — | **OPEN** |
 
@@ -778,19 +793,24 @@ and CPU time. Fix: add session-level cumulative counters that persist across `ex
 and OOM-ing the process. Fix: add `MemoryLimits` with caps on variable count, total bytes, array
 entries, and function count/size. See issue #656.
 
+**Note**: `PROC_SUB_COUNTER` (`AtomicU64`) is a global monotonic counter for process substitution
+paths (`/dev/fd/proc_sub_N`). This is a minor timing side-channel (reveals approximate execution
+ordering across concurrent sessions) but does not leak data since paths are resolved within each
+session's isolated VFS.
+
 **Current Risk**: MEDIUM - cumulative resource bypass (TM-ISO-005) and memory exhaustion (TM-ISO-006)
 
-**Implementation**: Each tenant gets separate instance with isolated state:
+**Implementation**: Each session gets separate instance with isolated state:
 ```rust
-// Each tenant gets isolated instance (TM-ISO-001, TM-ISO-002, TM-ISO-003)
-let tenant_a = Bash::builder()
+// Each session gets isolated instance (TM-ISO-001 through TM-ISO-020)
+let session_a = Bash::builder()
     .fs(Arc::new(InMemoryFs::new()))
-    .limits(tenant_limits)
+    .limits(session_limits)
     .build();
 
-let tenant_b = Bash::builder()
+let session_b = Bash::builder()
     .fs(Arc::new(InMemoryFs::new()))  // Separate FS
-    .limits(tenant_limits)
+    .limits(session_limits)
     .build();
 ```
 
@@ -1099,7 +1119,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-PY-023 | Shell injection in deepagents.py | Command injection within VFS | Use shlex.quote() or direct API |
 | TM-PY-024 | Heredoc content injection in write() | Command injection within VFS | Random delimiter or direct API |
 | TM-PY-025 | GIL deadlock in execute_sync | Python process deadlock | py.allow_threads() |
-| TM-ISO-004 | ~~Cross-tenant env pollution via jq~~ | ~~Tenant isolation breach~~ | ~~Same fix as TM-INF-013~~ (**FIXED**) |
+| TM-ISO-004 | ~~Cross-session env pollution via jq~~ | ~~Session isolation breach~~ | ~~Same fix as TM-INF-013~~ (**FIXED**) |
 | TM-ESC-013 | OverlayFs upper() exposes unlimited FS | VFS limit bypass | Restrict upper() visibility |
 
 ### Open (Medium Priority)


### PR DESCRIPTION
## Summary

- Add 14 new security tests covering session isolation gaps: aliases, traps, shell options, exported env vars, arrays, working directory, exit codes, concurrent sessions (vars + FS), snapshot/restore, adversarial probing, /proc probing, jq cross-session env, and subshell mutation leakage
- Rename `multi_tenant` test module to `session_isolation` for clarity
- Update threat model spec: renumber test IDs to avoid conflict with upstream TM-ISO-005/006, mark TM-ISO-004 (jq env pollution) as fixed, add PROC_SUB_COUNTER side-channel note

## What

Comprehensive explorative security testing for Bash session isolation. Each `Bash` instance should be a fully isolated sandbox — these tests verify that no state (variables, env, functions, aliases, traps, options, arrays, cwd, exit codes, files) leaks between sessions.

## Why

Previous coverage had only 4 basic isolation tests. This expands to 18 total, covering adversarial scenarios (secret enumeration, /proc probing), concurrency races (10 parallel sessions), and subtle state vectors (shell options, trap handlers, subshell mutations).

## Test plan

- [x] All 18 `threat_isolation_*` tests pass
- [x] Full `cargo test --all-features` green (2900+ tests, 0 failures)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Rebased on latest `origin/main`