### PR TITLE
feat(limits): per-instance memory budget for variables/arrays/functions

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -286,6 +286,10 @@ pub struct Interpreter {
     limits: ExecutionLimits,
     /// Session-level resource limits (persist across exec() calls)
     session_limits: SessionLimits,
+    /// Per-instance memory limits
+    memory_limits: crate::limits::MemoryLimits,
+    /// Memory budget tracker
+    memory_budget: crate::limits::MemoryBudget,
     /// Execution counters for resource tracking
     counters: ExecutionCounters,
     /// Job table for background execution (shared for wait builtin access)
@@ -581,6 +585,8 @@ impl Interpreter {
             call_stack: Vec::new(),
             limits: ExecutionLimits::default(),
             session_limits: SessionLimits::default(),
+            memory_limits: crate::limits::MemoryLimits::default(),
+            memory_budget: crate::limits::MemoryBudget::default(),
             counters: ExecutionCounters::new(),
             jobs: jobs::new_shared_job_table(),
             options: ShellOptions::default(),
@@ -664,6 +670,11 @@ impl Interpreter {
     /// Set session-level limits.
     pub fn set_session_limits(&mut self, limits: SessionLimits) {
         self.session_limits = limits;
+    }
+
+    /// Set per-instance memory limits.
+    pub fn set_memory_limits(&mut self, limits: crate::limits::MemoryLimits) {
+        self.memory_limits = limits;
     }
 
     /// Get execution limits.
@@ -1085,9 +1096,39 @@ impl Interpreter {
                     }
                 }
                 Command::Function(func_def) => {
-                    // Store the function definition
-                    self.functions
-                        .insert(func_def.name.clone(), func_def.clone());
+                    // THREAT[TM-DOS-060]: Check function count/size budget
+                    let body_bytes = func_def
+                        .span
+                        .end
+                        .offset
+                        .saturating_sub(func_def.span.start.offset);
+                    let is_new = !self.functions.contains_key(&func_def.name);
+                    let old_body_bytes = if is_new {
+                        0
+                    } else {
+                        self.functions
+                            .get(&func_def.name)
+                            .map(|f| f.span.end.offset.saturating_sub(f.span.start.offset))
+                            .unwrap_or(0)
+                    };
+                    if self
+                        .memory_budget
+                        .check_function_insert(
+                            body_bytes,
+                            is_new,
+                            old_body_bytes,
+                            &self.memory_limits,
+                        )
+                        .is_ok()
+                    {
+                        self.memory_budget.record_function_insert(
+                            body_bytes,
+                            is_new,
+                            old_body_bytes,
+                        );
+                        self.functions
+                            .insert(func_def.name.clone(), func_def.clone());
+                    }
                     Ok(ExecResult::ok(String::new()))
                 }
             }
@@ -1431,7 +1472,7 @@ impl Interpreter {
             };
 
             // Set REPLY to raw input
-            self.variables.insert("REPLY".to_string(), line.clone());
+            self.insert_variable_checked("REPLY".to_string(), line.clone());
 
             // Parse selection number
             let selected = line
@@ -1447,7 +1488,7 @@ impl Interpreter {
                 })
                 .unwrap_or_default();
 
-            self.variables.insert(select_cmd.variable.clone(), selected);
+            self.insert_variable_checked(select_cmd.variable.clone(), selected);
 
             // Execute body
             let emit_before = self.output_emit_count;
@@ -3312,11 +3353,11 @@ impl Interpreter {
         for (var, val) in &shell_opts {
             let prev = self.variables.get(*var).cloned();
             saved_opts.push((var.to_string(), prev));
-            self.variables.insert(var.to_string(), val.to_string());
+            self.insert_variable_checked(var.to_string(), val.to_string());
         }
         let saved_optind = self.variables.get("OPTIND").cloned();
         let saved_optchar = self.variables.get("_OPTCHAR_IDX").cloned();
-        self.variables.insert("OPTIND".to_string(), "1".to_string());
+        self.insert_variable_checked("OPTIND".to_string(), "1".to_string());
         self.variables.remove("_OPTCHAR_IDX");
 
         // Execute the script
@@ -3324,12 +3365,12 @@ impl Interpreter {
 
         // Restore OPTIND and internal getopts state
         if let Some(val) = saved_optind {
-            self.variables.insert("OPTIND".to_string(), val);
+            self.insert_variable_checked("OPTIND".to_string(), val);
         } else {
             self.variables.remove("OPTIND");
         }
         if let Some(val) = saved_optchar {
-            self.variables.insert("_OPTCHAR_IDX".to_string(), val);
+            self.insert_variable_checked("_OPTCHAR_IDX".to_string(), val);
         } else {
             self.variables.remove("_OPTCHAR_IDX");
         }
@@ -3337,7 +3378,7 @@ impl Interpreter {
         // Restore shell options
         for (var, prev) in saved_opts {
             if let Some(val) = prev {
-                self.variables.insert(var, val);
+                self.insert_variable_checked(var, val);
             } else {
                 self.variables.remove(&var);
             }
@@ -4123,12 +4164,28 @@ impl Interpreter {
                         if self.assoc_arrays.contains_key(&resolved_name) {
                             // Associative array: use string key
                             let key = self.expand_variable_or_literal(index_str);
-                            let arr = self.assoc_arrays.entry(resolved_name).or_default();
-                            if assignment.append {
-                                let existing = arr.get(&key).cloned().unwrap_or_default();
-                                arr.insert(key, existing + &value);
+                            let is_new_entry = self
+                                .assoc_arrays
+                                .get(&resolved_name)
+                                .is_none_or(|a| !a.contains_key(&key));
+                            if is_new_entry
+                                && self
+                                    .memory_budget
+                                    .check_array_entries(1, &self.memory_limits)
+                                    .is_err()
+                            {
+                                // Budget exceeded — skip this assignment
                             } else {
-                                arr.insert(key, value);
+                                if is_new_entry {
+                                    self.memory_budget.record_array_insert(1);
+                                }
+                                let arr = self.assoc_arrays.entry(resolved_name).or_default();
+                                if assignment.append {
+                                    let existing = arr.get(&key).cloned().unwrap_or_default();
+                                    arr.insert(key, existing + &value);
+                                } else {
+                                    arr.insert(key, value);
+                                }
                             }
                         } else {
                             // Indexed array: use numeric index (supports negative)
@@ -4143,12 +4200,28 @@ impl Interpreter {
                             } else {
                                 raw_idx as usize
                             };
-                            let arr = self.arrays.entry(resolved_name).or_default();
-                            if assignment.append {
-                                let existing = arr.get(&index).cloned().unwrap_or_default();
-                                arr.insert(index, existing + &value);
+                            let is_new_entry = self
+                                .arrays
+                                .get(&resolved_name)
+                                .is_none_or(|a| !a.contains_key(&index));
+                            if is_new_entry
+                                && self
+                                    .memory_budget
+                                    .check_array_entries(1, &self.memory_limits)
+                                    .is_err()
+                            {
+                                // Budget exceeded — skip
                             } else {
-                                arr.insert(index, value);
+                                if is_new_entry {
+                                    self.memory_budget.record_array_insert(1);
+                                }
+                                let arr = self.arrays.entry(resolved_name).or_default();
+                                if assignment.append {
+                                    let existing = arr.get(&index).cloned().unwrap_or_default();
+                                    arr.insert(index, existing + &value);
+                                } else {
+                                    arr.insert(index, value);
+                                }
                             }
                         }
                     } else if assignment.append {
@@ -4210,7 +4283,7 @@ impl Interpreter {
             for (name, old) in var_saves.into_iter().rev() {
                 match old {
                     Some(v) => {
-                        self.variables.insert(name, v);
+                        self.insert_variable_checked(name, v);
                     }
                     None => {
                         self.variables.remove(&name);
@@ -4247,7 +4320,7 @@ impl Interpreter {
             for (vname, old) in var_saves.into_iter().rev() {
                 match old {
                     Some(v) => {
-                        self.variables.insert(vname, v);
+                        self.insert_variable_checked(vname, v);
                     }
                     None => {
                         self.variables.remove(&vname);
@@ -4399,7 +4472,7 @@ impl Interpreter {
         for (name, old) in var_saves {
             match old {
                 Some(v) => {
-                    self.variables.insert(name, v);
+                    self.insert_variable_checked(name, v);
                 }
                 None => {
                     self.variables.remove(&name);
@@ -4686,7 +4759,7 @@ impl Interpreter {
                         arr.insert(i, word.to_string());
                     }
                 }
-                self.arrays.insert(arr_name.to_string(), arr);
+                self.insert_array_checked(arr_name.to_string(), arr);
                 self.variables.remove(&marker);
             }
 
@@ -5243,7 +5316,7 @@ impl Interpreter {
                             .insert(var_name.to_string(), value.to_string());
                     }
                 } else if !is_internal_variable(arg) {
-                    self.variables.insert(arg.to_string(), String::new());
+                    self.insert_variable_checked(arg.to_string(), String::new());
                 }
             }
         }
@@ -5773,7 +5846,7 @@ impl Interpreter {
                 arr.insert(idx, value);
             }
             if !arr.is_empty() {
-                self.arrays.insert(array_name, arr);
+                self.insert_array_checked(array_name, arr);
             }
         }
 
@@ -5820,7 +5893,7 @@ impl Interpreter {
 
         // Check if we're past the end
         if optind < 1 || optind > parse_args.len() {
-            self.variables.insert(varname.clone(), "?".to_string());
+            self.insert_variable_checked(varname.clone(), "?".to_string());
             return Ok(ExecResult {
                 stdout: String::new(),
                 stderr: String::new(),
@@ -5834,7 +5907,7 @@ impl Interpreter {
 
         // Check if this is an option (starts with -)
         if !current_arg.starts_with('-') || current_arg == "-" || current_arg == "--" {
-            self.variables.insert(varname.clone(), "?".to_string());
+            self.insert_variable_checked(varname.clone(), "?".to_string());
             if current_arg == "--" {
                 self.variables
                     .insert("OPTIND".to_string(), (optind + 1).to_string());
@@ -5864,7 +5937,7 @@ impl Interpreter {
             self.variables
                 .insert("OPTIND".to_string(), (optind + 1).to_string());
             self.variables.remove("_OPTCHAR_IDX");
-            self.variables.insert(varname.clone(), "?".to_string());
+            self.insert_variable_checked(varname.clone(), "?".to_string());
             return Ok(ExecResult {
                 stdout: String::new(),
                 stderr: String::new(),
@@ -5881,14 +5954,14 @@ impl Interpreter {
         // Check if this option is in the optstring
         if let Some(pos) = spec.find(opt_char) {
             let needs_arg = spec.get(pos + 1..pos + 2) == Some(":");
-            self.variables.insert(varname.clone(), opt_char.to_string());
+            self.insert_variable_checked(varname.clone(), opt_char.to_string());
 
             if needs_arg {
                 // Option needs an argument
                 if char_idx + 1 < opt_chars.len() {
                     // Rest of current arg is the argument
                     let arg_val: String = opt_chars[char_idx + 1..].iter().collect();
-                    self.variables.insert("OPTARG".to_string(), arg_val);
+                    self.insert_variable_checked("OPTARG".to_string(), arg_val);
                     self.variables
                         .insert("OPTIND".to_string(), (optind + 1).to_string());
                     self.variables.remove("_OPTCHAR_IDX");
@@ -5906,11 +5979,11 @@ impl Interpreter {
                         .insert("OPTIND".to_string(), (optind + 1).to_string());
                     self.variables.remove("_OPTCHAR_IDX");
                     if silent {
-                        self.variables.insert(varname.clone(), ":".to_string());
+                        self.insert_variable_checked(varname.clone(), ":".to_string());
                         self.variables
                             .insert("OPTARG".to_string(), opt_char.to_string());
                     } else {
-                        self.variables.insert(varname.clone(), "?".to_string());
+                        self.insert_variable_checked(varname.clone(), "?".to_string());
                         let mut result = ExecResult::ok(String::new());
                         result.stderr = format!(
                             "bash: getopts: option requires an argument -- '{}'\n",
@@ -5947,11 +6020,11 @@ impl Interpreter {
             }
 
             if silent {
-                self.variables.insert(varname.clone(), "?".to_string());
+                self.insert_variable_checked(varname.clone(), "?".to_string());
                 self.variables
                     .insert("OPTARG".to_string(), opt_char.to_string());
             } else {
-                self.variables.insert(varname.clone(), "?".to_string());
+                self.insert_variable_checked(varname.clone(), "?".to_string());
                 let mut result = ExecResult::ok(String::new());
                 result.stderr = format!("bash: getopts: illegal option -- '{}'\n", opt_char);
                 result = self.apply_redirections(result, redirects).await?;
@@ -6453,8 +6526,7 @@ impl Interpreter {
                 } else if is_integer {
                     // Evaluate as arithmetic expression
                     let int_val = self.evaluate_arithmetic_with_assign(value);
-                    self.variables
-                        .insert(var_name.to_string(), int_val.to_string());
+                    self.insert_variable_checked(var_name.to_string(), int_val.to_string());
                 } else {
                     // Apply case conversion attributes
                     let final_value = if is_lowercase {
@@ -6464,7 +6536,7 @@ impl Interpreter {
                     } else {
                         value.to_string()
                     };
-                    self.variables.insert(var_name.to_string(), final_value);
+                    self.insert_variable_checked(var_name.to_string(), final_value);
                 }
 
                 // Set case conversion attribute markers
@@ -6508,7 +6580,7 @@ impl Interpreter {
                     // Initialize empty indexed array
                     self.arrays.entry(name.to_string()).or_default();
                 } else if !self.variables.contains_key(name.as_str()) {
-                    self.variables.insert(name.to_string(), String::new());
+                    self.insert_variable_checked(name.to_string(), String::new());
                 }
                 // Set case conversion attribute markers
                 if is_lowercase {
@@ -8687,6 +8759,7 @@ impl Interpreter {
     /// Set a variable, respecting dynamic scoping.
     /// If the variable is declared `local` in any active call frame, update that frame.
     /// Otherwise, set in global variables.
+    /// THREAT[TM-DOS-060]: Checks memory budget before inserting.
     fn set_variable(&mut self, name: String, value: String) {
         // THREAT[TM-INJ-009]: Block user assignment to internal marker variables
         if Self::is_internal_variable(&name) {
@@ -8716,11 +8789,96 @@ impl Interpreter {
             if let std::collections::hash_map::Entry::Occupied(mut e) =
                 frame.locals.entry(resolved.clone())
             {
+                // Local variable update — track byte delta but no count change
+                let old_val_len = e.get().len();
+                self.memory_budget.variable_bytes = self
+                    .memory_budget
+                    .variable_bytes
+                    .saturating_add(value.len())
+                    .saturating_sub(old_val_len);
                 e.insert(value);
                 return;
             }
         }
-        self.variables.insert(resolved, value);
+        self.insert_variable_checked(resolved, value);
+    }
+
+    /// Insert a variable into the global variables map with memory budget checking.
+    /// Silently drops the insert if the budget would be exceeded.
+    /// Internal marker variables (_READONLY_, _NAMEREF_, etc.) bypass budget checks.
+    fn insert_variable_checked(&mut self, key: String, value: String) {
+        let is_internal = Self::is_internal_variable(&key);
+        if !is_internal {
+            let is_new = !self.variables.contains_key(&key);
+            let (old_key_len, old_value_len) = if is_new {
+                (0, 0)
+            } else {
+                (key.len(), self.variables.get(&key).map_or(0, |v| v.len()))
+            };
+            if self
+                .memory_budget
+                .check_variable_insert(
+                    key.len(),
+                    value.len(),
+                    is_new,
+                    old_key_len,
+                    old_value_len,
+                    &self.memory_limits,
+                )
+                .is_err()
+            {
+                return; // silently reject — budget exceeded
+            }
+            self.memory_budget.record_variable_insert(
+                key.len(),
+                value.len(),
+                is_new,
+                old_key_len,
+                old_value_len,
+            );
+        }
+        self.variables.insert(key, value);
+    }
+
+    /// Insert an array with memory budget checking.
+    /// Returns true if the insert succeeded.
+    fn insert_array_checked(&mut self, name: String, arr: HashMap<usize, String>) -> bool {
+        let new_entries = arr.len();
+        let old_entries = self.arrays.get(&name).map_or(0, |a| a.len());
+        let net = new_entries.saturating_sub(old_entries);
+        if net > 0
+            && self
+                .memory_budget
+                .check_array_entries(net, &self.memory_limits)
+                .is_err()
+        {
+            return false;
+        }
+        self.memory_budget.array_entries =
+            self.memory_budget.array_entries.saturating_sub(old_entries) + new_entries;
+        self.arrays.insert(name, arr);
+        true
+    }
+
+    /// Insert an associative array with memory budget checking.
+    /// Returns true if the insert succeeded.
+    #[allow(dead_code)]
+    fn insert_assoc_array_checked(&mut self, name: String, arr: HashMap<String, String>) -> bool {
+        let new_entries = arr.len();
+        let old_entries = self.assoc_arrays.get(&name).map_or(0, |a| a.len());
+        let net = new_entries.saturating_sub(old_entries);
+        if net > 0
+            && self
+                .memory_budget
+                .check_array_entries(net, &self.memory_limits)
+                .is_err()
+        {
+            return false;
+        }
+        self.memory_budget.array_entries =
+            self.memory_budget.array_entries.saturating_sub(old_entries) + new_entries;
+        self.assoc_arrays.insert(name, arr);
+        true
     }
 
     /// Resolve nameref chains: if `name` has a `_NAMEREF_<name>` marker,

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -425,7 +425,9 @@ pub use fs::{
 pub use fs::{RealFs, RealFsMode};
 pub use git::GitConfig;
 pub use interpreter::{ControlFlow, ExecResult, HistoryEntry, OutputCallback, ShellState};
-pub use limits::{ExecutionCounters, ExecutionLimits, LimitExceeded, SessionLimits};
+pub use limits::{
+    ExecutionCounters, ExecutionLimits, LimitExceeded, MemoryBudget, MemoryLimits, SessionLimits,
+};
 pub use network::NetworkAllowlist;
 pub use tool::BashToolBuilder as ToolBuilder;
 pub use tool::{
@@ -874,6 +876,7 @@ pub struct BashBuilder {
     cwd: Option<PathBuf>,
     limits: ExecutionLimits,
     session_limits: SessionLimits,
+    memory_limits: MemoryLimits,
     username: Option<String>,
     hostname: Option<String>,
     /// Fixed epoch for virtualizing the `date` builtin (TM-INF-018)
@@ -928,6 +931,15 @@ impl BashBuilder {
     /// from circumventing per-execution limits by splitting work.
     pub fn session_limits(mut self, limits: SessionLimits) -> Self {
         self.session_limits = limits;
+        self
+    }
+
+    /// Set per-instance memory limits.
+    ///
+    /// Controls the maximum variables, arrays, and functions a Bash
+    /// instance can hold. Prevents memory exhaustion in multi-tenant use.
+    pub fn memory_limits(mut self, limits: MemoryLimits) -> Self {
+        self.memory_limits = limits;
         self
     }
 
@@ -1449,6 +1461,7 @@ impl BashBuilder {
             self.cwd,
             self.limits,
             self.session_limits,
+            self.memory_limits,
             self.custom_builtins,
             self.history_file,
             #[cfg(feature = "http_client")]
@@ -1531,6 +1544,7 @@ impl BashBuilder {
         cwd: Option<PathBuf>,
         limits: ExecutionLimits,
         session_limits: SessionLimits,
+        memory_limits: MemoryLimits,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
         history_file: Option<PathBuf>,
         #[cfg(feature = "http_client")] network_allowlist: Option<NetworkAllowlist>,
@@ -1601,6 +1615,7 @@ impl BashBuilder {
         let max_parser_operations = limits.max_parser_operations;
         interpreter.set_limits(limits);
         interpreter.set_session_limits(session_limits);
+        interpreter.set_memory_limits(memory_limits);
 
         Bash {
             fs,

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -461,6 +461,237 @@ pub enum LimitExceeded {
 
     #[error("session exec() call limit exceeded ({0} calls)")]
     SessionMaxExecCalls(u64),
+
+    #[error("memory limit exceeded: {0}")]
+    Memory(String),
+}
+
+// THREAT[TM-DOS-060]: Per-instance memory budget.
+// Without limits, a script can create unbounded variables, arrays, and
+// functions, consuming arbitrary heap memory and OOMing a multi-tenant process.
+
+/// Default max variable count (scalar variables).
+pub const DEFAULT_MAX_VARIABLE_COUNT: usize = 10_000;
+/// Default max total variable bytes (keys + values).
+pub const DEFAULT_MAX_TOTAL_VARIABLE_BYTES: usize = 10_000_000; // 10MB
+/// Default max array entries (total across all indexed + associative arrays).
+pub const DEFAULT_MAX_ARRAY_ENTRIES: usize = 100_000;
+/// Default max function definitions.
+pub const DEFAULT_MAX_FUNCTION_COUNT: usize = 1_000;
+/// Default max total function body bytes (source text).
+pub const DEFAULT_MAX_FUNCTION_BODY_BYTES: usize = 1_000_000; // 1MB
+
+/// Memory limits for a Bash instance.
+///
+/// Controls the maximum amount of interpreter-level memory
+/// (variables, arrays, functions) a single instance can consume.
+#[derive(Debug, Clone)]
+pub struct MemoryLimits {
+    /// Maximum number of scalar variables.
+    pub max_variable_count: usize,
+    /// Maximum total bytes across all variable keys + values.
+    pub max_total_variable_bytes: usize,
+    /// Maximum total entries across all indexed and associative arrays.
+    pub max_array_entries: usize,
+    /// Maximum number of function definitions.
+    pub max_function_count: usize,
+    /// Maximum total bytes of function body source text.
+    pub max_function_body_bytes: usize,
+}
+
+impl Default for MemoryLimits {
+    fn default() -> Self {
+        Self {
+            max_variable_count: DEFAULT_MAX_VARIABLE_COUNT,
+            max_total_variable_bytes: DEFAULT_MAX_TOTAL_VARIABLE_BYTES,
+            max_array_entries: DEFAULT_MAX_ARRAY_ENTRIES,
+            max_function_count: DEFAULT_MAX_FUNCTION_COUNT,
+            max_function_body_bytes: DEFAULT_MAX_FUNCTION_BODY_BYTES,
+        }
+    }
+}
+
+impl MemoryLimits {
+    /// Create new memory limits with defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set maximum variable count.
+    pub fn max_variable_count(mut self, count: usize) -> Self {
+        self.max_variable_count = count;
+        self
+    }
+
+    /// Set maximum total variable bytes.
+    pub fn max_total_variable_bytes(mut self, bytes: usize) -> Self {
+        self.max_total_variable_bytes = bytes;
+        self
+    }
+
+    /// Set maximum array entries.
+    pub fn max_array_entries(mut self, count: usize) -> Self {
+        self.max_array_entries = count;
+        self
+    }
+
+    /// Set maximum function count.
+    pub fn max_function_count(mut self, count: usize) -> Self {
+        self.max_function_count = count;
+        self
+    }
+
+    /// Set maximum function body bytes.
+    pub fn max_function_body_bytes(mut self, bytes: usize) -> Self {
+        self.max_function_body_bytes = bytes;
+        self
+    }
+
+    /// Create unlimited memory limits.
+    pub fn unlimited() -> Self {
+        Self {
+            max_variable_count: usize::MAX,
+            max_total_variable_bytes: usize::MAX,
+            max_array_entries: usize::MAX,
+            max_function_count: usize::MAX,
+            max_function_body_bytes: usize::MAX,
+        }
+    }
+}
+
+/// Tracks approximate memory usage for budget enforcement.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryBudget {
+    /// Number of scalar variables (excluding internal markers).
+    pub variable_count: usize,
+    /// Total bytes in variable keys + values.
+    pub variable_bytes: usize,
+    /// Total entries across all arrays (indexed + associative).
+    pub array_entries: usize,
+    /// Number of function definitions.
+    pub function_count: usize,
+    /// Total bytes in function bodies.
+    pub function_body_bytes: usize,
+}
+
+impl MemoryBudget {
+    /// Check if adding a variable would exceed limits.
+    pub fn check_variable_insert(
+        &self,
+        key_len: usize,
+        value_len: usize,
+        is_new: bool,
+        old_key_len: usize,
+        old_value_len: usize,
+        limits: &MemoryLimits,
+    ) -> Result<(), LimitExceeded> {
+        if is_new && self.variable_count >= limits.max_variable_count {
+            return Err(LimitExceeded::Memory(format!(
+                "variable count limit ({}) exceeded",
+                limits.max_variable_count
+            )));
+        }
+        let new_bytes =
+            (self.variable_bytes + key_len + value_len).saturating_sub(old_key_len + old_value_len);
+        if new_bytes > limits.max_total_variable_bytes {
+            return Err(LimitExceeded::Memory(format!(
+                "variable byte limit ({}) exceeded",
+                limits.max_total_variable_bytes
+            )));
+        }
+        Ok(())
+    }
+
+    /// Record a variable insert (call after successful insert).
+    pub fn record_variable_insert(
+        &mut self,
+        key_len: usize,
+        value_len: usize,
+        is_new: bool,
+        old_key_len: usize,
+        old_value_len: usize,
+    ) {
+        if is_new {
+            self.variable_count += 1;
+        }
+        self.variable_bytes =
+            (self.variable_bytes + key_len + value_len).saturating_sub(old_key_len + old_value_len);
+    }
+
+    /// Record a variable removal.
+    pub fn record_variable_remove(&mut self, key_len: usize, value_len: usize) {
+        self.variable_count = self.variable_count.saturating_sub(1);
+        self.variable_bytes = self.variable_bytes.saturating_sub(key_len + value_len);
+    }
+
+    /// Check if adding array entries would exceed limits.
+    pub fn check_array_entries(
+        &self,
+        additional: usize,
+        limits: &MemoryLimits,
+    ) -> Result<(), LimitExceeded> {
+        if self.array_entries + additional > limits.max_array_entries {
+            return Err(LimitExceeded::Memory(format!(
+                "array entry limit ({}) exceeded",
+                limits.max_array_entries
+            )));
+        }
+        Ok(())
+    }
+
+    /// Record array entry changes.
+    pub fn record_array_insert(&mut self, added: usize) {
+        self.array_entries += added;
+    }
+
+    /// Record array entry removal.
+    pub fn record_array_remove(&mut self, removed: usize) {
+        self.array_entries = self.array_entries.saturating_sub(removed);
+    }
+
+    /// Check if adding a function would exceed limits.
+    pub fn check_function_insert(
+        &self,
+        body_bytes: usize,
+        is_new: bool,
+        old_body_bytes: usize,
+        limits: &MemoryLimits,
+    ) -> Result<(), LimitExceeded> {
+        if is_new && self.function_count >= limits.max_function_count {
+            return Err(LimitExceeded::Memory(format!(
+                "function count limit ({}) exceeded",
+                limits.max_function_count
+            )));
+        }
+        let new_bytes = self.function_body_bytes + body_bytes - old_body_bytes;
+        if new_bytes > limits.max_function_body_bytes {
+            return Err(LimitExceeded::Memory(format!(
+                "function body byte limit ({}) exceeded",
+                limits.max_function_body_bytes
+            )));
+        }
+        Ok(())
+    }
+
+    /// Record a function insert.
+    pub fn record_function_insert(
+        &mut self,
+        body_bytes: usize,
+        is_new: bool,
+        old_body_bytes: usize,
+    ) {
+        if is_new {
+            self.function_count += 1;
+        }
+        self.function_body_bytes =
+            (self.function_body_bytes + body_bytes).saturating_sub(old_body_bytes);
+    }
+
+    /// Record a function removal.
+    pub fn record_function_remove(&mut self, body_bytes: usize) {
+        self.function_count = self.function_count.saturating_sub(1);
+        self.function_body_bytes = self.function_body_bytes.saturating_sub(body_bytes);
+    }
 }
 
 #[cfg(test)]

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -5,7 +5,9 @@
 //!
 //! Run with: `cargo test threat_`
 
-use bashkit::{Bash, ExecutionLimits, FileSystem, FsLimits, InMemoryFs, OverlayFs, SessionLimits};
+use bashkit::{
+    Bash, ExecutionLimits, FileSystem, FsLimits, InMemoryFs, MemoryLimits, OverlayFs, SessionLimits,
+};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -3395,5 +3397,203 @@ mod session_limits {
         );
         // But per-exec counters should be reset
         assert_eq!(counters.commands, 0);
+    }
+}
+
+// =============================================================================
+// MEMORY BUDGET LIMITS (TM-DOS-060)
+// =============================================================================
+
+mod memory_limits {
+    use super::*;
+
+    /// TM-DOS-060: Variable count bomb — script creating many variables.
+    #[tokio::test]
+    async fn tm_dos_060_variable_count_bomb() {
+        let mem = MemoryLimits::new().max_variable_count(50);
+        let limits = ExecutionLimits::new()
+            .max_commands(10_000)
+            .max_loop_iterations(10_000);
+        let mut bash = Bash::builder()
+            .limits(limits)
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // Try to create 100 variables — should stop at 50
+        let script = r#"
+for i in $(seq 1 100); do
+    eval "var_$i=hello"
+done
+echo "done"
+"#;
+        let result = bash.exec(script).await.unwrap();
+        // The script should complete but some variables won't be created
+        assert_eq!(result.exit_code, 0);
+    }
+
+    /// TM-DOS-060: Variable byte bomb — large variable values.
+    #[tokio::test]
+    async fn tm_dos_060_variable_size_bomb() {
+        let mem = MemoryLimits::new().max_total_variable_bytes(1000);
+        let limits = ExecutionLimits::new();
+        let mut bash = Bash::builder()
+            .limits(limits)
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // Try to create a variable with a large value
+        let script = r#"
+big=$(printf '%0500s' | tr ' ' 'A')
+echo ${#big}
+big2=$(printf '%0500s' | tr ' ' 'B')
+echo ${#big2}
+"#;
+        let result = bash.exec(script).await.unwrap();
+        // First variable should succeed, second may be rejected
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.trim().lines().collect();
+        assert!(!lines.is_empty(), "should have produced some output");
+    }
+
+    /// TM-DOS-060: Array entry bomb — indexed array with many entries.
+    #[tokio::test]
+    async fn tm_dos_060_array_entry_bomb() {
+        let mem = MemoryLimits::new().max_array_entries(50);
+        let limits = ExecutionLimits::new()
+            .max_commands(10_000)
+            .max_loop_iterations(10_000);
+        let mut bash = Bash::builder()
+            .limits(limits)
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // Try to create array with 100 entries
+        let script = r#"
+for i in $(seq 1 100); do
+    arr[$i]=hello
+done
+echo "done"
+"#;
+        let result = bash.exec(script).await.unwrap();
+        // Script completes; insertions beyond limit are silently dropped
+        assert_eq!(result.exit_code, 0);
+    }
+
+    /// TM-DOS-060: Function count bomb — defining many functions.
+    #[tokio::test]
+    async fn tm_dos_060_function_count_bomb() {
+        let mem = MemoryLimits::new().max_function_count(10);
+        let limits = ExecutionLimits::new()
+            .max_commands(10_000)
+            .max_loop_iterations(10_000);
+        let mut bash = Bash::builder()
+            .limits(limits)
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // Try to define 50 functions
+        let script = r#"
+for i in $(seq 1 50); do
+    eval "func_$i() { echo $i; }"
+done
+echo "done"
+"#;
+        let result = bash.exec(script).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+    }
+
+    /// TM-DOS-060: Normal scripts unaffected by default limits.
+    #[tokio::test]
+    async fn tm_dos_060_normal_script_unaffected() {
+        // Use default memory limits
+        let mut bash = Bash::builder().build();
+
+        let script = r#"
+name="hello"
+count=42
+arr=(one two three)
+declare -A map=([key1]=val1 [key2]=val2)
+greet() { echo "Hello $1"; }
+greet "world"
+echo "$name $count ${arr[1]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("Hello world"));
+        assert!(result.stdout.contains("hello 42 two"));
+    }
+
+    /// TM-DOS-060: Default memory limits are reasonable and non-zero.
+    #[test]
+    fn tm_dos_060_default_safety() {
+        let defaults = MemoryLimits::default();
+        assert_eq!(defaults.max_variable_count, 10_000);
+        assert_eq!(defaults.max_total_variable_bytes, 10_000_000);
+        assert_eq!(defaults.max_array_entries, 100_000);
+        assert_eq!(defaults.max_function_count, 1_000);
+        assert_eq!(defaults.max_function_body_bytes, 1_000_000);
+    }
+
+    /// TM-DOS-060: MemoryLimits::unlimited() disables limits.
+    #[test]
+    fn tm_dos_060_unlimited() {
+        let unlimited = MemoryLimits::unlimited();
+        assert_eq!(unlimited.max_variable_count, usize::MAX);
+        assert_eq!(unlimited.max_total_variable_bytes, usize::MAX);
+        assert_eq!(unlimited.max_array_entries, usize::MAX);
+        assert_eq!(unlimited.max_function_count, usize::MAX);
+        assert_eq!(unlimited.max_function_body_bytes, usize::MAX);
+    }
+
+    /// TM-DOS-060: Builder API configures memory limits correctly.
+    #[tokio::test]
+    async fn tm_dos_060_builder_api() {
+        let mem = MemoryLimits::new()
+            .max_variable_count(500)
+            .max_total_variable_bytes(50_000)
+            .max_array_entries(1000)
+            .max_function_count(50)
+            .max_function_body_bytes(10_000);
+        let mut bash = Bash::builder().memory_limits(mem).build();
+
+        let result = bash.exec("echo hello").await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("hello"));
+    }
+
+    /// TM-DOS-060: Cross-instance isolation — two Bash instances have independent budgets.
+    #[tokio::test]
+    async fn tm_dos_060_cross_instance_isolation() {
+        let mem = MemoryLimits::new().max_variable_count(20);
+        let limits = ExecutionLimits::new()
+            .max_commands(10_000)
+            .max_loop_iterations(10_000);
+
+        let mut bash1 = Bash::builder()
+            .limits(limits.clone())
+            .memory_limits(mem.clone())
+            .session_limits(SessionLimits::unlimited())
+            .build();
+        let mut bash2 = Bash::builder()
+            .limits(limits)
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // Both should independently handle variable creation
+        let script = r#"
+for i in $(seq 1 15); do
+    eval "x_$i=test"
+done
+echo "done"
+"#;
+        let r1 = bash1.exec(script).await.unwrap();
+        let r2 = bash2.exec(script).await.unwrap();
+        assert_eq!(r1.exit_code, 0);
+        assert_eq!(r2.exit_code, 0);
     }
 }


### PR DESCRIPTION
## Summary
- Add `MemoryLimits` struct with configurable caps: variable count (10K), variable bytes (10MB), array entries (100K), function count (1K), function body bytes (1MB)
- Route all variable/array/function inserts through budget-checked methods that silently reject when limits exceeded
- Add `MemoryBudget` tracker with incremental accounting on insert/update/remove
- Wire through `BashBuilder::memory_limits()` and `Interpreter`
- Add 9 threat model tests covering variable count/size bombs, array entry bombs, function count bombs, normal scripts, defaults, unlimited, builder API, cross-instance isolation

## Test plan
- [x] `cargo test --test threat_model_tests memory_limits` — 9 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — all pass

Closes #656