### PR TITLE
test(parser): unskip parse_unexpected_do and parse_unexpected_rbrace

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/parse-errors.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/parse-errors.test.sh
@@ -26,7 +26,6 @@ done
 
 ### parse_unexpected_do
 # do unexpected outside loop - bashkit should reject this
-### skip: TODO parser does not reject unexpected 'do' keyword
 bash -c 'do echo hi' 2>/dev/null
 echo status=$?
 ### expect
@@ -35,7 +34,6 @@ status=2
 
 ### parse_unexpected_rbrace
 # } is a parse error at top level
-### skip: TODO parser does not reject unexpected '}' at top level
 bash -c '}' 2>/dev/null
 echo status=$?
 ### expect


### PR DESCRIPTION
## What

Remove `### skip` from two parse error tests that now pass.

## Why

After scanning all 25 skipped spec tests, these two now pass:
- `parse_unexpected_do` — parser correctly rejects unexpected `do` outside a loop
- `parse_unexpected_rbrace` — parser correctly rejects unexpected `}` at top level

All other 23 skipped tests still fail and remain skipped.

## Tests

Pass rate: 100% (1783 passed, 0 failed, 23 skipped — up from 1781 passed, 25 skipped)