### PR TITLE
feat(limits): add stdout/stderr output capture size limits

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5404,18 +5404,25 @@ impl Interpreter {
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         let mut unset_nameref = false;
+        let mut unset_function = false;
         let mut var_args: Vec<&String> = Vec::new();
         for arg in args {
             if arg == "-n" {
                 unset_nameref = true;
-            } else if arg == "-v" || arg == "-f" {
-                // -v (variable, default) and -f (function) flags - skip
+            } else if arg == "-f" {
+                unset_function = true;
+            } else if arg == "-v" {
+                // -v (variable, default) - explicit variable mode
             } else {
                 var_args.push(arg);
             }
         }
 
         for arg in &var_args {
+            if unset_function {
+                self.functions.remove(arg.as_str());
+                continue;
+            }
             if let Some(bracket) = arg.find('[')
                 && arg.ends_with(']')
             {

--- a/crates/bashkit/tests/unset_function_tests.rs
+++ b/crates/bashkit/tests/unset_function_tests.rs
@@ -1,0 +1,48 @@
+//! Tests for unset -f (issue #673)
+
+use bashkit::Bash;
+
+async fn run(script: &str) -> bashkit::ExecResult {
+    let mut bash = Bash::new();
+    bash.exec(script).await.unwrap()
+}
+
+#[tokio::test]
+async fn unset_f_removes_function() {
+    let result = run(r#"
+f() { echo hi; }
+f
+unset -f f
+f 2>/dev/null; echo $?
+"#)
+    .await;
+    assert_eq!(result.stdout, "hi\n127\n");
+}
+
+#[tokio::test]
+async fn unset_f_nonexistent_function_is_noop() {
+    let result = run("unset -f nonexistent; echo $?").await;
+    assert_eq!(result.stdout, "0\n");
+}
+
+#[tokio::test]
+async fn unset_f_does_not_affect_variables() {
+    let result = run(r#"
+x=hello
+unset -f x
+echo $x
+"#)
+    .await;
+    assert_eq!(result.stdout, "hello\n");
+}
+
+#[tokio::test]
+async fn unset_without_f_does_not_affect_functions() {
+    let result = run(r#"
+f() { echo hi; }
+unset f
+f
+"#)
+    .await;
+    assert_eq!(result.stdout, "hi\n");
+}


### PR DESCRIPTION
## Summary
- Add `max_stdout_bytes` and `max_stderr_bytes` to `ExecutionLimits` (default 1MB each)
- Add `stdout_truncated` and `stderr_truncated` flags to `ExecResult`
- Truncation happens at the capture layer in `Interpreter::execute()`, not in individual builtins
- Execution continues after truncation (script doesn't abort)

## Test plan
- [x] 8 new tests covering truncation, non-truncation, independent stdout/stderr limits, zero-byte limit, multi-command truncation
- [x] All existing tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #648