### PR TITLE
fix(parser): support parameter expansion operators on array element subscripts

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7211,6 +7211,30 @@ impl Interpreter {
             return (false, String::new());
         }
 
+        // Check for array element subscript: name[key]
+        if let Some(bracket) = name.find('[')
+            && name.ends_with(']')
+        {
+            let arr_name = &name[..bracket];
+            let key = &name[bracket + 1..name.len() - 1];
+            if let Some(arr) = self.assoc_arrays.get(arr_name) {
+                let expanded_key = self.expand_variable_or_literal(key);
+                return match arr.get(&expanded_key) {
+                    Some(v) => (true, v.clone()),
+                    None => (false, String::new()),
+                };
+            }
+            if let Some(arr) = self.arrays.get(arr_name)
+                && let Ok(idx) = key.parse::<usize>()
+            {
+                return match arr.get(&idx) {
+                    Some(v) => (true, v.clone()),
+                    None => (false, String::new()),
+                };
+            }
+            return (false, String::new());
+        }
+
         // Special parameters @ and *
         if name == "@" || name == "*" {
             if let Some(frame) = self.call_stack.last() {

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -2477,7 +2477,7 @@ impl<'a> Parser<'a> {
                             }
                             // After ], check for operators on array subscripts
                             if let Some(&next_c) = chars.peek() {
-                                if next_c == ':' && (index == "@" || index == "*") {
+                                if next_c == ':' {
                                     // Peek ahead to distinguish param ops (:- := :+ :?) from slice (:N)
                                     let mut lookahead = chars.clone();
                                     lookahead.next(); // skip ':'

--- a/crates/bashkit/tests/spec_cases/bash/blackbox-edge-cases.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/blackbox-edge-cases.test.sh
@@ -261,11 +261,10 @@ arr=($(echo a b c d)); echo ${#arr[@]} ${arr[2]}
 ### end
 
 ### assoc_array_default
-### bash_diff: ${m[key]:-default} expansion broken for associative arrays — outputs raw text (#674)
-# Associative array default value — bash: "default", bashkit: ":-default}"
+# Associative array default value
 declare -A m; echo "${m[nokey]:-default}"
 ### expect
-:-default}
+default
 ### end
 
 ### assoc_array_check_key


### PR DESCRIPTION
## Summary
- Fix `${assoc[key]:-default}` returning raw `:-default}` instead of `default`
- Parser now allows colon-variant operators (`:- := :+ :?`) on all array subscripts, not just `[@]` and `[*]`
- Add array element lookup in `resolve_param_expansion_name()` for `name[key]` patterns

## Test plan
- [x] Spec test `assoc_array_default` updated from `bash_diff` to passing
- [x] All spec tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

Closes #674