### PR TITLE
docs: fix rustdoc guides rendering on docs.rs

### DIFF
--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -94,6 +94,10 @@ python = ["dep:monty"]
 # Usage: cargo build --features realfs
 realfs = []
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dev-dependencies]
 tokio-test = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -380,9 +380,10 @@
 //! # Guides
 //!
 //! - [`custom_builtins_guide`] - Creating custom builtins
-//! - `python_guide` - Embedded Python (Monty) guide (requires `python` feature)
 //! - [`compatibility_scorecard`] - Feature parity tracking
-//! - `logging_guide` - Structured logging with security (requires `logging` feature)
+//! - [`live_mounts_guide`] - Live mount/unmount on running instances
+//! - [`python_guide`] - Embedded Python (Monty) guide (requires `python` feature)
+//! - [`logging_guide`] - Structured logging with security (requires `logging` feature)
 //!
 //! # Resources
 //!


### PR DESCRIPTION
## Summary

- Add `[package.metadata.docs.rs]` with `all-features = true` so feature-gated guide modules (`python_guide`, `logging_guide`) render on docs.rs
- Fix Guides section in crate docs: add missing `live_mounts_guide`, convert plain backticks to `[`link brackets`]` for clickable links

## Test plan

- [x] `cargo doc --all-features --no-deps` builds cleanly
- [x] All 6 guide links render correctly in generated HTML
- [x] `cargo test --all-features` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean