### PR TITLE
fix(awk): support backslash-newline line continuation

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -433,6 +433,10 @@ fn normalize_awk_newlines(input: &str) -> String {
                     i += 1;
                 }
             }
+            '\\' if i + 1 < chars.len() && chars[i + 1] == '\n' => {
+                // Backslash-newline: line continuation — join lines
+                i += 2;
+            }
             '\n' if brace_depth > 0 => {
                 // Inside action block: replace newline with semicolon
                 result.push(';');

--- a/crates/bashkit/tests/spec_cases/awk/awk.test.sh
+++ b/crates/bashkit/tests/spec_cases/awk/awk.test.sh
@@ -724,3 +724,24 @@ echo 'abc' | awk '/abc/ { print "yes" }'
 ### expect
 yes
 ### end
+
+### awk_backslash_newline_continuation
+# Issue #836: backslash-newline line continuation
+echo 'test' | awk '{
+    x = 1 + \
+        2
+    print x
+}'
+### expect
+3
+### end
+
+### awk_backslash_newline_condition
+# Issue #836: backslash-newline in condition
+echo '5' | awk '{
+    if ($1 > 3 && \
+        $1 < 10) print "yes"
+}'
+### expect
+yes
+### end


### PR DESCRIPTION
## Summary

- Backslash immediately before a newline is now treated as line continuation in awk programs
- The two characters are removed and physical lines are joined into one logical line
- This is standard POSIX awk behavior

## Test plan

- [x] `awk_backslash_newline_continuation` — basic line continuation in expression
- [x] `awk_backslash_newline_condition` — line continuation in condition
- [x] All 118 awk spec tests pass
- [x] All 1748 bash spec tests pass
- [x] `cargo fmt --check` and `cargo clippy` clean

Closes #836