### PR TITLE
fix(examples): exit langchain example to prevent NAPI event loop hang

### DIFF
--- a/examples/langchain_integration.mjs
+++ b/examples/langchain_integration.mjs
@@ -97,3 +97,6 @@ if (process.env.OPENAI_API_KEY) {
 } else {
   console.log("\nSkipping agent (no OPENAI_API_KEY). Self-contained tests passed.");
 }
+
+// Native NAPI module keeps the event loop alive; exit explicitly.
+process.exit(0);


### PR DESCRIPTION
## Summary

- Add `process.exit(0)` at the end of `langchain_integration.mjs` to prevent the native NAPI tokio runtime from keeping the Node event loop alive indefinitely
- This was causing all 4 Node CI jobs to hang on the "Run examples (self-contained)" step

## Test plan

- [x] Node CI jobs should complete within normal timeframe
- [x] Example output remains unchanged (just exits cleanly)