### PR TITLE
feat(interpreter): subprocess isolation for VFS script-by-path execution

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3725,6 +3725,22 @@ impl Interpreter {
         };
 
         self.apply_builtin_side_effects(&result);
+
+        // Sync exported variables into env so subprocess isolation can see them
+        if name == "export" && result.exit_code == 0 {
+            for arg in args {
+                if let Some(eq_pos) = arg.find('=') {
+                    let var_name = &arg[..eq_pos];
+                    if let Some(value) = self.variables.get(var_name) {
+                        self.env.insert(var_name.to_string(), value.clone());
+                    }
+                } else if let Some(value) = self.variables.get(arg.as_str()) {
+                    // export NAME (without =) — mark existing variable as exported
+                    self.env.insert(arg.to_string(), value.clone());
+                }
+            }
+        }
+
         self.apply_redirections(result, redirects).await
     }
 
@@ -3943,12 +3959,34 @@ impl Interpreter {
             }
         };
 
+        // Subprocess isolation: path-based script execution only inherits
+        // exported variables (env), not the full parent shell state.
+        // This matches real bash behavior where ./script.sh spawns a subprocess.
+        let saved_vars = self.variables.clone();
+        let saved_arrays = self.arrays.clone();
+        let saved_assoc = self.assoc_arrays.clone();
+        let saved_functions = self.functions.clone();
+        let saved_traps = self.traps.clone();
+        let saved_call_stack = self.call_stack.clone();
+        let saved_exit = self.last_exit_code;
+        let saved_aliases = self.aliases.clone();
+        let saved_coproc = self.coproc_buffers.clone();
+
+        // Child only sees exported variables (env), not all shell variables
+        self.variables = self.env.clone();
+        self.arrays.clear();
+        self.assoc_arrays.clear();
+        self.functions.clear();
+        self.traps.clear();
+        self.aliases.clear();
+        self.coproc_buffers.clear();
+
         // Push call frame: $0 = script name, $1..N = args
-        self.call_stack.push(CallFrame {
+        self.call_stack = vec![CallFrame {
             name: name.to_string(),
             locals: HashMap::new(),
             positional: args.to_vec(),
-        });
+        }];
 
         // Forward pipeline stdin so commands inside the script (cat, read, etc.) can consume it
         let prev_pipeline_stdin = self.pipeline_stdin.take();
@@ -3956,8 +3994,16 @@ impl Interpreter {
 
         let result = self.execute(&script).await;
 
-        // Pop call frame and restore pipeline stdin
-        self.call_stack.pop();
+        // Restore full parent state — child mutations don't propagate
+        self.variables = saved_vars;
+        self.arrays = saved_arrays;
+        self.assoc_arrays = saved_assoc;
+        self.functions = saved_functions;
+        self.traps = saved_traps;
+        self.call_stack = saved_call_stack;
+        self.last_exit_code = saved_exit;
+        self.aliases = saved_aliases;
+        self.coproc_buffers = saved_coproc;
         self.pipeline_stdin = prev_pipeline_stdin;
 
         match result {

--- a/crates/bashkit/tests/spec_cases/bash/subprocess-isolation.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/subprocess-isolation.test.sh
@@ -1,0 +1,143 @@
+### subprocess_non_exported_vars_not_visible
+# Non-exported variables should not be visible in child scripts
+local_var="secret"
+export PUBLIC_VAR="visible"
+
+cat > /tmp/check.sh <<'SCRIPT'
+#!/usr/bin/env bash
+echo "public=${PUBLIC_VAR:-unset}"
+echo "local=${local_var:-unset}"
+SCRIPT
+chmod +x /tmp/check.sh
+
+/tmp/check.sh
+### expect
+public=visible
+local=unset
+### end
+
+### subprocess_child_changes_dont_affect_parent
+# Variable changes in child script don't propagate to parent
+export COUNTER=0
+
+cat > /tmp/increment.sh <<'SCRIPT'
+#!/usr/bin/env bash
+COUNTER=$((COUNTER + 1))
+echo "child: ${COUNTER}"
+SCRIPT
+chmod +x /tmp/increment.sh
+
+/tmp/increment.sh
+echo "parent: ${COUNTER}"
+### expect
+child: 1
+parent: 0
+### end
+
+### subprocess_functions_not_inherited
+# Functions defined in parent are not visible in child scripts
+helper() { echo "from parent"; }
+
+cat > /tmp/call-helper.sh <<'SCRIPT'
+#!/usr/bin/env bash
+helper 2>/dev/null
+echo "exit=$?"
+SCRIPT
+chmod +x /tmp/call-helper.sh
+
+/tmp/call-helper.sh
+### expect
+exit=127
+### end
+
+### subprocess_non_exported_arrays_not_visible
+# Non-exported arrays should not be visible in child scripts
+my_array=(one two three)
+export SIMPLE="yes"
+
+cat > /tmp/check-array.sh <<'SCRIPT'
+#!/usr/bin/env bash
+echo "simple=${SIMPLE:-unset}"
+echo "array_len=${#my_array[@]}"
+SCRIPT
+chmod +x /tmp/check-array.sh
+
+/tmp/check-array.sh
+### expect
+simple=yes
+array_len=0
+### end
+
+### subprocess_source_shares_state
+# source/. should still share full parent state (not isolated)
+local_var="visible-to-source"
+
+cat > /tmp/sourced.sh <<'SCRIPT'
+echo "local=${local_var:-unset}"
+local_var="modified"
+SCRIPT
+
+source /tmp/sourced.sh
+echo "after source: ${local_var}"
+### expect
+local=visible-to-source
+after source: modified
+### end
+
+### subprocess_exit_code_propagation
+# Exit code from child script propagates correctly
+cat > /tmp/fail.sh <<'SCRIPT'
+#!/usr/bin/env bash
+exit 42
+SCRIPT
+chmod +x /tmp/fail.sh
+
+/tmp/fail.sh
+echo "exit: $?"
+### expect
+exit: 42
+### end
+
+### subprocess_exported_vars_survive_nesting
+# Exported variables survive through nested script execution
+export LEVEL="parent"
+
+cat > /tmp/outer.sh <<'SCRIPT'
+#!/usr/bin/env bash
+echo "outer sees: ${LEVEL}"
+export LEVEL="outer"
+cat > /tmp/inner.sh <<'INNERSCRIPT'
+#!/usr/bin/env bash
+echo "inner sees: ${LEVEL}"
+INNERSCRIPT
+chmod +x /tmp/inner.sh
+/tmp/inner.sh
+SCRIPT
+chmod +x /tmp/outer.sh
+
+/tmp/outer.sh
+echo "parent still: ${LEVEL}"
+### expect
+outer sees: parent
+inner sees: outer
+parent still: parent
+### end
+
+### subprocess_path_search_isolated
+# PATH-based script execution should also be isolated
+not_exported="hidden"
+export VISIBLE="yes"
+
+mkdir -p /usr/local/bin
+cat > /usr/local/bin/check-isolation <<'SCRIPT'
+#!/usr/bin/env bash
+echo "visible=${VISIBLE:-unset}"
+echo "hidden=${not_exported:-unset}"
+SCRIPT
+chmod +x /usr/local/bin/check-isolation
+
+PATH="/usr/local/bin:${PATH}" check-isolation
+### expect
+visible=yes
+hidden=unset
+### end


### PR DESCRIPTION
## Summary\n\n- Path-based script execution (`./script.sh`, `$PATH` search) now runs in isolated subprocess scope\n- Only exported variables are inherited; parent functions, arrays, assoc-arrays are not visible\n- Child variable changes don't propagate back to parent\n- `source`/`.` continues to share full parent state (unchanged)\n- Export builtin now syncs to `self.env` so subprocess isolation correctly sees exported variables\n\nCloses #792\n\n## Test plan\n\n- [x] Non-exported vars not visible in child scripts\n- [x] Child variable changes don't affect parent\n- [x] Parent functions not inherited by child scripts\n- [x] Non-exported arrays not visible in child scripts\n- [x] Source still shares full parent state\n- [x] Exit code propagation works\n- [x] Exported vars survive through nested script execution\n- [x] PATH-based script execution is also isolated\n- [x] `cargo test --all-features` all green\n- [x] `cargo clippy` and `cargo fmt` clean