### PR TITLE
chore: add cargo-vet exemptions for jni-sys 0.3.1, 0.4.1 and jni-sys-macros 0.4.1

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -630,6 +630,18 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.jni-sys]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-sys-macros]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.jobserver]]
 version = "0.1.34"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary
- Adds `safe-to-deploy` exemptions for `jni-sys:0.3.1`, `jni-sys:0.4.1`, and `jni-sys-macros:0.4.1`
- Fixes the `cargo vet --locked` audit failure in CI

## Context
These unvetted dependencies were causing the Audit and Check CI jobs to fail on all PRs (including #781).