### PR TITLE
fix(git): error on non-HEAD revision in git show rev:path

### DIFF
--- a/crates/bashkit/src/git/client.rs
+++ b/crates/bashkit/src/git/client.rs
@@ -1282,8 +1282,13 @@ impl GitClient {
 
         // Handle <rev>:<path> syntax — show file content at revision
         if let Some((rev, path)) = target.split_once(':') {
-            // For simplicity, show current file content (no true history tracking per-file)
-            let _ = rev; // TODO: resolve rev to actual snapshot
+            // Only HEAD is supported — other revisions require history tracking
+            if rev != "HEAD" {
+                return Err(Error::Execution(format!(
+                    "fatal: unsupported revision '{}' (only HEAD is supported in virtual git)",
+                    rev
+                )));
+            }
             let file_path = repo_path.join(path);
             if fs.exists(&file_path).await? {
                 let content = fs.read_file(&file_path).await?;

--- a/crates/bashkit/tests/git_inspection_tests.rs
+++ b/crates/bashkit/tests/git_inspection_tests.rs
@@ -66,6 +66,21 @@ mod show {
     }
 
     #[tokio::test]
+    async fn show_non_head_revision_returns_error() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        // Non-HEAD revisions are not supported — should error, not silently return current content
+        let result = bash
+            .exec("cd /repo && git show HEAD~1:README.md")
+            .await
+            .unwrap();
+        assert_ne!(
+            result.exit_code, 0,
+            "non-HEAD revision should fail, not silently return current content"
+        );
+    }
+
+    #[tokio::test]
     async fn show_no_commits() {
         let mut bash = create_git_bash();
         bash.exec("git init /repo && cd /repo").await.unwrap();


### PR DESCRIPTION
## Summary
- `git show HEAD~1:file.txt` previously returned current content silently (wrong output)
- Now returns explicit error for non-HEAD revisions since virtual git has no history tracking
- Add test `show_non_head_revision_returns_error`

Closes #738

## Test plan
- [x] New test: `show_non_head_revision_returns_error`
- [x] Existing `show_file_at_rev` (HEAD:file) still works
- [x] All tests pass