### PR TITLE
test(python): add security and integration tests

### DIFF
--- a/crates/bashkit-python/tests/test_integration.py
+++ b/crates/bashkit-python/tests/test_integration.py
@@ -1,0 +1,479 @@
+"""Integration tests for bashkit Python bindings.
+
+Covers: multi-step workflows, async/sync interleaving, ScriptedTool
+complex orchestration, state management, concurrent usage, and
+framework integration helpers.
+"""
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from bashkit import Bash, BashTool, ScriptedTool
+
+# ===========================================================================
+# Multi-step workflows
+# ===========================================================================
+
+
+def test_multi_step_file_workflow():
+    """Create, read, modify, and verify a file across multiple calls."""
+    bash = Bash()
+    bash.execute_sync("echo 'initial content' > /tmp/workflow.txt")
+    bash.execute_sync("echo 'appended line' >> /tmp/workflow.txt")
+    r = bash.execute_sync("wc -l < /tmp/workflow.txt")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "2"
+    r = bash.execute_sync("head -1 /tmp/workflow.txt")
+    assert r.stdout.strip() == "initial content"
+
+
+def test_directory_tree_workflow():
+    """Build a directory tree, populate files, and verify structure."""
+    bash = Bash()
+    bash.execute_sync("mkdir -p /tmp/project/src /tmp/project/tests")
+    bash.execute_sync("echo 'fn main() {}' > /tmp/project/src/main.rs")
+    bash.execute_sync("echo '[test]' > /tmp/project/tests/test.rs")
+    r = bash.execute_sync("find /tmp/project -type f | sort")
+    assert r.exit_code == 0
+    assert "/tmp/project/src/main.rs" in r.stdout
+    assert "/tmp/project/tests/test.rs" in r.stdout
+
+
+def test_pipeline_data_processing():
+    """Multi-stage pipeline: generate, filter, sort, count."""
+    bash = Bash()
+    r = bash.execute_sync("""
+        for i in $(seq 1 20); do echo "item-$i"; done \
+        | grep -E 'item-[0-9]$' \
+        | sort -t- -k2 -n \
+        | wc -l
+    """)
+    assert r.exit_code == 0
+    assert int(r.stdout.strip()) == 9  # item-1 through item-9
+
+
+def test_variable_computation_workflow():
+    """Use variables for multi-step computation."""
+    bash = Bash()
+    bash.execute_sync("SUM=0")
+    bash.execute_sync("for i in 1 2 3 4 5; do SUM=$((SUM + i)); done")
+    r = bash.execute_sync("echo $SUM")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "15"
+
+
+# ===========================================================================
+# Async/sync interleaving
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_async_then_sync_same_instance():
+    """Async execute followed by sync execute on same Bash."""
+    bash = Bash()
+    r1 = await bash.execute("export PHASE=async")
+    assert r1.exit_code == 0
+    r2 = bash.execute_sync("echo $PHASE")
+    assert r2.exit_code == 0
+    assert r2.stdout.strip() == "async"
+
+
+@pytest.mark.asyncio
+async def test_sync_then_async_same_instance():
+    """Sync execute followed by async execute on same Bash."""
+    bash = Bash()
+    r1 = bash.execute_sync("export MODE=sync")
+    assert r1.exit_code == 0
+    r2 = await bash.execute("echo $MODE")
+    assert r2.exit_code == 0
+    assert r2.stdout.strip() == "sync"
+
+
+@pytest.mark.asyncio
+async def test_interleaved_file_operations():
+    """Interleave sync and async file operations."""
+    bash = Bash()
+    bash.execute_sync("echo line1 > /tmp/interleave.txt")
+    await bash.execute("echo line2 >> /tmp/interleave.txt")
+    bash.execute_sync("echo line3 >> /tmp/interleave.txt")
+    r = await bash.execute("cat /tmp/interleave.txt")
+    assert r.exit_code == 0
+    lines = r.stdout.strip().splitlines()
+    assert lines == ["line1", "line2", "line3"]
+
+
+# ===========================================================================
+# ScriptedTool: complex orchestration
+# ===========================================================================
+
+
+def _make_crud_tool():
+    """Build a CRUD-like ScriptedTool for integration tests."""
+    db = {}
+
+    def create(params, stdin=None):
+        key = params.get("key", "")
+        value = params.get("value", "")
+        db[key] = value
+        return json.dumps({"created": key}) + "\n"
+
+    def read(params, stdin=None):
+        key = params.get("key", "")
+        if key in db:
+            return json.dumps({"key": key, "value": db[key]}) + "\n"
+        return json.dumps({"error": "not found"}) + "\n"
+
+    def list_all(params, stdin=None):
+        return json.dumps(list(db.keys())) + "\n"
+
+    def delete(params, stdin=None):
+        key = params.get("key", "")
+        if key in db:
+            del db[key]
+            return json.dumps({"deleted": key}) + "\n"
+        return json.dumps({"error": "not found"}) + "\n"
+
+    tool = ScriptedTool("crud_api", short_description="CRUD API")
+    schema = {"type": "object", "properties": {"key": {"type": "string"}, "value": {"type": "string"}}}
+    tool.add_tool("create", "Create a record", callback=create, schema=schema)
+    tool.add_tool("read", "Read a record", callback=read, schema=schema)
+    tool.add_tool("list_all", "List all keys", callback=list_all)
+    tool.add_tool("delete", "Delete a record", callback=delete, schema=schema)
+    return tool
+
+
+def test_crud_workflow():
+    """Full CRUD cycle via bash scripting."""
+    tool = _make_crud_tool()
+    r = tool.execute_sync("""
+        create --key user1 --value Alice
+        create --key user2 --value Bob
+        list_all | jq -r '.[]' | sort
+    """)
+    assert r.exit_code == 0
+    assert "user1" in r.stdout
+    assert "user2" in r.stdout
+
+
+def test_crud_with_conditional_logic():
+    """CRUD operations with bash conditionals."""
+    tool = _make_crud_tool()
+    r = tool.execute_sync("""
+        create --key config --value enabled
+        status=$(read --key config | jq -r '.value')
+        if [ "$status" = "enabled" ]; then
+            echo "CONFIG_ACTIVE"
+        else
+            echo "CONFIG_INACTIVE"
+        fi
+    """)
+    assert r.exit_code == 0
+    assert "CONFIG_ACTIVE" in r.stdout
+
+
+def test_crud_error_handling():
+    """Error handling in CRUD workflows."""
+    tool = _make_crud_tool()
+    r = tool.execute_sync("""
+        result=$(read --key nonexistent | jq -r '.error')
+        if [ "$result" = "not found" ]; then
+            echo "HANDLED"
+        else
+            echo "MISSED"
+        fi
+    """)
+    assert r.exit_code == 0
+    assert "HANDLED" in r.stdout
+
+
+def test_scripted_tool_chained_pipes():
+    """Chain multiple tools via pipes."""
+    tool = ScriptedTool("transform")
+    tool.add_tool("upper", "Uppercase", callback=lambda p, s=None: (s or "").upper())
+    tool.add_tool("prefix", "Add prefix", callback=lambda p, s=None: "PREFIX:" + (s or ""))
+    r = tool.execute_sync("echo hello | upper | prefix")
+    assert r.exit_code == 0
+    assert "PREFIX:HELLO" in r.stdout
+
+
+def test_scripted_tool_loop_with_accumulation():
+    """Loop over tools and accumulate results in a variable."""
+    tool = ScriptedTool("calc")
+    tool.add_tool(
+        "double",
+        "Double a number",
+        callback=lambda p, s=None: str(int(p.get("n", 0)) * 2) + "\n",
+        schema={"type": "object", "properties": {"n": {"type": "integer"}}},
+    )
+    r = tool.execute_sync("""
+        result=""
+        for i in 1 2 3 4 5; do
+            val=$(double --n $i)
+            result="$result $val"
+        done
+        echo $result
+    """)
+    assert r.exit_code == 0
+    nums = r.stdout.strip().split()
+    assert nums == ["2", "4", "6", "8", "10"]
+
+
+# ===========================================================================
+# State management
+# ===========================================================================
+
+
+def test_reset_clears_files_and_vars():
+    """reset() must clear both files and environment variables."""
+    bash = Bash()
+    bash.execute_sync("export MYVAR=hello")
+    bash.execute_sync("echo data > /tmp/resettest.txt")
+    bash.reset()
+    r1 = bash.execute_sync("echo ${MYVAR:-cleared}")
+    assert r1.stdout.strip() == "cleared"
+    r2 = bash.execute_sync("cat /tmp/resettest.txt")
+    assert r2.exit_code != 0
+
+
+def test_bashtool_reset_clears_state():
+    """BashTool reset() clears state but preserves config."""
+    tool = BashTool(username="testuser")
+    tool.execute_sync("export SECRET=123")
+    tool.execute_sync("echo data > /tmp/toolreset.txt")
+    tool.reset()
+    r1 = tool.execute_sync("echo ${SECRET:-cleared}")
+    assert r1.stdout.strip() == "cleared"
+    r2 = tool.execute_sync("whoami")
+    assert r2.stdout.strip() == "testuser"
+
+
+def test_multiple_resets_stable():
+    """Multiple consecutive resets don't break the interpreter."""
+    bash = Bash()
+    for i in range(10):
+        bash.execute_sync(f"export V{i}=val{i}")
+        bash.reset()
+    r = bash.execute_sync("echo ok")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "ok"
+
+
+# ===========================================================================
+# Concurrent usage
+# ===========================================================================
+
+
+def test_concurrent_bash_instances():
+    """Multiple Bash instances used from different threads."""
+    results = [None] * 4
+    errors = [None] * 4
+
+    def worker(idx):
+        try:
+            bash = Bash()
+            r = bash.execute_sync(f"echo thread-{idx}; echo done-{idx}")
+            results[idx] = r
+        except Exception as e:
+            errors[idx] = e
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    for i in range(4):
+        assert errors[i] is None, f"Thread {i} failed: {errors[i]}"
+        assert results[i] is not None, f"Thread {i} returned None"
+        assert results[i].exit_code == 0
+        assert f"thread-{i}" in results[i].stdout
+
+
+def test_concurrent_scripted_tool_instances():
+    """Multiple ScriptedTool instances from different threads."""
+    results = [None] * 3
+    errors = [None] * 3
+
+    def worker(idx):
+        try:
+            tool = ScriptedTool(f"api_{idx}")
+            tool.add_tool("id", "Return ID", callback=lambda p, s=None, i=idx: f"tool-{i}\n")
+            r = tool.execute_sync("id")
+            results[idx] = r
+        except Exception as e:
+            errors[idx] = e
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    for i in range(3):
+        assert errors[i] is None, f"Thread {i} failed: {errors[i]}"
+        assert results[i].exit_code == 0
+        assert f"tool-{i}" in results[i].stdout
+
+
+# ===========================================================================
+# Async concurrent operations
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_executions():
+    """Multiple async executions on separate instances concurrently."""
+    instances = [Bash() for _ in range(3)]
+    tasks = [inst.execute(f"echo async-{i}") for i, inst in enumerate(instances)]
+    results = await asyncio.gather(*tasks)
+    for i, r in enumerate(results):
+        assert r.exit_code == 0
+        assert f"async-{i}" in r.stdout
+
+
+@pytest.mark.asyncio
+async def test_async_scripted_tool_concurrent():
+    """Concurrent async ScriptedTool executions."""
+    tools = []
+    for i in range(3):
+        t = ScriptedTool(f"api_{i}")
+        t.add_tool("ping", "Ping", callback=lambda p, s=None, idx=i: f"pong-{idx}\n")
+        tools.append(t)
+    tasks = [t.execute("ping") for t in tools]
+    results = await asyncio.gather(*tasks)
+    for i, r in enumerate(results):
+        assert r.exit_code == 0
+        assert f"pong-{i}" in r.stdout
+
+
+# ===========================================================================
+# ExecResult contract
+# ===========================================================================
+
+
+def test_exec_result_to_dict_contract():
+    """ExecResult.to_dict() returns all expected fields."""
+    bash = Bash()
+    r = bash.execute_sync("echo hello")
+    d = r.to_dict()
+    assert set(d.keys()) == {"stdout", "stderr", "exit_code", "error"}
+    assert isinstance(d["stdout"], str)
+    assert isinstance(d["stderr"], str)
+    assert isinstance(d["exit_code"], int)
+
+
+def test_exec_result_success_property():
+    """ExecResult.success matches exit_code == 0."""
+    bash = Bash()
+    r_ok = bash.execute_sync("true")
+    assert r_ok.success is True
+    assert r_ok.exit_code == 0
+    r_fail = bash.execute_sync("false")
+    assert r_fail.success is False
+    assert r_fail.exit_code != 0
+
+
+def test_exec_result_error_on_parse_failure():
+    """Parse failures set both error and stderr fields."""
+    bash = Bash()
+    r = bash.execute_sync("echo $(")
+    assert r.exit_code != 0
+    assert r.error is not None
+    assert r.stderr != ""
+
+
+# ===========================================================================
+# BashTool metadata consistency
+# ===========================================================================
+
+
+def test_bashtool_schemas_are_valid_json():
+    """input_schema and output_schema return valid JSON."""
+    tool = BashTool()
+    inp = json.loads(tool.input_schema())
+    assert "properties" in inp or "type" in inp
+    out = json.loads(tool.output_schema())
+    assert "properties" in out or "type" in out
+
+
+def test_bashtool_system_prompt_includes_username():
+    """system_prompt reflects configured username."""
+    tool = BashTool(username="agent007")
+    sp = tool.system_prompt()
+    assert "agent007" in sp
+
+
+def test_bashtool_version_format():
+    """Version string looks like a semver."""
+    tool = BashTool()
+    parts = tool.version.split(".")
+    assert len(parts) >= 2
+    assert all(p.isdigit() for p in parts[:2])
+
+
+# ===========================================================================
+# ScriptedTool metadata consistency
+# ===========================================================================
+
+
+def test_scripted_tool_system_prompt_lists_all_tools():
+    """System prompt includes all registered tool names."""
+    tool = ScriptedTool("multi")
+    for name in ["alpha", "beta", "gamma"]:
+        tool.add_tool(name, f"Tool {name}", callback=lambda p, s=None: "ok\n")
+    sp = tool.system_prompt()
+    for name in ["alpha", "beta", "gamma"]:
+        assert name in sp
+
+
+def test_scripted_tool_help_markdown():
+    """Help output is valid markdown with tool name header."""
+    tool = ScriptedTool("myapi")
+    tool.add_tool("cmd", "A command", callback=lambda p, s=None: "ok\n")
+    h = tool.help()
+    assert "# myapi" in h
+    assert "cmd" in h
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+def test_very_long_command():
+    """Very long command strings don't crash."""
+    bash = Bash()
+    # 10K character command
+    long_val = "x" * 10000
+    r = bash.execute_sync(f"echo '{long_val}'")
+    assert r.exit_code == 0
+    assert len(r.stdout.strip()) == 10000
+
+
+def test_many_sequential_commands():
+    """50 sequential commands in one script."""
+    bash = Bash()
+    cmds = "; ".join(f"echo line{i}" for i in range(50))
+    r = bash.execute_sync(cmds)
+    assert r.exit_code == 0
+    lines = r.stdout.strip().splitlines()
+    assert len(lines) == 50
+
+
+def test_empty_pipeline_stages():
+    """Commands with empty output in pipeline don't crash."""
+    bash = Bash()
+    r = bash.execute_sync("echo '' | cat | cat")
+    assert r.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_async_error_propagation():
+    """Async execution properly propagates errors."""
+    bash = Bash()
+    r = await bash.execute("exit 42")
+    assert r.exit_code == 42
+    assert r.success is False

--- a/crates/bashkit-python/tests/test_security.py
+++ b/crates/bashkit-python/tests/test_security.py
@@ -1,0 +1,283 @@
+"""Security tests for bashkit Python bindings.
+
+Covers: command injection, VFS isolation, resource limits,
+callback safety, env var injection, and Unicode/special char handling.
+"""
+
+import pytest
+
+from bashkit import Bash, BashTool, ScriptedTool
+
+# ===========================================================================
+# VFS isolation: no host filesystem access
+# ===========================================================================
+
+
+def test_vfs_cannot_read_host_etc_passwd():
+    """VFS must not expose host /etc/passwd."""
+    bash = Bash()
+    r = bash.execute_sync("cat /etc/passwd")
+    # Should either fail or return VFS-only content (not real users)
+    if r.exit_code == 0:
+        assert "root:x:0:0" not in r.stdout, "Host /etc/passwd leaked into VFS"
+
+
+def test_vfs_cannot_read_host_proc():
+    """VFS must not expose /proc filesystem."""
+    bash = Bash()
+    r = bash.execute_sync("cat /proc/self/cmdline")
+    assert r.exit_code != 0 or r.stdout == "", "Host /proc leaked into VFS"
+
+
+def test_vfs_writes_isolated_between_instances():
+    """Files written in one VFS are not visible in another instance."""
+    bash = Bash()
+    bash.execute_sync("echo pwned > /tmp/vfs_test_file.txt")
+    r = bash.execute_sync("cat /tmp/vfs_test_file.txt")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "pwned"
+    # A separate instance must not see this file
+    bash2 = Bash()
+    r2 = bash2.execute_sync("cat /tmp/vfs_test_file.txt")
+    assert r2.exit_code != 0, "VFS state leaked between interpreter instances"
+
+
+def test_vfs_directory_traversal():
+    """Directory traversal must not escape VFS."""
+    bash = Bash()
+    r = bash.execute_sync("cat /home/user/../../../etc/hostname")
+    # Should resolve within VFS, not expose host
+    if r.exit_code == 0:
+        assert r.stdout.strip() != "", "Traversal returned host data"
+
+
+# ===========================================================================
+# Command injection via untrusted input
+# ===========================================================================
+
+
+def test_single_quoted_strings_prevent_expansion():
+    """Single-quoted strings must prevent all expansion."""
+    bash = Bash()
+    r = bash.execute_sync("echo '$(whoami) ${HOME} `date`'")
+    assert r.exit_code == 0
+    assert "$(whoami)" in r.stdout
+    assert "${HOME}" in r.stdout
+    assert "`date`" in r.stdout
+
+
+def test_semicolon_in_variable_does_not_execute():
+    """Semicolons in variable values must not become command separators."""
+    bash = Bash()
+    bash.execute_sync("export DATA='foo; echo INJECTED'")
+    r = bash.execute_sync('echo "$DATA"')
+    assert r.stdout.strip() == "foo; echo INJECTED"
+    assert r.stdout.count("INJECTED") <= 1  # Only the literal, not executed
+
+
+def test_backtick_in_echo_argument():
+    """Backtick injection in single-quoted strings stays literal."""
+    bash = Bash()
+    r = bash.execute_sync("echo '`echo INJECTED`'")
+    assert "INJECTED" not in r.stdout or "`echo INJECTED`" in r.stdout
+
+
+# ===========================================================================
+# ScriptedTool callback security
+# ===========================================================================
+
+
+def test_callback_exception_does_not_crash_interpreter():
+    """Callback exceptions must not crash the interpreter."""
+    tool = ScriptedTool("api")
+
+    def bad_callback(params, stdin=None):
+        raise Exception("catastrophic failure")
+
+    tool.add_tool("crash", "Crashes", callback=bad_callback)
+    r = tool.execute_sync("crash")
+    assert r.exit_code != 0
+    # Interpreter still works after crash
+    tool.add_tool("ok", "OK", callback=lambda p, s=None: "alive\n")
+    r2 = tool.execute_sync("ok")
+    assert r2.exit_code == 0
+    assert r2.stdout.strip() == "alive"
+
+
+def test_callback_returning_none_handled():
+    """Callback returning None should be handled gracefully."""
+    tool = ScriptedTool("api")
+    tool.add_tool("noner", "Returns None", callback=lambda p, s=None: None)
+    r = tool.execute_sync("noner")
+    # Should fail gracefully (callback must return str)
+    assert r.exit_code != 0
+
+
+def test_callback_with_huge_params():
+    """Callback receiving many parameters doesn't crash."""
+    tool = ScriptedTool("api")
+    tool.add_tool(
+        "many",
+        "Many params",
+        callback=lambda p, s=None: str(len(p)) + "\n",
+    )
+    # Build a command with many --key value pairs
+    args = " ".join(f"--key{i} val{i}" for i in range(50))
+    r = tool.execute_sync(f"many {args}")
+    assert r.exit_code == 0
+    assert int(r.stdout.strip()) == 50
+
+
+# ===========================================================================
+# Environment variable injection
+# ===========================================================================
+
+
+def test_env_var_value_not_executed():
+    """Environment variable values must not be executed as commands."""
+    tool = ScriptedTool("api")
+    tool.env("SAFE", "$(echo INJECTED)")
+    tool.add_tool("noop", "No-op", callback=lambda p, s=None: "ok\n")
+    r = tool.execute_sync('echo "$SAFE"')
+    assert r.exit_code == 0
+    # The literal string should appear, not the result of execution
+    assert "$(echo INJECTED)" in r.stdout
+
+
+def test_env_var_with_newlines():
+    """Environment variables with embedded newlines handled correctly."""
+    bash = Bash()
+    bash.execute_sync('export MULTI="line1\nline2"')
+    r = bash.execute_sync('echo -e "$MULTI"')
+    assert r.exit_code == 0
+
+
+# ===========================================================================
+# Resource limit enforcement
+# ===========================================================================
+
+
+def test_resource_limits_survive_reset():
+    """Resource limits must persist after reset (TM-PY-026)."""
+    bash = Bash(max_commands=3)
+    bash.reset()
+    r = bash.execute_sync("echo 1; echo 2; echo 3; echo 4; echo 5")
+    lines = [line for line in r.stdout.strip().splitlines() if line]
+    assert len(lines) < 5 or r.exit_code != 0, "max_commands not enforced after reset"
+
+
+def test_max_loop_iterations_enforced():
+    """Infinite loops must be stopped by max_loop_iterations."""
+    bash = Bash(max_loop_iterations=5)
+    r = bash.execute_sync("while true; do echo x; done")
+    assert r.exit_code != 0 or r.stdout.count("x") <= 50
+
+
+def test_fork_bomb_prevented():
+    """Fork bombs cannot run (no real processes in VFS)."""
+    bash = Bash(max_commands=10)
+    bash.execute_sync(":(){ :|:& };:")
+    # Should either fail to parse or hit command limit
+    # The key thing is it doesn't actually fork-bomb the host
+    assert True  # If we get here, host wasn't harmed
+
+
+# ===========================================================================
+# Unicode and special character handling
+# ===========================================================================
+
+
+def test_unicode_in_commands():
+    """Unicode characters in commands work correctly."""
+    bash = Bash()
+    r = bash.execute_sync("echo 'Hello \u4e16\u754c'")
+    assert r.exit_code == 0
+    assert "\u4e16\u754c" in r.stdout
+
+
+def test_emoji_in_output():
+    """Emoji characters pass through correctly."""
+    bash = Bash()
+    r = bash.execute_sync("echo '\U0001f680\U0001f30d'")
+    assert r.exit_code == 0
+    assert "\U0001f680" in r.stdout
+
+
+def test_null_bytes_in_input():
+    """Null bytes in input handled without crash."""
+    bash = Bash()
+    r = bash.execute_sync("echo 'before\\0after'")
+    assert r.exit_code == 0
+
+
+def test_special_shell_chars_in_strings():
+    """Special shell metacharacters in quoted strings stay literal."""
+    bash = Bash()
+    r = bash.execute_sync("echo 'hello & world | test > file < input'")
+    assert r.exit_code == 0
+    assert "&" in r.stdout
+    assert "|" in r.stdout
+
+
+# ===========================================================================
+# Deeply nested schema rejection
+# ===========================================================================
+
+
+def test_nested_json_beyond_limit_rejected():
+    """JSON nesting > 64 levels must be rejected to prevent stack exhaustion."""
+    nested = {"value": "leaf"}
+    for _ in range(70):
+        nested = {"child": nested}
+    tool = ScriptedTool("deep")
+    with pytest.raises(ValueError, match="nesting depth"):
+        tool.add_tool("deep", "Deep", callback=lambda p, s=None: "", schema=nested)
+
+
+# ===========================================================================
+# Cancellation safety
+# ===========================================================================
+
+
+def test_cancel_is_safe():
+    """Calling cancel() is safe even when nothing is running."""
+    bash = Bash()
+    bash.cancel()  # Should not raise
+    bash.execute_sync("echo still_works")
+    # After cancel, the next execution may or may not work depending on
+    # whether the token auto-resets, but it should not crash
+    assert True  # If we get here, no crash
+
+
+def test_bashtool_cancel_is_safe():
+    """BashTool cancel() is safe even when nothing is running."""
+    tool = BashTool()
+    tool.cancel()  # Should not raise
+    # Should not crash
+    assert True
+
+
+# ===========================================================================
+# Instance isolation
+# ===========================================================================
+
+
+def test_separate_instances_isolated():
+    """Two Bash instances must not share state."""
+    b1 = Bash()
+    b2 = Bash()
+    b1.execute_sync("export SECRET=hunter2")
+    b1.execute_sync("echo private > /tmp/secret.txt")
+    r = b2.execute_sync("echo ${SECRET:-empty}")
+    assert r.stdout.strip() == "empty", "Variables leaked between instances"
+    r2 = b2.execute_sync("cat /tmp/secret.txt")
+    assert r2.exit_code != 0, "Files leaked between instances"
+
+
+def test_separate_bashtool_instances_isolated():
+    """Two BashTool instances must not share state."""
+    t1 = BashTool()
+    t2 = BashTool()
+    t1.execute_sync("export TOKEN=secret123")
+    r = t2.execute_sync("echo ${TOKEN:-empty}")
+    assert r.stdout.strip() == "empty", "Variables leaked between BashTool instances"


### PR DESCRIPTION
## Summary
- Add `test_security.py` (24 tests): VFS isolation, command injection prevention, callback safety, resource limit enforcement, Unicode handling, cancellation safety, instance isolation, and nesting depth limits
- Add `test_integration.py` (31 tests): multi-step workflows, async/sync interleaving, ScriptedTool CRUD orchestration, state management, concurrent usage, ExecResult contract, and metadata consistency
- No CI changes needed — tests auto-discovered by existing `pytest tests/ -v` step

## Test plan
- [x] All 55 new tests pass locally
- [x] Full suite (165 tests) passes with no regressions
- [x] Ruff lint + format checks pass
- [ ] CI green on Python 3.9/3.12/3.13