### PR TITLE
fix(interpreter): declare -a/-i and local -a with inline init

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -206,6 +206,7 @@ pub(crate) fn is_internal_variable(name: &str) -> bool {
         || name.starts_with("_READONLY_")
         || name.starts_with("_UPPER_")
         || name.starts_with("_LOWER_")
+        || name.starts_with("_INTEGER_")
         || name.starts_with("_ARRAY_READ_")
         || name == "_EVAL_CMD"
         || name == "_SHIFT_COUNT"
@@ -5284,14 +5285,21 @@ impl Interpreter {
         args: &[String],
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
-        // Parse flags: -n for nameref
+        // Parse flags: -n for nameref, -a for indexed array, -A for assoc, -i for integer
         let mut is_nameref = false;
+        let mut is_array = false;
+        let mut is_assoc = false;
+        let mut is_integer = false;
         let mut var_args: Vec<&String> = Vec::new();
         for arg in args {
             if arg.starts_with('-') && !arg.contains('=') {
                 for c in arg[1..].chars() {
-                    if c == 'n' {
-                        is_nameref = true;
+                    match c {
+                        'n' => is_nameref = true,
+                        'a' => is_array = true,
+                        'A' => is_assoc = true,
+                        'i' => is_integer = true,
+                        _ => {}
                     }
                 }
             } else {
@@ -5299,9 +5307,31 @@ impl Interpreter {
             }
         }
 
-        if let Some(frame) = self.call_stack.last_mut() {
+        // Reconstruct compound assignments: local -a arr=(1 2 3)
+        // Args may be split: ["arr=(1", "2", "3)"]
+        let mut merged: Vec<String> = Vec::new();
+        let mut pending: Option<String> = None;
+        for arg in &var_args {
+            if let Some(ref mut p) = pending {
+                p.push(' ');
+                p.push_str(arg);
+                if arg.ends_with(')') {
+                    merged.push(p.clone());
+                    pending = None;
+                }
+            } else if arg.contains("=(") && !arg.ends_with(')') {
+                pending = Some(arg.to_string());
+            } else {
+                merged.push(arg.to_string());
+            }
+        }
+        if let Some(p) = pending {
+            merged.push(p);
+        }
+
+        if !self.call_stack.is_empty() {
             // In a function - set in locals
-            for arg in &var_args {
+            for arg in &merged {
                 if let Some(eq_pos) = arg.find('=') {
                     let var_name = &arg[..eq_pos];
                     let value = &arg[eq_pos + 1..];
@@ -5316,18 +5346,96 @@ impl Interpreter {
                     if is_internal_variable(var_name) {
                         continue;
                     }
-                    if is_nameref {
-                        frame.locals.insert(var_name.to_string(), String::new());
+                    // Handle compound array assignment: local -a arr=(1 2 3)
+                    if (is_array || is_assoc) && value.starts_with('(') && value.ends_with(')') {
+                        let inner = &value[1..value.len() - 1];
+                        if is_assoc {
+                            let arr = self.assoc_arrays.entry(var_name.to_string()).or_default();
+                            arr.clear();
+                            let mut rest = inner.trim();
+                            while let Some(bracket_start) = rest.find('[') {
+                                if let Some(bracket_end) = rest[bracket_start..].find(']') {
+                                    let key = &rest[bracket_start + 1..bracket_start + bracket_end];
+                                    let after = &rest[bracket_start + bracket_end + 1..];
+                                    if let Some(eq_rest) = after.strip_prefix('=') {
+                                        let eq_rest = eq_rest.trim_start();
+                                        let (val, remainder) =
+                                            if let Some(stripped) = eq_rest.strip_prefix('"') {
+                                                if let Some(end_q) = stripped.find('"') {
+                                                    (
+                                                        &stripped[..end_q],
+                                                        stripped[end_q + 1..].trim_start(),
+                                                    )
+                                                } else {
+                                                    (stripped.trim_end_matches('"'), "")
+                                                }
+                                            } else {
+                                                match eq_rest.find(char::is_whitespace) {
+                                                    Some(sp) => {
+                                                        (&eq_rest[..sp], eq_rest[sp..].trim_start())
+                                                    }
+                                                    None => (eq_rest, ""),
+                                                }
+                                            };
+                                        arr.insert(key.to_string(), val.to_string());
+                                        rest = remainder;
+                                    } else {
+                                        break;
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                        } else {
+                            let arr = self.arrays.entry(var_name.to_string()).or_default();
+                            arr.clear();
+                            for (idx, val) in inner.split_whitespace().enumerate() {
+                                arr.insert(idx, val.trim_matches('"').to_string());
+                            }
+                        }
+                        // Mark local
+                        self.call_stack
+                            .last_mut()
+                            .unwrap()
+                            .locals
+                            .insert(var_name.to_string(), String::new());
+                    } else if is_nameref {
+                        self.call_stack
+                            .last_mut()
+                            .unwrap()
+                            .locals
+                            .insert(var_name.to_string(), String::new());
+                    } else if is_integer {
+                        let int_val = self.evaluate_arithmetic_with_assign(value);
+                        self.call_stack
+                            .last_mut()
+                            .unwrap()
+                            .locals
+                            .insert(var_name.to_string(), int_val.to_string());
+                        self.variables
+                            .insert(format!("_INTEGER_{}", var_name), "1".to_string());
                     } else {
-                        frame.locals.insert(var_name.to_string(), value.to_string());
+                        self.call_stack
+                            .last_mut()
+                            .unwrap()
+                            .locals
+                            .insert(var_name.to_string(), value.to_string());
                     }
                 } else if !is_internal_variable(arg) {
-                    frame.locals.insert(arg.to_string(), String::new());
+                    self.call_stack
+                        .last_mut()
+                        .unwrap()
+                        .locals
+                        .insert(arg.to_string(), String::new());
+                    if is_integer {
+                        self.variables
+                            .insert(format!("_INTEGER_{}", arg), "1".to_string());
+                    }
                 }
             }
             // Set nameref markers (after frame borrow is released)
             if is_nameref {
-                for arg in &var_args {
+                for arg in &merged {
                     if let Some(eq_pos) = arg.find('=') {
                         let var_name = &arg[..eq_pos];
                         let value = &arg[eq_pos + 1..];
@@ -5340,7 +5448,7 @@ impl Interpreter {
             }
         } else {
             // Not in a function - set in global variables (bash behavior)
-            for arg in &var_args {
+            for arg in &merged {
                 if let Some(eq_pos) = arg.find('=') {
                     let var_name = &arg[..eq_pos];
                     let value = &arg[eq_pos + 1..];
@@ -6567,6 +6675,9 @@ impl Interpreter {
                     // Evaluate as arithmetic expression
                     let int_val = self.evaluate_arithmetic_with_assign(value);
                     self.insert_variable_checked(var_name.to_string(), int_val.to_string());
+                    // Set persistent integer attribute marker
+                    self.variables
+                        .insert(format!("_INTEGER_{}", var_name), "1".to_string());
                 } else {
                     // Apply case conversion attributes
                     let final_value = if is_lowercase {
@@ -6636,6 +6747,10 @@ impl Interpreter {
                 if is_readonly {
                     self.variables
                         .insert(format!("_READONLY_{}", name), "1".to_string());
+                }
+                if is_integer {
+                    self.variables
+                        .insert(format!("_INTEGER_{}", name), "1".to_string());
                 }
                 if is_export {
                     self.env.insert(
@@ -8807,6 +8922,17 @@ impl Interpreter {
         }
         // Resolve nameref: if `name` is a nameref, assign to the target instead
         let resolved = self.resolve_nameref(&name).to_string();
+        // Apply integer attribute (declare -i): evaluate as arithmetic
+        let value = if self
+            .variables
+            .get(&format!("_INTEGER_{}", resolved))
+            .map(|v| v == "1")
+            .unwrap_or(false)
+        {
+            self.evaluate_arithmetic_with_assign(&value).to_string()
+        } else {
+            value
+        };
         // Apply case conversion attributes (declare -l / declare -u)
         let value = if self
             .variables

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -744,7 +744,6 @@ impl<'a> Lexer<'a> {
             } else if ch == '(' && word.ends_with('=') && self.looks_like_assoc_assign() {
                 // Associative compound assignment: var=([k]="v" ...) — keep entire
                 // (...) as part of word so declare -A m=([k]="v") stays one token.
-                // Regular indexed arr=(a b "c d") is left for parser token-by-token path.
                 word.push(ch);
                 self.advance();
                 let mut depth = 1;

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -1852,6 +1852,59 @@ impl<'a> Parser<'a> {
                         }
                     }
 
+                    // Handle compound array assignment in arg position:
+                    // declare -a arr=(x y z) → arr=(x y z) as single arg
+                    if w.ends_with('=') && !words.is_empty() {
+                        // Peek at next token — if LeftParen, collect compound assignment
+                        let saved_w = w.clone();
+                        self.advance();
+                        if matches!(self.current_token, Some(tokens::Token::LeftParen)) {
+                            self.advance(); // consume '('
+                            let mut compound = saved_w;
+                            compound.push('(');
+                            loop {
+                                match &self.current_token {
+                                    Some(tokens::Token::RightParen) => {
+                                        compound.push(')');
+                                        self.advance();
+                                        break;
+                                    }
+                                    Some(tokens::Token::Word(elem))
+                                    | Some(tokens::Token::LiteralWord(elem))
+                                    | Some(tokens::Token::QuotedWord(elem)) => {
+                                        if !compound.ends_with('(') {
+                                            compound.push(' ');
+                                        }
+                                        compound.push_str(elem);
+                                        self.advance();
+                                    }
+                                    None => break,
+                                    _ => {
+                                        self.advance();
+                                    }
+                                }
+                            }
+                            let word = self.parse_word(compound);
+                            words.push(word);
+                            continue;
+                        }
+                        // Not a compound assignment — treat as regular word
+                        let word = if is_literal {
+                            Word {
+                                parts: vec![WordPart::Literal(saved_w)],
+                                quoted: true,
+                            }
+                        } else {
+                            let mut word = self.parse_word(saved_w);
+                            if is_quoted {
+                                word.quoted = true;
+                            }
+                            word
+                        };
+                        words.push(word);
+                        continue;
+                    }
+
                     let word = if is_literal {
                         Word {
                             parts: vec![WordPart::Literal(w.clone())],

--- a/crates/bashkit/tests/spec_cases/bash/blackbox-edge-cases.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/blackbox-edge-cases.test.sh
@@ -282,12 +282,11 @@ declare -A m; m[a]=1; m[b]=2; unset m[a]; echo ${#m[@]}
 ### end
 
 ### declare_i_arithmetic
-### bash_diff: declare -i does not auto-evaluate arithmetic in assignments (#664)
-# Integer variable auto-evaluates — bash: "8\n8", bashkit: "3+5\n2 * 4"
+# Integer variable auto-evaluates arithmetic in assignments
 declare -i x; x=3+5; echo $x; x="2 * 4"; echo $x
 ### expect
-3+5
-2 * 4
+8
+8
 ### end
 
 ### trap_debug

--- a/crates/bashkit/tests/spec_cases/bash/blackbox-exploration.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/blackbox-exploration.test.sh
@@ -1112,11 +1112,10 @@ hello123
 ### end
 
 ### declare_a_array
-### bash_diff: declare -a arr=(...) does not initialize the array with values (#664)
-# declare -a explicit array — bash: "3 y", bashkit: "0"
+# declare -a explicit array
 declare -a arr=(x y z); echo ${#arr[@]} ${arr[1]}
 ### expect
-0
+3 y
 ### end
 
 ### readonly_variable
@@ -1283,11 +1282,10 @@ inner: HELLO
 ### end
 
 ### function_with_local_array
-### bash_diff: local -a arr=(...) does not initialize array with values (#664)
-# Function with local array — bash: "1 2 3", bashkit: empty
+# Function with local array
 f() { local -a arr=(1 2 3); result=${arr[@]}; [ -n "$result" ] && echo "$result" || echo "EMPTY"; }; f
 ### expect
-EMPTY
+1 2 3
 ### end
 
 ### getopts_basic


### PR DESCRIPTION
## Summary
- Parser collects compound assignment `=(…)` in arg position for declare/local
- `declare -a arr=(x y z)` now initializes array with values
- `declare -i` sets persistent `_INTEGER_` marker; subsequent assignments auto-evaluate arithmetic
- `local -a/-A/-i` flags supported with compound assignment
- `set_variable()` respects `_INTEGER_` marker on assignment

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all pass
- [x] `declare_a_array` spec test updated: `3 y` (was `0`)
- [x] `function_with_local_array` spec test updated: `1 2 3` (was `EMPTY`)
- [x] `declare_i_arithmetic` spec test updated: `8\n8` (was `3+5\n2 * 4`)

Closes #664