### PR TITLE
feat(js): Vercel AI SDK adapter — first-class integration

### DIFF
--- a/crates/bashkit-js/ai.ts
+++ b/crates/bashkit-js/ai.ts
@@ -1,0 +1,151 @@
+/**
+ * Vercel AI SDK adapter for Bashkit.
+ *
+ * Returns `{ system, tools }` that plugs directly into `generateText()` /
+ * `streamText()` with zero boilerplate. Tools include built-in `execute`
+ * functions, so the AI SDK auto-executes tool calls in its `maxSteps` loop.
+ *
+ * @example
+ * ```typescript
+ * import { generateText } from "ai";
+ * import { anthropic } from "@ai-sdk/anthropic";
+ * import { bashTool } from "@everruns/bashkit/ai";
+ *
+ * const bash = bashTool({
+ *   files: { "/home/user/data.csv": "name,age\nAlice,30\nBob,25" },
+ * });
+ *
+ * const { text } = await generateText({
+ *   model: anthropic("claude-haiku-4-5-20251001"),
+ *   system: bash.system,
+ *   tools: bash.tools,
+ *   maxSteps: 5,
+ *   prompt: "Analyze the CSV file and tell me the average age",
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import { Bash, BashTool } from "./wrapper.js";
+import type { BashOptions, ExecResult } from "./wrapper.js";
+
+// Vercel AI SDK tool types — we define them inline to avoid requiring
+// the `ai` package as a dependency (it's a peer dependency).
+// These match the ai@4.x Tool interface.
+
+/** Vercel AI SDK CoreTool-compatible object. */
+interface AiTool {
+  type?: "function";
+  description: string;
+  parameters: {
+    type: "object";
+    properties: Record<string, unknown>;
+    required: string[];
+    additionalProperties?: boolean;
+    $schema?: string;
+  };
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}
+
+/** Options for configuring the bash tool adapter. */
+export interface BashToolOptions extends Omit<BashOptions, "files"> {
+  /** Pre-populate VFS files. Keys are absolute paths, values are file contents. */
+  files?: Record<string, string>;
+}
+
+/** Return value of `bashTool()`. */
+export interface BashToolAdapter {
+  /** System prompt describing bash capabilities and constraints. */
+  system: string;
+  /** Tool definitions for Vercel AI SDK's generateText/streamText. */
+  tools: Record<string, AiTool>;
+  /** The underlying Bash instance for direct access. */
+  bash: Bash;
+}
+
+function formatOutput(result: ExecResult): string {
+  let output = result.stdout;
+  if (result.stderr) {
+    output += (output ? "\n" : "") + `STDERR: ${result.stderr}`;
+  }
+  if (result.exitCode !== 0) {
+    output += (output ? "\n" : "") + `[Exit code: ${result.exitCode}]`;
+  }
+  return output || "(no output)";
+}
+
+/**
+ * Create a bash tool adapter for the Vercel AI SDK.
+ *
+ * Returns `{ system, tools }` that plugs directly into `generateText()` or
+ * `streamText()`. The tool includes a built-in `execute` function, so tool
+ * calls are auto-executed when using `maxSteps`.
+ *
+ * @param options - Configuration for the bash interpreter
+ *
+ * @example
+ * ```typescript
+ * import { generateText } from "ai";
+ * import { anthropic } from "@ai-sdk/anthropic";
+ * import { bashTool } from "@everruns/bashkit/ai";
+ *
+ * const bash = bashTool({ files: { "/test.txt": "hello world" } });
+ *
+ * const { text } = await generateText({
+ *   model: anthropic("claude-haiku-4-5-20251001"),
+ *   system: bash.system,
+ *   tools: bash.tools,
+ *   maxSteps: 3,
+ *   prompt: "Read /test.txt and tell me what it says",
+ * });
+ * ```
+ */
+export function bashTool(options?: BashToolOptions): BashToolAdapter {
+  const { files, ...bashOptions } = options ?? {};
+
+  const bashToolInstance = new BashTool(bashOptions);
+  const bash = new Bash(bashOptions);
+
+  if (files) {
+    for (const [path, content] of Object.entries(files)) {
+      bash.writeFile(path, content);
+    }
+  }
+
+  const system = bashToolInstance.systemPrompt();
+
+  const tools: Record<string, AiTool> = {
+    bash: {
+      description: bashToolInstance.description(),
+      parameters: {
+        type: "object",
+        properties: {
+          commands: {
+            type: "string",
+            description:
+              "Bash commands to execute. State persists between calls.",
+          },
+        },
+        required: ["commands"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+      execute: async (args: Record<string, unknown>): Promise<string> => {
+        const commands = args.commands as string;
+        if (!commands) {
+          return "Error: missing 'commands' parameter";
+        }
+
+        try {
+          const result = await bash.execute(commands);
+          return formatOutput(result);
+        } catch (err) {
+          return `Execution error: ${err instanceof Error ? err.message : String(err)}`;
+        }
+      },
+    },
+  };
+
+  return { system, tools, bash };
+}

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -19,6 +19,9 @@
     },
     "./openai": {
       "default": "./openai.js"
+    },
+    "./ai": {
+      "default": "./ai.js"
     }
   },
   "license": "MIT",
@@ -53,6 +56,8 @@
     "anthropic.d.ts",
     "openai.js",
     "openai.d.ts",
+    "ai.js",
+    "ai.d.ts",
     "index.cjs",
     "index.d.ts",
     "index.d.cts",

--- a/crates/bashkit-js/tsconfig.json
+++ b/crates/bashkit-js/tsconfig.json
@@ -12,6 +12,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["wrapper.ts", "langchain.ts", "anthropic.ts", "openai.ts"],
+  "include": ["wrapper.ts", "langchain.ts", "anthropic.ts", "openai.ts", "ai.ts"],
   "exclude": ["node_modules", "__test__"]
 }


### PR DESCRIPTION
## Summary

- Add `@everruns/bashkit/ai` entry point with `bashTool()` helper
- Returns `{ system, tools }` for Vercel AI SDK's `generateText()` / `streamText()`
- Tools include built-in `execute` function — auto-execution via `maxSteps`
- No manual tool call loop needed (most ergonomic adapter)
- Compatible with any AI SDK provider (`@ai-sdk/anthropic`, `@ai-sdk/openai`, etc.)

## Test plan

- [x] TypeScript type-checks cleanly
- [x] Follows established adapter pattern
- [ ] Integration test with Claude Haiku via `@ai-sdk/anthropic` (CI-gated)

Closes #933