### PR TITLE
fix: find with multiple paths no longer discards results on missing path

### DIFF
--- a/crates/bashkit/src/builtins/ls.rs
+++ b/crates/bashkit/src/builtins/ls.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use super::{Builtin, Context, ExecutionPlan, SubCommand, resolve_path};
 use crate::error::Result;
 use crate::fs::FileType;
-use crate::interpreter::ExecResult;
+use crate::interpreter::{ControlFlow, ExecResult};
 
 /// Options for ls command
 struct LsOptions {
@@ -472,10 +472,13 @@ async fn collect_find_paths(
     for path_str in search_paths {
         let path = resolve_path(ctx.cwd, path_str);
         if !ctx.fs.exists(&path).await.unwrap_or(false) {
-            // Skip non-existent paths in collection phase
             continue;
         }
-        find_recursive(ctx, &path, path_str, &temp_opts, 0, &mut output).await?;
+        // Intentionally swallowing errors (`let _ =`) rather than propagating (`?`):
+        // this feeds execution_plan(), which is only an optimization hint. Propagating
+        // would bubble up as Err and abort the entire command. Real error handling
+        // (stderr messages, exit codes) lives in execute(), which is always called.
+        let _ = find_recursive(ctx, &path, path_str, &temp_opts, 0, &mut output).await;
     }
     // Parse the output back into paths (each line is a path)
     for line in output.lines() {
@@ -547,24 +550,34 @@ impl Builtin for Find {
             Err(e) => return Ok(e),
         };
 
-        // Check paths exist
+        let mut output = String::new();
+        let mut errors = String::new();
+        let mut had_error = false;
+
         for path_str in &search_paths {
             let path = resolve_path(ctx.cwd, path_str);
             if !ctx.fs.exists(&path).await.unwrap_or(false) {
-                return Ok(ExecResult::err(
-                    format!("find: '{}': No such file or directory\n", path_str),
-                    1,
+                errors.push_str(&format!(
+                    "find: '{}': No such file or directory\n",
+                    path_str
                 ));
+                had_error = true;
+                continue;
+            }
+
+            if let Err(e) = find_recursive(&ctx, &path, path_str, &opts, 0, &mut output).await {
+                errors.push_str(&format!("find: '{}': {}\n", path_str, e));
+                had_error = true;
             }
         }
 
-        let mut output = String::new();
-        for path_str in &search_paths {
-            let path = resolve_path(ctx.cwd, path_str);
-            find_recursive(&ctx, &path, path_str, &opts, 0, &mut output).await?;
-        }
-
-        Ok(ExecResult::ok(output))
+        Ok(ExecResult {
+            stdout: output,
+            stderr: errors,
+            exit_code: if had_error { 1 } else { 0 },
+            control_flow: ControlFlow::None,
+            ..Default::default()
+        })
     }
 
     async fn execution_plan(&self, ctx: &Context<'_>) -> Result<Option<ExecutionPlan>> {
@@ -578,15 +591,7 @@ impl Builtin for Find {
             return Ok(None);
         }
 
-        // Check paths exist
-        for path_str in &search_paths {
-            let path = resolve_path(ctx.cwd, path_str);
-            if !ctx.fs.exists(&path).await.unwrap_or(false) {
-                return Ok(None); // Let execute() handle errors
-            }
-        }
-
-        // Collect matched paths
+        // Collect matched paths (collect_find_paths skips missing paths)
         let matched_paths = collect_find_paths(ctx, &search_paths, &opts).await?;
         if matched_paths.is_empty() {
             return Ok(None);

--- a/crates/bashkit/tests/find_multi_path_tests.rs
+++ b/crates/bashkit/tests/find_multi_path_tests.rs
@@ -1,0 +1,149 @@
+//! Tests for find command with multiple paths, ensuring that:
+//! - Results from valid paths are not discarded when another path is missing
+//! - Errors for missing paths go to stderr
+//! - Exit code is 1 when any path fails, 0 when all succeed
+
+use bashkit::Bash;
+
+#[tokio::test]
+async fn find_multi_path_second_missing() {
+    let mut bash = Bash::builder().build();
+
+    // Create files in the first path
+    bash.exec("mkdir -p /tmp/path_a/.director/memory")
+        .await
+        .unwrap();
+    bash.exec("echo data > /tmp/path_a/.director/memory/MEMORY.md")
+        .await
+        .unwrap();
+
+    // Find with first path valid, second path missing
+    let result = bash
+        .exec(
+            "find /tmp/path_a/.director/memory/ /tmp/path_b/.director/memory/ -type f 2>/dev/null",
+        )
+        .await
+        .unwrap();
+
+    // Should still output results from the valid first path
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.stdout.contains("MEMORY.md"),
+        "Expected MEMORY.md in stdout, got: {:?}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn find_multi_path_first_missing() {
+    let mut bash = Bash::builder().build();
+
+    // Create files in the second path
+    bash.exec("mkdir -p /tmp/path_c/.director/memory")
+        .await
+        .unwrap();
+    bash.exec("echo data > /tmp/path_c/.director/memory/notes.md")
+        .await
+        .unwrap();
+
+    // Find with first path missing, second path valid
+    let result = bash
+        .exec("find /tmp/path_missing /tmp/path_c/.director/memory/ -type f 2>/dev/null")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.stdout.contains("notes.md"),
+        "Expected notes.md in stdout, got: {:?}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn find_multi_path_all_valid() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/all_a && touch /tmp/all_a/f1.txt")
+        .await
+        .unwrap();
+    bash.exec("mkdir -p /tmp/all_b && touch /tmp/all_b/f2.txt")
+        .await
+        .unwrap();
+
+    let result = bash
+        .exec("find /tmp/all_a /tmp/all_b -type f | sort")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.stdout.contains("f1.txt"), "Missing f1.txt");
+    assert!(result.stdout.contains("f2.txt"), "Missing f2.txt");
+}
+
+#[tokio::test]
+async fn find_missing_path_reports_stderr() {
+    let mut bash = Bash::builder().build();
+
+    // Without 2>/dev/null, error should go to stderr
+    let result = bash.exec("find /tmp/does_not_exist_xyz").await.unwrap();
+
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.stderr.contains("No such file or directory"),
+        "Expected error in stderr, got: {:?}",
+        result.stderr
+    );
+}
+
+#[tokio::test]
+async fn find_multi_path_both_missing() {
+    let mut bash = Bash::builder().build();
+
+    let result = bash
+        .exec("find /tmp/nope_a /tmp/nope_b -type f 2>/dev/null")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.stdout.is_empty(),
+        "Expected no stdout, got: {:?}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn find_single_valid_path_exit_zero() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/single && touch /tmp/single/ok.txt")
+        .await
+        .unwrap();
+
+    let result = bash.exec("find /tmp/single -type f").await.unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(result.stdout.contains("ok.txt"));
+}
+
+#[tokio::test]
+async fn find_multi_path_mixed_has_exit_one() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/mixed_ok && touch /tmp/mixed_ok/x.txt")
+        .await
+        .unwrap();
+
+    // One valid path + one missing = exit code 1
+    let result = bash
+        .exec("find /tmp/mixed_ok /tmp/mixed_bad -type f 2>/dev/null")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.stdout.contains("x.txt"),
+        "Valid path results should still appear"
+    );
+}

--- a/crates/bashkit/tests/spec_cases/bash/find.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/find.test.sh
@@ -148,6 +148,49 @@ find /tmp/pf5 -type f -printf '%f\t%y\n'
 a.txt	f
 ### end
 
+### find_multi_path_one_missing
+### bash_diff: Virtual /tmp vs real /tmp may have different state
+# Find with multiple paths where one doesn't exist should still output results from valid paths
+mkdir -p /tmp/multi_exist
+touch /tmp/multi_exist/file1.txt
+touch /tmp/multi_exist/file2.txt
+find /tmp/multi_exist /tmp/multi_nonexist -type f 2>/dev/null | sort
+### expect
+/tmp/multi_exist/file1.txt
+/tmp/multi_exist/file2.txt
+### end
+
+### find_multi_path_missing_first
+### bash_diff: Virtual /tmp vs real /tmp may have different state
+# Find with missing first path should still output results from second path
+mkdir -p /tmp/multi_second
+touch /tmp/multi_second/found.txt
+find /tmp/multi_missing_first /tmp/multi_second -type f 2>/dev/null
+### expect
+/tmp/multi_second/found.txt
+### end
+
+### find_multi_path_all_valid
+### bash_diff: Virtual /tmp vs real /tmp may have different state
+# Find with multiple valid paths should output results from all
+mkdir -p /tmp/multi_a
+mkdir -p /tmp/multi_b
+touch /tmp/multi_a/a.txt
+touch /tmp/multi_b/b.txt
+find /tmp/multi_a /tmp/multi_b -type f | sort
+### expect
+/tmp/multi_a/a.txt
+/tmp/multi_b/b.txt
+### end
+
+### find_missing_path_stderr
+### bash_diff: Virtual /tmp vs real /tmp may have different state
+# Find with missing path should output error to stderr and exit 1
+find /tmp/totally_nonexistent_path 2>&1
+### expect
+find: '/tmp/totally_nonexistent_path': No such file or directory
+### end
+
 ### ls_recursive
 # ls -R should list nested directories
 mkdir -p /tmp/lsrec/a/b


### PR DESCRIPTION
When `find` was given multiple paths and one didn't exist, it would early-return with an error, discarding all stdout accumulated from previously valid paths. Now it continues processing all paths, collecting errors separately in stderr, and sets exit code 1 only if any path failed — matching real Unix find behavior.