### PR TITLE
fix(deps): override langsmith >=0.4.6 to fix SSRF vulnerability

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -378,26 +378,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/console-table-printer": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
@@ -442,16 +422,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
@@ -488,14 +458,14 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.10.tgz",
+      "integrity": "sha512-unBdaaD/CqAOLIYjd9kT33FgHUMvHSsyBIPbQa+p/rE/Sv/l4pAC5ISEE79zphxi+vV4qxHqEgqahVXj2Xvz7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
+        "chalk": "^5.6.2",
         "console-table-printer": "^2.12.1",
         "p-queue": "^6.6.2",
         "semver": "^7.6.3",
@@ -505,7 +475,8 @@
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -519,40 +490,10 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/langsmith/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/langsmith/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/mustache": {
@@ -707,19 +648,6 @@
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/swr": {
       "version": "2.4.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -16,6 +16,9 @@
     "@langchain/openai": "^0.5",
     "zod": "^3"
   },
+  "overrides": {
+    "langsmith": ">=0.4.6"
+  },
   "scripts": {
     "examples": "node bash_basics.mjs && node data_pipeline.mjs && node llm_tool.mjs",
     "examples:ai": "node openai_tool.mjs && node vercel_ai_tool.mjs && node langchain_agent.mjs"


### PR DESCRIPTION
## Summary

- Adds npm `overrides` for `langsmith >= 0.4.6` in `examples/package.json` to fix Dependabot alert #3 (SSRF via tracing header injection)
- `langsmith` is a transitive dependency of `@langchain/core ^0.3` which pins `^0.3.67`; the override forces resolution to the patched version
- Regenerated `package-lock.json` to reflect the override

## Test plan

- [ ] Verify `npm audit` no longer reports the langsmith SSRF vulnerability
- [ ] Verify `npm install` in `examples/` succeeds without errors
- [ ] Verify CI passes (examples scripts still run)