### PR TITLE
fix(interpreter): resolve namerefs in parameter expansion for assoc array subscripts

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6312,12 +6312,14 @@ impl Interpreter {
             .strip_suffix("[@]")
             .or_else(|| name.strip_suffix("[*]"))
         {
+            // Resolve nameref: if arr_name is a nameref, follow it to the target
+            let resolved_arr_name = self.resolve_nameref(arr_name);
             let sep = if is_star {
                 self.get_ifs_separator()
             } else {
                 " ".to_string()
             };
-            if let Some(arr) = self.assoc_arrays.get(arr_name) {
+            if let Some(arr) = self.assoc_arrays.get(resolved_arr_name) {
                 let is_set = !arr.is_empty();
                 let mut keys: Vec<_> = arr.keys().collect();
                 keys.sort();
@@ -6325,7 +6327,7 @@ impl Interpreter {
                     keys.iter().filter_map(|k| arr.get(*k).cloned()).collect();
                 return (is_set, values.join(&sep));
             }
-            if let Some(arr) = self.arrays.get(arr_name) {
+            if let Some(arr) = self.arrays.get(resolved_arr_name) {
                 let is_set = !arr.is_empty();
                 let mut indices: Vec<_> = arr.keys().collect();
                 indices.sort();
@@ -6343,15 +6345,17 @@ impl Interpreter {
             && name.ends_with(']')
         {
             let arr_name = &name[..bracket];
+            // Resolve nameref: if arr_name is a nameref, follow it to the target
+            let resolved_arr_name = self.resolve_nameref(arr_name);
             let key = &name[bracket + 1..name.len() - 1];
-            if let Some(arr) = self.assoc_arrays.get(arr_name) {
+            if let Some(arr) = self.assoc_arrays.get(resolved_arr_name) {
                 let expanded_key = self.expand_variable_or_literal(key);
                 return match arr.get(&expanded_key) {
                     Some(v) => (true, v.clone()),
                     None => (false, String::new()),
                 };
             }
-            if let Some(arr) = self.arrays.get(arr_name)
+            if let Some(arr) = self.arrays.get(resolved_arr_name)
                 && let Ok(idx) = key.parse::<usize>()
             {
                 return match arr.get(&idx) {

--- a/crates/bashkit/tests/spec_cases/bash/nameref.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/nameref.test.sh
@@ -264,3 +264,57 @@ echo "$result"
 ### expect
 computed
 ### end
+
+### nameref_assoc_default_value
+# ${ref[key]:-default} through nameref to assoc array (issue #801)
+declare -A m=([x]=1 [y]=2)
+f() {
+  local -n ref="$1"
+  echo "${ref[x]:-EMPTY}"
+  echo "${ref[y]:-EMPTY}"
+  echo "${ref[z]:-EMPTY}"
+}
+f m
+### expect
+1
+2
+EMPTY
+### end
+
+### nameref_assoc_replacement
+# ${ref[key]:+alt} through nameref to assoc array
+declare -A m=([a]=val)
+f() {
+  local -n ref="$1"
+  echo "${ref[a]:+found}"
+  echo "${ref[missing]:+found}"
+}
+f m
+### expect
+found
+
+### end
+
+### nameref_assoc_subscript_at_default
+# ${ref[@]:-default} through nameref to assoc array
+declare -A m=([k]=v)
+f() {
+  local -n ref="$1"
+  echo "${ref[@]:-EMPTY}"
+}
+f m
+### expect
+v
+### end
+
+### nameref_assoc_subscript_at_empty
+# ${ref[@]:-default} through nameref to empty assoc array
+declare -A m
+f() {
+  local -n ref="$1"
+  echo "${ref[@]:-EMPTY}"
+}
+f m
+### expect
+EMPTY
+### end


### PR DESCRIPTION
`resolve_param_expansion_name` didn't resolve namerefs before looking up array names for subscript access and bulk operations (`[@]`, `[*]`). This caused `${ref[key]:-default}` and `${ref[key]:+alt}` to always treat the value as unset when `ref` was a nameref to an associative array.

## Changes

- Resolve namerefs for `arr_name` in the `[@]`/`[*]` bulk access path
- Resolve namerefs for `arr_name` in the individual `[key]` subscript path
- Add 4 spec tests covering `:-`, `:+`, and `[@]:-` through namerefs

## Test plan

- [x] 4 new spec tests in `nameref.test.sh` (3 were failing before fix, all pass after)
- [x] All 1814 bash spec tests pass (0 failures, 23 skips)
- [x] Full harness compatibility suite: 98/98 pass
- [x] Issue #801 test cases: 16/16 pass
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #801