### PR TITLE
feat(trace): structured execution trace events

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -290,6 +290,8 @@ pub struct Interpreter {
     memory_limits: crate::limits::MemoryLimits,
     /// Memory budget tracker
     memory_budget: crate::limits::MemoryBudget,
+    /// Trace event collector
+    trace: crate::trace::TraceCollector,
     /// Execution counters for resource tracking
     counters: ExecutionCounters,
     /// Job table for background execution (shared for wait builtin access)
@@ -587,6 +589,7 @@ impl Interpreter {
             session_limits: SessionLimits::default(),
             memory_limits: crate::limits::MemoryLimits::default(),
             memory_budget: crate::limits::MemoryBudget::default(),
+            trace: crate::trace::TraceCollector::default(),
             counters: ExecutionCounters::new(),
             jobs: jobs::new_shared_job_table(),
             options: ShellOptions::default(),
@@ -675,6 +678,11 @@ impl Interpreter {
     /// Set per-instance memory limits.
     pub fn set_memory_limits(&mut self, limits: crate::limits::MemoryLimits) {
         self.memory_limits = limits;
+    }
+
+    /// Set the trace collector.
+    pub fn set_trace(&mut self, trace: crate::trace::TraceCollector) {
+        self.trace = trace;
     }
 
     /// Get execution limits.
@@ -995,6 +1003,8 @@ impl Interpreter {
             None
         };
 
+        let events = self.trace.take_events();
+
         Ok(ExecResult {
             stdout,
             stderr,
@@ -1003,6 +1013,7 @@ impl Interpreter {
             stdout_truncated,
             stderr_truncated,
             final_env,
+            events,
         })
     }
 
@@ -4584,6 +4595,35 @@ impl Interpreter {
             None
         };
 
+        // TRACE: Record command start event
+        let trace_start = if self.trace.mode() != crate::trace::TraceMode::Off {
+            self.trace
+                .command_start(name, &args, self.cwd.to_string_lossy().as_ref());
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        let result = self.dispatch_command(name, command, args, stdin).await;
+
+        // TRACE: Record command exit event for all dispatch paths
+        if let (Some(start), Ok(r)) = (trace_start, &result) {
+            self.trace.command_exit(name, r.exit_code, start.elapsed());
+        }
+
+        result
+    }
+
+    /// Inner dispatch logic for command execution.
+    /// Separated from `execute_dispatched_command` so trace start/exit events
+    /// wrap all return paths uniformly.
+    async fn dispatch_command(
+        &mut self,
+        name: &str,
+        command: &SimpleCommand,
+        args: Vec<String>,
+        stdin: Option<String>,
+    ) -> Result<ExecResult> {
         // Check for functions first
         if let Some(func_def) = self.functions.get(name).cloned() {
             return self

--- a/crates/bashkit/src/interpreter/state.rs
+++ b/crates/bashkit/src/interpreter/state.rs
@@ -30,6 +30,8 @@ pub struct ExecResult {
     pub stderr_truncated: bool,
     /// Final environment state after execution (opt-in via `capture_final_env`)
     pub final_env: Option<std::collections::HashMap<String, String>>,
+    /// Structured trace events (empty when `TraceMode::Off`).
+    pub events: Vec<crate::trace::TraceEvent>,
 }
 
 impl ExecResult {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -412,6 +412,8 @@ pub mod parser;
 pub mod scripted_tool;
 /// Tool contract for LLM integration
 pub mod tool;
+/// Structured execution trace events.
+pub mod trace;
 
 pub use async_trait::async_trait;
 pub use builtins::{Builtin, Context as BuiltinContext};
@@ -434,6 +436,9 @@ pub use tool::{
     BashTool, BashToolBuilder, Tool, ToolError, ToolExecution, ToolImage, ToolOutput,
     ToolOutputChunk, ToolOutputMetadata, ToolRequest, ToolResponse, ToolService, ToolStatus,
     VERSION,
+};
+pub use trace::{
+    TraceCallback, TraceCollector, TraceEvent, TraceEventDetails, TraceEventKind, TraceMode,
 };
 
 #[cfg(feature = "scripted_tool")]
@@ -877,6 +882,8 @@ pub struct BashBuilder {
     limits: ExecutionLimits,
     session_limits: SessionLimits,
     memory_limits: MemoryLimits,
+    trace_mode: TraceMode,
+    trace_callback: Option<TraceCallback>,
     username: Option<String>,
     hostname: Option<String>,
     /// Fixed epoch for virtualizing the `date` builtin (TM-INF-018)
@@ -940,6 +947,25 @@ impl BashBuilder {
     /// instance can hold. Prevents memory exhaustion in multi-tenant use.
     pub fn memory_limits(mut self, limits: MemoryLimits) -> Self {
         self.memory_limits = limits;
+        self
+    }
+
+    /// Set the trace mode for structured execution tracing.
+    ///
+    /// - `TraceMode::Off` (default): No events, zero overhead
+    /// - `TraceMode::Redacted`: Events with secrets scrubbed
+    /// - `TraceMode::Full`: Raw events, no redaction
+    pub fn trace_mode(mut self, mode: TraceMode) -> Self {
+        self.trace_mode = mode;
+        self
+    }
+
+    /// Set a real-time callback for trace events.
+    ///
+    /// The callback is invoked for each trace event as it occurs.
+    /// Requires `trace_mode` to be set to `Redacted` or `Full`.
+    pub fn on_trace_event(mut self, callback: TraceCallback) -> Self {
+        self.trace_callback = Some(callback);
         self
     }
 
@@ -1462,6 +1488,8 @@ impl BashBuilder {
             self.limits,
             self.session_limits,
             self.memory_limits,
+            self.trace_mode,
+            self.trace_callback,
             self.custom_builtins,
             self.history_file,
             #[cfg(feature = "http_client")]
@@ -1545,6 +1573,8 @@ impl BashBuilder {
         limits: ExecutionLimits,
         session_limits: SessionLimits,
         memory_limits: MemoryLimits,
+        trace_mode: TraceMode,
+        trace_callback: Option<TraceCallback>,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
         history_file: Option<PathBuf>,
         #[cfg(feature = "http_client")] network_allowlist: Option<NetworkAllowlist>,
@@ -1616,6 +1646,11 @@ impl BashBuilder {
         interpreter.set_limits(limits);
         interpreter.set_session_limits(session_limits);
         interpreter.set_memory_limits(memory_limits);
+        let mut trace_collector = TraceCollector::new(trace_mode);
+        if let Some(cb) = trace_callback {
+            trace_collector.set_callback(cb);
+        }
+        interpreter.set_trace(trace_collector);
 
         Bash {
             fs,

--- a/crates/bashkit/src/trace.rs
+++ b/crates/bashkit/src/trace.rs
@@ -1,0 +1,413 @@
+// THREAT[TM-INF-019]: Trace events may contain secrets.
+// TraceMode::Redacted scrubs common secret patterns in argv.
+// TraceMode::Off (default) disables all tracing with zero overhead.
+
+//! Structured execution trace events.
+//!
+//! Records structured events during script execution for debugging
+//! and observability. Events are returned in `ExecResult.events`.
+
+use std::time::Duration;
+
+/// Controls what trace information is collected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TraceMode {
+    /// No events recorded, zero overhead (default).
+    #[default]
+    Off,
+    /// Events recorded with secret-bearing argv scrubbed.
+    Redacted,
+    /// Raw events with no redaction. Unsafe for shared sinks.
+    Full,
+}
+
+/// Kind of trace event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceEventKind {
+    /// A command is about to execute.
+    CommandStart,
+    /// A command has finished executing.
+    CommandExit,
+    /// A file was accessed (read, stat, readdir).
+    FileAccess,
+    /// A file was mutated (write, mkdir, remove, rename, chmod).
+    FileMutation,
+    /// A policy check denied an action.
+    PolicyDenied,
+}
+
+/// Per-kind details for a trace event.
+#[derive(Debug, Clone)]
+pub enum TraceEventDetails {
+    /// Details for CommandStart.
+    CommandStart {
+        /// The command name.
+        command: String,
+        /// Command arguments.
+        argv: Vec<String>,
+        /// Working directory at execution time.
+        cwd: String,
+    },
+    /// Details for CommandExit.
+    CommandExit {
+        /// The command name.
+        command: String,
+        /// Exit code.
+        exit_code: i32,
+        /// Duration of command execution.
+        duration: Duration,
+    },
+    /// Details for FileAccess.
+    FileAccess {
+        /// File path accessed.
+        path: String,
+        /// Action performed.
+        action: String,
+    },
+    /// Details for FileMutation.
+    FileMutation {
+        /// File path mutated.
+        path: String,
+        /// Action performed (write, mkdir, remove, rename, chmod).
+        action: String,
+    },
+    /// Details for PolicyDenied.
+    PolicyDenied {
+        /// Subject of the policy check.
+        subject: String,
+        /// Reason for denial.
+        reason: String,
+        /// Action that was denied.
+        action: String,
+    },
+}
+
+/// A single trace event.
+#[derive(Debug, Clone)]
+pub struct TraceEvent {
+    /// Kind of event.
+    pub kind: TraceEventKind,
+    /// Monotonic sequence number within the execution.
+    pub seq: u64,
+    /// Per-kind details.
+    pub details: TraceEventDetails,
+}
+
+/// Callback type for real-time trace event streaming.
+pub type TraceCallback = Box<dyn FnMut(&TraceEvent) + Send + Sync>;
+
+/// Collector for trace events during execution.
+#[derive(Default)]
+pub struct TraceCollector {
+    mode: TraceMode,
+    events: Vec<TraceEvent>,
+    seq: u64,
+    callback: Option<TraceCallback>,
+}
+
+impl TraceCollector {
+    /// Create a new trace collector with the given mode.
+    pub fn new(mode: TraceMode) -> Self {
+        Self {
+            mode,
+            events: Vec::new(),
+            seq: 0,
+            callback: None,
+        }
+    }
+
+    /// Set the real-time callback.
+    pub fn set_callback(&mut self, callback: TraceCallback) {
+        self.callback = Some(callback);
+    }
+
+    /// Get the current trace mode.
+    pub fn mode(&self) -> TraceMode {
+        self.mode
+    }
+
+    /// Record a trace event. No-op if mode is Off.
+    pub fn record(&mut self, kind: TraceEventKind, details: TraceEventDetails) {
+        if self.mode == TraceMode::Off {
+            return;
+        }
+
+        let details = if self.mode == TraceMode::Redacted {
+            redact_details(details)
+        } else {
+            details
+        };
+
+        let event = TraceEvent {
+            kind,
+            seq: self.seq,
+            details,
+        };
+        self.seq += 1;
+
+        if let Some(cb) = &mut self.callback {
+            cb(&event);
+        }
+        self.events.push(event);
+    }
+
+    /// Drain collected events (moves them out).
+    pub fn take_events(&mut self) -> Vec<TraceEvent> {
+        std::mem::take(&mut self.events)
+    }
+
+    /// Record a command start event.
+    pub fn command_start(&mut self, command: &str, argv: &[String], cwd: &str) {
+        self.record(
+            TraceEventKind::CommandStart,
+            TraceEventDetails::CommandStart {
+                command: command.to_string(),
+                argv: argv.to_vec(),
+                cwd: cwd.to_string(),
+            },
+        );
+    }
+
+    /// Record a command exit event.
+    pub fn command_exit(&mut self, command: &str, exit_code: i32, duration: Duration) {
+        self.record(
+            TraceEventKind::CommandExit,
+            TraceEventDetails::CommandExit {
+                command: command.to_string(),
+                exit_code,
+                duration,
+            },
+        );
+    }
+
+    /// Record a file access event.
+    pub fn file_access(&mut self, path: &str, action: &str) {
+        self.record(
+            TraceEventKind::FileAccess,
+            TraceEventDetails::FileAccess {
+                path: path.to_string(),
+                action: action.to_string(),
+            },
+        );
+    }
+
+    /// Record a file mutation event.
+    pub fn file_mutation(&mut self, path: &str, action: &str) {
+        self.record(
+            TraceEventKind::FileMutation,
+            TraceEventDetails::FileMutation {
+                path: path.to_string(),
+                action: action.to_string(),
+            },
+        );
+    }
+
+    /// Record a policy denied event.
+    pub fn policy_denied(&mut self, subject: &str, reason: &str, action: &str) {
+        self.record(
+            TraceEventKind::PolicyDenied,
+            TraceEventDetails::PolicyDenied {
+                subject: subject.to_string(),
+                reason: reason.to_string(),
+                action: action.to_string(),
+            },
+        );
+    }
+}
+
+// Secret patterns to redact in Redacted mode.
+const SECRET_SUFFIXES: &[&str] = &[
+    "_KEY",
+    "_SECRET",
+    "_TOKEN",
+    "_PASSWORD",
+    "_PASS",
+    "_CREDENTIAL",
+];
+const SECRET_HEADERS: &[&str] = &["authorization", "x-api-key", "x-auth-token"];
+
+/// Redact secret patterns from trace event details.
+fn redact_details(details: TraceEventDetails) -> TraceEventDetails {
+    match details {
+        TraceEventDetails::CommandStart { command, argv, cwd } => TraceEventDetails::CommandStart {
+            command,
+            argv: redact_argv(&argv),
+            cwd,
+        },
+        other => other,
+    }
+}
+
+/// Redact secret values in command arguments.
+fn redact_argv(argv: &[String]) -> Vec<String> {
+    let mut result = Vec::with_capacity(argv.len());
+    let mut redact_next = false;
+
+    for arg in argv {
+        if redact_next {
+            result.push("[REDACTED]".to_string());
+            redact_next = false;
+            continue;
+        }
+
+        let lower = arg.to_lowercase();
+
+        // Check for -H "Authorization: Bearer xxx" style headers
+        if lower == "-h" || lower == "--header" {
+            result.push(arg.clone());
+            redact_next = true;
+            continue;
+        }
+
+        // Check for "Authorization: xxx" or "Bearer xxx" inline
+        if SECRET_HEADERS
+            .iter()
+            .any(|h| lower.starts_with(&format!("{h}:")))
+        {
+            if let Some(colon_pos) = arg.find(':') {
+                result.push(format!("{}: [REDACTED]", &arg[..colon_pos]));
+            } else {
+                result.push("[REDACTED]".to_string());
+            }
+            continue;
+        }
+
+        // Check for KEY=value env-style assignments with secret suffixes
+        if let Some(eq_pos) = arg.find('=') {
+            let key = &arg[..eq_pos].to_uppercase();
+            if SECRET_SUFFIXES.iter().any(|s| key.ends_with(s)) {
+                result.push(format!("{}=[REDACTED]", &arg[..eq_pos]));
+                continue;
+            }
+        }
+
+        // Check for URL credentials (user:pass@host)
+        if arg.contains("://") && arg.contains('@') {
+            result.push(redact_url_credentials(arg));
+            continue;
+        }
+
+        result.push(arg.clone());
+    }
+
+    result
+}
+
+/// Redact credentials from a URL (user:pass@host → [REDACTED]@host).
+fn redact_url_credentials(url: &str) -> String {
+    if let Some(scheme_end) = url.find("://") {
+        let after_scheme = &url[scheme_end + 3..];
+        if let Some(at_pos) = after_scheme.find('@') {
+            return format!(
+                "{}://[REDACTED]@{}",
+                &url[..scheme_end],
+                &after_scheme[at_pos + 1..]
+            );
+        }
+    }
+    url.to_string()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_trace_mode_default_is_off() {
+        assert_eq!(TraceMode::default(), TraceMode::Off);
+    }
+
+    #[test]
+    fn test_collector_off_no_events() {
+        let mut c = TraceCollector::new(TraceMode::Off);
+        c.command_start("echo", &["hello".into()], "/home");
+        assert!(c.take_events().is_empty());
+    }
+
+    #[test]
+    fn test_collector_full_records() {
+        let mut c = TraceCollector::new(TraceMode::Full);
+        c.command_start("echo", &["hello".into()], "/home");
+        c.command_exit("echo", 0, Duration::from_millis(1));
+        let events = c.take_events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, TraceEventKind::CommandStart);
+        assert_eq!(events[1].kind, TraceEventKind::CommandExit);
+        assert_eq!(events[0].seq, 0);
+        assert_eq!(events[1].seq, 1);
+    }
+
+    #[test]
+    fn test_redact_authorization_header() {
+        let argv = vec![
+            "curl".into(),
+            "-H".into(),
+            "Authorization: Bearer secret123".into(),
+            "https://api.example.com".into(),
+        ];
+        let redacted = redact_argv(&argv);
+        assert_eq!(redacted[0], "curl");
+        assert_eq!(redacted[1], "-H");
+        assert_eq!(redacted[2], "[REDACTED]");
+        assert_eq!(redacted[3], "https://api.example.com");
+    }
+
+    #[test]
+    fn test_redact_inline_header() {
+        let argv = vec!["curl".into(), "Authorization: Bearer secret".into()];
+        let redacted = redact_argv(&argv);
+        assert_eq!(redacted[1], "Authorization: [REDACTED]");
+    }
+
+    #[test]
+    fn test_redact_env_secret() {
+        let argv = vec!["env".into(), "API_KEY=supersecret".into(), "command".into()];
+        let redacted = redact_argv(&argv);
+        assert_eq!(redacted[1], "API_KEY=[REDACTED]");
+    }
+
+    #[test]
+    fn test_redact_url_credentials() {
+        let url = "https://user:password@api.example.com/path";
+        let redacted = redact_url_credentials(url);
+        assert_eq!(redacted, "https://[REDACTED]@api.example.com/path");
+    }
+
+    #[test]
+    fn test_no_redact_normal_args() {
+        let argv = vec!["ls".into(), "-la".into(), "/tmp".into()];
+        let redacted = redact_argv(&argv);
+        assert_eq!(redacted, argv);
+    }
+
+    #[test]
+    fn test_collector_callback() {
+        use std::sync::{Arc, Mutex};
+        let count = Arc::new(Mutex::new(0u32));
+        let count_clone = count.clone();
+        let mut c = TraceCollector::new(TraceMode::Full);
+        c.set_callback(Box::new(move |_event| {
+            *count_clone.lock().unwrap() += 1;
+        }));
+        c.command_start("echo", &["hi".into()], "/");
+        c.file_access("/tmp/file", "read");
+        assert_eq!(*count.lock().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_redacted_mode_scrubs() {
+        let mut c = TraceCollector::new(TraceMode::Redacted);
+        c.command_start(
+            "curl",
+            &["-H".into(), "Authorization: Bearer secret".into()],
+            "/",
+        );
+        let events = c.take_events();
+        if let TraceEventDetails::CommandStart { argv, .. } = &events[0].details {
+            assert_eq!(argv[1], "[REDACTED]");
+        } else {
+            panic!("wrong event type");
+        }
+    }
+}

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -6,7 +6,8 @@
 //! Run with: `cargo test threat_`
 
 use bashkit::{
-    Bash, ExecutionLimits, FileSystem, FsLimits, InMemoryFs, MemoryLimits, OverlayFs, SessionLimits,
+    Bash, ExecutionLimits, FileSystem, FsLimits, InMemoryFs, MemoryLimits, OverlayFs,
+    SessionLimits, TraceEventDetails, TraceEventKind, TraceMode,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -3595,5 +3596,232 @@ echo "done"
         let r2 = bash2.exec(script).await.unwrap();
         assert_eq!(r1.exit_code, 0);
         assert_eq!(r2.exit_code, 0);
+    }
+}
+
+// =============================================================================
+// TRACE EVENT TESTS (TM-INF-019)
+// =============================================================================
+
+mod trace_events {
+    use super::*;
+
+    #[tokio::test]
+    async fn trace_off_produces_no_events() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Off).build();
+        let r = bash.exec("echo hello; echo world").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert!(r.events.is_empty(), "Off mode should produce no events");
+    }
+
+    #[tokio::test]
+    async fn trace_full_records_command_start_and_exit() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+        let r = bash.exec("echo hello").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert!(
+            r.events.len() >= 2,
+            "Full mode should record at least start+exit, got {}",
+            r.events.len()
+        );
+
+        // First event should be CommandStart for echo
+        assert_eq!(r.events[0].kind, TraceEventKind::CommandStart);
+        if let TraceEventDetails::CommandStart { command, argv, .. } = &r.events[0].details {
+            assert_eq!(command, "echo");
+            assert_eq!(argv, &["hello"]);
+        } else {
+            panic!("expected CommandStart details");
+        }
+
+        // Second event should be CommandExit for echo
+        assert_eq!(r.events[1].kind, TraceEventKind::CommandExit);
+        if let TraceEventDetails::CommandExit {
+            command, exit_code, ..
+        } = &r.events[1].details
+        {
+            assert_eq!(command, "echo");
+            assert_eq!(*exit_code, 0);
+        } else {
+            panic!("expected CommandExit details");
+        }
+    }
+
+    #[tokio::test]
+    async fn trace_full_multiple_commands() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+        let r = bash.exec("echo a; echo b; echo c").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+
+        // Should have start+exit for each of three echo commands
+        let starts: Vec<_> = r
+            .events
+            .iter()
+            .filter(|e| e.kind == TraceEventKind::CommandStart)
+            .collect();
+        let exits: Vec<_> = r
+            .events
+            .iter()
+            .filter(|e| e.kind == TraceEventKind::CommandExit)
+            .collect();
+        assert_eq!(starts.len(), 3, "3 commands should have 3 starts");
+        assert_eq!(exits.len(), 3, "3 commands should have 3 exits");
+    }
+
+    #[tokio::test]
+    async fn trace_full_seq_numbers_monotonic() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+        let r = bash.exec("echo a; echo b").await.unwrap();
+        assert!(r.events.len() >= 4);
+        for i in 1..r.events.len() {
+            assert!(
+                r.events[i].seq > r.events[i - 1].seq,
+                "seq numbers should be strictly monotonic"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn trace_redacted_scrubs_secrets_in_argv() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Redacted).build();
+        // Use printf to avoid actual HTTP call; the trace records the command start
+        let r = bash
+            .exec(r#"printf "%s\n" -H "Authorization: Bearer secret123" "https://api.example.com""#)
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert!(!r.events.is_empty());
+
+        // Check that no event leaks "secret123"
+        for event in &r.events {
+            if let TraceEventDetails::CommandStart { argv, .. } = &event.details {
+                for arg in argv {
+                    assert!(
+                        !arg.contains("secret123"),
+                        "Redacted mode should not leak secrets: {arg}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn trace_redacted_scrubs_env_secrets() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Redacted).build();
+        // printf with env-style key=value argument containing a secret suffix
+        let r = bash
+            .exec(r#"printf "%s" "API_KEY=supersecret""#)
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0);
+
+        for event in &r.events {
+            if let TraceEventDetails::CommandStart { argv, .. } = &event.details {
+                for arg in argv {
+                    assert!(
+                        !arg.contains("supersecret"),
+                        "Redacted mode should scrub env secrets: {arg}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn trace_full_does_not_scrub() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+        let r = bash
+            .exec(r#"printf "%s" "API_KEY=supersecret""#)
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0);
+
+        let mut found_secret = false;
+        for event in &r.events {
+            if let TraceEventDetails::CommandStart { argv, .. } = &event.details {
+                for arg in argv {
+                    if arg.contains("supersecret") {
+                        found_secret = true;
+                    }
+                }
+            }
+        }
+        assert!(found_secret, "Full mode should preserve raw secrets");
+    }
+
+    #[tokio::test]
+    async fn trace_callback_receives_events() {
+        use std::sync::{Arc, Mutex};
+        let count = Arc::new(Mutex::new(0u32));
+        let count_clone = count.clone();
+        let mut bash = Bash::builder()
+            .trace_mode(TraceMode::Full)
+            .on_trace_event(Box::new(move |_event| {
+                *count_clone.lock().unwrap() += 1;
+            }))
+            .build();
+        let r = bash.exec("echo hello").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+        let cb_count = *count.lock().unwrap();
+        assert!(
+            cb_count >= 2,
+            "callback should fire for at least start+exit, got {cb_count}"
+        );
+        // events should also be in the result
+        assert_eq!(r.events.len() as u32, cb_count);
+    }
+
+    #[tokio::test]
+    async fn trace_off_zero_overhead() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Off).build();
+        // Run a loop to verify no events accumulate
+        let r = bash
+            .exec("for i in $(seq 1 100); do echo $i; done")
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert!(r.events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn trace_records_function_calls() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+        let r = bash.exec("myfn() { echo inside; }; myfn").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+
+        // Should see start/exit for myfn and start/exit for echo inside it
+        let fn_starts: Vec<_> = r
+            .events
+            .iter()
+            .filter(|e| {
+                e.kind == TraceEventKind::CommandStart
+                    && matches!(&e.details, TraceEventDetails::CommandStart { command, .. } if command == "myfn")
+            })
+            .collect();
+        assert!(
+            !fn_starts.is_empty(),
+            "should record CommandStart for function call"
+        );
+    }
+
+    #[tokio::test]
+    async fn trace_records_command_not_found() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+        let r = bash.exec("nonexistent_command_xyz").await.unwrap();
+        assert_ne!(r.exit_code, 0);
+
+        // Should still get start+exit (exit code 127)
+        let exits: Vec<_> = r
+            .events
+            .iter()
+            .filter(|e| {
+                e.kind == TraceEventKind::CommandExit
+                    && matches!(&e.details, TraceEventDetails::CommandExit { exit_code, .. } if exit_code == &127)
+            })
+            .collect();
+        assert!(
+            !exits.is_empty(),
+            "should record CommandExit with code 127 for not-found"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `TraceMode` (Off/Redacted/Full), `TraceEvent`, `TraceCollector` with real-time callback
- Events collected in `ExecResult.events` — zero overhead when Off (default)
- Redacted mode scrubs secrets (Authorization headers, env vars, URL credentials)
- Extract `dispatch_command()` helper so trace start/exit wraps all command return paths uniformly
- 11 integration tests covering all modes, redaction, callbacks, monotonic seq numbers

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all pass
- [x] 11 new trace integration tests in `threat_model_tests.rs`
- [x] 10 unit tests in `trace.rs` for collector, redaction, callbacks

Closes #657