### PR TITLE
feat(fs): optional SearchCapable trait for indexed search

### DIFF
--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -505,52 +505,59 @@ impl Builtin for Grep {
             }
             vec![(stdin_name.to_string(), stdin_content)]
         } else if opts.recursive {
-            // Recursive mode: traverse directories
-            let mut inputs = Vec::new();
-            let mut dirs_to_process: Vec<std::path::PathBuf> = Vec::new();
+            // Try indexed search via SearchCapable if available
+            let search_result = try_indexed_search(&*ctx.fs, &opts, ctx.cwd);
 
-            for file in &opts.files {
-                let path = if file.starts_with('/') {
-                    std::path::PathBuf::from(file)
-                } else {
-                    ctx.cwd.join(file)
-                };
-                dirs_to_process.push(path);
-            }
+            if let Some(indexed_inputs) = search_result {
+                indexed_inputs
+            } else {
+                // Fallback: linear directory traversal
+                let mut inputs = Vec::new();
+                let mut dirs_to_process: Vec<std::path::PathBuf> = Vec::new();
 
-            while let Some(path) = dirs_to_process.pop() {
-                if let Ok(entries) = ctx.fs.read_dir(&path).await {
-                    for entry in entries {
-                        let entry_path = path.join(&entry.name);
-                        if entry.metadata.file_type.is_dir() {
-                            // Skip dirs matching --exclude-dir patterns
-                            if opts
-                                .exclude_dir_patterns
-                                .iter()
-                                .any(|p| glob_matches(&entry.name, p))
-                            {
-                                continue;
-                            }
-                            dirs_to_process.push(entry_path);
-                        } else if entry.metadata.file_type.is_file()
-                            && should_include_file(
-                                &entry.name,
-                                &opts.include_patterns,
-                                &opts.exclude_patterns,
-                            )
-                            && let Ok(content) = ctx.fs.read_file(&entry_path).await
-                        {
-                            let text = process_content(content, opts.binary_as_text);
-                            inputs.push((entry_path.to_string_lossy().into_owned(), text));
-                        }
-                    }
-                } else if let Ok(content) = ctx.fs.read_file(&path).await {
-                    // It's a file, not a directory
-                    let text = process_content(content, opts.binary_as_text);
-                    inputs.push((path.to_string_lossy().into_owned(), text));
+                for file in &opts.files {
+                    let path = if file.starts_with('/') {
+                        std::path::PathBuf::from(file)
+                    } else {
+                        ctx.cwd.join(file)
+                    };
+                    dirs_to_process.push(path);
                 }
+
+                while let Some(path) = dirs_to_process.pop() {
+                    if let Ok(entries) = ctx.fs.read_dir(&path).await {
+                        for entry in entries {
+                            let entry_path = path.join(&entry.name);
+                            if entry.metadata.file_type.is_dir() {
+                                // Skip dirs matching --exclude-dir patterns
+                                if opts
+                                    .exclude_dir_patterns
+                                    .iter()
+                                    .any(|p| glob_matches(&entry.name, p))
+                                {
+                                    continue;
+                                }
+                                dirs_to_process.push(entry_path);
+                            } else if entry.metadata.file_type.is_file()
+                                && should_include_file(
+                                    &entry.name,
+                                    &opts.include_patterns,
+                                    &opts.exclude_patterns,
+                                )
+                                && let Ok(content) = ctx.fs.read_file(&entry_path).await
+                            {
+                                let text = process_content(content, opts.binary_as_text);
+                                inputs.push((entry_path.to_string_lossy().into_owned(), text));
+                            }
+                        }
+                    } else if let Ok(content) = ctx.fs.read_file(&path).await {
+                        // It's a file, not a directory
+                        let text = process_content(content, opts.binary_as_text);
+                        inputs.push((path.to_string_lossy().into_owned(), text));
+                    }
+                }
+                inputs
             }
-            inputs
         } else {
             // Read from specified files
             let mut inputs = Vec::new();
@@ -850,6 +857,63 @@ impl Builtin for Grep {
 
         Ok(ExecResult::with_code(output, exit_code))
     }
+}
+
+/// Try to use an indexed search provider for recursive grep.
+///
+/// Returns `Some(inputs)` if a `SearchCapable` provider handled the search,
+/// `None` to fall back to linear scan.
+fn try_indexed_search(
+    fs: &dyn crate::fs::FileSystem,
+    opts: &GrepOptions,
+    cwd: &std::path::Path,
+) -> Option<Vec<(String, String)>> {
+    let sc = fs.as_search_capable()?;
+    let root = if let Some(first) = opts.files.first() {
+        if first.starts_with('/') {
+            std::path::PathBuf::from(first)
+        } else {
+            cwd.join(first)
+        }
+    } else {
+        cwd.to_path_buf()
+    };
+    let provider = sc.search_provider(&root)?;
+    let caps = provider.capabilities();
+    if !caps.content_search {
+        return None;
+    }
+
+    // Build combined pattern string
+    let pattern = opts.patterns.join("|");
+    let query = crate::fs::SearchQuery {
+        pattern,
+        is_regex: !opts.fixed_strings && caps.regex,
+        case_insensitive: opts.ignore_case,
+        root,
+        glob_filter: opts.include_patterns.first().cloned(),
+        max_results: opts.max_count,
+    };
+
+    let results = provider.search(&query).ok()?;
+
+    // Group matches by file path to build (filename, content) pairs
+    let mut file_map: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for m in &results.matches {
+        let key = m.path.to_string_lossy().into_owned();
+        file_map
+            .entry(key)
+            .or_default()
+            .push(m.line_content.clone());
+    }
+
+    Some(
+        file_map
+            .into_iter()
+            .map(|(path, lines)| (path, lines.join("\n")))
+            .collect(),
+    )
 }
 
 #[cfg(test)]

--- a/crates/bashkit/src/fs/mod.rs
+++ b/crates/bashkit/src/fs/mod.rs
@@ -397,6 +397,7 @@ mod overlay;
 mod posix;
 #[cfg(feature = "realfs")]
 mod realfs;
+mod search;
 mod traits;
 
 pub use backend::FsBackend;
@@ -407,6 +408,10 @@ pub use overlay::OverlayFs;
 pub use posix::PosixFs;
 #[cfg(feature = "realfs")]
 pub use realfs::{RealFs, RealFsMode};
+#[allow(unused_imports)]
+pub use search::{
+    SearchCapabilities, SearchCapable, SearchMatch, SearchProvider, SearchQuery, SearchResults,
+};
 #[allow(unused_imports)]
 pub use traits::{DirEntry, FileSystem, FileType, Metadata, fs_errors};
 

--- a/crates/bashkit/src/fs/search.rs
+++ b/crates/bashkit/src/fs/search.rs
@@ -1,0 +1,297 @@
+// SearchCapable is a separate opt-in trait — FileSystem unchanged.
+// Builtins (grep) check via downcast at runtime, fall back to linear scan.
+
+//! Optional indexed search support for filesystem implementations.
+//!
+//! The [`SearchCapable`] trait allows filesystem implementations to provide
+//! optimized content and filename search. Commands like `grep` check for this
+//! at runtime via [`Any`] downcast and fall back to linear scanning when
+//! unavailable.
+//!
+//! # Implementing SearchCapable
+//!
+//! ```rust,ignore
+//! use bashkit::fs::{FileSystem, SearchCapable, SearchProvider, SearchQuery, SearchResult};
+//!
+//! struct IndexedFs { /* ... */ }
+//!
+//! impl SearchCapable for IndexedFs {
+//!     fn search_provider(&self, path: &Path) -> Option<Box<dyn SearchProvider>> {
+//!         Some(Box::new(MyProvider::new(path)))
+//!     }
+//! }
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+
+/// Optional trait for filesystems that support indexed search.
+///
+/// Builtins check for this via downcast and use it when available.
+/// Not implementing this trait has zero cost — builtins fall back
+/// to linear file enumeration.
+pub trait SearchCapable: super::FileSystem {
+    /// Returns a search provider scoped to the given path.
+    /// Returns `None` if no index covers this path.
+    fn search_provider(&self, path: &Path) -> Option<Box<dyn SearchProvider>>;
+}
+
+/// Provides content and filename search within a filesystem scope.
+pub trait SearchProvider: Send + Sync {
+    /// Execute a content search query.
+    fn search(&self, query: &SearchQuery) -> Result<SearchResults>;
+
+    /// Report what this provider can do.
+    fn capabilities(&self) -> SearchCapabilities;
+}
+
+/// Parameters for a search query.
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    /// Pattern to search for.
+    pub pattern: String,
+    /// Whether the pattern is a regex (vs literal string).
+    pub is_regex: bool,
+    /// Case-insensitive matching.
+    pub case_insensitive: bool,
+    /// Root path to scope the search.
+    pub root: PathBuf,
+    /// Optional glob filter for filenames (e.g., `"*.rs"`).
+    pub glob_filter: Option<String>,
+    /// Maximum number of results to return.
+    pub max_results: Option<usize>,
+}
+
+/// Results from a search query.
+#[derive(Debug, Clone, Default)]
+pub struct SearchResults {
+    /// Matching lines.
+    pub matches: Vec<SearchMatch>,
+    /// Whether results were truncated due to `max_results`.
+    pub truncated: bool,
+}
+
+/// A single match from a search.
+#[derive(Debug, Clone)]
+pub struct SearchMatch {
+    /// Path to the file containing the match.
+    pub path: PathBuf,
+    /// 1-based line number within the file.
+    pub line_number: usize,
+    /// Content of the matching line (without trailing newline).
+    pub line_content: String,
+}
+
+/// Describes what a search provider supports.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SearchCapabilities {
+    /// Supports regex patterns.
+    pub regex: bool,
+    /// Supports glob-based file filtering.
+    pub glob_filter: bool,
+    /// Supports content (full-text) search.
+    pub content_search: bool,
+    /// Supports filename search.
+    pub filename_search: bool,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::fs::{FileSystem, InMemoryFs};
+
+    /// Mock searchable filesystem for testing.
+    struct MockSearchFs {
+        inner: InMemoryFs,
+    }
+
+    impl MockSearchFs {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryFs::new(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl FileSystem for MockSearchFs {
+        async fn read_file(&self, path: &Path) -> Result<Vec<u8>> {
+            self.inner.read_file(path).await
+        }
+        async fn write_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+            self.inner.write_file(path, content).await
+        }
+        async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()> {
+            self.inner.append_file(path, content).await
+        }
+        async fn mkdir(&self, path: &Path, recursive: bool) -> Result<()> {
+            self.inner.mkdir(path, recursive).await
+        }
+        async fn remove(&self, path: &Path, recursive: bool) -> Result<()> {
+            self.inner.remove(path, recursive).await
+        }
+        async fn stat(&self, path: &Path) -> Result<crate::fs::Metadata> {
+            self.inner.stat(path).await
+        }
+        async fn read_dir(&self, path: &Path) -> Result<Vec<crate::fs::DirEntry>> {
+            self.inner.read_dir(path).await
+        }
+        async fn exists(&self, path: &Path) -> Result<bool> {
+            self.inner.exists(path).await
+        }
+        async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+            self.inner.rename(from, to).await
+        }
+        async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+            self.inner.copy(from, to).await
+        }
+        async fn symlink(&self, target: &Path, link: &Path) -> Result<()> {
+            self.inner.symlink(target, link).await
+        }
+        async fn read_link(&self, path: &Path) -> Result<std::path::PathBuf> {
+            self.inner.read_link(path).await
+        }
+        async fn chmod(&self, path: &Path, mode: u32) -> Result<()> {
+            self.inner.chmod(path, mode).await
+        }
+        fn as_search_capable(&self) -> Option<&dyn SearchCapable> {
+            Some(self)
+        }
+    }
+
+    struct MockProvider {
+        results: Vec<SearchMatch>,
+    }
+
+    impl SearchProvider for MockProvider {
+        fn search(&self, _query: &SearchQuery) -> Result<SearchResults> {
+            Ok(SearchResults {
+                matches: self.results.clone(),
+                truncated: false,
+            })
+        }
+        fn capabilities(&self) -> SearchCapabilities {
+            SearchCapabilities {
+                regex: true,
+                glob_filter: true,
+                content_search: true,
+                filename_search: false,
+            }
+        }
+    }
+
+    impl SearchCapable for MockSearchFs {
+        fn search_provider(&self, _path: &Path) -> Option<Box<dyn SearchProvider>> {
+            Some(Box::new(MockProvider {
+                results: vec![SearchMatch {
+                    path: PathBuf::from("/test.txt"),
+                    line_number: 1,
+                    line_content: "hello world".to_string(),
+                }],
+            }))
+        }
+    }
+
+    #[test]
+    fn search_query_defaults() {
+        let q = SearchQuery {
+            pattern: "test".into(),
+            is_regex: false,
+            case_insensitive: false,
+            root: PathBuf::from("/"),
+            glob_filter: None,
+            max_results: None,
+        };
+        assert_eq!(q.pattern, "test");
+        assert!(!q.is_regex);
+    }
+
+    #[test]
+    fn search_capabilities_default() {
+        let c = SearchCapabilities::default();
+        assert!(!c.regex);
+        assert!(!c.glob_filter);
+        assert!(!c.content_search);
+        assert!(!c.filename_search);
+    }
+
+    #[test]
+    fn mock_provider_returns_results() {
+        let provider = MockProvider {
+            results: vec![SearchMatch {
+                path: PathBuf::from("/a.txt"),
+                line_number: 5,
+                line_content: "found it".into(),
+            }],
+        };
+        let r = provider
+            .search(&SearchQuery {
+                pattern: "found".into(),
+                is_regex: false,
+                case_insensitive: false,
+                root: PathBuf::from("/"),
+                glob_filter: None,
+                max_results: None,
+            })
+            .unwrap();
+        assert_eq!(r.matches.len(), 1);
+        assert_eq!(r.matches[0].line_number, 5);
+        assert!(!r.truncated);
+    }
+
+    #[test]
+    fn mock_searchable_fs_provides_search() {
+        let fs = MockSearchFs::new();
+        let provider = fs.search_provider(Path::new("/")).unwrap();
+        assert!(provider.capabilities().content_search);
+        let r = provider
+            .search(&SearchQuery {
+                pattern: "hello".into(),
+                is_regex: false,
+                case_insensitive: false,
+                root: PathBuf::from("/"),
+                glob_filter: None,
+                max_results: None,
+            })
+            .unwrap();
+        assert_eq!(r.matches.len(), 1);
+        assert_eq!(r.matches[0].line_content, "hello world");
+    }
+
+    #[test]
+    fn as_search_capable_returns_provider() {
+        let fs = MockSearchFs::new();
+        // MockSearchFs implements SearchCapable, so as_search_capable returns Some
+        let sc = fs.as_search_capable().unwrap();
+        let provider = sc.search_provider(Path::new("/")).unwrap();
+        assert!(provider.capabilities().content_search);
+    }
+
+    #[test]
+    fn non_searchable_fs_returns_none() {
+        let fs = InMemoryFs::new();
+        // InMemoryFs does NOT implement SearchCapable — returns None
+        assert!(fs.as_search_capable().is_none());
+    }
+
+    #[test]
+    fn search_results_default_is_empty() {
+        let r = SearchResults::default();
+        assert!(r.matches.is_empty());
+        assert!(!r.truncated);
+    }
+
+    #[test]
+    fn search_match_debug() {
+        let m = SearchMatch {
+            path: PathBuf::from("/test.txt"),
+            line_number: 42,
+            line_content: "hello".into(),
+        };
+        let dbg = format!("{:?}", m);
+        assert!(dbg.contains("test.txt"));
+        assert!(dbg.contains("42"));
+    }
+}

--- a/crates/bashkit/src/fs/traits.rs
+++ b/crates/bashkit/src/fs/traits.rs
@@ -323,6 +323,16 @@ pub trait FileSystem: Send + Sync {
     fn limits(&self) -> FsLimits {
         FsLimits::unlimited()
     }
+
+    /// Returns a reference to this filesystem as a [`SearchCapable`](super::SearchCapable)
+    /// implementation, if supported.
+    ///
+    /// Builtins like `grep` call this to check for optimized search support.
+    /// Returns `None` by default — override in implementations that provide
+    /// indexed search.
+    fn as_search_capable(&self) -> Option<&dyn super::SearchCapable> {
+        None
+    }
 }
 
 /// File or directory metadata.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -420,7 +420,8 @@ pub use builtins::{Builtin, Context as BuiltinContext};
 pub use error::{Error, Result};
 pub use fs::{
     DirEntry, FileSystem, FileType, FsBackend, FsLimitExceeded, FsLimits, FsUsage, InMemoryFs,
-    Metadata, MountableFs, OverlayFs, PosixFs, VfsSnapshot, normalize_path,
+    Metadata, MountableFs, OverlayFs, PosixFs, SearchCapabilities, SearchCapable, SearchMatch,
+    SearchProvider, SearchQuery, SearchResults, VfsSnapshot, normalize_path,
     verify_filesystem_requirements,
 };
 #[cfg(feature = "realfs")]


### PR DESCRIPTION
## Summary
- Add `SearchCapable`, `SearchProvider`, `SearchQuery`, `SearchResults` types as opt-in VFS extension
- `FileSystem` gains `as_search_capable()` with default `None` — zero cost when unused
- `grep` builtin checks for indexed search in recursive mode, falls back to linear scan
- 8 unit tests for mock provider, capabilities, and runtime discovery

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all pass
- [x] Unit tests with mock SearchCapable implementation
- [x] Existing grep tests unaffected (no regression)

Closes #658