### PR TITLE
chore(deps): require major version upgrades in maintenance checklist

### DIFF
--- a/.claude/commands/maintain.md
+++ b/.claude/commands/maintain.md
@@ -10,7 +10,17 @@ Each section below is an outcome to achieve, not a script to follow. Use whateve
 
 ### 1. Dependencies are current and clean
 
-Ensure all direct dependencies are up to date, no CVEs exist, and license/advisory/supply-chain checks pass.
+Ensure all direct dependencies are at their latest versions — including major/breaking upgrades. Don't just run `cargo update`; also check `cargo outdated` for major version bumps and update the version constraints in `Cargo.toml` accordingly.
+
+For each outdated dependency (including major bumps):
+1. Bump the version constraint in workspace `Cargo.toml` (or crate-level if not in workspace)
+2. Run `cargo build` — fix compilation errors from API changes
+3. Run `cargo test` — fix test failures
+4. If an upgrade requires non-trivial refactoring (>50 lines changed), defer it to a tracked GitHub issue
+
+After all bumps, run `cargo update` to lock latest patch versions.
+
+Ensure no CVEs exist and license/advisory/supply-chain checks pass.
 
 Key tools: `cargo update`, `cargo outdated`, `cargo audit`, `cargo deny check`, `just vet`
 

--- a/specs/012-maintenance.md
+++ b/specs/012-maintenance.md
@@ -18,11 +18,17 @@ dependency rot, or security gaps ship in a release.
 
 ### Dependencies
 
-- All direct dependencies at latest compatible versions
+- All direct dependencies at latest versions, including major/breaking upgrades
+- Upgrade procedure for each outdated dependency:
+  1. Bump version constraint in `Cargo.toml` (workspace or crate-level)
+  2. Run `cargo build` — fix any compilation errors from API changes
+  3. Run `cargo test` — fix any test failures
+  4. If upgrade requires non-trivial refactoring (>50 lines changed), defer to a
+     tracked GitHub issue instead of blocking the maintenance pass
+- `cargo update` run after all version bumps to lock latest patch versions
 - No known CVEs in dependency tree
 - License and advisory checks pass (`deny.toml`)
 - Supply chain audit passes
-- Major version bumps evaluated and upgraded where safe
 
 ### Security
 


### PR DESCRIPTION
## Summary

- Updated `specs/012-maintenance.md` to require upgrading **all** dependencies including major/breaking versions, not just semver-compatible ones
- Added step-by-step upgrade procedure: bump constraint → build → test → fix or defer (>50 lines) to tracked issue
- Updated `.claude/commands/maintain.md` skill with matching instructions so `/maintain` actually bumps `Cargo.toml` version constraints

## Why

`cargo update` only resolves within semver-compatible ranges. Dependencies like `jaq-core "2.2"` (available: 3.0.0) and `sha2 "0.10"` (available: 0.11.0) were silently skipped during maintenance passes because the spec was vague ("evaluated and upgraded where safe").

## Test plan

- [x] `just build` passes
- [x] `just test` passes
- [x] `just pre-pr` passes (except `cargo vet` not installed in cloud env)
- [x] Docs-only change — no code paths affected