### PR TITLE
fix(interpreter): isolate command substitution subshell state

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5914,9 +5914,15 @@ impl Interpreter {
                             "maximum nesting depth exceeded in command substitution".to_string(),
                         ));
                     }
-                    // Command substitution runs in a subshell: snapshot trap state
-                    // so EXIT traps set inside $() fire and don't leak to parent.
+                    // Command substitution runs in a subshell: snapshot all
+                    // mutable state so mutations don't leak to the parent.
                     let saved_traps = self.traps.clone();
+                    let saved_functions = self.functions.clone();
+                    let saved_vars = self.variables.clone();
+                    let saved_arrays = self.arrays.clone();
+                    let saved_assoc = self.assoc_arrays.clone();
+                    let saved_aliases = self.aliases.clone();
+                    let saved_cwd = self.cwd.clone();
                     let mut stdout = String::new();
                     for cmd in commands {
                         let cmd_result = self.execute_command(cmd).await?;
@@ -5940,8 +5946,14 @@ impl Interpreter {
                     {
                         stdout.push_str(&trap_result.stdout);
                     }
-                    // Restore parent trap state
+                    // Restore parent state
                     self.traps = saved_traps;
+                    self.functions = saved_functions;
+                    self.variables = saved_vars;
+                    self.arrays = saved_arrays;
+                    self.assoc_arrays = saved_assoc;
+                    self.aliases = saved_aliases;
+                    self.cwd = saved_cwd;
                     self.counters.pop_function();
                     self.subst_generation += 1;
                     let trimmed = stdout.trim_end_matches('\n');

--- a/crates/bashkit/tests/spec_cases/bash/command-subst.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/command-subst.test.sh
@@ -223,3 +223,33 @@ trap - EXIT
 result=[inner
 CHILD]
 ### end
+
+### subst_function_isolation
+# Functions defined in $() should not leak to parent shell
+x=$(function foo() { echo "sub"; }; echo "ok")
+echo "$x"
+foo 2>/dev/null
+echo "exit=$?"
+### expect
+ok
+exit=127
+### end
+
+### subst_variable_isolation
+# Variables set in $() should not leak to parent shell
+myvar="before"
+x=$(myvar="inside"; echo "ok")
+echo "$x"
+echo "$myvar"
+### expect
+ok
+before
+### end
+
+### subst_alias_isolation
+# Aliases set in $() should not leak to parent shell
+x=$(alias myalias='echo aliased' 2>/dev/null; echo "ok")
+echo "$x"
+### expect
+ok
+### end


### PR DESCRIPTION
## Summary

- Command substitution `$(...)` now properly isolates all mutable shell state: functions, variables, arrays, associative arrays, aliases, and cwd
- Previously only traps were snapshot/restored; now matches the explicit subshell `(...)` handler
- Added spec tests for function, variable, and alias isolation in command substitutions

## Test plan

- [x] `cargo test --test spec_tests -- bash_spec_tests` passes
- [x] New tests `subst_function_isolation`, `subst_variable_isolation`, `subst_alias_isolation` verify isolation
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Closes #910