### PR TITLE
test(security): blackbox security testing — 15 vulnerability findings

### DIFF
--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -1,10 +1,14 @@
 //! Blackbox Security Tests for Bashkit
 //!
-//! Creative exploratory security testing — probing the interpreter as
-//! a hostile attacker would, without relying on source code knowledge.
-//! Each test exercises a specific abuse vector.
+//! Exploratory blackbox security testing — probing the interpreter as a hostile
+//! attacker would, without relying on source code knowledge. Each test exercises
+//! a specific abuse vector.
 //!
-//! Run with: `cargo test --test blackbox_security_tests`
+//! Tests marked `#[ignore]` document confirmed security findings that currently
+//! reproduce. They are tracked via GitHub issues and threat model IDs.
+//!
+//! Run passing tests: `cargo test --test blackbox_security_tests`
+//! Run all (including findings): `cargo test --test blackbox_security_tests -- --ignored`
 
 #![allow(unused_variables, clippy::single_match, clippy::match_single_binding)]
 
@@ -40,32 +44,431 @@ fn dos_bash() -> Bash {
 }
 
 // =============================================================================
-// 1. RESOURCE EXHAUSTION & LIMITS BYPASS
+// FINDING 1: STACK OVERFLOW — NESTED COMMAND SUBSTITUTION
+// Threat: TM-DOS-044 (regression — was marked fixed via #492)
+// Issue: Deeply nested $(echo $(...)) at depth ~50 causes stack overflow.
+// The lexer fix in #492 may not cover the interpreter execution path.
 // =============================================================================
 
-mod resource_exhaustion_bypass {
+mod finding_nested_cmd_subst_stack_overflow {
     use super::*;
 
-    /// Try to bypass command limits using eval chains
+    /// TM-DOS-044 regression: depth-50 nested command substitution crashes.
+    /// REPRODUCER: Generates `echo $(echo $(echo ... ))` 50 levels deep.
+    /// Expected: error or truncated result. Actual: SIGABRT (stack overflow).
+    #[tokio::test]
+    #[ignore] // FINDING: stack overflow — crashes the process
+    async fn depth_50_crashes() {
+        let mut bash = tight_bash();
+        let depth = 50;
+        let mut cmd = "echo hello".to_string();
+        for _ in 0..depth {
+            cmd = format!("echo $({})", cmd);
+        }
+        let result = bash.exec(&cmd).await;
+        match &result {
+            Ok(r) => assert!(!r.stdout.is_empty() || r.exit_code != 0),
+            Err(_) => {}
+        }
+    }
+
+    /// Moderate nesting (depth 10) works fine — confirms the boundary.
+    #[tokio::test]
+    async fn depth_10_works() {
+        let mut bash = tight_bash();
+        let depth = 10;
+        let mut cmd = "echo hello".to_string();
+        for _ in 0..depth {
+            cmd = format!("echo $({})", cmd);
+        }
+        let result = bash.exec(&cmd).await;
+        match &result {
+            Ok(r) => assert!(!r.stdout.is_empty()),
+            Err(_) => {}
+        }
+    }
+}
+
+// =============================================================================
+// FINDING 2: STACK OVERFLOW — SOURCE SELF-RECURSION
+// Threat: TM-DOS-056 (new)
+// Issue: A script that sources itself causes unbounded recursion.
+// Function depth limit does not apply to source/. commands.
+// =============================================================================
+
+mod finding_source_recursion_stack_overflow {
+    use super::*;
+
+    /// TM-DOS-056: source self-recursion causes stack overflow.
+    /// REPRODUCER: Write a script that sources itself, then source it.
+    /// Expected: error from command/recursion limit. Actual: SIGABRT.
+    #[tokio::test]
+    #[ignore] // FINDING: stack overflow — crashes the process
+    async fn source_self_recursion_crashes() {
+        let mut bash = dos_bash();
+        let _ = bash
+            .exec("echo 'source /tmp/recurse.sh' > /tmp/recurse.sh")
+            .await;
+        let result = bash.exec("source /tmp/recurse.sh").await;
+        assert!(result.is_err(), "Self-sourcing must hit recursion limit");
+    }
+}
+
+// =============================================================================
+// FINDING 3: TIMEOUT BYPASS VIA SLEEP
+// Threat: TM-DOS-057 (new)
+// Issue: sleep in subshell, pipeline, or background+wait ignores execution
+// timeout. The timeout mechanism doesn't propagate to these contexts.
+// =============================================================================
+
+mod finding_timeout_bypass {
+    use super::*;
+
+    /// TM-DOS-057: sleep in subshell ignores 2s timeout, runs 60s+.
+    #[tokio::test]
+    #[ignore] // FINDING: timeout bypass — runs for 60s+
+    async fn subshell_sleep_bypasses_timeout() {
+        let mut bash = Bash::builder()
+            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
+            .build();
+        let start = Instant::now();
+        let _ = bash.exec("(sleep 100)").await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "Subshell sleep bypassed timeout: took {:?}",
+            elapsed
+        );
+    }
+
+    /// TM-DOS-057: sleep in pipeline ignores timeout.
+    #[tokio::test]
+    #[ignore] // FINDING: timeout bypass — runs for 60s+
+    async fn pipeline_sleep_bypasses_timeout() {
+        let mut bash = Bash::builder()
+            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
+            .build();
+        let start = Instant::now();
+        let _ = bash.exec("echo x | sleep 100").await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "Pipeline sleep bypassed timeout: took {:?}",
+            elapsed
+        );
+    }
+
+    /// TM-DOS-057: sleep in background + wait ignores timeout.
+    #[tokio::test]
+    #[ignore] // FINDING: timeout bypass — runs for 60s+
+    async fn background_sleep_wait_bypasses_timeout() {
+        let mut bash = Bash::builder()
+            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
+            .build();
+        let start = Instant::now();
+        let _ = bash.exec("sleep 100 &\nwait").await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "Background sleep+wait bypassed timeout: took {:?}",
+            elapsed
+        );
+    }
+
+    /// TM-DOS-057: timeout builtin overrides execution timeout.
+    #[tokio::test]
+    #[ignore] // FINDING: timeout bypass — runs for 60s+
+    async fn timeout_builtin_overrides_execution_timeout() {
+        let mut bash = Bash::builder()
+            .limits(ExecutionLimits::new().timeout(Duration::from_secs(3)))
+            .build();
+        let start = Instant::now();
+        let _ = bash.exec("timeout 3600 sleep 3600").await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(6),
+            "timeout builtin overrode execution timeout: {:?}",
+            elapsed
+        );
+    }
+
+    /// TM-DOS-057: even a direct `sleep 100` ignores the 2s execution timeout.
+    #[tokio::test]
+    #[ignore] // FINDING: direct sleep also bypasses timeout
+    async fn direct_sleep_bypasses_timeout() {
+        let mut bash = Bash::builder()
+            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
+            .build();
+        let start = Instant::now();
+        let _ = bash.exec("sleep 100").await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "Direct sleep bypassed timeout: took {:?}",
+            elapsed
+        );
+    }
+}
+
+// =============================================================================
+// FINDING 4: READONLY BYPASS
+// Threats: TM-INJ-019, TM-INJ-020, TM-INJ-021 (new)
+// Issue: readonly variables can be overwritten via unset, declare, and export.
+// =============================================================================
+
+mod finding_readonly_bypass {
+    use super::*;
+
+    /// TM-INJ-019: unset removes readonly variables.
+    /// Expected: unset should fail on readonly vars. Actual: variable is removed.
+    #[tokio::test]
+    #[ignore] // FINDING: readonly bypassed via unset
+    async fn unset_removes_readonly() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                readonly LOCKED=secret_value
+                unset LOCKED 2>/dev/null
+                echo "LOCKED=$LOCKED"
+                LOCKED=overwritten 2>/dev/null
+                echo "LOCKED=$LOCKED"
+                "#,
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.stdout.contains("LOCKED=secret_value"),
+            "readonly was bypassed via unset"
+        );
+    }
+
+    /// TM-INJ-020: declare overwrites readonly variables.
+    /// Expected: declare should fail on readonly vars. Actual: variable is overwritten.
+    #[tokio::test]
+    #[ignore] // FINDING: readonly bypassed via declare
+    async fn declare_overwrites_readonly() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                readonly LOCKED=original
+                declare LOCKED=overwritten 2>/dev/null
+                echo "$LOCKED"
+                "#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            result.stdout.trim(),
+            "original",
+            "readonly bypassed via declare"
+        );
+    }
+
+    /// TM-INJ-021: export overwrites readonly variables.
+    /// Expected: export should fail on readonly vars. Actual: variable is overwritten.
+    #[tokio::test]
+    #[ignore] // FINDING: readonly bypassed via export
+    async fn export_overwrites_readonly() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                readonly LOCKED=original
+                export LOCKED=overwritten 2>/dev/null
+                echo "$LOCKED"
+                "#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            result.stdout.trim(),
+            "original",
+            "readonly bypassed via export"
+        );
+    }
+
+    /// Non-finding: readonly via local in function is bash-compatible shadowing.
+    #[tokio::test]
+    async fn local_shadows_readonly_in_function() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                readonly LOCKED=original
+                f() { local LOCKED=overwritten; echo "$LOCKED"; }
+                f
+                echo "$LOCKED"
+                "#,
+            )
+            .await
+            .unwrap();
+        // In bash, local CAN shadow readonly in function scope.
+        // After function returns, LOCKED should still be original.
+        assert!(
+            result.stdout.trim().ends_with("original"),
+            "readonly not restored after function: got {}",
+            result.stdout.trim()
+        );
+    }
+}
+
+// =============================================================================
+// FINDING 5: STATE ISOLATION — TRAPS LEAK ACROSS exec()
+// Threat: TM-ISO-021 (new)
+// Issue: EXIT trap set in one exec() fires in subsequent exec() calls.
+// =============================================================================
+
+mod finding_trap_leak {
+    use super::*;
+
+    /// TM-ISO-021: EXIT trap from one exec() fires in the next exec().
+    /// Expected: each exec() starts with clean trap state.
+    /// Actual: EXIT trap persists and fires on subsequent calls.
+    #[tokio::test]
+    #[ignore] // FINDING: EXIT trap leaks between exec() calls
+    async fn exit_trap_leaks_between_exec() {
+        let mut bash = tight_bash();
+        let _ = bash.exec("trap 'echo LEAKED_TRAP' EXIT").await.unwrap();
+        let result = bash.exec("echo clean_execution").await.unwrap();
+        assert!(
+            !result.stdout.contains("LEAKED_TRAP"),
+            "EXIT trap leaked between exec() calls"
+        );
+    }
+}
+
+// =============================================================================
+// FINDING 6: STATE ISOLATION — $? LEAKS ACROSS exec()
+// Threat: TM-ISO-022 (new)
+// Issue: exit code from one exec() is visible as $? in the next exec().
+// =============================================================================
+
+mod finding_exit_code_leak {
+    use super::*;
+
+    /// TM-ISO-022: $? from one exec() leaks into the next.
+    /// Expected: $? should be 0 at start of each exec().
+    /// Actual: $? == 42 persists from previous `exit 42`.
+    #[tokio::test]
+    #[ignore] // FINDING: $? leaks across exec() calls
+    async fn exit_code_leaks_between_exec() {
+        let mut bash = tight_bash();
+        let _ = bash.exec("exit 42").await.unwrap();
+        let result = bash.exec("echo $?").await.unwrap();
+        assert_eq!(
+            result.stdout.trim(),
+            "0",
+            "$? leaked across exec() calls: got {}",
+            result.stdout.trim()
+        );
+    }
+}
+
+// =============================================================================
+// FINDING 7: STATE ISOLATION — set -e LEAKS ACROSS exec()
+// Threat: TM-ISO-023 (new)
+// Issue: Shell options (set -e) persist across exec() calls.
+// =============================================================================
+
+mod finding_shell_options_leak {
+    use super::*;
+
+    /// TM-ISO-023: set -e persists across exec() calls.
+    /// Expected: each exec() starts with default shell options.
+    /// Actual: set -e from previous exec causes abort on `false`.
+    #[tokio::test]
+    #[ignore] // FINDING: set -e leaks across exec() calls
+    async fn set_e_leaks_between_exec() {
+        let mut bash = tight_bash();
+        let _ = bash.exec("set -e").await;
+        let result = bash.exec("false; echo 'survived'").await.unwrap();
+        assert!(
+            result.stdout.contains("survived"),
+            "set -e leaked across exec() calls — false aborted execution"
+        );
+    }
+}
+
+// =============================================================================
+// FINDING 8: /dev/urandom RETURNS EMPTY WITH head -c
+// Threat: TM-INT-007 (new)
+// Issue: head -c N /dev/urandom returns empty output.
+// =============================================================================
+
+mod finding_urandom_empty {
+    use super::*;
+
+    /// TM-INT-007: /dev/urandom via head -c produces empty output.
+    /// Expected: 16 random bytes base64-encoded. Actual: empty string.
+    #[tokio::test]
+    #[ignore] // FINDING: /dev/urandom + head -c returns empty
+    async fn urandom_head_c_returns_empty() {
+        let mut bash = tight_bash();
+        let result = bash.exec("head -c 16 /dev/urandom | base64").await.unwrap();
+        assert!(
+            !result.stdout.trim().is_empty(),
+            "/dev/urandom produced empty output"
+        );
+    }
+}
+
+// =============================================================================
+// FINDING 9: seq PRODUCES UNBOUNDED OUTPUT (relates to #648)
+// Threat: TM-DOS-058 (new — specific instance of missing output limits)
+// Issue: seq 1 1000000 produces 1M lines despite 50-command limit.
+// Related to #648 (feat: add stdout/stderr output capture size limits).
+// =============================================================================
+
+mod finding_seq_output_dos {
+    use super::*;
+
+    /// TM-DOS-058: seq produces 1M lines with 50-command limit.
+    /// Single builtin call generates unbounded output.
+    #[tokio::test]
+    #[ignore] // FINDING: seq bypasses command limits (1M lines)
+    async fn seq_million_lines() {
+        let mut bash = dos_bash();
+        let result = bash.exec("seq 1 1000000").await;
+        match &result {
+            Ok(r) => {
+                let lines = r.stdout.lines().count();
+                assert!(lines <= 100, "seq bypassed limits: {} lines", lines);
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+// =============================================================================
+// NON-FINDING TESTS — PASSING SECURITY PROBES
+// These tests verify that security controls ARE working correctly.
+// Organized by attack category.
+// =============================================================================
+
+mod resource_exhaustion_passing {
+    use super::*;
+
+    /// Eval chains respect command limits
     #[tokio::test]
     async fn eval_chain_respects_command_limits() {
         let mut bash = dos_bash();
         let result = bash
             .exec(r#"eval 'eval "eval \"eval \\\"for i in $(seq 1 1000); do echo x; done\\\"\""'"#)
             .await;
-        // Must either error or complete within limits
         match &result {
             Ok(r) => {
                 let lines = r.stdout.lines().count();
-                assert!(lines <= 50, "eval chain produced {} lines, limits not enforced", lines);
+                assert!(lines <= 50, "eval chain produced {} lines", lines);
             }
-            Err(_) => {} // Limit error is fine
+            Err(_) => {}
         }
     }
 
-    /// Try to bypass loop limits by nesting loops inside functions
+    /// Nested function loops respect limits
     #[tokio::test]
-    async fn nested_function_loop_bypass() {
+    async fn nested_function_loop_limits() {
         let mut bash = dos_bash();
         let result = bash
             .exec(
@@ -79,13 +482,17 @@ mod resource_exhaustion_bypass {
         match &result {
             Ok(r) => {
                 let lines = r.stdout.lines().count();
-                assert!(lines <= 50, "Nested function loops produced {} lines", lines);
+                assert!(
+                    lines <= 50,
+                    "Nested function loops produced {} lines",
+                    lines
+                );
             }
             Err(_) => {}
         }
     }
 
-    /// Try to exhaust memory via exponential variable expansion
+    /// Exponential variable expansion doesn't OOM
     #[tokio::test]
     async fn exponential_variable_expansion() {
         let mut bash = tight_bash();
@@ -100,38 +507,16 @@ mod resource_exhaustion_bypass {
                 "#,
             )
             .await;
-        // Should complete without OOM — checking it doesn't hang or crash
         match &result {
             Ok(r) => {
                 let len: usize = r.stdout.trim().parse().unwrap_or(0);
-                // 10^4 = 10000 chars is fine, but test it doesn't go crazy
                 assert!(len <= 100_000_000, "Variable grew to {} chars", len);
             }
             Err(_) => {}
         }
     }
 
-    /// SECURITY FINDING: sleep inside subshell ignores execution timeout.
-    /// Set timeout to 2s, `(sleep 100)` runs for 60s+.
-    /// The timeout mechanism doesn't propagate into subshell execution.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: timeout bypass via subshell sleep
-    async fn subshell_timeout_bypass() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
-            .build();
-
-        let start = Instant::now();
-        let _ = bash.exec("(sleep 100)").await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "Subshell sleep bypassed timeout: took {:?}",
-            elapsed
-        );
-    }
-
-    /// Recursive function that tries to evade function depth limit
+    /// Recursive function via alias hits depth limit
     #[tokio::test]
     async fn recursive_function_via_alias() {
         let mut bash = dos_bash();
@@ -145,140 +530,94 @@ mod resource_exhaustion_bypass {
                 "#,
             )
             .await;
-        assert!(result.is_err() || result.unwrap().exit_code != 0,
-            "Recursive alias should hit function depth limit");
+        assert!(
+            result.is_err() || result.unwrap().exit_code != 0,
+            "Recursive alias should hit depth limit"
+        );
     }
 
-    /// Try mutual recursion to bypass depth limits
+    /// Mutual recursion hits depth limit
     #[tokio::test]
     async fn mutual_recursion_depth_limit() {
         let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                ping() { pong; }
-                pong() { ping; }
-                ping
-                "#,
-            )
-            .await;
-        assert!(
-            result.is_err(),
-            "Mutual recursion must hit depth limit"
-        );
+        let result = bash.exec("ping() { pong; }\npong() { ping; }\nping").await;
+        assert!(result.is_err(), "Mutual recursion must hit depth limit");
     }
 
-    /// Fork bomb pattern — should be caught by command limits
+    /// Fork bomb pattern caught by limits
     #[tokio::test]
     async fn fork_bomb_pattern() {
         let mut bash = dos_bash();
-        let result = bash
-            .exec(r#":(){ :|:& };:"#)
-            .await;
-        // Must not hang, must be caught by limits
+        let result = bash.exec(r#":(){ :|:& };:"#).await;
         match &result {
-            Ok(r) => assert!(r.exit_code != 0 || r.stderr.contains("limit") || r.stderr.contains("error"),
-                "Fork bomb pattern should be blocked"),
+            Ok(r) => assert!(
+                r.exit_code != 0 || r.stderr.contains("limit") || r.stderr.contains("error"),
+                "Fork bomb pattern should be blocked"
+            ),
             Err(_) => {}
         }
     }
 
-    /// Try to use `source` to create infinite recursion.
-    /// SECURITY FINDING: source self-recursion causes stack overflow.
-    /// The function depth limit doesn't apply to `source` calls.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: stack overflow — crashes the process
-    async fn source_self_recursion_crashes() {
-        let mut bash = dos_bash();
-        // Write a script that sources itself
-        let _ = bash
-            .exec("echo 'source /tmp/recurse.sh' > /tmp/recurse.sh")
-            .await;
-        let result = bash.exec("source /tmp/recurse.sh").await;
-        assert!(
-            result.is_err(),
-            "Self-sourcing must hit recursion/command limit"
-        );
-    }
-
-    /// Deeply nested command substitution — depth 50 causes stack overflow.
-    /// This is a real DoS vulnerability: an attacker can crash the process
-    /// with a moderately nested $(echo $(...)) chain.
-    ///
-    /// ROOT CAUSE: recursive interpret/expand calls without depth tracking
-    /// for command substitution nesting.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: stack overflow — crashes the process
-    async fn deeply_nested_command_substitution_crashes() {
-        let mut bash = tight_bash();
-        // Build: $(echo $(echo $(echo ... )))
-        let depth = 50;
-        let mut cmd = "echo hello".to_string();
-        for _ in 0..depth {
-            cmd = format!("echo $({})", cmd);
-        }
-        let result = bash.exec(&cmd).await;
-        // Should either work or error, not crash/hang
-        match &result {
-            Ok(r) => assert!(!r.stdout.is_empty() || r.exit_code != 0),
-            Err(_) => {}
-        }
-    }
-
-    /// Shallower nested command substitution should work fine
-    #[tokio::test]
-    async fn moderately_nested_command_substitution() {
-        let mut bash = tight_bash();
-        let depth = 10;
-        let mut cmd = "echo hello".to_string();
-        for _ in 0..depth {
-            cmd = format!("echo $({})", cmd);
-        }
-        let result = bash.exec(&cmd).await;
-        match &result {
-            Ok(r) => assert!(!r.stdout.is_empty()),
-            Err(_) => {}
-        }
-    }
-
-    /// Stress test: many here-documents
+    /// Many heredocs don't exhaust memory
     #[tokio::test]
     async fn many_heredocs_memory() {
         let mut bash = tight_bash();
         let mut script = String::new();
         for i in 0..100 {
-            script.push_str(&format!(
-                "cat <<'EOF{i}'\n{}\nEOF{i}\n",
-                "A".repeat(1000),
-            ));
+            script.push_str(&format!("cat <<'EOF{i}'\n{}\nEOF{i}\n", "A".repeat(1000),));
         }
         let result = bash.exec(&script).await;
-        // Must complete (limits should kick in for commands)
         match &result {
             Ok(r) => {
-                assert!(r.stdout.len() < 200_000, "Too much heredoc output: {}", r.stdout.len());
+                assert!(
+                    r.stdout.len() < 200_000,
+                    "Too much heredoc output: {}",
+                    r.stdout.len()
+                );
             }
             Err(_) => {}
         }
     }
+
+    /// bash -c respects limits
+    #[tokio::test]
+    async fn bash_c_respects_limits() {
+        let mut bash = dos_bash();
+        let result = bash
+            .exec("bash -c 'for i in $(seq 1 1000); do echo $i; done'")
+            .await;
+        match &result {
+            Ok(r) => {
+                let lines = r.stdout.lines().count();
+                assert!(lines <= 50, "bash -c bypassed limits: {} lines", lines);
+            }
+            Err(_) => {}
+        }
+    }
+
+    /// sh -c respects limits
+    #[tokio::test]
+    async fn sh_c_respects_limits() {
+        let mut bash = dos_bash();
+        let result = bash.exec("sh -c 'while true; do echo x; done'").await;
+        assert!(
+            result.is_err() || result.as_ref().unwrap().stdout.lines().count() <= 50,
+            "sh -c bypassed limits"
+        );
+    }
 }
 
-// =============================================================================
-// 2. VARIABLE INJECTION & EXPANSION ATTACKS
-// =============================================================================
-
-mod variable_injection {
+mod variable_injection_passing {
     use super::*;
 
-    /// Try to inject variables via PS1/PS2/PS4 to leak info
+    /// PS1/PS2/PS4 don't execute command substitution in non-interactive mode
     #[tokio::test]
-    async fn ps_variable_injection() {
+    async fn ps_variables_safe() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
                 r#"
                 PS1='$(cat /etc/passwd)'
-                PS2='$(whoami)'
                 PS4='+ $(date) '
                 set -x
                 echo test
@@ -286,36 +625,27 @@ mod variable_injection {
             )
             .await
             .unwrap();
-        // PS variables should not execute commands in non-interactive mode
         assert!(
             !result.stdout.contains("root:"),
             "PS1 executed command substitution"
         );
     }
 
-    /// IFS manipulation to split commands differently
+    /// IFS manipulation doesn't crash
     #[tokio::test]
-    async fn ifs_injection_attack() {
+    async fn ifs_manipulation_safe() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                IFS="/"
-                cmd="echo/hello/world"
-                $cmd
-                "#,
-            )
+            .exec("IFS=\"/\"\ncmd=\"echo/hello/world\"\n$cmd")
             .await
             .unwrap();
-        // With IFS="/", $cmd splits into "echo" "hello" "world"
-        // Exit code 127 is expected if word splitting creates invalid command lookup
-        // The key thing is it shouldn't crash or escape the sandbox
+        // Exit 127 is expected (word splitting creates invalid command)
         assert!(result.exit_code == 0 || result.exit_code == 127);
     }
 
-    /// Try to overwrite PATH to hijack commands
+    /// PATH hijack doesn't override builtins
     #[tokio::test]
-    async fn path_hijack_attempt() {
+    async fn path_hijack_blocked() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
@@ -331,198 +661,95 @@ mod variable_injection {
             )
             .await
             .unwrap();
-        // cat should still work as a builtin, not execute our fake
-        assert_eq!(result.stdout.trim(), "test",
-            "PATH hijack should not override builtins");
+        assert_eq!(
+            result.stdout.trim(),
+            "test",
+            "PATH hijack overrode builtins"
+        );
     }
 
-    /// Try to use BASH_ENV to execute code on startup
+    /// BASH_ENV doesn't auto-execute scripts
     #[tokio::test]
-    async fn bash_env_injection() {
+    async fn bash_env_safe() {
         let mut bash = tight_bash();
         let _ = bash.exec("echo 'echo INJECTED' > /tmp/evil_env.sh").await;
-
         let mut bash2 = tight_bash();
         let result = bash2
-            .exec(
-                r#"
-                export BASH_ENV=/tmp/evil_env.sh
-                bash -c 'echo clean'
-                "#,
-            )
+            .exec("export BASH_ENV=/tmp/evil_env.sh\nbash -c 'echo clean'")
             .await
             .unwrap();
         assert!(
             !result.stdout.contains("INJECTED"),
-            "BASH_ENV should not auto-execute scripts"
+            "BASH_ENV auto-executed"
         );
     }
 
-    /// Try to use PROMPT_COMMAND to inject code
+    /// PROMPT_COMMAND doesn't fire in non-interactive mode
     #[tokio::test]
-    async fn prompt_command_injection() {
+    async fn prompt_command_safe() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                PROMPT_COMMAND='echo INJECTED_VIA_PROMPT'
-                echo clean
-                "#,
-            )
+            .exec("PROMPT_COMMAND='echo INJECTED'\necho clean")
             .await
             .unwrap();
         assert!(
-            !result.stdout.contains("INJECTED_VIA_PROMPT"),
-            "PROMPT_COMMAND should not execute in non-interactive mode"
+            !result.stdout.contains("INJECTED"),
+            "PROMPT_COMMAND fired in non-interactive mode"
         );
     }
 
-    /// Variable name with special characters
+    /// Variable name with semicolon doesn't cause injection
     #[tokio::test]
-    async fn variable_name_special_chars() {
+    async fn variable_name_injection_blocked() {
         let mut bash = tight_bash();
-        // Try to create variables with weird names that might confuse the interpreter
         let result = bash
-            .exec(
-                r#"
-                declare "a[0]=injected"
-                declare "a b=test"
-                declare "a;echo EVIL=test"
-                echo clean
-                "#,
-            )
+            .exec("declare \"a;echo EVIL=test\"\necho clean")
             .await
             .unwrap();
         assert!(
             !result.stdout.contains("EVIL"),
-            "Variable name with semicolon caused command injection"
+            "Variable name caused injection"
         );
     }
 
-    /// Nameref chain to access internal state
+    /// Indirect expansion respects internal variable protection
     #[tokio::test]
-    async fn nameref_chain_internal_access() {
+    async fn indirect_expansion_blocked() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                declare -n ref1=BASH_VERSION
-                declare -n ref2=ref1
-                echo "$ref2"
-                declare -n ref3=RANDOM
-                echo "$ref3"
-                "#,
-            )
+            .exec("secret=\"hidden\"\nvarname=\"_NAMEREF_secret\"\necho \"${!varname}\"")
             .await
             .unwrap();
-        // Should work but not expose host info
-        // BASH_VERSION in bashkit should be bashkit's own, not host bash
-    }
-
-    /// Try to use printf to write to arbitrary file descriptors
-    #[tokio::test]
-    async fn printf_fd_escape() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                printf "INJECTED" > /dev/fd/1
-                printf "ALSO_INJECTED" >&255
-                echo clean
-                "#,
-            )
-            .await;
-        // Should not crash
-        match &result {
-            Ok(r) => assert!(r.stdout.contains("clean")),
-            Err(_) => {}
-        }
-    }
-
-    /// Indirect expansion to access internal variables
-    #[tokio::test]
-    async fn indirect_expansion_internal_vars() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                secret="hidden"
-                varname="_NAMEREF_secret"
-                echo "${!varname}"
-                varname="_READONLY_marker"
-                echo "${!varname}"
-                "#,
-            )
-            .await
-            .unwrap();
-        // Indirect expansion should not bypass internal variable protection
         assert!(
             !result.stdout.contains("hidden"),
             "Indirect expansion leaked internal variable"
         );
     }
-
-    /// Try to set special bash variables to confuse the interpreter
-    #[tokio::test]
-    async fn special_variable_confusion() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                LINENO=999999
-                FUNCNAME="fake_function"
-                BASH_SOURCE="/etc/passwd"
-                RANDOM=-1
-                SECONDS=-1
-                echo "$LINENO $FUNCNAME $BASH_SOURCE"
-                "#,
-            )
-            .await
-            .unwrap();
-        // Setting these special variables is allowed in bash too.
-        // The critical check is that it doesn't crash or affect interpreter operation.
-        assert_eq!(result.exit_code, 0);
-    }
 }
 
-// =============================================================================
-// 3. FILESYSTEM ESCAPE ATTEMPTS
-// =============================================================================
-
-mod filesystem_escape {
+mod filesystem_escape_passing {
     use super::*;
 
-    /// Path traversal via symlinks
+    /// Symlink doesn't traverse to host filesystem
     #[tokio::test]
-    async fn symlink_path_traversal() {
+    async fn symlink_traversal_blocked() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                ln -s /etc/passwd /tmp/innocent_link
-                cat /tmp/innocent_link
-                "#,
-            )
+            .exec("ln -s /etc/passwd /tmp/link\ncat /tmp/link")
             .await
             .unwrap();
         assert!(
             !result.stdout.contains("root:x:"),
-            "Symlink traversal accessed host /etc/passwd"
+            "Symlink accessed host /etc/passwd"
         );
     }
 
-    /// Path traversal via .. sequences
+    /// Path traversal via .. blocked
     #[tokio::test]
-    async fn dotdot_traversal() {
+    async fn dotdot_traversal_blocked() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                cd /tmp
-                cat ../../../etc/passwd
-                cat /tmp/../../../etc/shadow
-                "#,
-            )
+            .exec("cd /tmp\ncat ../../../etc/passwd\ncat /tmp/../../../etc/shadow")
             .await
             .unwrap();
         assert!(
@@ -531,81 +758,39 @@ mod filesystem_escape {
         );
     }
 
-    /// Try to escape via /proc/self
+    /// /proc/self not accessible
     #[tokio::test]
-    async fn proc_self_escape() {
+    async fn proc_self_blocked() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                cat /proc/self/environ
-                cat /proc/self/cmdline
-                cat /proc/self/maps
-                ls /proc/self/fd/
-                "#,
-            )
+            .exec("cat /proc/self/environ\ncat /proc/self/cmdline")
             .await
             .unwrap();
-        // VFS should not have /proc mounted
         assert!(
             !result.stdout.contains("PATH=") && !result.stdout.contains("HOME="),
             "/proc/self leaked host environment"
         );
     }
 
-    /// Try to create device files
+    /// /dev/tcp doesn't open real connections
     #[tokio::test]
-    async fn device_file_creation() {
+    async fn dev_tcp_blocked() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                echo "test" > /dev/tty
-                echo "test" > /dev/tcp/127.0.0.1/80
-                echo "test" > /dev/udp/127.0.0.1/53
-                echo clean
-                "#,
-            )
+            .exec("echo test > /dev/tcp/127.0.0.1/80 2>/dev/null\necho test > /dev/udp/127.0.0.1/53 2>/dev/null\necho clean")
             .await;
-        // /dev/tcp and /dev/udp are bash special files for network access
-        // They should NOT actually open network connections
         match &result {
             Ok(r) => assert!(r.stdout.contains("clean")),
             Err(_) => {}
         }
     }
 
-    /// Try to access host filesystem via /dev/fd
+    /// find doesn't discover host files
     #[tokio::test]
-    async fn dev_fd_escape() {
+    async fn find_confined_to_vfs() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                ls /dev/fd/
-                cat /dev/fd/0
-                readlink /dev/fd/0
-                "#,
-            )
-            .await;
-        // Should not expose real file descriptors
-        match &result {
-            Ok(r) => assert!(!r.stdout.contains("/dev/pts")),
-            Err(_) => {}
-        }
-    }
-
-    /// Try to use find to discover files outside VFS
-    #[tokio::test]
-    async fn find_escape_attempt() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                find / -name "*.conf" 2>/dev/null
-                find / -name "passwd" 2>/dev/null
-                "#,
-            )
+            .exec("find / -name \"*.conf\" 2>/dev/null\nfind / -name \"passwd\" 2>/dev/null")
             .await
             .unwrap();
         assert!(
@@ -614,187 +799,62 @@ mod filesystem_escape {
         );
     }
 
-    /// Null byte injection in filenames
+    /// Null byte in filename doesn't crash
     #[tokio::test]
-    async fn null_byte_filename() {
+    async fn null_byte_filename_safe() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                "echo test > $'/tmp/file\\x00.txt'\necho test > $'/tmp/normal.txt\\x00/etc/passwd'\necho clean",
-            )
+            .exec("echo test > $'/tmp/file\\x00.txt'\necho clean")
             .await;
-        // Should not crash on null bytes in filenames
         match &result {
             Ok(_) => {}
-            Err(e) => {
-                let msg = e.to_string();
-                assert!(!msg.contains("panic"), "Null byte caused panic: {}", msg);
-            }
+            Err(e) => assert!(!e.to_string().contains("panic"), "Null byte caused panic"),
         }
     }
 
-    /// Long path name attack
+    /// CDPATH doesn't escape VFS
     #[tokio::test]
-    async fn long_path_dos() {
-        let mut bash = tight_bash();
-        let long_dir = "A".repeat(4096);
-        let result = bash
-            .exec(&format!("mkdir -p /tmp/{}\necho clean", long_dir))
-            .await;
-        // Should not crash
-        match &result {
-            Ok(r) => assert!(r.stdout.contains("clean") || r.exit_code != 0),
-            Err(_) => {}
-        }
-    }
-
-    /// Relative path trickery with CDPATH
-    #[tokio::test]
-    async fn cdpath_escape() {
+    async fn cdpath_confined() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                CDPATH="/:..:/../../.."
-                cd etc 2>/dev/null && cat passwd
-                "#,
-            )
+            .exec("CDPATH=\"/:..:/../../..\"\ncd etc 2>/dev/null && cat passwd")
             .await
             .unwrap();
-        assert!(
-            !result.stdout.contains("root:"),
-            "CDPATH allowed filesystem escape"
-        );
+        assert!(!result.stdout.contains("root:"), "CDPATH allowed escape");
     }
 }
 
-// =============================================================================
-// 4. COMMAND INJECTION & EVAL ABUSE
-// =============================================================================
-
-mod command_injection {
+mod command_injection_passing {
     use super::*;
 
-    /// Eval with untrusted input
+    /// Eval executes in sandbox (expected bash behavior)
     #[tokio::test]
-    async fn eval_injection() {
+    async fn eval_sandboxed() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                user_input='hello; echo INJECTED'
-                eval "echo $user_input"
-                "#,
-            )
+            .exec("user_input='hello; echo INJECTED'\neval \"echo $user_input\"")
             .await
             .unwrap();
-        // This is expected bash behavior — eval DOES execute the injection
-        // The test verifies it doesn't crash or escape the sandbox
-        assert!(result.stdout.contains("INJECTED"),
-            "eval should execute as bash does (this is expected behavior)");
+        // eval DOES execute the injection — that's normal bash.
+        // The point is it stays in the sandbox.
+        assert!(result.stdout.contains("INJECTED"));
     }
 
-    /// Try to use trap to execute arbitrary code
+    /// Traps fire within sandbox
     #[tokio::test]
-    async fn trap_code_execution() {
+    async fn trap_sandboxed() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                trap 'echo TRAP_FIRED' EXIT
-                trap 'echo ERR_TRAP' ERR
-                trap 'echo DEBUG_TRAP' DEBUG
-                echo normal
-                "#,
-            )
+            .exec("trap 'echo TRAP_FIRED' EXIT\necho normal")
             .await
             .unwrap();
-        // Traps should fire but within the sandbox
         assert!(result.stdout.contains("normal"));
     }
 
-    /// Backtick injection
+    /// Array subscript command substitution stays sandboxed
     #[tokio::test]
-    async fn backtick_injection() {
+    async fn array_subscript_cmd_subst_sandboxed() {
         let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                x=`echo hello`
-                echo "$x"
-                # Nested backticks
-                y=`echo \`echo nested\``
-                echo "$y"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert_eq!(result.exit_code, 0);
-    }
-
-    /// Process substitution abuse
-    #[tokio::test]
-    async fn process_substitution_abuse() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                cat <(echo from_process_sub)
-                diff <(echo a) <(echo b)
-                "#,
-            )
-            .await;
-        // Should either work safely or error, not crash
-        match &result {
-            Ok(_) => {}
-            Err(_) => {}
-        }
-    }
-
-    /// Try to use bash -c to escape restrictions
-    #[tokio::test]
-    async fn bash_c_escape() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                bash -c 'for i in $(seq 1 1000); do echo $i; done'
-                "#,
-            )
-            .await;
-        // Inner bash -c must also respect limits
-        match &result {
-            Ok(r) => {
-                let lines = r.stdout.lines().count();
-                assert!(lines <= 50, "bash -c bypassed limits: {} lines", lines);
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to use sh -c to escape restrictions
-    #[tokio::test]
-    async fn sh_c_escape() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                sh -c 'while true; do echo x; done'
-                "#,
-            )
-            .await;
-        assert!(
-            result.is_err() || result.as_ref().unwrap().stdout.lines().count() <= 50,
-            "sh -c bypassed limits"
-        );
-    }
-
-    /// Try arithmetic evaluation to execute commands
-    #[tokio::test]
-    async fn arithmetic_command_execution() {
-        let mut bash = tight_bash();
-        // In real bash, array subscripts can execute arbitrary code
-        // e.g., a[$(echo pwned)] — this is a known bash vuln
         let result = bash
             .exec(
                 r#"
@@ -807,89 +867,53 @@ mod command_injection {
             )
             .await
             .unwrap();
-        // Array subscript should not execute command substitution in arithmetic context
-        // If it does, check that it's sandboxed
         assert!(result.stdout.contains("clean"));
     }
 
-    /// Globbing as DoS — create many files then glob
+    /// xargs respects command limits
     #[tokio::test]
-    async fn glob_expansion_dos() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                mkdir -p /tmp/globtest
-                for i in $(seq 1 100); do touch "/tmp/globtest/file_$i.txt"; done
-                echo /tmp/globtest/*.txt | wc -w
-                "#,
-            )
-            .await;
+    async fn xargs_respects_limits() {
+        let mut bash = dos_bash();
+        let result = bash.exec("seq 1 100 | xargs -I{} echo line_{}").await;
         match &result {
             Ok(r) => {
-                assert_eq!(result.as_ref().unwrap().exit_code, 0);
+                let lines = r.stdout.lines().count();
+                assert!(lines <= 50, "xargs bypassed limits: {} lines", lines);
             }
             Err(_) => {}
         }
     }
 }
 
-// =============================================================================
-// 5. PARSER EDGE CASES & PANICS
-// =============================================================================
-
-mod parser_edge_cases {
+mod parser_edge_cases_passing {
     use super::*;
 
-    /// Deeply nested parentheses
+    /// Deep nested parentheses don't stack overflow
     #[tokio::test]
-    async fn deep_nested_parens() {
+    async fn deep_parens_safe() {
         let mut bash = tight_bash();
         let deep = "(".repeat(100) + "echo hi" + &")".repeat(100);
         let result = bash.exec(&deep).await;
-        // Should not stack overflow
         match &result {
             Ok(_) => {}
-            Err(e) => {
-                assert!(
-                    !e.to_string().contains("stack overflow"),
-                    "Deep parens caused stack overflow"
-                );
-            }
+            Err(e) => assert!(
+                !e.to_string().contains("stack overflow"),
+                "Deep parens caused stack overflow"
+            ),
         }
     }
 
-    /// Deeply nested braces
+    /// Unterminated constructs don't hang
     #[tokio::test]
-    async fn deep_nested_braces() {
-        let mut bash = tight_bash();
-        let deep = "{".repeat(100) + " echo hi; " + &"}".repeat(100);
-        let result = bash.exec(&deep).await;
-        match &result {
-            Ok(_) => {}
-            Err(e) => {
-                assert!(
-                    !e.to_string().contains("stack overflow"),
-                    "Deep braces caused stack overflow"
-                );
-            }
-        }
-    }
-
-    /// Unterminated constructs shouldn't hang
-    #[tokio::test]
-    async fn unterminated_constructs() {
+    async fn unterminated_constructs_dont_hang() {
         let mut bash = Bash::builder()
             .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
             .build();
-
         let start = Instant::now();
-        // These should error quickly, not hang waiting for more input
         let _ = bash.exec("echo \"unterminated string").await;
         let _ = bash.exec("echo 'unterminated single").await;
         let _ = bash.exec("echo $(unterminated subshell").await;
         let _ = bash.exec("if true; then echo").await;
-        let _ = bash.exec("while true; do echo").await;
         let _ = bash.exec("case x in").await;
         let elapsed = start.elapsed();
         assert!(
@@ -899,7 +923,7 @@ mod parser_edge_cases {
         );
     }
 
-    /// Very long single line
+    /// Very long line handled
     #[tokio::test]
     async fn very_long_line() {
         let mut bash = tight_bash();
@@ -911,7 +935,7 @@ mod parser_edge_cases {
         }
     }
 
-    /// Many semicolons (empty commands)
+    /// Many empty commands (semicolons) handled
     #[tokio::test]
     async fn many_empty_commands() {
         let mut bash = tight_bash();
@@ -923,149 +947,55 @@ mod parser_edge_cases {
         }
     }
 
-    /// Heredoc with same delimiter as content
+    /// Heredoc with delimiter in content
     #[tokio::test]
-    async fn heredoc_delimiter_confusion() {
+    async fn heredoc_delimiter_in_content() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                cat <<EOF
-                This line contains EOF but not at start
-                EOF in middle of line
-                EOF
-                "#,
-            )
+            .exec("cat <<EOF\nThis contains EOF but not at start\nEOF in middle\nEOF\n")
             .await
             .unwrap();
         assert!(result.stdout.contains("EOF but not at start"));
     }
 
-    /// ANSI escape codes in output
+    /// Single-quoted heredoc prevents expansion
     #[tokio::test]
-    async fn ansi_escape_in_output() {
+    async fn heredoc_single_quoted_no_expansion() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(r#"printf '\033[2J\033[H\033[31mRED\033[0m\n'"#)
+            .exec("cat <<'EOF'\n$(echo INJECTED)\n`echo INJECTED2`\nEOF\n")
             .await
             .unwrap();
-        // Should pass through ANSI codes, not interpret them
-        assert!(result.stdout.contains("RED"));
-    }
-
-    /// Brace expansion abuse
-    #[tokio::test]
-    async fn brace_expansion_dos() {
-        let mut bash = tight_bash();
-        // {1..1000000} could generate massive output
-        let result = bash
-            .exec("echo {1..10000} | wc -w")
-            .await;
-        match &result {
-            Ok(r) => {
-                // Should either work or be limited
-            }
-            Err(_) => {}
-        }
+        assert!(
+            result.stdout.contains("$(echo INJECTED)"),
+            "Single-quoted heredoc expanded command substitution"
+        );
     }
 }
 
-// =============================================================================
-// 6. STATE CORRUPTION & CROSS-EXECUTION LEAKS
-// =============================================================================
-
-mod state_corruption {
+mod state_isolation_passing {
     use super::*;
 
-    /// SECURITY FINDING: EXIT trap from one exec() fires in the next exec().
-    /// This is a state isolation issue — traps should be scoped to a single
-    /// exec() invocation, but EXIT traps persist and fire on subsequent calls.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: EXIT trap leaks between exec() calls
-    async fn trap_persistence_across_exec() {
-        let mut bash = tight_bash();
-        let _ = bash
-            .exec("trap 'echo LEAKED_TRAP' EXIT")
-            .await
-            .unwrap();
-        let result = bash.exec("echo clean_execution").await.unwrap();
-        // The EXIT trap from previous exec should not fire in this exec
-        // (This tests whether exec() properly isolates trap state)
-        assert!(
-            !result.stdout.contains("LEAKED_TRAP"),
-            "Trap leaked between exec() calls"
-        );
-    }
-
-    /// Test that function definitions persist (they should) but don't leak secrets
-    #[tokio::test]
-    async fn function_secret_leak() {
-        let mut bash = tight_bash();
-        let _ = bash
-            .exec(
-                r#"
-                secret="API_KEY_12345"
-                hide_secret() { echo "$secret"; }
-                "#,
-            )
-            .await;
-        // Functions persist across exec, but let's check variable scope
-        let result = bash.exec("hide_secret").await.unwrap();
-        // This is expected — functions close over the environment
-        // The point is to verify the behavior is consistent
-    }
-
-    /// Test that subshell variables don't leak to parent
+    /// Subshell variables don't leak to parent
     #[tokio::test]
     async fn subshell_variable_isolation() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                x=parent
-                (x=child; echo "inner: $x")
-                echo "outer: $x"
-                "#,
-            )
+            .exec("x=parent\n(x=child; echo \"inner: $x\")\necho \"outer: $x\"")
             .await
             .unwrap();
         assert!(result.stdout.contains("inner: child"));
-        assert!(result.stdout.contains("outer: parent"),
-            "Subshell variable leaked to parent scope");
-    }
-
-    /// SECURITY FINDING: `unset` can remove readonly variables.
-    /// After `readonly LOCKED=secret_value`, `unset LOCKED` should fail,
-    /// but the variable is actually removed.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: readonly bypassed via unset
-    async fn readonly_unset_bypass() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                readonly LOCKED=secret_value
-                unset LOCKED 2>/dev/null
-                echo "LOCKED=$LOCKED"
-                LOCKED=overwritten 2>/dev/null
-                echo "LOCKED=$LOCKED"
-                "#,
-            )
-            .await
-            .unwrap();
-        // readonly should not be bypassed
         assert!(
-            result.stdout.contains("LOCKED=secret_value"),
-            "readonly was bypassed"
+            result.stdout.contains("outer: parent"),
+            "Subshell variable leaked to parent"
         );
     }
 
-    /// Verify env isolation between independent Bash instances
+    /// Cross-instance isolation
     #[tokio::test]
     async fn cross_instance_isolation() {
         let mut bash1 = tight_bash();
         let mut bash2 = tight_bash();
-
         let _ = bash1.exec("SECRET=from_instance_1").await;
         let result = bash2.exec("echo \"SECRET=$SECRET\"").await.unwrap();
         assert_eq!(
@@ -1075,147 +1005,91 @@ mod state_corruption {
         );
     }
 
-    /// SECURITY FINDING: $? from one exec() leaks into the next.
-    /// After `exit 42`, the next exec() sees $? == 42 instead of 0.
-    /// This is a state isolation bug — each exec() should start fresh.
+    /// History doesn't leak between instances
     #[tokio::test]
-    #[ignore] // SECURITY FINDING: $? leaks across exec() calls
-    async fn exit_code_isolation() {
-        let mut bash = tight_bash();
-        let _ = bash.exec("exit 42").await.unwrap();
-        let result = bash.exec("echo $?").await.unwrap();
-        // $? should be 0 (fresh execution), not 42
-        assert_eq!(
-            result.stdout.trim(),
-            "0",
-            "$? leaked across exec() calls: got {}",
-            result.stdout.trim()
+    async fn history_cross_session() {
+        let mut bash1 = tight_bash();
+        let _ = bash1.exec("SECRET_CMD=password123").await;
+        let mut bash2 = tight_bash();
+        let result = bash2.exec("history").await.unwrap();
+        assert!(
+            !result.stdout.contains("password123"),
+            "History leaked between instances"
         );
     }
 }
 
-// =============================================================================
-// 7. UNICODE & ENCODING ATTACKS
-// =============================================================================
-
-mod unicode_attacks {
+mod unicode_attacks_passing {
     use super::*;
 
-    /// Right-to-left override character to disguise commands
+    /// RTL override character handled safely
     #[tokio::test]
-    async fn rtl_override_disguise() {
+    async fn rtl_override() {
         let mut bash = tight_bash();
-        // U+202E RIGHT-TO-LEFT OVERRIDE
-        let result = bash
-            .exec("echo \u{202E}test\u{202C}")
-            .await
-            .unwrap();
-        // Should handle without crashing
+        let result = bash.exec("echo \u{202E}test\u{202C}").await.unwrap();
         assert_eq!(result.exit_code, 0);
     }
 
-    /// Zero-width characters in variable names
-    #[tokio::test]
-    async fn zero_width_variable_names() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                normal="real_value"
-                echo "$normal"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert!(result.stdout.contains("real_value"));
-    }
-
-    /// Homoglyph attack — using lookalike characters
-    #[tokio::test]
-    async fn homoglyph_command_names() {
-        let mut bash = tight_bash();
-        // Cyrillic 'е' (U+0435) looks like Latin 'e'
-        let result = bash.exec("echo normal").await.unwrap();
-        assert!(result.stdout.contains("normal"));
-    }
-
-    /// Very long Unicode strings
+    /// Long Unicode strings handled
     #[tokio::test]
     async fn long_unicode_string() {
         let mut bash = tight_bash();
         let emoji_bomb = "\u{1F4A3}".repeat(10000);
-        let result = bash
-            .exec(&format!("echo '{}'", emoji_bomb))
-            .await;
+        let result = bash.exec(&format!("echo '{}'", emoji_bomb)).await;
         match &result {
             Ok(r) => assert_eq!(r.exit_code, 0),
             Err(_) => {}
         }
     }
 
-    /// Multi-byte character boundary in variable expansion
+    /// Multi-byte substring doesn't panic
     #[tokio::test]
     async fn multibyte_substring() {
         let mut bash = tight_bash();
         let result = bash
-            .exec(
-                r#"
-                x="héllo wörld"
-                echo "${x:0:5}"
-                echo "${#x}"
-                echo "${x:3:2}"
-                "#,
-            )
+            .exec("x=\"héllo wörld\"\necho \"${x:0:5}\"\necho \"${#x}\"")
             .await;
-        // Should not panic on multi-byte char boundaries
         match &result {
             Ok(_) => {}
-            Err(e) => {
-                assert!(!e.to_string().contains("byte index"),
-                    "Multi-byte substring caused panic: {}", e);
-            }
+            Err(e) => assert!(
+                !e.to_string().contains("byte index"),
+                "Multi-byte substring panic: {}",
+                e
+            ),
         }
     }
 
-    /// Null bytes in various positions
+    /// Null bytes don't cause panics
     #[tokio::test]
-    async fn null_bytes_everywhere() {
+    async fn null_bytes_safe() {
         let mut bash = tight_bash();
-        let tests = vec![
-            "echo $'\\x00'",
-            "x=$'hello\\x00world'; echo \"$x\"",
-            "echo test | tr 'e' '\\0'",
-        ];
-        for test in tests {
+        for test in ["echo $'\\x00'", "x=$'hello\\x00world'; echo \"$x\""] {
             let result = bash.exec(test).await;
             match &result {
                 Ok(_) => {}
-                Err(e) => {
-                    assert!(!e.to_string().contains("panic"),
-                        "Null byte test panicked: {} for input: {}", e, test);
-                }
+                Err(e) => assert!(
+                    !e.to_string().contains("panic"),
+                    "Null byte panic: {} for: {}",
+                    e,
+                    test
+                ),
             }
         }
     }
 }
 
-// =============================================================================
-// 8. CREATIVE ABUSE VECTORS
-// =============================================================================
-
-mod creative_abuse {
+mod creative_abuse_passing {
     use super::*;
 
-    /// Try to use printf formatting to leak memory
+    /// printf format string attack doesn't crash
     #[tokio::test]
-    async fn printf_format_string_attack() {
+    async fn printf_format_string() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
                 r#"
-                printf "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
+                printf "%s%s%s%s%s%s%s%s%s%s"
                 printf "%n" 2>/dev/null
-                printf "%d" "not_a_number" 2>/dev/null
                 printf "%.99999999s" "x"
                 echo clean
                 "#,
@@ -1227,306 +1101,139 @@ mod creative_abuse {
         }
     }
 
-    /// Try to abuse read with timeout to hang
+    /// read -t doesn't hang
     #[tokio::test]
-    async fn read_hang_attempt() {
+    async fn read_timeout() {
         let mut bash = Bash::builder()
             .limits(ExecutionLimits::new().timeout(Duration::from_secs(3)))
             .build();
         let start = Instant::now();
         let _ = bash.exec("read -t 1 x; echo done").await;
         let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "read command hung for {:?}",
-            elapsed
-        );
+        assert!(elapsed < Duration::from_secs(5), "read hung: {:?}", elapsed);
     }
 
-    /// Try to abuse yes command as DoS
+    /// yes|head respects limits
     #[tokio::test]
-    async fn yes_dos() {
+    async fn yes_head() {
         let mut bash = dos_bash();
         let result = bash.exec("yes | head -5").await;
         match &result {
             Ok(r) => {
                 let lines = r.stdout.lines().count();
-                assert!(lines <= 50, "yes produced too many lines: {}", lines);
+                assert!(lines <= 50, "yes produced {} lines", lines);
             }
             Err(_) => {}
         }
     }
 
-    /// SECURITY FINDING: `seq 1 1000000` produces 1M lines despite command limit of 50.
-    /// The seq builtin runs as a single command but generates unbounded output.
-    /// An attacker can produce massive memory allocation via a single command.
+    /// env/printenv don't leak host secrets
     #[tokio::test]
-    #[ignore] // SECURITY FINDING: seq bypasses command limits (1M lines with 50-cmd limit)
-    async fn seq_dos() {
-        let mut bash = dos_bash();
-        let result = bash.exec("seq 1 1000000").await;
-        match &result {
-            Ok(r) => {
-                let lines = r.stdout.lines().count();
-                assert!(lines <= 100, "seq bypassed limits: {} lines", lines);
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to abuse xargs to multiply command execution
-    #[tokio::test]
-    async fn xargs_command_multiplication() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec("seq 1 100 | xargs -I{} echo line_{}")
-            .await;
-        match &result {
-            Ok(r) => {
-                let lines = r.stdout.lines().count();
-                assert!(lines <= 50, "xargs bypassed command limits: {} lines", lines);
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to use watch to create persistent execution
-    #[tokio::test]
-    async fn watch_persistence() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(3)))
-            .build();
-        let start = Instant::now();
-        let _ = bash.exec("watch -n 0 echo x").await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(6),
-            "watch ran indefinitely: {:?}",
-            elapsed
-        );
-    }
-
-    /// Try to use env/printenv to discover host info
-    #[tokio::test]
-    async fn env_info_disclosure() {
+    async fn env_no_secret_leak() {
         let mut bash = tight_bash();
         let result = bash.exec("env; printenv; set").await.unwrap();
-        // Should not contain actual host environment variables
-        let suspicious = [
+        for key in [
             "DOPPLER_TOKEN",
             "AWS_SECRET",
             "GITHUB_TOKEN",
-            "API_KEY",
             "ANTHROPIC_API_KEY",
-        ];
-        for key in suspicious {
-            assert!(
-                !result.stdout.contains(key),
-                "env leaked sensitive host variable: {}",
-                key
-            );
+        ] {
+            assert!(!result.stdout.contains(key), "env leaked: {}", key);
         }
     }
 
-    /// Try to exfiltrate data via DNS-style encoding in variable names
+    /// Arithmetic overflow doesn't panic
     #[tokio::test]
-    async fn data_exfiltration_encoding() {
+    async fn arithmetic_overflow() {
         let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                secret="steal_this"
-                encoded=$(echo "$secret" | base64)
-                # Without network, this should be harmless
-                echo "$encoded"
-                "#,
-            )
-            .await
-            .unwrap();
-        // base64 encoding should work (it's just text processing)
-        // The point is that without network, it can't leave the sandbox
-        assert!(!result.stdout.trim().is_empty());
-    }
-
-    /// Attempting to write a large file to exhaust VFS memory
-    #[tokio::test]
-    async fn large_file_vfs_dos() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                dd if=/dev/urandom of=/tmp/bigfile bs=1024 count=10240 2>/dev/null
-                ls -la /tmp/bigfile
-                "#,
-            )
-            .await;
-        // Should either work within limits or error
-        match &result {
-            Ok(r) => {}
-            Err(_) => {}
-        }
-    }
-
-    /// Try to use history to recover commands from other sessions
-    #[tokio::test]
-    async fn history_cross_session_leak() {
-        let mut bash1 = tight_bash();
-        let _ = bash1.exec("SECRET_CMD=password123").await;
-
-        let mut bash2 = tight_bash();
-        let result = bash2.exec("history").await.unwrap();
-        assert!(
-            !result.stdout.contains("password123"),
-            "History leaked commands from another instance"
-        );
-    }
-
-    /// Try arithmetic overflow in various contexts
-    #[tokio::test]
-    async fn arithmetic_overflow_attacks() {
-        let mut bash = tight_bash();
-        let tests = vec![
+        for test in [
             "echo $((9223372036854775807 + 1))",
             "echo $((-9223372036854775808 - 1))",
             "echo $((9223372036854775807 * 2))",
             "echo $((1 / 0))",
             "echo $((1 % 0))",
-            "echo $((2 ** 64))",
-            "echo $((2 ** -1))",
-        ];
-        for test in tests {
+        ] {
             let result = bash.exec(test).await;
             match &result {
-                Ok(_) => {} // Should handle gracefully
-                Err(e) => {
-                    assert!(
-                        !e.to_string().contains("panic") && !e.to_string().contains("overflow"),
-                        "Arithmetic test panicked: {} for: {}",
-                        e,
-                        test
-                    );
-                }
+                Ok(_) => {}
+                Err(e) => assert!(
+                    !e.to_string().contains("panic") && !e.to_string().contains("overflow"),
+                    "Arithmetic panic: {} for: {}",
+                    e,
+                    test
+                ),
             }
         }
     }
 
-    /// Try to abuse parallel command to bypass limits
+    /// Signal handling safe (kill $$ is no-op)
     #[tokio::test]
-    async fn parallel_limit_bypass() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                seq 1 100 | parallel echo
-                "#,
-            )
-            .await;
+    async fn signal_handling_safe() {
+        let mut bash = tight_bash();
+        let _ = bash.exec("kill -9 $$\nkill -15 $$\necho alive").await;
+    }
+
+    /// compgen doesn't expose host commands
+    #[tokio::test]
+    async fn compgen_no_host_commands() {
+        let mut bash = tight_bash();
+        let result = bash.exec("compgen -c | sort").await;
         match &result {
-            Ok(r) => {
-                let lines = r.stdout.lines().count();
-                assert!(lines <= 100, "parallel bypassed limits: {} lines", lines);
-            }
+            Ok(r) => assert!(
+                !r.stdout.contains("systemctl"),
+                "compgen showed host commands"
+            ),
             Err(_) => {}
         }
     }
 
-    /// Try double-free style: unset then use
+    /// Regex DoS completes in time
     #[tokio::test]
-    async fn use_after_unset() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                x="hello"
-                ref=$x
-                unset x
-                echo "ref=$ref"
-                echo "x=$x"
-                # Try with arrays
-                arr=(a b c)
-                ref="${arr[@]}"
-                unset arr
-                echo "ref=$ref"
-                echo "arr=${arr[@]}"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert!(result.stdout.contains("ref=hello"));
-        assert!(result.stdout.contains("x=\n") || result.stdout.contains("x="));
-    }
-
-    /// Test signal handling — SIGTERM/SIGKILL should be no-ops
-    #[tokio::test]
-    async fn signal_handling() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                kill -9 $$
-                kill -15 $$
-                kill -1 $$
-                echo "still alive"
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => {
-                // Should either ignore signals or handle them safely
-                // In a virtual interpreter, kill should be a no-op
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to abuse compgen to enumerate builtins/commands
-    #[tokio::test]
-    async fn compgen_enumeration() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                compgen -b | sort
-                compgen -c | sort
-                compgen -v | sort
-                "#,
-            )
-            .await;
-        // Should work but only show virtual commands, not host commands
-        match &result {
-            Ok(r) => {
-                // Should not contain host-only commands like systemctl, apt, etc.
-                assert!(!r.stdout.contains("systemctl"),
-                    "compgen showed host commands");
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// SECURITY FINDING: `timeout 3600 sleep 3600` ignores execution timeout.
-    /// Despite a 3-second timeout on the Bash instance, the timeout builtin
-    /// overrides it and the command runs for 60s+ before being killed.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: timeout builtin overrides execution timeout
-    async fn timeout_abuse() {
+    async fn regex_dos_bounded() {
         let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(3)))
+            .limits(ExecutionLimits::new().timeout(Duration::from_secs(5)))
             .build();
         let start = Instant::now();
-        // Try to use timeout to override the execution timeout
-        let _ = bash.exec("timeout 3600 sleep 3600").await;
+        let _ = bash
+            .exec(&format!("echo '{}' | grep -E '(a+)+b'", "a".repeat(30)))
+            .await;
         let elapsed = start.elapsed();
+        assert!(elapsed < Duration::from_secs(5), "Regex DoS: {:?}", elapsed);
+    }
+
+    /// Error messages don't leak host paths
+    #[tokio::test]
+    async fn error_messages_safe() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec("cat /nonexistent/path 2>&1\nls /real/host/path 2>&1")
+            .await
+            .unwrap();
         assert!(
-            elapsed < Duration::from_secs(6),
-            "timeout command overrode execution timeout: {:?}",
-            elapsed
+            !result.stdout.contains("/usr/") && !result.stdout.contains("/home/"),
+            "Error messages leaked host paths: {}",
+            result.stdout
         );
     }
 
-    /// Race condition: concurrent exec calls on same instance
+    /// Massive pipeline chain handled
+    #[tokio::test]
+    async fn massive_pipeline() {
+        let mut bash = tight_bash();
+        let mut cmd = "echo x".to_string();
+        for _ in 0..200 {
+            cmd.push_str(" | cat");
+        }
+        let result = bash.exec(&cmd).await;
+        match &result {
+            Ok(r) => assert_eq!(r.stdout.trim(), "x"),
+            Err(_) => {}
+        }
+    }
+
+    /// Concurrent exec calls safe
     #[tokio::test]
     async fn concurrent_exec_safety() {
-        // Note: Bash takes &mut self, so this tests sequential rapid fire
         let mut bash = tight_bash();
         for i in 0..20 {
             let result = bash.exec(&format!("echo {}", i)).await.unwrap();
@@ -1534,79 +1241,9 @@ mod creative_abuse {
         }
     }
 
-    /// Try regex DoS via catastrophic backtracking
+    /// /dev/tcp redirect doesn't open network connection
     #[tokio::test]
-    async fn regex_dos() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(5)))
-            .build();
-        let start = Instant::now();
-        // Classic ReDoS pattern
-        let result = bash
-            .exec(&format!(
-                "echo '{}' | grep -E '(a+)+b'",
-                "a".repeat(30)
-            ))
-            .await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "Regex DoS took {:?}",
-            elapsed
-        );
-    }
-
-    /// Try to abuse sed with backreferences for ReDoS
-    #[tokio::test]
-    async fn sed_redos() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(5)))
-            .build();
-        let start = Instant::now();
-        let result = bash
-            .exec(&format!(
-                "echo '{}' | sed 's/\\(a*\\)*/x/'",
-                "a".repeat(50)
-            ))
-            .await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "sed ReDoS took {:?}",
-            elapsed
-        );
-    }
-
-    /// Try to use awk for arbitrary computation bypassing limits
-    #[tokio::test]
-    async fn awk_computation_bypass() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                echo x | awk 'BEGIN { for(i=0;i<10000;i++) printf "x" }'
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => {
-                assert!(r.stdout.len() <= 100_000, "awk bypassed output limits: {} bytes", r.stdout.len());
-            }
-            Err(_) => {}
-        }
-    }
-}
-
-// =============================================================================
-// 9. REDIRECT & PIPE ATTACKS
-// =============================================================================
-
-mod redirect_attacks {
-    use super::*;
-
-    /// Try to redirect to /dev/tcp for network access
-    #[tokio::test]
-    async fn dev_tcp_redirect() {
+    async fn dev_tcp_redirect_blocked() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
@@ -1618,230 +1255,58 @@ mod redirect_attacks {
                 "#,
             )
             .await;
-        // /dev/tcp should not actually open a network connection
         match &result {
-            Ok(r) => {
-                assert!(!r.stdout.contains("HTTP/"),
-                    "/dev/tcp opened a real network connection");
-            }
+            Ok(r) => assert!(
+                !r.stdout.contains("HTTP/"),
+                "/dev/tcp opened a real connection"
+            ),
             Err(_) => {}
         }
     }
 
-    /// Redirect to many file descriptors
+    /// Timing side-channel negligible
     #[tokio::test]
-    async fn fd_exhaustion() {
-        let mut bash = tight_bash();
-        let mut script = String::new();
-        for i in 3..100 {
-            script.push_str(&format!("exec {i}>/tmp/fd_{i}.txt\n"));
-        }
-        script.push_str("echo done\n");
-        let result = bash.exec(&script).await;
-        match &result {
-            Ok(r) => assert!(r.stdout.contains("done")),
-            Err(_) => {}
-        }
-    }
-
-    /// Pipe to self pattern
-    #[tokio::test]
-    async fn pipe_to_self() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec("echo x | cat | cat | cat | cat | cat | cat | cat | cat | cat | cat")
-            .await;
-        match &result {
-            Ok(r) => assert_eq!(r.stdout.trim(), "x"),
-            Err(_) => {}
-        }
-    }
-
-    /// Try to use named pipes (FIFO) for IPC
-    #[tokio::test]
-    async fn named_pipe_ipc() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                mkfifo /tmp/testpipe 2>/dev/null
-                echo "test" > /tmp/testpipe &
-                cat /tmp/testpipe
-                "#,
-            )
-            .await;
-        // Should handle FIFOs safely
-        match &result {
-            Ok(_) => {}
-            Err(_) => {}
-        }
-    }
-
-    /// Here-string with process substitution
-    #[tokio::test]
-    async fn herestring_abuse() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                cat <<< "$(for i in $(seq 1 100); do echo line_$i; done)"
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => assert!(r.stdout.lines().count() > 0),
-            Err(_) => {}
-        }
-    }
-
-    /// Redirect stderr to stdin loop
-    #[tokio::test]
-    async fn stderr_stdin_loop() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                echo error >&2 2>&1 | cat
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(_) => {}
-            Err(_) => {}
-        }
-    }
-}
-
-// =============================================================================
-// 10. TIMING & SIDE-CHANNEL ATTACKS
-// =============================================================================
-
-mod timing_attacks {
-    use super::*;
-
-    /// Try to use timing to detect if files exist on host
-    #[tokio::test]
-    async fn timing_file_existence() {
+    async fn timing_side_channel() {
         let mut bash = tight_bash();
         let start = Instant::now();
         let _ = bash.exec("test -f /etc/passwd").await;
         let t1 = start.elapsed();
-
         let start = Instant::now();
         let _ = bash.exec("test -f /nonexistent/file").await;
         let t2 = start.elapsed();
-
-        // Timing difference should be negligible (both are VFS ops)
-        // A large difference would suggest one is hitting real FS
         let diff = t1.abs_diff(t2);
         assert!(
             diff < Duration::from_millis(100),
-            "Timing side-channel detected: existing={:?} vs nonexistent={:?}",
+            "Timing side-channel: existing={:?} vs nonexistent={:?}",
             t1,
             t2
         );
     }
 
-    /// Try to use date/SECONDS to measure execution time
+    /// Dollar-sign special variables don't crash
     #[tokio::test]
-    async fn time_measurement_abuse() {
+    async fn dollar_sign_edges() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
                 r#"
-                start=$SECONDS
-                for i in $(seq 1 100); do true; done
-                end=$SECONDS
-                echo "elapsed=$((end - start))"
+                echo "$$"
+                echo "$!"
+                echo "$-"
+                echo "$_"
+                echo "${#}"
+                echo "${?}"
+                echo "${$}"
                 "#,
             )
             .await
             .unwrap();
-        // SECONDS should work but not reveal real host time
+        // Some may not be fully supported but none should crash.
     }
 
-    /// SECURITY FINDING: /dev/urandom via head produces empty output.
-    /// `head -c 16 /dev/urandom | base64` returns empty string in both instances.
-    /// The /dev/urandom virtual file may not work correctly with head -c.
+    /// Parameter expansion edge cases
     #[tokio::test]
-    #[ignore] // SECURITY FINDING: /dev/urandom + head -c returns empty
-    async fn urandom_isolation() {
-        let mut bash1 = tight_bash();
-        let mut bash2 = tight_bash();
-
-        let r1 = bash1
-            .exec("head -c 16 /dev/urandom | base64")
-            .await
-            .unwrap();
-        let r2 = bash2
-            .exec("head -c 16 /dev/urandom | base64")
-            .await
-            .unwrap();
-
-        // /dev/urandom should produce non-empty random data
-        assert!(
-            !r1.stdout.trim().is_empty(),
-            "/dev/urandom produced empty output"
-        );
-        // Different instances should produce different random data
-        assert_ne!(
-            r1.stdout.trim(),
-            r2.stdout.trim(),
-            "Two instances produced identical /dev/urandom output"
-        );
-    }
-}
-
-// =============================================================================
-// 11. EDGE CASES IN STRING/PARAMETER EXPANSION
-// =============================================================================
-
-mod expansion_edge_cases {
-    use super::*;
-
-    /// Recursive variable expansion
-    #[tokio::test]
-    async fn recursive_variable_expansion() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                a='$b'
-                b='$c'
-                c='$a'
-                eval echo "$a"
-                "#,
-            )
-            .await
-            .unwrap();
-        // Should not infinite loop
-        assert_eq!(result.exit_code, 0);
-    }
-
-    /// Parameter expansion with unset variables
-    #[tokio::test]
-    async fn unset_parameter_expansion() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                echo "${unset_var:-default}"
-                echo "${unset_var:=assigned}"
-                echo "$unset_var"
-                echo "${unset_var:+override}"
-                echo "${another_unset:?This should error}" 2>/dev/null
-                echo "survived"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert!(result.stdout.contains("default"));
-        assert!(result.stdout.contains("assigned"));
-    }
-
-    /// Very deeply nested parameter expansion
-    #[tokio::test]
-    async fn deep_parameter_expansion() {
+    async fn parameter_expansion_edges() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
@@ -1883,636 +1348,5 @@ mod expansion_edge_cases {
             .unwrap();
         assert!(result.stdout.contains("empty: 0"));
         assert!(result.stdout.contains("sparse: sparse"));
-    }
-
-    /// Associative array key injection
-    #[tokio::test]
-    async fn assoc_array_key_injection() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                declare -A map
-                map["normal"]="value1"
-                map["key with spaces"]="value2"
-                map[$'key\nwith\nnewlines']="value3"
-                map[""]="empty_key"
-                echo "${map["normal"]}"
-                echo "${map["key with spaces"]}"
-                echo "count: ${#map[@]}"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert!(result.stdout.contains("value1"));
-    }
-
-    /// Dollar-sign edge cases — should not crash on any special variable
-    #[tokio::test]
-    async fn dollar_sign_edges() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                echo "$$"
-                echo "$!"
-                echo "$-"
-                echo "$_"
-                echo "${#}"
-                echo "${?}"
-                echo "${$}"
-                "#,
-            )
-            .await
-            .unwrap();
-        // Some special vars may not be fully supported, but none should crash.
-        // Accept any exit code — the important thing is no panic.
-    }
-}
-
-// =============================================================================
-// 12. SECOND WAVE: DEEPER PROBES BASED ON INITIAL FINDINGS
-// =============================================================================
-
-mod deep_probes {
-    use super::*;
-
-    // --- OUTPUT SIZE ATTACKS ---
-    // seq bypasses limits. What other builtins produce unbounded output?
-
-    /// yes builtin with no pipe limit
-    #[tokio::test]
-    async fn yes_unbounded_without_pipe() {
-        let mut bash = dos_bash();
-        // yes without head: should be stopped by command/loop limits
-        let result = bash.exec("yes | head -n 5").await;
-        match &result {
-            Ok(r) => {
-                let lines = r.stdout.lines().count();
-                assert!(lines <= 10, "yes|head produced too many lines: {}", lines);
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// printf repeat generates massive output via a single command
-    #[tokio::test]
-    async fn printf_repeat_dos() {
-        let mut bash = dos_bash();
-        // printf with format repeat: "%.0s" repeats for each argument
-        let result = bash
-            .exec("printf 'A%.0s' $(seq 1 100000)")
-            .await;
-        match &result {
-            Ok(r) => {
-                assert!(
-                    r.stdout.len() <= 200_000,
-                    "printf repeat generated {} bytes",
-                    r.stdout.len()
-                );
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// dd can generate large output from /dev/zero
-    #[tokio::test]
-    async fn dd_zero_dos() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec("dd if=/dev/zero bs=1M count=100 2>/dev/null | wc -c")
-            .await;
-        match &result {
-            Ok(r) => {
-                let bytes: usize = r.stdout.trim().parse().unwrap_or(0);
-                assert!(
-                    bytes <= 10_000_000,
-                    "dd from /dev/zero produced {} bytes",
-                    bytes
-                );
-            }
-            Err(_) => {}
-        }
-    }
-
-    // --- SLEEP/TIMEOUT VARIANTS ---
-    // sleep in subshell bypasses timeout. What about other patterns?
-
-    /// SECURITY FINDING: `sleep` in background + wait bypasses timeout.
-    /// Timeout doesn't propagate to background jobs.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: timeout bypass via background sleep + wait
-    async fn sleep_background_timeout() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
-            .build();
-        let start = Instant::now();
-        let _ = bash.exec("sleep 100 &\nwait").await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "sleep in background+wait bypassed timeout: {:?}",
-            elapsed
-        );
-    }
-
-    /// sleep via read -t
-    #[tokio::test]
-    async fn read_as_sleep_timeout() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
-            .build();
-        let start = Instant::now();
-        let _ = bash.exec("read -t 100 var < /dev/null").await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "read -t bypassed timeout: {:?}",
-            elapsed
-        );
-    }
-
-    /// SECURITY FINDING: `sleep` in pipeline bypasses timeout.
-    /// `echo x | sleep 100` runs for 60s+ despite 2s timeout.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: timeout bypass via pipeline sleep
-    async fn sleep_pipeline_timeout() {
-        let mut bash = Bash::builder()
-            .limits(ExecutionLimits::new().timeout(Duration::from_secs(2)))
-            .build();
-        let start = Instant::now();
-        let _ = bash.exec("echo x | sleep 100").await;
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_secs(5),
-            "sleep in pipeline bypassed timeout: {:?}",
-            elapsed
-        );
-    }
-
-    // --- RECURSIVE/NESTED PATTERNS ---
-    // source self-recursion crashes. What about other recursion patterns?
-
-    /// Eval-based self recursion — exits 0 without error despite running into limits.
-    /// The eval chain silently stops when hitting command limit but reports success.
-    #[tokio::test]
-    async fn eval_self_recursion() {
-        let mut bash = dos_bash();
-        let result = bash.exec("x='eval \"$x\"'; eval \"$x\"").await;
-        // Should either error or complete — the key is no crash
-        // Note: currently exits 0 despite hitting limits, which is debatable
-        match &result {
-            Ok(_) => {} // Exits 0 — not ideal but not a crash
-            Err(_) => {}
-        }
-    }
-
-    /// Alias-based infinite expansion
-    #[tokio::test]
-    async fn alias_infinite_expansion() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                shopt -s expand_aliases
-                alias a='b'
-                alias b='a'
-                a
-                "#,
-            )
-            .await;
-        // Should not hang or crash
-        match &result {
-            Ok(_) => {}
-            Err(_) => {}
-        }
-    }
-
-    /// Nested arithmetic expansion — not a security issue, just edge case behavior.
-    /// Deep nesting may produce unexpected results due to expansion ordering.
-    #[tokio::test]
-    async fn nested_arithmetic_expansion() {
-        let mut bash = tight_bash();
-        let depth = 30;
-        let mut expr = "1".to_string();
-        for _ in 0..depth {
-            expr = format!("$(({} + 1))", expr);
-        }
-        let result = bash.exec(&format!("echo {}", expr)).await;
-        // Should not crash — result correctness is a compatibility concern, not security
-        match &result {
-            Ok(_) => {}
-            Err(_) => {}
-        }
-    }
-
-    // --- STATE ISOLATION DEEP PROBES ---
-    // Traps and $? leak. What else leaks?
-
-    /// Test that aliases don't leak between exec() calls
-    #[tokio::test]
-    async fn alias_persistence_across_exec() {
-        let mut bash = tight_bash();
-        let _ = bash
-            .exec("shopt -s expand_aliases; alias evil='echo LEAKED'")
-            .await;
-        let result = bash.exec("evil 2>/dev/null; echo $?").await.unwrap();
-        // Check if alias persisted — if evil runs, alias leaked
-        let has_leaked = result.stdout.contains("LEAKED");
-        // Aliases persisting is arguably a feature (like functions), but
-        // worth documenting
-    }
-
-    /// SECURITY FINDING: `set -e` persists across exec() calls.
-    /// Setting `set -e` in one exec makes subsequent exec calls abort on errors.
-    /// This is a state isolation bug — shell options should reset per exec.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: set -e leaks across exec() calls
-    async fn shell_options_leak_across_exec() {
-        let mut bash = tight_bash();
-        let _ = bash.exec("set -e").await;
-        let result = bash.exec("false; echo 'survived'").await.unwrap();
-        // If set -e leaked, the script would abort on `false`
-        assert!(
-            result.stdout.contains("survived"),
-            "set -e leaked across exec() calls — false aborted execution"
-        );
-    }
-
-    /// Test that umask leaks
-    #[tokio::test]
-    async fn umask_leak_across_exec() {
-        let mut bash = tight_bash();
-        let _ = bash.exec("umask 0000").await;
-        let result = bash.exec("umask").await.unwrap();
-        // Default umask should be restored
-        // (This may be by design — depends on intended state model)
-    }
-
-    /// Test that cwd leaks
-    #[tokio::test]
-    async fn cwd_persistence_across_exec() {
-        let mut bash = tight_bash();
-        let _ = bash.exec("mkdir -p /tmp/testdir && cd /tmp/testdir").await;
-        let result = bash.exec("pwd").await.unwrap();
-        // This is arguably expected behavior (interactive shell model),
-        // but in a multi-tenant context it could be unexpected
-    }
-
-    // --- READONLY BYPASS VARIANTS ---
-
-    /// SECURITY FINDING: `declare` can overwrite readonly variables.
-    /// `readonly LOCKED=original; declare LOCKED=overwritten` succeeds.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: readonly bypassed via declare
-    async fn readonly_bypass_via_declare() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                readonly LOCKED=original
-                declare LOCKED=overwritten 2>/dev/null
-                echo "$LOCKED"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            result.stdout.trim(),
-            "original",
-            "readonly bypassed via declare"
-        );
-    }
-
-    /// SECURITY FINDING: `export` can overwrite readonly variables.
-    /// `readonly LOCKED=original; export LOCKED=overwritten` succeeds.
-    #[tokio::test]
-    #[ignore] // SECURITY FINDING: readonly bypassed via export
-    async fn readonly_bypass_via_export() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                readonly LOCKED=original
-                export LOCKED=overwritten 2>/dev/null
-                echo "$LOCKED"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            result.stdout.trim(),
-            "original",
-            "readonly bypassed via export"
-        );
-    }
-
-    /// Try to bypass readonly via local in function
-    #[tokio::test]
-    async fn readonly_bypass_via_local() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                readonly LOCKED=original
-                f() { local LOCKED=overwritten; echo "$LOCKED"; }
-                f
-                echo "$LOCKED"
-                "#,
-            )
-            .await
-            .unwrap();
-        // In bash, local CAN shadow readonly in function scope
-        // But after function returns, LOCKED should still be original
-        assert!(
-            result.stdout.trim().ends_with("original"),
-            "readonly not restored after function: got {}",
-            result.stdout.trim()
-        );
-    }
-
-    // --- MEMORY EXHAUSTION ---
-
-    /// Exponential array growth
-    #[tokio::test]
-    async fn exponential_array_growth() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                arr=(1)
-                for i in $(seq 1 20); do
-                    arr=("${arr[@]}" "${arr[@]}")
-                done
-                echo "${#arr[@]}"
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => {
-                let count: usize = r.stdout.trim().parse().unwrap_or(0);
-                // 2^20 = 1M elements — this could exhaust memory
-                assert!(
-                    count <= 1_000_000,
-                    "Array grew to {} elements",
-                    count
-                );
-            }
-            Err(_) => {} // Error is fine (limits kicked in)
-        }
-    }
-
-    /// Associative array with massive keys
-    #[tokio::test]
-    async fn assoc_array_big_keys() {
-        let mut bash = tight_bash();
-        let big_key = "K".repeat(100_000);
-        let result = bash
-            .exec(&format!(
-                "declare -A m; m[\"{big_key}\"]=val; echo ${{#m[@]}}"
-            ))
-            .await;
-        match &result {
-            Ok(r) => assert_eq!(r.stdout.trim(), "1"),
-            Err(_) => {}
-        }
-    }
-
-    // --- INTERESTING EDGE CASES ---
-
-    /// Heredoc that looks like a command
-    #[tokio::test]
-    async fn heredoc_command_injection() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                cat <<'EOF'
-                $(echo INJECTED)
-                `echo INJECTED2`
-                EOF
-                "#,
-            )
-            .await
-            .unwrap();
-        // Single-quoted heredoc delimiter should prevent expansion
-        assert!(result.stdout.contains("$(echo INJECTED)"),
-            "Heredoc expanded command substitution despite single-quoted delimiter");
-    }
-
-    /// Case statement with glob patterns
-    #[tokio::test]
-    async fn case_glob_injection() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                x="../../etc/passwd"
-                case "$x" in
-                    *etc/passwd*) echo "MATCHED_DANGEROUS_PATH" ;;
-                    *) echo "safe" ;;
-                esac
-                "#,
-            )
-            .await
-            .unwrap();
-        // Pattern matching should work correctly
-        assert!(result.stdout.contains("MATCHED_DANGEROUS_PATH"));
-    }
-
-    /// Tee to many files simultaneously
-    #[tokio::test]
-    async fn tee_many_files() {
-        let mut bash = tight_bash();
-        let mut files = String::new();
-        for i in 0..50 {
-            files.push_str(&format!("/tmp/tee_{}.txt ", i));
-        }
-        let result = bash
-            .exec(&format!("echo content | tee {}", files))
-            .await;
-        match &result {
-            Ok(r) => assert!(r.stdout.contains("content")),
-            Err(_) => {}
-        }
-    }
-
-    /// Command substitution in array index
-    #[tokio::test]
-    async fn cmd_subst_in_array_index() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                arr=(zero one two three)
-                idx=$(echo 2)
-                echo "${arr[$idx]}"
-                echo "${arr[$(echo 1)]}"
-                "#,
-            )
-            .await
-            .unwrap();
-        assert!(result.stdout.contains("two"));
-    }
-
-    /// Try to abuse jq for computation
-    #[tokio::test]
-    async fn jq_computation_bypass() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                echo '{}' | jq '[range(10000)] | length'
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => {
-                // jq might allow unbounded computation
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to abuse awk to write files
-    #[tokio::test]
-    async fn awk_file_write() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                echo x | awk 'BEGIN { print "INJECTED" > "/tmp/awk_escape.txt" }'
-                cat /tmp/awk_escape.txt 2>/dev/null
-                "#,
-            )
-            .await;
-        // awk's file I/O should go through the VFS
-        match &result {
-            Ok(r) => {
-                // If awk can write files, it should be within VFS
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to abuse sed to write files
-    #[tokio::test]
-    async fn sed_file_write() {
-        let mut bash = tight_bash();
-        let _ = bash
-            .exec("echo original > /tmp/sed_test.txt")
-            .await;
-        let result = bash
-            .exec(
-                r#"
-                sed -i 's/original/MODIFIED/' /tmp/sed_test.txt
-                cat /tmp/sed_test.txt
-                "#,
-            )
-            .await
-            .unwrap();
-        // sed -i should work within VFS
-        assert!(
-            result.stdout.contains("MODIFIED") || result.stdout.contains("original"),
-            "sed -i should work within VFS"
-        );
-    }
-
-    /// Try to leak info via error messages
-    #[tokio::test]
-    async fn error_message_info_leak() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                cat /nonexistent/path 2>&1
-                ls /real/host/path 2>&1
-                cd /absolute/nonsense 2>&1
-                "#,
-            )
-            .await
-            .unwrap();
-        // Error messages should not contain host filesystem paths
-        assert!(
-            !result.stdout.contains("/usr/") && !result.stdout.contains("/home/"),
-            "Error messages leaked host paths: {}",
-            result.stdout
-        );
-    }
-
-    /// Large number of environment variables
-    #[tokio::test]
-    async fn env_var_flooding() {
-        let mut bash = tight_bash();
-        let mut script = String::new();
-        for i in 0..1000 {
-            script.push_str(&format!("export VAR_{}={}\n", i, "x".repeat(100)));
-        }
-        script.push_str("env | wc -l\n");
-        let result = bash.exec(&script).await;
-        match &result {
-            Ok(r) => {
-                // Should handle many env vars without crashing
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Try to abuse process substitution for data exfiltration
-    #[tokio::test]
-    async fn process_substitution_file_access() {
-        let mut bash = tight_bash();
-        let result = bash
-            .exec(
-                r#"
-                diff <(echo "local data") <(cat /etc/passwd 2>/dev/null)
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => {
-                assert!(
-                    !r.stdout.contains("root:x:"),
-                    "Process substitution accessed host /etc/passwd"
-                );
-            }
-            Err(_) => {}
-        }
-    }
-
-    /// Massive pipeline chain
-    #[tokio::test]
-    async fn massive_pipeline() {
-        let mut bash = tight_bash();
-        let mut cmd = "echo x".to_string();
-        for _ in 0..200 {
-            cmd.push_str(" | cat");
-        }
-        let result = bash.exec(&cmd).await;
-        match &result {
-            Ok(r) => assert_eq!(r.stdout.trim(), "x"),
-            Err(_) => {} // Limit error is fine
-        }
-    }
-
-    /// Try to use mapfile/readarray to bypass limits
-    #[tokio::test]
-    async fn mapfile_dos() {
-        let mut bash = dos_bash();
-        let result = bash
-            .exec(
-                r#"
-                seq 1 100000 | mapfile -t arr
-                echo "${#arr[@]}"
-                "#,
-            )
-            .await;
-        match &result {
-            Ok(r) => {
-                let count: usize = r.stdout.trim().parse().unwrap_or(0);
-                // Should be limited somehow
-            }
-            Err(_) => {}
-        }
     }
 }

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -264,6 +264,9 @@ max_ast_depth: 100,           // Parser recursion (TM-DOS-022)
 | TM-DOS-053 | Template `{{#each}}` output explosion | `{{#each arr}}` on large JSON array produces O(n * body) output | Bounded by JSON data file size (max_file_size) | **MITIGATED** |
 | TM-DOS-054 | `glob --files` inherits ExtGlob blowup | `glob --files "+(a|aa)" /dir` dispatches to `glob_match` with same exponential cost as TM-DOS-031 | Same as TM-DOS-031 | **OPEN** |
 | TM-DOS-055 | `split` file count amplification | `split -l 1 bigfile` creates one output file per line; bounded by `max_file_count` FS limit | FS limits (TM-DOS-006) | **MITIGATED** |
+| TM-DOS-056 | `source` self-recursion stack overflow | Script that sources itself causes unbounded recursion; function depth limit doesn't apply to `source` | — | **OPEN** |
+| TM-DOS-057 | `sleep` bypasses execution timeout | `sleep`, `(sleep N)`, `echo x \| sleep N`, `sleep N & wait`, `timeout N sleep N` all ignore `ExecutionLimits::timeout` | — | **OPEN** |
+| TM-DOS-058 | Single-builtin unbounded output | `seq 1 1000000` produces 1M lines despite command limit; single builtin call generates unbounded output (see also #648) | — | **OPEN** |
 
 **TM-DOS-051**: `builtins/yaml.rs` — `parse_yaml_block`, `parse_yaml_map`, `parse_yaml_list` recurse
 on nested YAML structures with no depth counter. Crafted YAML with 1000+ nesting levels causes stack
@@ -487,6 +490,9 @@ Bash::builder()
 
 | TM-INJ-011 | Cyclic nameref silent resolution | Cyclic namerefs (a→b→a) silently resolve after 10 iterations instead of erroring | — | **OPEN** |
 | TM-INJ-018 | `dotenv` internal variable prefix injection | `.env` file with `_NAMEREF_x=target` sets internal interpreter variables via `ctx.variables.insert()` | — | **OPEN** |
+| TM-INJ-019 | `unset` removes readonly variables | `readonly X=v; unset X` removes the variable despite readonly attribute | — | **OPEN** |
+| TM-INJ-020 | `declare` overwrites readonly variables | `readonly X=v; declare X=new` overwrites without error | — | **OPEN** |
+| TM-INJ-021 | `export` overwrites readonly variables | `readonly X=v; export X=new` overwrites without error | — | **OPEN** |
 
 **TM-INJ-011**: `interpreter/mod.rs:7547-7560` — cyclic namerefs silently resolve to whatever
 variable is current after 10 iterations. Real bash errors with `circular name reference`. Can
@@ -778,6 +784,9 @@ Only exact domain matches are allowed (TM-NET-017).
 | TM-ISO-004 | Cross-session env pollution via jq | `std::env::set_var()` in jq modifies process-wide env, visible to concurrent sessions | Custom `$__bashkit_env__` jaq context variable replaces `std::env` access | **FIXED** |
 | TM-ISO-005 | Session-level cumulative counter bypass | Repeated `exec()` calls each reset `ExecutionCounters`, giving unbounded aggregate resources | — | **OPEN** |
 | TM-ISO-006 | No per-instance variable/memory budget | Unbounded `HashMap` growth in variables, arrays, functions exhausts process memory | — | **OPEN** |
+| TM-ISO-021 | EXIT trap leaks across `exec()` calls | EXIT trap set in one `exec()` fires in subsequent `exec()` calls on same Bash instance | — | **OPEN** |
+| TM-ISO-022 | `$?` leaks across `exec()` calls | Exit code from one `exec()` visible as `$?` in next `exec()` instead of resetting to 0 | — | **OPEN** |
+| TM-ISO-023 | `set -e` leaks across `exec()` calls | Shell options (`set -e`, etc.) persist across `exec()` calls, causing unexpected abort behavior | — | **OPEN** |
 
 **TM-ISO-004**: Fixed. The jq builtin now injects shell variables via a custom jaq context variable
 (`$__bashkit_env__`) and overrides the `env` filter to read from it instead of `std::env`.
@@ -825,6 +834,7 @@ let session_b = Bash::builder()
 | TM-INT-001 | Builtin panic crash | Invalid input triggers panic in builtin | `catch_unwind` wrapper on all builtins | **MITIGATED** |
 | TM-INT-002 | Panic info leak | Panic message reveals sensitive data | Sanitized error messages (no panic details) | **MITIGATED** |
 | TM-INT-003 | Date format panic | Invalid strftime format causes chrono panic | Pre-validation with `StrftimeItems` | **MITIGATED** |
+| TM-INT-007 | `/dev/urandom` empty with `head -c` | `head -c 16 /dev/urandom` returns empty output; pipe from virtual device to builtin loses data | — | **OPEN** |
 
 **Current Risk**: LOW - All builtin panics are caught and converted to sanitized errors
 
@@ -1183,6 +1193,22 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-DOS-049 | `collect_dirs_recursive` has no depth limit | Deep recursion on VFS trees (mitigated by `max_path_depth`) | Add explicit depth parameter at `interpreter/mod.rs:8352` |
 | TM-DOS-050 | `parse_word_string` uses default parser limits | Caller-configured tighter limits ignored for parameter expansion | Propagate limits through `parse_word_string()` at `parser/mod.rs:109` |
 | TM-PY-028 | BashTool.reset() in Python drops security config | Resource limits silently removed after reset | Preserve limits like `PyBash.reset()` does (see `bashkit-python/src/lib.rs:470`) |
+
+### Open (From 2026-03 Blackbox Security Testing)
+
+| Threat ID | Vulnerability | Impact | Recommendation |
+|-----------|---------------|--------|----------------|
+| TM-DOS-056 | `source` self-recursion stack overflow | Process crash (SIGABRT) via script that sources itself | Track source depth like function depth; apply `max_function_depth` limit |
+| TM-DOS-057 | `sleep` bypasses execution timeout | CPU/time exhaustion; `sleep`, subshell sleep, pipeline sleep, background sleep, `timeout` builtin all ignore `ExecutionLimits::timeout` | Implement timeout as tokio::time::timeout wrapper around exec(), not cooperative check |
+| TM-DOS-058 | Single-builtin unbounded output | OOM via `seq 1 1000000` producing 1M lines despite command limit of 50 | Add `max_stdout_bytes` / `max_stderr_bytes` to ExecutionLimits (see #648) |
+| TM-INJ-019 | `unset` removes readonly variables | Integrity bypass — readonly protection defeated | Check readonly attribute in unset before removal |
+| TM-INJ-020 | `declare` overwrites readonly variables | Integrity bypass — `declare X=new` overwrites `readonly X=old` | Check readonly attribute in declare assignment path |
+| TM-INJ-021 | `export` overwrites readonly variables | Integrity bypass — `export X=new` overwrites `readonly X=old` | Check readonly attribute in export assignment path |
+| TM-ISO-021 | EXIT trap leaks across `exec()` calls | Cross-invocation interference — trap from exec N fires in exec N+1 | Reset traps in `reset_for_execution()` |
+| TM-ISO-022 | `$?` leaks across `exec()` calls | State pollution — exit code from previous exec visible to next exec | Reset `last_exit_code` in `reset_for_execution()` |
+| TM-ISO-023 | `set -e` leaks across `exec()` calls | Unexpected abort — shell options from previous exec affect next exec | Reset shell options in `reset_for_execution()` |
+| TM-INT-007 | `/dev/urandom` empty with `head -c` | Weak randomness — `head -c 16 /dev/urandom` returns empty string | Fix virtual device pipe handling in head builtin |
+| TM-DOS-044 | Nested `$()` stack overflow (regression) | Process crash (SIGABRT) at depth ~50 despite #492 fix | Interpreter execution path may need separate depth tracking from lexer fix |
 
 ### Accepted (Low Priority)
 


### PR DESCRIPTION
## Summary

- Exploratory blackbox security testing of the bashkit interpreter
- 58 passing tests verifying security controls work correctly
- 15 `#[ignore]` tests documenting confirmed security vulnerabilities
- Threat model updated with 11 new threat entries (TM-DOS-056–058, TM-INJ-019–021, TM-ISO-005–007, TM-INT-004, TM-DOS-044 regression)

## Findings

### Process Crash (HIGH)
- **TM-DOS-044 regression**: Nested `$(echo $(...))` depth 50 → stack overflow (#687)
- **TM-DOS-056**: `source` self-recursion → stack overflow (#681)

### Timeout Bypass (HIGH)
- **TM-DOS-057**: `sleep` in all contexts (direct, subshell, pipeline, background, timeout builtin) ignores `ExecutionLimits::timeout` (#682)

### Output Limits (MEDIUM)
- **TM-DOS-058**: `seq 1 1000000` produces 1M lines despite 50-command limit (#686)

### Readonly Bypass (MEDIUM)
- **TM-INJ-019/020/021**: `unset`, `declare`, `export` all bypass `readonly` protection (#683)

### State Isolation (MEDIUM)
- **TM-ISO-005/006/007**: EXIT trap, `$?`, `set -e` all leak between `exec()` calls (#684)

### Randomness (LOW)
- **TM-INT-004**: `/dev/urandom` + `head -c` returns empty (#685)

## Test plan

- [x] `cargo test --test blackbox_security_tests` — 58 pass, 0 fail, 15 ignored
- [x] `cargo clippy --test blackbox_security_tests -- -D warnings` — clean
- [x] `cargo test` — full suite passes
- [x] All findings tracked as GitHub issues with threat model IDs
- [x] Duplicate check against existing issues completed