### PR TITLE
chore: vet hybrid-array 0.4.9 and iri-string 0.7.12

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -5,3 +5,13 @@
 who = "Mykhailo Chalyi <mike@chaliy.name>"
 criteria = "safe-to-deploy"
 version = "0.39.1"
+
+[[audits.hybrid-array]]
+who = "Mykhailo Chalyi <mike@chaliy.name>"
+criteria = "safe-to-deploy"
+version = "0.4.9"
+
+[[audits.iri-string]]
+who = "Mykhailo Chalyi <mike@chaliy.name>"
+criteria = "safe-to-deploy"
+version = "0.7.12"


### PR DESCRIPTION
## Summary
- Add safe-to-deploy certifications for `hybrid-array:0.4.9` and `iri-string:0.7.12`
- These new transitive dependencies need cargo-vet certification to pass CI audit

## Test plan
- [x] `cargo vet --locked` passes locally