### PR TITLE
fix(awk): treat # inside regex literals as literal, not comment

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -402,8 +402,8 @@ fn normalize_awk_newlines(input: &str) -> String {
                     i += 1;
                 }
             }
-            '/' if brace_depth > 0 => {
-                // Potential regex literal — pass through unchanged
+            '/' => {
+                // Regex literal — pass through unchanged (both pattern and expression context)
                 result.push('/');
                 i += 1;
                 while i < chars.len() && chars[i] != '/' {

--- a/crates/bashkit/tests/spec_cases/awk/awk.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/awk.test.sh
@@ -703,3 +703,24 @@ awk 'BEGIN{print "caf\u00E9"}'
 ### expect
 café
 ### end
+
+### awk_regex_hash_pattern
+# Issue #835: # inside regex pattern should not be treated as comment
+echo '#test' | awk '/#/ { print "matched" }'
+### expect
+matched
+### end
+
+### awk_regex_hash_caret
+# Issue #835: /^#/ pattern
+printf '# heading\nnormal\n' | awk '/^#/ { print "comment:", $0 }'
+### expect
+comment: # heading
+### end
+
+### awk_regex_hash_no_match
+# Regex without # still works
+echo 'abc' | awk '/abc/ { print "yes" }'
+### expect
+yes
+### end


### PR DESCRIPTION
## Summary

- The awk normalizer now recognizes regex literals (`/pattern/`) in both pattern and action contexts
- Previously, regex was only recognized inside `{ }` braces, so `/#/` in a pattern position caused `#` to be treated as a comment start, resulting in "unterminated regex" errors

## Test plan

- [x] `awk_regex_hash_pattern` — `/#/` matches lines containing `#`
- [x] `awk_regex_hash_caret` — `/^#/` matches comment lines
- [x] `awk_regex_hash_no_match` — non-hash regex still works
- [x] All 119 awk spec tests pass
- [x] All 1748 bash spec tests pass
- [x] `cargo fmt --check` and `cargo clippy` clean

Closes #835