### PR TITLE
feat(api): add BashBuilder::tty() for configurable terminal detection

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1092,6 +1092,26 @@ impl BashBuilder {
         self
     }
 
+    /// Configure whether a file descriptor is reported as a terminal by `[ -t fd ]`.
+    ///
+    /// In a sandboxed VFS environment, all FDs default to non-terminal (false).
+    /// Use this to simulate interactive mode for scripts that check `[ -t 0 ]`
+    /// (stdin), `[ -t 1 ]` (stdout), or `[ -t 2 ]` (stderr).
+    ///
+    /// ```rust
+    /// # use bashkit::Bash;
+    /// let bash = Bash::builder()
+    ///     .tty(0, true)  // stdin is a terminal
+    ///     .tty(1, true)  // stdout is a terminal
+    ///     .build();
+    /// ```
+    pub fn tty(mut self, fd: u32, is_terminal: bool) -> Self {
+        if is_terminal {
+            self.env.insert(format!("_TTY_{}", fd), "1".to_string());
+        }
+        self
+    }
+
     /// Set a fixed Unix epoch for the `date` builtin.
     ///
     /// THREAT[TM-INF-018]: Prevents `date` from leaking real host time.

--- a/crates/bashkit/tests/tty_tests.rs
+++ b/crates/bashkit/tests/tty_tests.rs
@@ -1,0 +1,46 @@
+//! Tests for [[ -t fd ]] terminal detection
+
+use bashkit::Bash;
+
+/// Issue #799: -t defaults to false in sandbox
+#[tokio::test]
+async fn tty_defaults_to_false() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("[[ -t 0 ]] && echo yes || echo no")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "no");
+}
+
+/// -t can be configured via builder
+#[tokio::test]
+async fn tty_configurable_via_builder() {
+    let mut bash = Bash::builder().tty(0, true).tty(1, true).build();
+    let result = bash
+        .exec("[[ -t 0 ]] && echo stdin_tty || echo stdin_no")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "stdin_tty");
+
+    let result = bash
+        .exec("[[ -t 1 ]] && echo stdout_tty || echo stdout_no")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "stdout_tty");
+
+    // fd 2 not configured, should be false
+    let result = bash
+        .exec("[[ -t 2 ]] && echo stderr_tty || echo stderr_no")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "stderr_no");
+}
+
+/// test builtin [ -t ] also works
+#[tokio::test]
+async fn tty_test_builtin_bracket() {
+    let mut bash = Bash::builder().tty(1, true).build();
+    let result = bash.exec("[ -t 1 ] && echo yes || echo no").await.unwrap();
+    assert_eq!(result.stdout.trim(), "yes");
+}


### PR DESCRIPTION
## Summary
- Add `BashBuilder::tty(fd, is_terminal)` method for configuring terminal detection
- `[ -t fd ]` and `[[ -t fd ]]` now respect per-FD configuration
- Defaults remain false (non-interactive) for all FDs in sandbox

## Test plan
- [x] `tty_defaults_to_false` — default behavior unchanged
- [x] `tty_configurable_via_builder` — stdin/stdout configurable, unconfigured FDs still false
- [x] `tty_test_builtin_bracket` — `[ -t ]` single-bracket also works
- [x] Full test suite passes

Closes #799