### PR TITLE
fix(security): resolve code scanning and dependabot alerts

### DIFF
--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -5,6 +5,13 @@
 //!
 //! Exposes `Bash` (core interpreter), `BashTool` (interpreter + LLM metadata),
 //! and `ExecResult` via napi-rs for use from JavaScript/TypeScript.
+//!
+//! # Safety: Arc<SharedState> pattern
+//!
+//! Both `Bash` and `BashTool` wrap all mutable state in `Arc<SharedState>`.
+//! Every `#[napi]` method clones the `Arc` *before* doing any blocking or async
+//! work. This prevents CodeQL `rust/access-invalid-pointer` alerts caused by
+//! holding a raw-pointer-derived `&self` across `block_on` or `.await` points.
 
 use bashkit::tool::VERSION;
 use bashkit::{Bash as RustBash, BashTool as RustBashTool, ExecutionLimits, Tool};
@@ -59,6 +66,33 @@ fn default_opts() -> BashOptions {
 }
 
 // ============================================================================
+// SharedState — all mutable state behind Arc to avoid raw pointer issues
+// ============================================================================
+
+struct SharedState {
+    inner: Mutex<RustBash>,
+    rt: Mutex<tokio::runtime::Runtime>,
+    cancelled: Arc<AtomicBool>,
+    username: Option<String>,
+    hostname: Option<String>,
+    max_commands: Option<u32>,
+    max_loop_iterations: Option<u32>,
+}
+
+/// Clone `Arc<SharedState>`, then use the runtime to block on a future that
+/// captures only the cloned Arc. This avoids holding raw `&self` across
+/// `block_on` boundaries.
+fn block_on_with<Fut, T>(state: &Arc<SharedState>, f: impl FnOnce(Arc<SharedState>) -> Fut) -> T
+where
+    Fut: std::future::Future<Output = T>,
+{
+    let s = state.clone();
+    let rt_guard = s.rt.blocking_lock();
+    let s2 = state.clone();
+    rt_guard.block_on(f(s2))
+}
+
+// ============================================================================
 // Bash — core interpreter
 // ============================================================================
 
@@ -68,13 +102,7 @@ fn default_opts() -> BashOptions {
 /// available in subsequent calls.
 #[napi]
 pub struct Bash {
-    inner: Arc<Mutex<RustBash>>,
-    rt: tokio::runtime::Runtime,
-    cancelled: Arc<AtomicBool>,
-    username: Option<String>,
-    hostname: Option<String>,
-    max_commands: Option<u32>,
-    max_loop_iterations: Option<u32>,
+    state: Arc<SharedState>,
 }
 
 #[napi]
@@ -98,23 +126,24 @@ impl Bash {
             .map_err(|e| napi::Error::from_reason(format!("Failed to create runtime: {e}")))?;
 
         Ok(Self {
-            inner: Arc::new(Mutex::new(bash)),
-            rt,
-            cancelled,
-            username: opts.username,
-            hostname: opts.hostname,
-            max_commands: opts.max_commands,
-            max_loop_iterations: opts.max_loop_iterations,
+            state: Arc::new(SharedState {
+                inner: Mutex::new(bash),
+                rt: Mutex::new(rt),
+                cancelled,
+                username: opts.username,
+                hostname: opts.hostname,
+                max_commands: opts.max_commands,
+                max_loop_iterations: opts.max_loop_iterations,
+            }),
         })
     }
 
     /// Execute bash commands synchronously.
     #[napi]
     pub fn execute_sync(&self, commands: String) -> napi::Result<ExecResult> {
-        self.cancelled.store(false, Ordering::Relaxed);
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let mut bash = inner.lock().await;
+        self.state.cancelled.store(false, Ordering::Relaxed);
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
             match bash.exec(&commands).await {
                 Ok(result) => Ok(ExecResult {
                     stdout: result.stdout,
@@ -144,8 +173,8 @@ impl Bash {
     /// Execute bash commands asynchronously, returning a Promise.
     #[napi]
     pub async fn execute(&self, commands: String) -> napi::Result<ExecResult> {
-        let inner = self.inner.clone();
-        let mut bash = inner.lock().await;
+        let s = self.state.clone();
+        let mut bash = s.inner.lock().await;
         match bash.exec(&commands).await {
             Ok(result) => Ok(ExecResult {
                 stdout: result.stdout,
@@ -177,25 +206,19 @@ impl Bash {
     /// command boundary.
     #[napi]
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Relaxed);
+        self.state.cancelled.store(true, Ordering::Relaxed);
     }
 
     /// Reset interpreter to fresh state, preserving configuration.
     #[napi]
     pub fn reset(&self) -> napi::Result<()> {
-        let inner = self.inner.clone();
-        let username = self.username.clone();
-        let hostname = self.hostname.clone();
-        let max_commands = self.max_commands;
-        let max_loop_iterations = self.max_loop_iterations;
-
-        self.rt.block_on(async move {
-            let mut bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
             let new_bash = build_bash(
-                username.as_deref(),
-                hostname.as_deref(),
-                max_commands,
-                max_loop_iterations,
+                s.username.as_deref(),
+                s.hostname.as_deref(),
+                s.max_commands,
+                s.max_loop_iterations,
                 None,
             );
             *bash = new_bash;
@@ -210,9 +233,8 @@ impl Bash {
     /// Read a file from the virtual filesystem. Returns contents as a UTF-8 string.
     #[napi]
     pub fn read_file(&self, path: String) -> napi::Result<String> {
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
             let bytes = bash
                 .fs()
                 .read_file(Path::new(&path))
@@ -227,9 +249,8 @@ impl Bash {
     /// Creates the file if it doesn't exist, replaces contents if it does.
     #[napi]
     pub fn write_file(&self, path: String, content: String) -> napi::Result<()> {
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
             bash.fs()
                 .write_file(Path::new(&path), content.as_bytes())
                 .await
@@ -240,9 +261,8 @@ impl Bash {
     /// Create a directory. If recursive is true, creates parent directories as needed.
     #[napi]
     pub fn mkdir(&self, path: String, recursive: Option<bool>) -> napi::Result<()> {
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
             bash.fs()
                 .mkdir(Path::new(&path), recursive.unwrap_or(false))
                 .await
@@ -253,9 +273,8 @@ impl Bash {
     /// Check if a path exists in the virtual filesystem.
     #[napi]
     pub fn exists(&self, path: String) -> napi::Result<bool> {
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
             bash.fs()
                 .exists(Path::new(&path))
                 .await
@@ -266,9 +285,8 @@ impl Bash {
     /// Remove a file or directory. If recursive is true, removes directory contents.
     #[napi]
     pub fn remove(&self, path: String, recursive: Option<bool>) -> napi::Result<()> {
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
             bash.fs()
                 .remove(Path::new(&path), recursive.unwrap_or(false))
                 .await
@@ -287,31 +305,25 @@ impl Bash {
 /// Use this when integrating with AI frameworks that need tool definitions.
 #[napi]
 pub struct BashTool {
-    inner: Arc<Mutex<RustBash>>,
-    rt: tokio::runtime::Runtime,
-    cancelled: Arc<AtomicBool>,
-    username: Option<String>,
-    hostname: Option<String>,
-    max_commands: Option<u32>,
-    max_loop_iterations: Option<u32>,
+    state: Arc<SharedState>,
 }
 
 impl BashTool {
-    fn build_rust_tool(&self) -> RustBashTool {
+    fn build_rust_tool(state: &SharedState) -> RustBashTool {
         let mut builder = RustBashTool::builder();
 
-        if let Some(ref username) = self.username {
+        if let Some(ref username) = state.username {
             builder = builder.username(username);
         }
-        if let Some(ref hostname) = self.hostname {
+        if let Some(ref hostname) = state.hostname {
             builder = builder.hostname(hostname);
         }
 
         let mut limits = ExecutionLimits::new();
-        if let Some(mc) = self.max_commands {
+        if let Some(mc) = state.max_commands {
             limits = limits.max_commands(mc as usize);
         }
-        if let Some(mli) = self.max_loop_iterations {
+        if let Some(mli) = state.max_loop_iterations {
             limits = limits.max_loop_iterations(mli as usize);
         }
 
@@ -340,23 +352,24 @@ impl BashTool {
             .map_err(|e| napi::Error::from_reason(format!("Failed to create runtime: {e}")))?;
 
         Ok(Self {
-            inner: Arc::new(Mutex::new(bash)),
-            rt,
-            cancelled,
-            username: opts.username,
-            hostname: opts.hostname,
-            max_commands: opts.max_commands,
-            max_loop_iterations: opts.max_loop_iterations,
+            state: Arc::new(SharedState {
+                inner: Mutex::new(bash),
+                rt: Mutex::new(rt),
+                cancelled,
+                username: opts.username,
+                hostname: opts.hostname,
+                max_commands: opts.max_commands,
+                max_loop_iterations: opts.max_loop_iterations,
+            }),
         })
     }
 
     /// Execute bash commands synchronously.
     #[napi]
     pub fn execute_sync(&self, commands: String) -> napi::Result<ExecResult> {
-        self.cancelled.store(false, Ordering::Relaxed);
-        let inner = self.inner.clone();
-        self.rt.block_on(async move {
-            let mut bash = inner.lock().await;
+        self.state.cancelled.store(false, Ordering::Relaxed);
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
             match bash.exec(&commands).await {
                 Ok(result) => Ok(ExecResult {
                     stdout: result.stdout,
@@ -386,8 +399,8 @@ impl BashTool {
     /// Execute bash commands asynchronously, returning a Promise.
     #[napi]
     pub async fn execute(&self, commands: String) -> napi::Result<ExecResult> {
-        let inner = self.inner.clone();
-        let mut bash = inner.lock().await;
+        let s = self.state.clone();
+        let mut bash = s.inner.lock().await;
         match bash.exec(&commands).await {
             Ok(result) => Ok(ExecResult {
                 stdout: result.stdout,
@@ -416,25 +429,19 @@ impl BashTool {
     /// Cancel the currently running execution.
     #[napi]
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Relaxed);
+        self.state.cancelled.store(true, Ordering::Relaxed);
     }
 
     /// Reset interpreter to fresh state, preserving configuration.
     #[napi]
     pub fn reset(&self) -> napi::Result<()> {
-        let inner = self.inner.clone();
-        let username = self.username.clone();
-        let hostname = self.hostname.clone();
-        let max_commands = self.max_commands;
-        let max_loop_iterations = self.max_loop_iterations;
-
-        self.rt.block_on(async move {
-            let mut bash = inner.lock().await;
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
             let new_bash = build_bash(
-                username.as_deref(),
-                hostname.as_deref(),
-                max_commands,
-                max_loop_iterations,
+                s.username.as_deref(),
+                s.hostname.as_deref(),
+                s.max_commands,
+                s.max_loop_iterations,
                 None,
             );
             *bash = new_bash;
@@ -457,25 +464,25 @@ impl BashTool {
     /// Get token-efficient tool description.
     #[napi]
     pub fn description(&self) -> String {
-        self.build_rust_tool().description().to_string()
+        Self::build_rust_tool(&self.state).description().to_string()
     }
 
     /// Get help as a Markdown document.
     #[napi]
     pub fn help(&self) -> String {
-        self.build_rust_tool().help()
+        Self::build_rust_tool(&self.state).help()
     }
 
     /// Get compact system-prompt text for orchestration.
     #[napi]
     pub fn system_prompt(&self) -> String {
-        self.build_rust_tool().system_prompt()
+        Self::build_rust_tool(&self.state).system_prompt()
     }
 
     /// Get JSON input schema as string.
     #[napi]
     pub fn input_schema(&self) -> napi::Result<String> {
-        let schema = self.build_rust_tool().input_schema();
+        let schema = Self::build_rust_tool(&self.state).input_schema();
         serde_json::to_string_pretty(&schema)
             .map_err(|e| napi::Error::from_reason(format!("Schema serialization failed: {e}")))
     }
@@ -483,7 +490,7 @@ impl BashTool {
     /// Get JSON output schema as string.
     #[napi]
     pub fn output_schema(&self) -> napi::Result<String> {
-        let schema = self.build_rust_tool().output_schema();
+        let schema = Self::build_rust_tool(&self.state).output_schema();
         serde_json::to_string_pretty(&schema)
             .map_err(|e| napi::Error::from_reason(format!("Schema serialization failed: {e}")))
     }

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -15,9 +15,58 @@
         "@langchain/core": "^0.3",
         "@langchain/langgraph": "^0.2",
         "@langchain/openai": "^0.5",
-        "ai": "^4",
+        "ai": "^5.0.52",
         "openai": "^5",
         "zod": "^3"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.58",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.58.tgz",
+      "integrity": "sha512-HLPfF5k/rUre8fBMSJnJP6UL7ONx+W/BksTGdand0/Jkq5nCVlwmoUC4URc8PtZ+UtnMP6waQlD4b9/rPOHk7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.22",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.22.tgz",
+      "integrity": "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
@@ -60,49 +109,6 @@
         "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -263,10 +269,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -291,31 +297,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "version": "5.0.154",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.154.tgz",
+      "integrity": "sha512-xdUSSfliDWIQq/9Easp1z5oRIFwNS07Ys4BCGDtroDcyEbNDMw5Rj1m2i7Fh8khPbAEByxFfWyUzlrPi2VIlDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
+        "@ai-sdk/gateway": "2.0.58",
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.22",
+        "@opentelemetry/api": "1.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
       },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.22.tgz",
+      "integrity": "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ansi-styles": {
@@ -378,26 +417,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/console-table-printer": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
@@ -418,23 +437,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -442,14 +444,14 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/js-tiktoken": {
@@ -469,33 +471,15 @@
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.10.tgz",
+      "integrity": "sha512-unBdaaD/CqAOLIYjd9kT33FgHUMvHSsyBIPbQa+p/rE/Sv/l4pAC5ISEE79zphxi+vV4qxHqEgqahVXj2Xvz7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
+        "chalk": "^5.6.2",
         "console-table-printer": "^2.12.1",
         "p-queue": "^6.6.2",
         "semver": "^7.6.3",
@@ -505,7 +489,8 @@
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -519,40 +504,10 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/langsmith/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/langsmith/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/mustache": {
@@ -660,17 +615,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -707,56 +651,6 @@
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/swr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
-      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/uuid": {
       "version": "10.0.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,12 +9,16 @@
   },
   "devDependencies": {
     "openai": "^5",
-    "ai": "^4",
+    "ai": "^5.0.52",
     "@ai-sdk/openai": "^1",
     "@langchain/core": "^0.3",
     "@langchain/langgraph": "^0.2",
     "@langchain/openai": "^0.5",
     "zod": "^3"
+  },
+  "overrides": {
+    "langsmith": ">=0.4.6",
+    "jsondiffpatch": ">=0.7.2"
   },
   "scripts": {
     "examples": "node bash_basics.mjs && node data_pipeline.mjs && node llm_tool.mjs",


### PR DESCRIPTION
## Summary
- Wraps `Bash` and `BashTool` napi structs in `Arc<SharedState>` to prevent invalid pointer dereferences across `block_on`/`.await` boundaries (CodeQL alerts #7, #8: `rust/access-invalid-pointer`)
- Bumps `ai` SDK from `^4` to `^5.0.52` to fix file upload bypass vulnerability (dependabot alert #2)
- Adds npm overrides for `langsmith >=0.4.6` (SSRF, dependabot alert #3) and `jsondiffpatch >=0.7.2` (XSS, dependabot alert #1)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` — all 435 tests pass, 0 failures
- [x] `npm audit` reports 0 vulnerabilities in examples/
- [ ] CI green