### PR TITLE
fix(interpreter): resolve namerefs before nounset check

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -8001,7 +8001,12 @@ impl Interpreter {
     }
 
     /// Check if a variable is set (for `set -u` / nounset).
+    /// Follows nameref indirection so that a nameref pointing to a defined
+    /// target is considered "set".
     fn is_variable_set(&self, name: &str) -> bool {
+        // Resolve nameref before checking — a nameref whose target exists is "set".
+        let name = self.resolve_nameref(name);
+
         // Special variables are always "set"
         if matches!(
             name,

--- a/crates/bashkit/tests/spec_cases/bash/nameref.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/nameref.test.sh
@@ -206,3 +206,61 @@ echo $x
 hello
 world
 ### end
+
+### nameref_nounset_basic
+# basic nameref under set -u (issue #834)
+set -u
+target="hello"
+declare -n ref=target
+echo "${ref}"
+### expect
+hello
+### end
+
+### nameref_nounset_local_n
+# local -n inside function under set -u
+set -u
+val="world"
+f() {
+  local -n r=$1
+  echo "$r"
+}
+f val
+### expect
+world
+### end
+
+### nameref_nounset_array
+# nameref to array under set -u
+set -u
+arr=(one two three)
+declare -n ref=arr
+echo "${ref[1]}"
+### expect
+two
+### end
+
+### nameref_nounset_write_through
+# nameref write-through under set -u
+set -u
+target="before"
+declare -n ref=target
+ref="after"
+echo "$target"
+### expect
+after
+### end
+
+### nameref_nounset_harness
+# harness pattern: set -euo pipefail with nameref function
+set -euo pipefail
+get_value() {
+  local -n out=$1
+  out="computed"
+}
+result=""
+get_value result
+echo "$result"
+### expect
+computed
+### end


### PR DESCRIPTION
## Summary

- Nameref variables are now followed to their target before checking if a variable is unbound under `set -u`
- Previously, the nameref itself was checked, causing false "unbound variable" errors even when the target was defined

## Test plan

- [x] `nameref_nounset_basic` — basic nameref under set -u
- [x] `nameref_nounset_local_n` — local -n inside function under nounset
- [x] `nameref_nounset_array` — nameref to array under nounset
- [x] `nameref_nounset_write_through` — nameref write-through under nounset
- [x] `nameref_nounset_harness_pattern` — set -euo pipefail with nameref function
- [x] All 1753 bash spec tests pass
- [x] No regressions

Closes #834