### PR TITLE
fix: add SessionStart hook to enforce human git identity

### DIFF
--- a/.claude/hooks/fix-git-identity.sh
+++ b/.claude/hooks/fix-git-identity.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SessionStart hook: override agent-like git identity with real user.
+# Runs automatically when a Claude Code session starts.
+
+set -euo pipefail
+
+# Only act inside a git repo
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$REPO_ROOT/scripts/lib/common.sh"
+
+configure_commit_git_identity_if_needed 2>/dev/null || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,18 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/fix-git-identity.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Shared helpers for bashkit development scripts.
+
+set -euo pipefail
+
+GIT_AGENT_IDENTITY_PATTERN="(claude|cursor|copilot|github-actions|bot|ai-agent|openai|anthropic|gpt)"
+
+# Returns 0 if the value matches a known agent/bot pattern.
+git_identity_looks_agent_like() {
+  local value="${1:-}"
+  [ -z "$value" ] && return 1
+  printf '%s\n' "$value" | grep -iEq "$GIT_AGENT_IDENTITY_PATTERN"
+}
+
+# Resolves a human git identity from git config or env vars.
+# Sets RESOLVED_GIT_AUTHOR_NAME, RESOLVED_GIT_AUTHOR_EMAIL, RESOLVED_GIT_AUTHOR_SOURCE.
+resolve_commit_git_identity() {
+  local current_name current_email
+  current_name="$(git config user.name 2>/dev/null || true)"
+  current_email="$(git config user.email 2>/dev/null || true)"
+
+  RESOLVED_GIT_AUTHOR_NAME=""
+  RESOLVED_GIT_AUTHOR_EMAIL=""
+  RESOLVED_GIT_AUTHOR_SOURCE=""
+
+  if [ -n "$current_name" ] && [ -n "$current_email" ] && \
+    ! git_identity_looks_agent_like "$current_name" && \
+    ! git_identity_looks_agent_like "$current_email"; then
+    RESOLVED_GIT_AUTHOR_NAME="$current_name"
+    RESOLVED_GIT_AUTHOR_EMAIL="$current_email"
+    RESOLVED_GIT_AUTHOR_SOURCE="git"
+  else
+    if [ -z "${GIT_USER_NAME:-}" ] || [ -z "${GIT_USER_EMAIL:-}" ]; then
+      echo "git commit identity is missing or agent-like; set GIT_USER_NAME and GIT_USER_EMAIL to a real user before committing" >&2
+      return 1
+    fi
+
+    RESOLVED_GIT_AUTHOR_NAME="$GIT_USER_NAME"
+    RESOLVED_GIT_AUTHOR_EMAIL="$GIT_USER_EMAIL"
+    RESOLVED_GIT_AUTHOR_SOURCE="env"
+  fi
+
+  if git_identity_looks_agent_like "$RESOLVED_GIT_AUTHOR_NAME" || \
+    git_identity_looks_agent_like "$RESOLVED_GIT_AUTHOR_EMAIL"; then
+    echo "resolved git commit identity looks agent-like: '$RESOLVED_GIT_AUTHOR_NAME <$RESOLVED_GIT_AUTHOR_EMAIL>'" >&2
+    return 1
+  fi
+}
+
+# Configures git user.name/email if current identity is missing or agent-like.
+configure_commit_git_identity_if_needed() {
+  resolve_commit_git_identity || return 1
+  git config user.name "$RESOLVED_GIT_AUTHOR_NAME"
+  git config user.email "$RESOLVED_GIT_AUTHOR_EMAIL"
+}


### PR DESCRIPTION
## What

Adds a SessionStart hook that automatically configures git `user.name` and `user.email` to a real human identity when a Claude Code session starts. This prevents commits from being attributed to AI agents/bots.

## Why

AGENTS.md requires all commits be attributed to the real human user, never to a coding agent. The existing documentation describes this policy, but there was no automated enforcement at session start. This hook makes it automatic.

## How

- **`.claude/hooks/fix-git-identity.sh`** — SessionStart hook that sources shared helpers and calls `configure_commit_git_identity_if_needed`
- **`.claude/settings.json`** — Registers the hook under `hooks.SessionStart`
- **`scripts/lib/common.sh`** — Shared helpers:
  - `git_identity_looks_agent_like()` — regex check against known bot/agent patterns
  - `resolve_commit_git_identity()` — resolves identity from git config or `GIT_USER_NAME`/`GIT_USER_EMAIL` env vars
  - `configure_commit_git_identity_if_needed()` — applies resolved identity to git config

## Key behaviors

- If git config already has a human name+email, no action is taken (env vars not needed)
- If git config is missing or agent-like, falls back to `GIT_USER_NAME`/`GIT_USER_EMAIL` env vars
- If resolution fails entirely, the hook swallows the error (`|| true`) — never blocks a session
- Final validation rejects resolved identities that still look agent-like

## Test plan

- [x] Shell syntax validation (`bash -n`) passes for both scripts
- [x] `git_identity_looks_agent_like` correctly detects: "Claude", "cursor-bot"
- [x] `git_identity_looks_agent_like` correctly passes: "John Doe", empty string
- [x] `resolve_commit_git_identity` resolves from existing git config (source: git)
- [x] Hook runs successfully end-to-end without errors
- [x] No env vars needed when git config already has human identity
- [x] `cargo fmt --check`, `cargo clippy`, `cargo test --all-features` all pass