### PR TITLE
fix(js): update exec security test for sandbox-safe exec behavior

### DIFF
--- a/crates/bashkit-js/__test__/security.spec.ts
+++ b/crates/bashkit-js/__test__/security.spec.ts
@@ -120,10 +120,11 @@ test("WB: stderr truncation on massive error output", (t) => {
 // 3. WHITE-BOX — Sandbox Escape Prevention (TM-ESC)
 // ============================================================================
 
-test("WB: exec builtin blocked (TM-ESC-001)", (t) => {
+test("WB: exec cannot escape sandbox (TM-ESC-001)", (t) => {
   const bash = new Bash();
-  const r = bash.executeSync("exec ls");
-  t.not(r.exitCode, 0, "exec must be blocked");
+  // exec runs commands within VFS sandbox — external binaries don't exist
+  const r = bash.executeSync("exec /bin/bash");
+  t.not(r.exitCode, 0, "exec of external binary must fail in sandbox");
 });
 
 test("WB: /proc filesystem not accessible (TM-ESC-003)", (t) => {


### PR DESCRIPTION
## Summary

- Fix JS CI failure on main caused by stale security test
- PR #815 changed `exec cmd` to run within VFS sandbox instead of blocking
- The Rust threat model tests were updated but the JS security test was not
- `exec ls` now succeeds (exit 0) since `ls` is a valid builtin in the sandbox
- Changed test to use `exec /bin/bash` which correctly fails (external binary not in VFS)

## Test plan

- [x] All 321 JS tests pass (including updated security test)
- [x] All JS examples pass (bash_basics, data_pipeline, llm_tool, langchain_integration)
- [x] All Rust tests pass (`cargo test --all-features`)
- [x] `cargo fmt --check` and `cargo clippy` clean