### PR TITLE
feat(interpreter): implement set -a (allexport)

### DIFF
--- a/crates/bashkit/src/builtins/export.rs
+++ b/crates/bashkit/src/builtins/export.rs
@@ -16,6 +16,17 @@ pub struct Export;
 #[async_trait]
 impl Builtin for Export {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        // Handle `export -p` — print all exported variables
+        if ctx.args.first().map(|s| s.as_str()) == Some("-p") {
+            let mut output = String::new();
+            let mut pairs: Vec<_> = ctx.env.iter().collect();
+            pairs.sort_by_key(|(k, _)| (*k).clone());
+            for (name, value) in pairs {
+                output.push_str(&format!("declare -x {}=\"{}\"\n", name, value));
+            }
+            return Ok(ExecResult::ok(output));
+        }
+
         for arg in ctx.args {
             // Handle NAME=VALUE format
             if let Some(eq_pos) = arg.find('=') {

--- a/crates/bashkit/src/builtins/vars.rs
+++ b/crates/bashkit/src/builtins/vars.rs
@@ -36,6 +36,7 @@ pub struct Set;
 /// Map long option names to their SHOPT_* variable names
 fn option_name_to_var(name: &str) -> Option<&'static str> {
     match name {
+        "allexport" => Some("SHOPT_a"),
         "errexit" => Some("SHOPT_e"),
         "nounset" => Some("SHOPT_u"),
         "xtrace" => Some("SHOPT_x"),
@@ -50,6 +51,7 @@ fn option_name_to_var(name: &str) -> Option<&'static str> {
 
 /// All known `set -o` options with their variable names, in display order.
 const SET_O_OPTIONS: &[(&str, &str)] = &[
+    ("allexport", "SHOPT_a"),
     ("errexit", "SHOPT_e"),
     ("noglob", "SHOPT_f"),
     ("noclobber", "SHOPT_C"),

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7550,6 +7550,13 @@ impl Interpreter {
         } else {
             value
         };
+        // Check allexport (set -a): auto-export to env
+        let allexport = self
+            .variables
+            .get("SHOPT_a")
+            .map(|v| v == "1")
+            .unwrap_or(false);
+
         for frame in self.call_stack.iter_mut().rev() {
             if let std::collections::hash_map::Entry::Occupied(mut e) =
                 frame.locals.entry(resolved.clone())
@@ -7561,9 +7568,15 @@ impl Interpreter {
                     .variable_bytes
                     .saturating_add(value.len())
                     .saturating_sub(old_val_len);
+                if allexport {
+                    self.env.insert(resolved, value.clone());
+                }
                 e.insert(value);
                 return;
             }
+        }
+        if allexport {
+            self.env.insert(resolved.clone(), value.clone());
         }
         self.insert_variable_checked(resolved, value);
     }

--- a/crates/bashkit/tests/spec_cases/bash/set-allexport.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/set-allexport.test.sh
@@ -1,0 +1,67 @@
+### set_a_basic
+# set -a exports new variables to env
+set -a
+FOO="bar"
+BAZ="qux"
+set +a
+AFTER="not-exported"
+env | grep -c "^FOO=bar$"
+env | grep -c "^BAZ=qux$"
+env | grep -c "^AFTER="
+### expect
+1
+1
+0
+### end
+
+### set_o_allexport
+# set -o allexport / set +o allexport works
+set -o allexport
+X="hello"
+set +o allexport
+Y="world"
+env | grep -c "^X=hello$"
+env | grep -c "^Y="
+### expect
+1
+0
+### end
+
+### set_a_not_retroactive
+# Variables assigned before set -a are not retroactively exported
+BEFORE="exists"
+set -a
+DURING="new"
+set +a
+env | grep -c "^BEFORE="
+env | grep -c "^DURING=new$"
+### expect
+0
+1
+### end
+
+### set_a_export_p
+# export -p lists allexported variables
+set -a
+EXPVAR="test123"
+set +a
+export -p | grep -c "declare -x EXPVAR="
+### expect
+1
+### end
+
+### set_a_source
+# set -a with source exports sourced variables
+cat > /tmp/vars.env <<'EOF'
+DB_HOST=localhost
+DB_PORT=5432
+EOF
+set -a
+source /tmp/vars.env
+set +a
+env | grep -c "^DB_HOST=localhost$"
+env | grep -c "^DB_PORT=5432$"
+### expect
+1
+1
+### end


### PR DESCRIPTION
## Summary\n\n- Map `allexport` in `option_name_to_var()` and `SET_O_OPTIONS` so `set -o allexport` works\n- Check `SHOPT_a` in `set_variable()` to auto-export variables to `self.env`\n- Implement `export -p` to list exported variables from env\n\nCloses #793\n\n## Test plan\n\n- [x] `set -a` exports new variables\n- [x] `set -o allexport` / `set +o allexport` works\n- [x] Variables assigned before `set -a` not retroactively exported\n- [x] `export -p` lists allexported variables\n- [x] `set -a` with `source` exports sourced variables\n- [x] `cargo test --all-features` green\n- [x] `cargo clippy` and `cargo fmt` clean