### PR TITLE
fix(interpreter): implement unset -f to remove function definitions

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5404,18 +5404,25 @@ impl Interpreter {
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         let mut unset_nameref = false;
+        let mut unset_function = false;
         let mut var_args: Vec<&String> = Vec::new();
         for arg in args {
             if arg == "-n" {
                 unset_nameref = true;
-            } else if arg == "-v" || arg == "-f" {
-                // -v (variable, default) and -f (function) flags - skip
+            } else if arg == "-f" {
+                unset_function = true;
+            } else if arg == "-v" {
+                // -v (variable, default) - explicit variable mode
             } else {
                 var_args.push(arg);
             }
         }
 
         for arg in &var_args {
+            if unset_function {
+                self.functions.remove(arg.as_str());
+                continue;
+            }
             if let Some(bracket) = arg.find('[')
                 && arg.ends_with(']')
             {

--- a/crates/bashkit/tests/spec_cases/bash/blackbox-edge-cases.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/blackbox-edge-cases.test.sh
@@ -63,13 +63,11 @@ v2
 ### end
 
 ### unset_function
-### bash_diff: unset -f does not remove function definition (#673)
-# Unset a function — bash: "hi\n127", bashkit: "hi\nhi\n0"
+# Unset a function
 f() { echo hi; }; f; unset -f f; f 2>/dev/null; echo $?
 ### expect
 hi
-hi
-0
+127
 ### end
 
 ### array_negative_slice

--- a/crates/bashkit/tests/unset_function_tests.rs
+++ b/crates/bashkit/tests/unset_function_tests.rs
@@ -1,0 +1,48 @@
+//! Tests for unset -f (issue #673)
+
+use bashkit::Bash;
+
+async fn run(script: &str) -> bashkit::ExecResult {
+    let mut bash = Bash::new();
+    bash.exec(script).await.unwrap()
+}
+
+#[tokio::test]
+async fn unset_f_removes_function() {
+    let result = run(r#"
+f() { echo hi; }
+f
+unset -f f
+f 2>/dev/null; echo $?
+"#)
+    .await;
+    assert_eq!(result.stdout, "hi\n127\n");
+}
+
+#[tokio::test]
+async fn unset_f_nonexistent_function_is_noop() {
+    let result = run("unset -f nonexistent; echo $?").await;
+    assert_eq!(result.stdout, "0\n");
+}
+
+#[tokio::test]
+async fn unset_f_does_not_affect_variables() {
+    let result = run(r#"
+x=hello
+unset -f x
+echo $x
+"#)
+    .await;
+    assert_eq!(result.stdout, "hello\n");
+}
+
+#[tokio::test]
+async fn unset_without_f_does_not_affect_functions() {
+    let result = run(r#"
+f() { echo hi; }
+unset f
+f
+"#)
+    .await;
+    assert_eq!(result.stdout, "hi\n");
+}


### PR DESCRIPTION
## Summary
- `unset -f` now properly removes function definitions from the interpreter
- Previously the `-f` flag was parsed but silently ignored
- `unset` without `-f` continues to only affect variables (not functions)

## Test plan
- [x] 4 new tests: removes function, noop on nonexistent, doesn't affect variables, unset without -f doesn't affect functions
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

Closes #673