### PR TITLE
refactor(error): simplify Error enum by merging Parse/ParseAt and removing dead CommandNotFound

### DIFF
--- a/crates/bashkit/src/error.rs
+++ b/crates/bashkit/src/error.rs
@@ -17,13 +17,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// exposing internal details or sensitive information.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// Parse error occurred while parsing the script (without location info).
-    #[error("parse error: {0}")]
-    Parse(String),
-
-    /// Parse error with source location information.
-    #[error("parse error at line {line}, column {column}: {message}")]
-    ParseAt {
+    /// Parse error occurred while parsing the script.
+    ///
+    /// When `line` and `column` are 0, the error has no source location.
+    #[error("parse error{}: {message}", if *line > 0 { format!(" at line {}, column {}", line, column) } else { String::new() })]
+    Parse {
         message: String,
         line: usize,
         column: usize,
@@ -36,10 +34,6 @@ pub enum Error {
     /// I/O error from filesystem operations.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
-
-    /// Command not found.
-    #[error("command not found: {0}")]
-    CommandNotFound(String),
 
     /// Resource limit exceeded.
     #[error("resource limit exceeded: {0}")]
@@ -77,10 +71,19 @@ pub enum Error {
 impl Error {
     /// Create a parse error with source location.
     pub fn parse_at(message: impl Into<String>, line: usize, column: usize) -> Self {
-        Self::ParseAt {
+        Self::Parse {
             message: message.into(),
             line,
             column,
+        }
+    }
+
+    /// Create a parse error without source location.
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::Parse {
+            message: message.into(),
+            line: 0,
+            column: 0,
         }
     }
 }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -625,7 +625,7 @@ impl Bash {
                         error = %join_error,
                         "Parser task failed"
                     );
-                    return Err(Error::Parse(format!("parser task failed: {}", join_error)));
+                    return Err(Error::parse(format!("parser task failed: {}", join_error)));
                 }
                 Err(_elapsed) => {
                     #[cfg(feature = "logging")]

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
     fn tick(&mut self) -> Result<()> {
         if self.fuel == 0 {
             let used = self.max_fuel;
-            return Err(Error::Parse(format!(
+            return Err(Error::parse(format!(
                 "parser fuel exhausted ({} operations, max {})",
                 used, self.max_fuel
             )));
@@ -146,7 +146,7 @@ impl<'a> Parser<'a> {
     fn push_depth(&mut self) -> Result<()> {
         self.current_depth += 1;
         if self.current_depth > self.max_depth {
-            return Err(Error::Parse(format!(
+            return Err(Error::parse(format!(
                 "AST nesting too deep ({} levels, max {})",
                 self.current_depth, self.max_depth
             )));
@@ -711,7 +711,7 @@ impl<'a> Parser<'a> {
             | Some(tokens::Token::QuotedWord(w)) => w.clone(),
             _ => {
                 self.pop_depth();
-                return Err(Error::Parse(
+                return Err(Error::parse(
                     "expected variable name in for loop".to_string(),
                 ));
             }
@@ -802,7 +802,7 @@ impl<'a> Parser<'a> {
             | Some(tokens::Token::QuotedWord(w)) => w.clone(),
             _ => {
                 self.pop_depth();
-                return Err(Error::Parse("expected variable name in select".to_string()));
+                return Err(Error::parse("expected variable name in select".to_string()));
             }
         };
         self.advance();
@@ -810,7 +810,7 @@ impl<'a> Parser<'a> {
         // Expect 'in' keyword
         if !self.is_keyword("in") {
             self.pop_depth();
-            return Err(Error::Parse("expected 'in' in select".to_string()));
+            return Err(Error::parse("expected 'in' in select".to_string()));
         }
         self.advance(); // consume 'in'
 
@@ -958,7 +958,7 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
                 None => {
-                    return Err(Error::Parse(
+                    return Err(Error::parse(
                         "unexpected end of input in for loop".to_string(),
                     ));
                 }
@@ -1307,7 +1307,7 @@ impl<'a> Parser<'a> {
             self.current_token = Some(tokens::Token::RightParen);
         } else if !matches!(self.current_token, Some(tokens::Token::RightParen)) {
             self.pop_depth();
-            return Err(Error::Parse("expected ')' to close subshell".to_string()));
+            return Err(Error::parse("expected ')' to close subshell".to_string()));
         } else {
             self.advance(); // consume ')'
         }
@@ -1335,7 +1335,7 @@ impl<'a> Parser<'a> {
 
         if !matches!(self.current_token, Some(tokens::Token::RightBrace)) {
             self.pop_depth();
-            return Err(Error::Parse(
+            return Err(Error::parse(
                 "expected '}' to close brace group".to_string(),
             ));
         }
@@ -1437,7 +1437,7 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
                 None => {
-                    return Err(crate::error::Error::Parse(
+                    return Err(crate::error::Error::parse(
                         "unexpected end of input in [[ ]]".to_string(),
                     ));
                 }
@@ -1555,7 +1555,7 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
                 None => {
-                    return Err(Error::Parse(
+                    return Err(Error::parse(
                         "unexpected end of input in arithmetic command".to_string(),
                     ));
                 }
@@ -1586,7 +1586,7 @@ impl<'a> Parser<'a> {
         if matches!(self.current_token, Some(tokens::Token::LeftParen)) {
             self.advance(); // consume '('
             if !matches!(self.current_token, Some(tokens::Token::RightParen)) {
-                return Err(Error::Parse(
+                return Err(Error::parse(
                     "expected ')' in function definition".to_string(),
                 ));
             }
@@ -1596,7 +1596,7 @@ impl<'a> Parser<'a> {
 
         // Expect { for body
         if !matches!(self.current_token, Some(tokens::Token::LeftBrace)) {
-            return Err(Error::Parse("expected '{' for function body".to_string()));
+            return Err(Error::parse("expected '{' for function body".to_string()));
         }
 
         // Parse body as brace group
@@ -2026,7 +2026,7 @@ impl<'a> Parser<'a> {
                         Some(tokens::Token::Word(w)) => (w.clone(), false),
                         Some(tokens::Token::LiteralWord(w)) => (w.clone(), true),
                         Some(tokens::Token::QuotedWord(w)) => (w.clone(), true),
-                        _ => return Err(Error::Parse("expected delimiter after <<".to_string())),
+                        _ => return Err(Error::parse("expected delimiter after <<".to_string())),
                     };
                     // Don't advance - let read_heredoc consume directly from lexer position
 
@@ -2435,7 +2435,7 @@ impl<'a> Parser<'a> {
                             self.advance();
                         }
                         None => {
-                            return Err(Error::Parse(
+                            return Err(Error::parse(
                                 "unexpected end of input in process substitution".to_string(),
                             ));
                         }

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -960,10 +960,9 @@ impl Tool for BashTool {
 /// Extract error kind from Error for categorization
 fn error_kind(e: &Error) -> String {
     match e {
-        Error::Parse(_) | Error::ParseAt { .. } => "parse_error".to_string(),
+        Error::Parse { .. } => "parse_error".to_string(),
         Error::Execution(_) => "execution_error".to_string(),
         Error::Io(_) => "io_error".to_string(),
-        Error::CommandNotFound(_) => "command_not_found".to_string(),
         Error::ResourceLimit(_) => "resource_limit".to_string(),
         Error::Network(_) => "network_error".to_string(),
         Error::Regex(_) => "regex_error".to_string(),

--- a/crates/bashkit/tests/proptest_differential.rs
+++ b/crates/bashkit/tests/proptest_differential.rs
@@ -31,7 +31,7 @@ async fn run_bashkit(script: &str) -> (String, i32) {
         Ok(result) => (result.stdout, result.exit_code),
         Err(e) => {
             // Parse errors should return exit code 2 (like bash)
-            let exit_code = if matches!(e, bashkit::Error::Parse(_)) {
+            let exit_code = if matches!(e, bashkit::Error::Parse { .. }) {
                 2
             } else {
                 1


### PR DESCRIPTION
## Summary
- Merge `Parse` and `ParseAt` into single `Parse` variant with line/column fields (0 = unknown location)
- Remove `CommandNotFound` variant — never constructed anywhere in the codebase
- Add `Error::parse()` convenience constructor for parse errors without location
- Reduces Error from 9 variants to 7

Closes #741

## Test plan
- [x] All tests pass (error format preserved for both location/no-location cases)
- [x] `cargo fmt --check` and `cargo clippy` clean
- [x] `error_kind()` in tool.rs updated to match new variant structure