### PR TITLE
test(allexport): add regression tests for set -a behavior

### DIFF
--- a/crates/bashkit/tests/allexport_tests.rs
+++ b/crates/bashkit/tests/allexport_tests.rs
@@ -46,12 +46,9 @@ async fn allexport_with_source() {
     let mut bash = Bash::new();
     let fs = bash.fs();
 
-    fs.write_file(
-        Path::new("/vars.env"),
-        b"DB_HOST=localhost\nDB_PORT=5432",
-    )
-    .await
-    .unwrap();
+    fs.write_file(Path::new("/vars.env"), b"DB_HOST=localhost\nDB_PORT=5432")
+        .await
+        .unwrap();
 
     fs.write_file(
         Path::new("/check.sh"),


### PR DESCRIPTION
## Summary
- Add 5 regression tests for `set -a` (allexport) behavior
- Feature was already fully implemented; this adds test coverage
- Tests verify: basic export to subprocess, source integration, long option form, non-retroactivity, for-loop variable

## Test plan
- [x] All 5 new tests pass
- [x] Full test suite passes

Closes #793