### PR TITLE
feat(fs): expose live mount/unmount on running Bash instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
           cargo run --example custom_fs
           cargo run --example resource_limits
           cargo run --example text_processing
+          cargo run --example live_mounts
           cargo run --example git_workflow --features git
           cargo run --example python_external_functions --features python
           cargo run --example realfs_readonly --features realfs

--- a/crates/bashkit/docs/live_mounts.md
+++ b/crates/bashkit/docs/live_mounts.md
@@ -1,0 +1,193 @@
+# Live Mount/Unmount Guide
+
+Bashkit supports attaching and detaching filesystems on a **running** interpreter
+without rebuilding it. Shell state — environment variables, working directory,
+history, aliases — is fully preserved across mount operations.
+
+## Motivation
+
+Before live mounts, the only way to add a filesystem after `build()` was to
+accumulate mount configs and call `reset()`, which rebuilds the entire
+interpreter and loses all in-flight state. Live mounts solve this by exposing
+the internal [`MountableFs`] layer that wraps every `Bash` instance.
+
+Common use cases:
+
+- **Agent workflows**: attach a host directory mid-session when a tool needs it
+- **Plugin systems**: mount/unmount plugin filesystems without restarting
+- **Hot-swap deployments**: replace a mounted app filesystem with a new version
+- **Testing**: inject mock data at specific paths during a test
+
+## Quick Start
+
+```rust
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use std::path::Path;
+use std::sync::Arc;
+
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+let mut bash = Bash::new();
+
+// Create and populate a filesystem
+let data_fs = Arc::new(InMemoryFs::new());
+data_fs.write_file(Path::new("/users.json"), br#"["alice"]"#).await?;
+
+// Mount it live — no rebuild needed
+bash.mount("/mnt/data", data_fs)?;
+
+let result = bash.exec("cat /mnt/data/users.json").await?;
+assert!(result.stdout.contains("alice"));
+
+// Unmount when done
+bash.unmount("/mnt/data")?;
+# Ok(())
+# }
+```
+
+## API
+
+### `Bash::mount(vfs_path, fs)`
+
+Mounts `fs` at `vfs_path`. The mount takes effect immediately — subsequent
+`exec()` calls see files from the mounted filesystem. If a mount already exists
+at `vfs_path`, it is replaced (hot-swap).
+
+```rust
+# use bashkit::{Bash, FileSystem, InMemoryFs};
+# use std::sync::Arc;
+# use std::path::Path;
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+let bash = Bash::new();
+let fs = Arc::new(InMemoryFs::new());
+bash.mount("/mnt/data", fs)?;
+# Ok(())
+# }
+```
+
+**Errors:** Returns `Err` if `vfs_path` is not absolute (after normalization).
+
+### `Bash::unmount(vfs_path)`
+
+Removes the mount at `vfs_path`. Paths that previously resolved to the mounted
+filesystem fall back to the root filesystem or the next shorter mount prefix.
+
+```rust
+# use bashkit::{Bash, FileSystem, InMemoryFs};
+# use std::sync::Arc;
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+# let bash = Bash::new();
+# let fs = Arc::new(InMemoryFs::new());
+# bash.mount("/mnt/data", fs)?;
+bash.unmount("/mnt/data")?;
+# Ok(())
+# }
+```
+
+**Errors:** Returns `Err` if nothing is mounted at `vfs_path`.
+
+## How It Works
+
+Every `Bash` instance wraps its filesystem stack in a [`MountableFs`] as the
+outermost layer. This layer uses longest-prefix matching to route path
+operations to the correct mounted filesystem:
+
+```text
+┌──────────────────────────────┐
+│  MountableFs (live mounts)   │  ← Bash::mount() / unmount()
+├──────────────────────────────┤
+│  OverlayFs (text mounts)     │  ← BashBuilder::mount_text()
+├──────────────────────────────┤
+│  MountableFs (real mounts)   │  ← BashBuilder::mount_real_*_at()
+├──────────────────────────────┤
+│  Base filesystem             │  ← InMemoryFs or custom
+└──────────────────────────────┘
+```
+
+Because the interpreter holds an `Arc<dyn FileSystem>` pointing to the
+outermost `MountableFs`, any mount/unmount operation is visible to the
+interpreter immediately — no rebuild or state transfer required.
+
+## Builder Mounts vs Live Mounts
+
+| | Builder mounts | Live mounts |
+|---|---|---|
+| **When** | Before `build()` | After `build()` |
+| **Method** | `BashBuilder::mount_text()`, `mount_real_*()` | `Bash::mount()` |
+| **State** | N/A (no interpreter yet) | Fully preserved |
+| **Use case** | Initial configuration | Dynamic attachment |
+
+Both approaches can be combined: configure initial mounts with the builder, then
+add/remove mounts at runtime.
+
+## Examples
+
+### Multiple Mounts
+
+```rust
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use std::path::Path;
+use std::sync::Arc;
+
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+let mut bash = Bash::new();
+
+let logs = Arc::new(InMemoryFs::new());
+logs.write_file(Path::new("/app.log"), b"started\n").await?;
+
+let config = Arc::new(InMemoryFs::new());
+config.write_file(Path::new("/app.toml"), b"port = 8080\n").await?;
+
+bash.mount("/var/log", logs)?;
+bash.mount("/etc/app", config)?;
+
+let result = bash.exec("cat /var/log/app.log").await?;
+assert_eq!(result.stdout, "started\n");
+
+let result = bash.exec("cat /etc/app/app.toml").await?;
+assert_eq!(result.stdout, "port = 8080\n");
+# Ok(())
+# }
+```
+
+### Hot-Swap
+
+Re-mounting at the same path replaces the filesystem atomically:
+
+```rust
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use std::path::Path;
+use std::sync::Arc;
+
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+let mut bash = Bash::new();
+
+let v1 = Arc::new(InMemoryFs::new());
+v1.write_file(Path::new("/version"), b"1.0").await?;
+bash.mount("/app", v1)?;
+
+let result = bash.exec("cat /app/version").await?;
+assert_eq!(result.stdout, "1.0");
+
+// Hot-swap to v2
+let v2 = Arc::new(InMemoryFs::new());
+v2.write_file(Path::new("/version"), b"2.0").await?;
+bash.mount("/app", v2)?;
+
+let result = bash.exec("cat /app/version").await?;
+assert_eq!(result.stdout, "2.0");
+# Ok(())
+# }
+```
+
+## See Also
+
+- [`MountableFs`] — the underlying mount infrastructure
+- [`BashBuilder::mount_text`] — pre-build text file mounts
+- [`BashBuilder::fs`] — custom filesystem injection
+- [`Bash::fs`] — direct filesystem access
+- [VFS specification](https://github.com/everruns/bashkit/blob/main/specs/003-vfs.md)

--- a/crates/bashkit/examples/live_mounts.rs
+++ b/crates/bashkit/examples/live_mounts.rs
@@ -1,0 +1,138 @@
+//! Live mount/unmount example
+//!
+//! Demonstrates attaching and detaching filesystems on a running Bash
+//! instance without rebuilding the interpreter or losing shell state.
+//!
+//! Run with: cargo run --example live_mounts
+
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use std::path::Path;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    println!("=== Live Mount/Unmount Example ===\n");
+
+    basic_live_mount().await?;
+    println!();
+    state_preservation().await?;
+    println!();
+    hot_swap_mount().await?;
+
+    Ok(())
+}
+
+/// Mount a filesystem on a running interpreter.
+async fn basic_live_mount() -> anyhow::Result<()> {
+    println!("--- Basic Live Mount ---");
+
+    let mut bash = Bash::new();
+
+    // Create a data filesystem and populate it
+    let data_fs = Arc::new(InMemoryFs::new());
+    data_fs
+        .write_file(
+            Path::new("/users.json"),
+            br#"[{"name": "alice"}, {"name": "bob"}]"#,
+        )
+        .await?;
+    data_fs
+        .write_file(Path::new("/readme.txt"), b"Welcome to the data store")
+        .await?;
+
+    // Mount it live — no builder, no rebuild
+    bash.mount("/mnt/data", data_fs)?;
+
+    let result = bash.exec("cat /mnt/data/readme.txt").await?;
+    println!("Data store: {}", result.stdout);
+
+    let result = bash.exec("ls /mnt/data").await?;
+    println!("Files: {}", result.stdout);
+
+    // Unmount when done
+    bash.unmount("/mnt/data")?;
+    println!("Unmounted /mnt/data");
+
+    let result = bash.exec("ls /mnt/data 2>&1; echo \"exit=$?\"").await?;
+    println!("After unmount: {}", result.stdout.trim());
+
+    Ok(())
+}
+
+/// Shell state (env vars, cwd) is preserved across mount operations.
+async fn state_preservation() -> anyhow::Result<()> {
+    println!("--- State Preservation ---");
+
+    let mut bash = Bash::builder().env("APP_ENV", "production").build();
+
+    // Set up shell state
+    bash.exec("export SESSION_ID=abc123").await?;
+    bash.exec("cd /tmp").await?;
+    bash.exec("counter=0").await?;
+
+    println!("Before mount:");
+    let result = bash
+        .exec("echo env=$APP_ENV session=$SESSION_ID cwd=$(pwd)")
+        .await?;
+    print!("  {}", result.stdout);
+
+    // Mount a plugin filesystem
+    let plugin_fs = Arc::new(InMemoryFs::new());
+    plugin_fs
+        .write_file(Path::new("/init.sh"), b"echo 'Plugin loaded'")
+        .await?;
+    bash.mount("/plugins/auth", plugin_fs)?;
+
+    println!("After mount:");
+    let result = bash
+        .exec("echo env=$APP_ENV session=$SESSION_ID cwd=$(pwd)")
+        .await?;
+    print!("  {}", result.stdout);
+
+    // Use the mount
+    let result = bash.exec("source /plugins/auth/init.sh").await?;
+    println!("  Plugin: {}", result.stdout.trim());
+
+    // Unmount — state still preserved
+    bash.unmount("/plugins/auth")?;
+
+    println!("After unmount:");
+    let result = bash
+        .exec("echo env=$APP_ENV session=$SESSION_ID cwd=$(pwd)")
+        .await?;
+    print!("  {}", result.stdout);
+
+    Ok(())
+}
+
+/// Hot-swap a mounted filesystem to simulate a rolling update.
+async fn hot_swap_mount() -> anyhow::Result<()> {
+    println!("--- Hot-Swap Mount ---");
+
+    let mut bash = Bash::new();
+
+    // Version 1
+    let v1 = Arc::new(InMemoryFs::new());
+    v1.write_file(Path::new("/version"), b"1.0.0").await?;
+    v1.write_file(Path::new("/greeting"), b"Hello from v1")
+        .await?;
+
+    bash.mount("/app", v1)?;
+    let result = bash.exec("cat /app/version").await?;
+    println!("App version: {}", result.stdout.trim());
+
+    // Hot-swap to version 2 — just re-mount at the same path
+    let v2 = Arc::new(InMemoryFs::new());
+    v2.write_file(Path::new("/version"), b"2.0.0").await?;
+    v2.write_file(Path::new("/greeting"), b"Hello from v2")
+        .await?;
+
+    bash.mount("/app", v2)?;
+    let result = bash.exec("cat /app/version").await?;
+    println!("App version: {}", result.stdout.trim());
+
+    let result = bash.exec("cat /app/greeting").await?;
+    println!("Greeting: {}", result.stdout.trim());
+
+    Ok(())
+}

--- a/crates/bashkit/src/fs/mountable.rs
+++ b/crates/bashkit/src/fs/mountable.rs
@@ -490,6 +490,12 @@ impl FileSystemExt for MountableFs {
         // Return root filesystem limits as the overall limits
         self.root.limits()
     }
+
+    async fn mkfifo(&self, path: &Path, mode: u32) -> Result<()> {
+        self.validate_path(path)?;
+        let (fs, resolved) = self.resolve(path);
+        fs.mkfifo(&resolved, mode).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -487,6 +487,8 @@ use std::sync::Arc;
 /// Provides a virtual bash interpreter with an in-memory virtual filesystem.
 pub struct Bash {
     fs: Arc<dyn FileSystem>,
+    /// Outermost MountableFs layer for live mount/unmount after build.
+    mountable: Arc<MountableFs>,
     interpreter: Interpreter,
     /// Parser timeout (stored separately for use before interpreter runs)
     #[cfg(not(target_family = "wasm"))]
@@ -511,7 +513,9 @@ impl Default for Bash {
 impl Bash {
     /// Create a new Bash instance with default settings.
     pub fn new() -> Self {
-        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let base_fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mountable = Arc::new(MountableFs::new(base_fs));
+        let fs: Arc<dyn FileSystem> = Arc::clone(&mountable) as Arc<dyn FileSystem>;
         let interpreter = Interpreter::new(Arc::clone(&fs));
         #[cfg(not(target_family = "wasm"))]
         let parser_timeout = ExecutionLimits::default().parser_timeout;
@@ -520,6 +524,7 @@ impl Bash {
         let max_parser_operations = ExecutionLimits::default().max_parser_operations;
         Self {
             fs,
+            mountable,
             interpreter,
             #[cfg(not(target_family = "wasm"))]
             parser_timeout,
@@ -797,6 +802,91 @@ impl Bash {
     /// ```
     pub fn fs(&self) -> Arc<dyn FileSystem> {
         Arc::clone(&self.fs)
+    }
+
+    /// Mount a filesystem at `vfs_path` on a live interpreter.
+    ///
+    /// Unlike [`BashBuilder`] mount methods which configure mounts before build,
+    /// this method attaches a filesystem **after** the interpreter is running.
+    /// Shell state (env vars, cwd, history) is preserved — no rebuild needed.
+    ///
+    /// The mount takes effect immediately: subsequent `exec()` calls will see
+    /// files from the mounted filesystem at the given path.
+    ///
+    /// # Arguments
+    ///
+    /// * `vfs_path` - Absolute path where the filesystem will appear (e.g. `/mnt/data`)
+    /// * `fs` - The filesystem to mount
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `vfs_path` is not absolute.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{Bash, FileSystem, InMemoryFs};
+    /// use std::path::Path;
+    /// use std::sync::Arc;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let mut bash = Bash::new();
+    ///
+    /// // Create and populate a filesystem
+    /// let data_fs = Arc::new(InMemoryFs::new());
+    /// data_fs.write_file(Path::new("/users.json"), br#"["alice"]"#).await?;
+    ///
+    /// // Mount it live — no rebuild, no state loss
+    /// bash.mount("/mnt/data", data_fs)?;
+    ///
+    /// let result = bash.exec("cat /mnt/data/users.json").await?;
+    /// assert!(result.stdout.contains("alice"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn mount(
+        &self,
+        vfs_path: impl AsRef<std::path::Path>,
+        fs: Arc<dyn FileSystem>,
+    ) -> Result<()> {
+        self.mountable.mount(vfs_path, fs)
+    }
+
+    /// Unmount a previously mounted filesystem.
+    ///
+    /// After unmounting, paths under `vfs_path` fall back to the root filesystem
+    /// or the next shorter mount prefix. Shell state is preserved.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if nothing is mounted at `vfs_path`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{Bash, FileSystem, InMemoryFs};
+    /// use std::path::Path;
+    /// use std::sync::Arc;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> bashkit::Result<()> {
+    /// let mut bash = Bash::new();
+    ///
+    /// let tmp_fs = Arc::new(InMemoryFs::new());
+    /// tmp_fs.write_file(Path::new("/data.txt"), b"temp").await?;
+    ///
+    /// bash.mount("/scratch", tmp_fs)?;
+    /// let result = bash.exec("cat /scratch/data.txt").await?;
+    /// assert_eq!(result.stdout, "temp");
+    ///
+    /// bash.unmount("/scratch")?;
+    /// // /scratch/data.txt is no longer accessible
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn unmount(&self, vfs_path: impl AsRef<std::path::Path>) -> Result<()> {
+        self.mountable.unmount(vfs_path)
     }
 
     /// Capture the current shell state (variables, env, cwd, options).
@@ -1483,7 +1573,7 @@ impl BashBuilder {
         let base_fs = Self::apply_real_mounts(&self.real_mounts, base_fs);
 
         // Layer 2: If there are mounted text files, wrap in an OverlayFs
-        let fs: Arc<dyn FileSystem> = if self.mounted_files.is_empty() {
+        let base_fs: Arc<dyn FileSystem> = if self.mounted_files.is_empty() {
             base_fs
         } else {
             let overlay = OverlayFs::new(base_fs);
@@ -1494,8 +1584,13 @@ impl BashBuilder {
             Arc::new(overlay)
         };
 
+        // Layer 3: Wrap in MountableFs for post-build live mount/unmount
+        let mountable = Arc::new(MountableFs::new(base_fs));
+        let fs: Arc<dyn FileSystem> = Arc::clone(&mountable) as Arc<dyn FileSystem>;
+
         Self::build_with_fs(
             fs,
+            mountable,
             self.env,
             self.username,
             self.hostname,
@@ -1581,6 +1676,7 @@ impl BashBuilder {
     #[allow(clippy::too_many_arguments)]
     fn build_with_fs(
         fs: Arc<dyn FileSystem>,
+        mountable: Arc<MountableFs>,
         env: HashMap<String, String>,
         username: Option<String>,
         hostname: Option<String>,
@@ -1670,6 +1766,7 @@ impl BashBuilder {
 
         Bash {
             fs,
+            mountable,
             interpreter,
             #[cfg(not(target_family = "wasm"))]
             parser_timeout,
@@ -1745,6 +1842,18 @@ pub mod threat_model {}
 #[cfg(feature = "python")]
 #[doc = include_str!("../docs/python.md")]
 pub mod python_guide {}
+
+/// Guide for live mount/unmount on a running Bash instance.
+///
+/// This guide covers:
+/// - Attaching/detaching filesystems post-build
+/// - State preservation across mount operations
+/// - Hot-swapping mounted filesystems
+/// - Layered filesystem architecture
+///
+/// **Related:** [`Bash::mount`], [`Bash::unmount`], [`MountableFs`], [`BashBuilder::mount_text`]
+#[doc = include_str!("../docs/live_mounts.md")]
+pub mod live_mounts_guide {}
 
 /// Logging guide for Bashkit.
 ///

--- a/crates/bashkit/tests/live_mount_tests.rs
+++ b/crates/bashkit/tests/live_mount_tests.rs
@@ -1,0 +1,156 @@
+//! Tests for live mount/unmount on a running Bash instance (issue #782).
+//!
+//! Verifies that `Bash::mount()` and `Bash::unmount()` work without
+//! rebuilding the interpreter, preserving shell state across operations.
+
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use std::path::Path;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn live_mount_makes_files_visible() {
+    let mut bash = Bash::new();
+
+    let data_fs = Arc::new(InMemoryFs::new());
+    data_fs
+        .write_file(Path::new("/hello.txt"), b"world")
+        .await
+        .unwrap();
+
+    bash.mount("/mnt/data", data_fs).unwrap();
+
+    let result = bash.exec("cat /mnt/data/hello.txt").await.unwrap();
+    assert_eq!(result.stdout, "world");
+}
+
+#[tokio::test]
+async fn live_unmount_removes_files() {
+    let mut bash = Bash::new();
+
+    let tmp_fs = Arc::new(InMemoryFs::new());
+    tmp_fs
+        .write_file(Path::new("/file.txt"), b"temp")
+        .await
+        .unwrap();
+
+    bash.mount("/scratch", tmp_fs).unwrap();
+    let result = bash.exec("cat /scratch/file.txt").await.unwrap();
+    assert_eq!(result.stdout, "temp");
+
+    bash.unmount("/scratch").unwrap();
+    let result = bash.exec("cat /scratch/file.txt 2>&1").await.unwrap();
+    assert_ne!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn live_mount_preserves_shell_state() {
+    let mut bash = Bash::new();
+
+    // Set up shell state before mount
+    bash.exec("export MY_VAR=preserved").await.unwrap();
+    bash.exec("cd /tmp").await.unwrap();
+
+    let data_fs = Arc::new(InMemoryFs::new());
+    data_fs
+        .write_file(Path::new("/data.txt"), b"content")
+        .await
+        .unwrap();
+
+    bash.mount("/mnt/data", data_fs).unwrap();
+
+    // Shell state should be preserved
+    let result = bash.exec("echo $MY_VAR").await.unwrap();
+    assert_eq!(result.stdout, "preserved\n");
+
+    let result = bash.exec("pwd").await.unwrap();
+    assert_eq!(result.stdout, "/tmp\n");
+
+    // Mounted data is accessible
+    let result = bash.exec("cat /mnt/data/data.txt").await.unwrap();
+    assert_eq!(result.stdout, "content");
+}
+
+#[tokio::test]
+async fn live_mount_works_with_builder() {
+    let mut bash = Bash::builder()
+        .mount_text("/config/app.conf", "debug=true\n")
+        .env("HOME", "/home/user")
+        .build();
+
+    // Pre-existing text mount still works
+    let result = bash.exec("cat /config/app.conf").await.unwrap();
+    assert_eq!(result.stdout, "debug=true\n");
+
+    // Live mount on top of builder config
+    let plugin_fs = Arc::new(InMemoryFs::new());
+    plugin_fs
+        .write_file(Path::new("/init.sh"), b"echo plugin loaded")
+        .await
+        .unwrap();
+
+    bash.mount("/plugins", plugin_fs).unwrap();
+
+    let result = bash.exec("cat /plugins/init.sh").await.unwrap();
+    assert_eq!(result.stdout, "echo plugin loaded");
+
+    // Builder env preserved
+    let result = bash.exec("echo $HOME").await.unwrap();
+    assert_eq!(result.stdout, "/home/user\n");
+}
+
+#[tokio::test]
+async fn unmount_nonexistent_returns_error() {
+    let bash = Bash::new();
+    assert!(bash.unmount("/nonexistent").is_err());
+}
+
+#[tokio::test]
+async fn multiple_live_mounts() {
+    let mut bash = Bash::new();
+
+    let fs_a = Arc::new(InMemoryFs::new());
+    fs_a.write_file(Path::new("/a.txt"), b"AAA").await.unwrap();
+
+    let fs_b = Arc::new(InMemoryFs::new());
+    fs_b.write_file(Path::new("/b.txt"), b"BBB").await.unwrap();
+
+    bash.mount("/mnt/a", fs_a).unwrap();
+    bash.mount("/mnt/b", fs_b).unwrap();
+
+    let result = bash.exec("cat /mnt/a/a.txt").await.unwrap();
+    assert_eq!(result.stdout, "AAA");
+
+    let result = bash.exec("cat /mnt/b/b.txt").await.unwrap();
+    assert_eq!(result.stdout, "BBB");
+
+    // Unmount one, other stays
+    bash.unmount("/mnt/a").unwrap();
+    let result = bash.exec("cat /mnt/b/b.txt").await.unwrap();
+    assert_eq!(result.stdout, "BBB");
+}
+
+#[tokio::test]
+async fn live_mount_replace() {
+    let mut bash = Bash::new();
+
+    let fs_v1 = Arc::new(InMemoryFs::new());
+    fs_v1
+        .write_file(Path::new("/version"), b"v1")
+        .await
+        .unwrap();
+
+    let fs_v2 = Arc::new(InMemoryFs::new());
+    fs_v2
+        .write_file(Path::new("/version"), b"v2")
+        .await
+        .unwrap();
+
+    bash.mount("/app", fs_v1).unwrap();
+    let result = bash.exec("cat /app/version").await.unwrap();
+    assert_eq!(result.stdout, "v1");
+
+    // Re-mount replaces the filesystem
+    bash.mount("/app", fs_v2).unwrap();
+    let result = bash.exec("cat /app/version").await.unwrap();
+    assert_eq!(result.stdout, "v2");
+}

--- a/specs/003-vfs.md
+++ b/specs/003-vfs.md
@@ -184,6 +184,7 @@ pub struct OverlayFs {
 - Mount multiple filesystems at different paths
 - Like Unix mount points
 - Longest-prefix matching for nested mounts
+- Always used as outermost FS layer for live mount/unmount support
 
 ```rust
 pub struct MountableFs {
@@ -260,6 +261,35 @@ When using mount points, `MountableFs` routes paths to the appropriate FS:
 See `crates/bashkit/examples/realfs_readonly.rs`,
 `crates/bashkit/examples/realfs_readwrite.rs`, and
 `examples/realfs_mount.sh` (bash script calling bashkit CLI).
+
+#### Live Mount/Unmount
+
+Every `Bash` instance wraps its filesystem stack in a `MountableFs` as
+the outermost layer. This enables post-build mount/unmount without
+rebuilding the interpreter:
+
+```rust
+bash.mount("/mnt/data", data_fs)?;   // attach filesystem
+bash.unmount("/mnt/data")?;          // detach filesystem
+```
+
+Shell state (env vars, cwd, history) is fully preserved across operations.
+The full layered stack:
+
+```text
+┌──────────────────────────────────┐
+│  MountableFs (live mounts)       │  ← Bash::mount() / unmount()
+├──────────────────────────────────┤
+│  OverlayFs (text mounts)         │  ← BashBuilder::mount_text()
+├──────────────────────────────────┤
+│  MountableFs (real mounts)       │  ← BashBuilder::mount_real_*_at()
+├──────────────────────────────────┤
+│  Base filesystem                 │  ← InMemoryFs or custom
+└──────────────────────────────────┘
+```
+
+See `crates/bashkit/examples/live_mounts.rs` and
+`crates/bashkit/docs/live_mounts.md` for details.
 
 ### Custom FileSystem Implementations
 


### PR DESCRIPTION
## Summary

- Add `Bash::mount()` and `Bash::unmount()` methods for attaching/detaching filesystems on a running interpreter without rebuilding — shell state (env vars, cwd, history) fully preserved
- Every `Bash` instance now wraps its filesystem stack in a `MountableFs` as the outermost layer, enabling post-build mount operations
- Delegate `mkfifo` through `MountableFs` to fix FIFO support through the new layer
- Add rustdoc guide (`crates/bashkit/docs/live_mounts.md`), example (`live_mounts.rs`), integration tests, and VFS spec update

Closes #782

## Test plan

- [x] 7 integration tests in `live_mount_tests.rs` covering mount, unmount, state preservation, builder compat, multiple mounts, hot-swap, and error cases
- [x] All 2099+ existing tests pass (including mkfifo tests through the new MountableFs layer)
- [x] `live_mounts` example runs successfully
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Example added to CI workflow