### PR TITLE
fix(deps): bump ai SDK to ^5.0.52 and override jsondiffpatch >=0.7.2

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -15,9 +15,58 @@
         "@langchain/core": "^0.3",
         "@langchain/langgraph": "^0.2",
         "@langchain/openai": "^0.5",
-        "ai": "^4",
+        "ai": "^5.0.52",
         "openai": "^5",
         "zod": "^3"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.58",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.58.tgz",
+      "integrity": "sha512-HLPfF5k/rUre8fBMSJnJP6UL7ONx+W/BksTGdand0/Jkq5nCVlwmoUC4URc8PtZ+UtnMP6waQlD4b9/rPOHk7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.22",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.22.tgz",
+      "integrity": "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
@@ -60,49 +109,6 @@
         "@ai-sdk/provider": "1.1.3",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -263,10 +269,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -291,31 +297,64 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "version": "5.0.154",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.154.tgz",
+      "integrity": "sha512-xdUSSfliDWIQq/9Easp1z5oRIFwNS07Ys4BCGDtroDcyEbNDMw5Rj1m2i7Fh8khPbAEByxFfWyUzlrPi2VIlDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
+        "@ai-sdk/gateway": "2.0.58",
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.22",
+        "@opentelemetry/api": "1.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
       },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.22.tgz",
+      "integrity": "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ansi-styles": {
@@ -398,29 +437,22 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
@@ -438,24 +470,6 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
     },
     "node_modules/langsmith": {
       "version": "0.5.10",
@@ -601,17 +615,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -648,43 +651,6 @@
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/swr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
-      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/uuid": {
       "version": "10.0.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "openai": "^5",
-    "ai": "^4",
+    "ai": "^5.0.52",
     "@ai-sdk/openai": "^1",
     "@langchain/core": "^0.3",
     "@langchain/langgraph": "^0.2",
@@ -17,7 +17,8 @@
     "zod": "^3"
   },
   "overrides": {
-    "langsmith": ">=0.4.6"
+    "langsmith": ">=0.4.6",
+    "jsondiffpatch": ">=0.7.2"
   },
   "scripts": {
     "examples": "node bash_basics.mjs && node data_pipeline.mjs && node llm_tool.mjs",


### PR DESCRIPTION
## Summary

- Bumps `ai` SDK from `^4` to `^5.0.52` to fix Dependabot alert #2 (file upload bypass vulnerability)
- Adds `jsondiffpatch >= 0.7.2` override to fix Dependabot alert #1 (XSS vulnerability)
- Regenerated `package-lock.json`; `jsondiffpatch` is removed from the tree entirely since `ai` v5 no longer depends on it

## Test plan

- [ ] CI passes (examples workflow installs and runs successfully)
- [ ] `npm audit` in `examples/` shows no new vulnerabilities from these packages
- [ ] Dependabot alerts #1 and #2 are resolved after merge