### PR TITLE
fix(interpreter): reset transient state between exec() calls (TM-ISO-005/006/007)

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -691,6 +691,16 @@ impl Interpreter {
         &self.limits
     }
 
+    /// THREAT[TM-ISO-005/006/007]: Reset per-exec transient state.
+    /// Called by Bash::exec() before each top-level execution to prevent
+    /// traps, exit code, and shell options from leaking across calls.
+    pub fn reset_transient_state(&mut self) {
+        self.traps.clear();
+        self.last_exit_code = 0;
+        self.options = ShellOptions::default();
+        self.variables.retain(|k, _| !k.starts_with("SHOPT_"));
+    }
+
     /// Set an environment variable.
     pub fn set_env(&mut self, key: &str, value: &str) {
         self.env.insert(key.to_string(), value.to_string());
@@ -897,6 +907,10 @@ impl Interpreter {
         // Reset per-execution counters so each exec() gets a fresh budget.
         // Without this, hitting the limit in one exec() permanently poisons the session.
         self.counters.reset_for_execution();
+
+        // Note: per-exec state reset (traps, exit code, options) is done in
+        // Bash::exec() before calling this method, to avoid clearing state
+        // set by internal callers like execute_bash_builtin.
 
         // THREAT[TM-DOS-059]: Increment session-level exec call counter and
         // check session limits before starting execution.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -541,6 +541,9 @@ impl Bash {
     /// input size, then parses the script with a timeout, AST depth limit, and fuel limit,
     /// then executes the resulting AST.
     pub async fn exec(&mut self, script: &str) -> Result<ExecResult> {
+        // THREAT[TM-ISO-005/006/007]: Reset transient state between exec() calls
+        self.interpreter.reset_transient_state();
+
         // THREAT[TM-LOG-001]: Sensitive data in logs
         // Mitigation: Use LogConfig to redact sensitive script content
         #[cfg(feature = "logging")]

--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -331,12 +331,9 @@ mod finding_readonly_bypass {
 mod finding_trap_leak {
     use super::*;
 
-    /// TM-ISO-021: EXIT trap from one exec() fires in the next exec().
-    /// Expected: each exec() starts with clean trap state.
-    /// Actual: EXIT trap persists and fires on subsequent calls.
+    /// TM-ISO-005: EXIT trap from one exec() does not fire in the next exec().
     #[tokio::test]
-    #[ignore] // FINDING: EXIT trap leaks between exec() calls
-    async fn exit_trap_leaks_between_exec() {
+    async fn exit_trap_does_not_leak_between_exec() {
         let mut bash = tight_bash();
         let _ = bash.exec("trap 'echo LEAKED_TRAP' EXIT").await.unwrap();
         let result = bash.exec("echo clean_execution").await.unwrap();
@@ -356,12 +353,9 @@ mod finding_trap_leak {
 mod finding_exit_code_leak {
     use super::*;
 
-    /// TM-ISO-022: $? from one exec() leaks into the next.
-    /// Expected: $? should be 0 at start of each exec().
-    /// Actual: $? == 42 persists from previous `exit 42`.
+    /// TM-ISO-006: $? from one exec() does not leak into the next.
     #[tokio::test]
-    #[ignore] // FINDING: $? leaks across exec() calls
-    async fn exit_code_leaks_between_exec() {
+    async fn exit_code_does_not_leak_between_exec() {
         let mut bash = tight_bash();
         let _ = bash.exec("exit 42").await.unwrap();
         let result = bash.exec("echo $?").await.unwrap();
@@ -383,12 +377,9 @@ mod finding_exit_code_leak {
 mod finding_shell_options_leak {
     use super::*;
 
-    /// TM-ISO-023: set -e persists across exec() calls.
-    /// Expected: each exec() starts with default shell options.
-    /// Actual: set -e from previous exec causes abort on `false`.
+    /// TM-ISO-007: set -e does not persist across exec() calls.
     #[tokio::test]
-    #[ignore] // FINDING: set -e leaks across exec() calls
-    async fn set_e_leaks_between_exec() {
+    async fn set_e_does_not_leak_between_exec() {
         let mut bash = tight_bash();
         let _ = bash.exec("set -e").await;
         let result = bash.exec("false; echo 'survived'").await.unwrap();


### PR DESCRIPTION
## Summary
- Add `reset_transient_state()` method to clear traps, exit code, shell options, SHOPT_ vars
- Called from `Bash::exec()` (not `Interpreter::execute()`) to preserve state for internal callers like `bash -e -c '...'`
- Prevents EXIT trap, $?, and set -e from leaking across successive exec() calls

## Test plan
- [x] `cargo test --test blackbox_security_tests "does_not_leak"` — all 3 pass
- [x] `cargo test -p bashkit bash_spec_tests` — 100% pass rate (1699/1699)
- [x] `cargo test --test blackbox_security_tests` — 71 pass, 0 fail
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #684