### PR TITLE
fix(interpreter): expand special variables ($#, $?, etc.) in arithmetic

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7165,6 +7165,17 @@ impl Interpreter {
                     } else {
                         result.push_str(&expanded);
                     }
+                } else if let Some(&c) = chars.peek()
+                    && matches!(c, '#' | '?' | '$' | '!' | '@' | '*' | '-')
+                {
+                    // Handle special variables: $#, $?, $$, $!, $@, $*, $-
+                    chars.next();
+                    let value = self.expand_variable(&c.to_string());
+                    if value.is_empty() {
+                        result.push('0');
+                    } else {
+                        result.push_str(&value);
+                    }
                 } else {
                     // Handle $var syntax (common in arithmetic)
                     let mut name = String::new();

--- a/crates/bashkit/tests/spec_cases/bash/arithmetic.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arithmetic.test.sh
@@ -493,3 +493,26 @@ echo $x
 ### expect
 42
 ### end
+
+### arith_special_var_hash
+# $# in arithmetic context
+set -- a b c
+echo "argc: $#"
+(( $# > 0 )) && echo "true" || echo "false"
+(( 3 > 0 )) && echo "true2" || echo "false2"
+x=$#
+(( x > 0 )) && echo "true3" || echo "false3"
+### expect
+argc: 3
+true
+true2
+true3
+### end
+
+### arith_special_var_question
+# $? in arithmetic context
+true
+(( $? == 0 )) && echo "zero" || echo "nonzero"
+### expect
+zero
+### end


### PR DESCRIPTION
## Summary
- Special variables like `$#`, `$?`, `$$` were not expanded inside `(( ))` arithmetic because `expand_arithmetic_vars_depth` only consumed alphanumeric/underscore chars after `$`
- Add handling for special variable characters (`#`, `?`, `$`, `!`, `@`, `*`, `-`) in the arithmetic variable expansion
- Add spec tests `arith_special_var_hash` and `arith_special_var_question`

## Test plan
- [x] New spec tests pass
- [x] All 1812 bash spec tests pass (100%)
- [x] Full `cargo test --all-features` passes
- [x] `cargo fmt --check` and `cargo clippy` clean

Closes #876