### PR TITLE
chore(supply-chain): update exemptions for hybrid-array, hyper

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -507,11 +507,11 @@ version = "1.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.hybrid-array]]
-version = "0.4.8"
+version = "0.4.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper]]
-version = "1.8.1"
+version = "1.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-rustls]]


### PR DESCRIPTION
## Summary
- Updates cargo-vet exemptions for `hybrid-array` 0.4.8→0.4.10 and `hyper` 1.8.1→1.9.0
- Fixes Audit CI failure blocking all open PRs

## Test plan
- [x] `cargo vet --locked` passes locally