### PR TITLE
fix(interpreter): block readonly variable bypass via unset/declare/export (TM-INJ-019/020/021)

### DIFF
--- a/crates/bashkit/src/builtins/export.rs
+++ b/crates/bashkit/src/builtins/export.rs
@@ -39,9 +39,14 @@ impl Builtin for Export {
                     ));
                 }
                 // THREAT[TM-INJ-015]: Block internal variable prefix injection via export
-                if !is_internal_variable(name) {
-                    ctx.variables.insert(name.to_string(), value.to_string());
+                if is_internal_variable(name) {
+                    continue;
                 }
+                // THREAT[TM-INJ-021]: Refuse to overwrite readonly variables
+                if ctx.variables.contains_key(&format!("_READONLY_{}", name)) {
+                    continue;
+                }
+                ctx.variables.insert(name.to_string(), value.to_string());
             } else {
                 // Just marking for export - in our model this is a no-op
                 // unless the variable exists, in which case we keep it

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5802,6 +5802,13 @@ impl Interpreter {
                 self.variables.remove(&format!("_NAMEREF_{}", arg));
             } else {
                 let resolved = self.resolve_nameref(arg).to_string();
+                // THREAT[TM-INJ-019]: Refuse to unset readonly variables
+                if self
+                    .variables
+                    .contains_key(&format!("_READONLY_{}", resolved))
+                {
+                    continue;
+                }
                 self.variables.remove(&resolved);
                 self.arrays.remove(&resolved);
                 self.assoc_arrays.remove(&resolved);
@@ -6648,6 +6655,14 @@ impl Interpreter {
 
                 // THREAT[TM-INJ-012]: Block internal variable prefix injection via declare
                 if is_internal_variable(var_name) {
+                    continue;
+                }
+
+                // THREAT[TM-INJ-020]: Refuse to overwrite readonly variables
+                if self
+                    .variables
+                    .contains_key(&format!("_READONLY_{}", var_name))
+                {
                     continue;
                 }
 
@@ -8955,6 +8970,13 @@ impl Interpreter {
         }
         // Resolve nameref: if `name` is a nameref, assign to the target instead
         let resolved = self.resolve_nameref(&name).to_string();
+        // THREAT[TM-INJ-019/020/021]: Block assignment to readonly variables
+        if self
+            .variables
+            .contains_key(&format!("_READONLY_{}", resolved))
+        {
+            return;
+        }
         // Apply integer attribute (declare -i): evaluate as arithmetic
         let value = if self
             .variables

--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -233,11 +233,9 @@ mod finding_timeout_bypass {
 mod finding_readonly_bypass {
     use super::*;
 
-    /// TM-INJ-019: unset removes readonly variables.
-    /// Expected: unset should fail on readonly vars. Actual: variable is removed.
+    /// TM-INJ-019: unset cannot remove readonly variables.
     #[tokio::test]
-    #[ignore] // FINDING: readonly bypassed via unset
-    async fn unset_removes_readonly() {
+    async fn unset_cannot_remove_readonly() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
@@ -257,11 +255,9 @@ mod finding_readonly_bypass {
         );
     }
 
-    /// TM-INJ-020: declare overwrites readonly variables.
-    /// Expected: declare should fail on readonly vars. Actual: variable is overwritten.
+    /// TM-INJ-020: declare cannot overwrite readonly variables.
     #[tokio::test]
-    #[ignore] // FINDING: readonly bypassed via declare
-    async fn declare_overwrites_readonly() {
+    async fn declare_cannot_overwrite_readonly() {
         let mut bash = tight_bash();
         let result = bash
             .exec(
@@ -280,11 +276,9 @@ mod finding_readonly_bypass {
         );
     }
 
-    /// TM-INJ-021: export overwrites readonly variables.
-    /// Expected: export should fail on readonly vars. Actual: variable is overwritten.
+    /// TM-INJ-021: export cannot overwrite readonly variables.
     #[tokio::test]
-    #[ignore] // FINDING: readonly bypassed via export
-    async fn export_overwrites_readonly() {
+    async fn export_cannot_overwrite_readonly() {
         let mut bash = tight_bash();
         let result = bash
             .exec(


### PR DESCRIPTION
## Summary
- Add readonly checks to `unset`, `declare`, `export` builtins and `set_variable`
- Previously readonly variables could be removed via `unset`, overwritten via `declare` or `export`
- All paths now check `_READONLY_` marker and silently reject modifications

## Test plan
- [x] `cargo test --test blackbox_security_tests finding_readonly_bypass` — all 4 pass (3 unignored + 1 existing)
- [x] `cargo test --all-features` — all pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #683