### PR TITLE
fix(interpreter): expand command substitutions in assoc array keys

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7714,15 +7714,18 @@ impl Interpreter {
         s.to_string()
     }
 
-    /// Expand an associative array key with full word expansion.
-    /// Unlike `expand_variable_or_literal`, this handles command substitutions
-    /// (`$(...)`, backticks) and all other expansion types. (Issue #872)
+    /// Fully expand an associative array key, including command substitutions.
+    /// Falls back to `expand_variable_or_literal` for keys without `$(` or backtick.
     async fn expand_assoc_key(&mut self, s: &str) -> Result<String> {
-        if s.contains('$') || s.contains('`') {
-            let word = crate::parser::Parser::parse_word_string(s);
+        if s.contains("$(") || s.contains('`') {
+            let word = Parser::parse_word_string_with_limits(
+                s,
+                self.limits.max_ast_depth,
+                self.limits.max_parser_operations,
+            );
             self.expand_word(&word).await
         } else {
-            Ok(s.to_string())
+            Ok(self.expand_variable_or_literal(s))
         }
     }
 

--- a/crates/bashkit/tests/spec_cases/bash/assoc-arrays.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/assoc-arrays.test.sh
@@ -202,6 +202,16 @@ result: [a
 b]
 ### end
 
+### assoc_key_command_substitution
+declare -A m=()
+m["$(echo hello)"]="world"
+echo "count: ${#m[@]}"
+for k in "${!m[@]}"; do echo "key=[$k] val=[${m[$k]}]"; done
+### expect
+count: 1
+key=[hello] val=[world]
+### end
+
 ### assoc_iteration
 declare -A m
 m[a]="1"


### PR DESCRIPTION
## Summary
- Associative array assignments where the key is a command substitution (e.g. `m["$(echo hello)"]="world"`) silently produced an empty key
- Add async `expand_assoc_key()` that parses the subscript as a full Word and expands it with `expand_word()` when it contains `$(` or backtick
- Add spec test `assoc_key_command_substitution`

## Test plan
- [x] New spec test `assoc_key_command_substitution` passes
- [x] All 1811 bash spec tests pass (100%)
- [x] Full `cargo test --all-features` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

Closes #872