### PR TITLE
fix(interpreter): prevent stack overflow in nested command substitution

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7099,6 +7099,12 @@ impl Interpreter {
                     }
                 }
                 WordPart::CommandSubstitution(commands) => {
+                    // THREAT[TM-DOS-044]: Track substitution depth to prevent stack overflow
+                    if self.counters.push_function(&self.limits).is_err() {
+                        return Err(crate::error::Error::Execution(
+                            "maximum nesting depth exceeded in command substitution".to_string(),
+                        ));
+                    }
                     // Execute the commands and capture stdout
                     let mut stdout = String::new();
                     for cmd in commands {
@@ -7107,6 +7113,7 @@ impl Interpreter {
                         // Propagate exit code from last command in substitution
                         self.last_exit_code = cmd_result.exit_code;
                     }
+                    self.counters.pop_function();
                     self.subst_generation += 1;
                     // Remove trailing newline (bash behavior)
                     let trimmed = stdout.trim_end_matches('\n');

--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -53,12 +53,9 @@ fn dos_bash() -> Bash {
 mod finding_nested_cmd_subst_stack_overflow {
     use super::*;
 
-    /// TM-DOS-044 regression: depth-50 nested command substitution crashes.
-    /// REPRODUCER: Generates `echo $(echo $(echo ... ))` 50 levels deep.
-    /// Expected: error or truncated result. Actual: SIGABRT (stack overflow).
+    /// TM-DOS-044: depth-50 nested command substitution is bounded.
     #[tokio::test]
-    #[ignore] // FINDING: stack overflow — crashes the process
-    async fn depth_50_crashes() {
+    async fn depth_50_is_bounded() {
         let mut bash = tight_bash();
         let depth = 50;
         let mut cmd = "echo hello".to_string();


### PR DESCRIPTION
## Summary
- Track command substitution nesting depth using `push_function`/`pop_function`
- Deeply nested `$(echo $(...))` patterns (depth 50+) now return an error instead of crashing with SIGABRT
- Un-ignores and renames the `depth_50_is_bounded` security test

## Test plan
- [x] `cargo test --test blackbox_security_tests finding_nested_cmd_subst` — both depth_10 and depth_50 pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green

Closes #687