### PR TITLE
feat(awk): implement FILENAME built-in variable for multi-file processing

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -3036,8 +3036,20 @@ impl Builtin for Awk {
             inputs
         };
 
-        'files: for input in inputs {
+        'files: for (file_idx, input) in inputs.iter().enumerate() {
             interp.state.fnr = 0;
+            // Set FILENAME to current file path, or empty for stdin
+            if !files.is_empty() {
+                interp.state.variables.insert(
+                    "FILENAME".to_string(),
+                    AwkValue::String(files[file_idx].clone()),
+                );
+            } else {
+                interp
+                    .state
+                    .variables
+                    .insert("FILENAME".to_string(), AwkValue::String(String::new()));
+            }
             // Index-based iteration so getline can advance the index
             interp.input_lines = input.lines().map(|l| l.to_string()).collect();
             interp.line_index = 0;

--- a/crates/bashkit/tests/spec_cases/awk/filename.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/filename.test.sh
@@ -1,0 +1,37 @@
+### awk_filename_single_file
+# FILENAME is set when processing a single file
+echo -e "line1\nline2" > /tmp/f1.txt
+awk '{print FILENAME, $0}' /tmp/f1.txt
+### expect
+/tmp/f1.txt line1
+/tmp/f1.txt line2
+### end
+
+### awk_filename_multi_file
+# FILENAME changes between files
+echo "alpha" > /tmp/a.txt
+echo "beta" > /tmp/b.txt
+awk '{print FILENAME, $0}' /tmp/a.txt /tmp/b.txt
+### expect
+/tmp/a.txt alpha
+/tmp/b.txt beta
+### end
+
+### awk_filename_fnr_reset
+# FNR resets per file, FILENAME tracks current file
+echo -e "x\ny" > /tmp/p.txt
+echo -e "a\nb" > /tmp/q.txt
+awk '{print FILENAME, FNR, $0}' /tmp/p.txt /tmp/q.txt
+### expect
+/tmp/p.txt 1 x
+/tmp/p.txt 2 y
+/tmp/q.txt 1 a
+/tmp/q.txt 2 b
+### end
+
+### awk_filename_stdin_empty
+# FILENAME is empty when reading from stdin
+echo "hello" | awk '{print "file=[" FILENAME "]", $0}'
+### expect
+file=[] hello
+### end


### PR DESCRIPTION
## Summary\n\n- Set `FILENAME` to current file path before processing each file's lines in the awk interpreter\n- When reading from stdin (no file args), `FILENAME` is set to empty string\n\nCloses #795\n\n## Test plan\n\n- [x] FILENAME set for single file\n- [x] FILENAME changes between multiple files\n- [x] FNR resets per file while FILENAME tracks current\n- [x] FILENAME empty when reading from stdin\n- [x] All tests green