### PR TITLE
fix(parser): reconstruct braces in process substitution token loop

### DIFF
--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -2448,6 +2448,17 @@ impl<'a> Parser<'a> {
                             cmd_str.push_str(&format!(" {}> ", fd));
                             self.advance();
                         }
+                        Some(tokens::Token::LeftBrace) => {
+                            if !cmd_str.is_empty() {
+                                cmd_str.push(' ');
+                            }
+                            cmd_str.push('{');
+                            self.advance();
+                        }
+                        Some(tokens::Token::RightBrace) => {
+                            cmd_str.push_str(" }");
+                            self.advance();
+                        }
                         Some(tokens::Token::Newline) => {
                             cmd_str.push('\n');
                             self.advance();

--- a/crates/bashkit/tests/spec_cases/bash/procsub.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/procsub.test.sh
@@ -101,3 +101,32 @@ a
 b
 c
 ### end
+
+### process_subst_group_pipe
+### bash_diff: requires /dev/fd/
+# { ... } | cmd inside < <(...) should produce output
+while IFS= read -r line; do echo "$line"; done < <({ echo "a"; echo "b"; } | cat)
+### expect
+a
+b
+### end
+
+### process_subst_group_pipe_tac
+### bash_diff: requires /dev/fd/
+# { ... } | tac inside < <(...)
+while IFS= read -r line; do echo "$line"; done < <({ echo "1"; echo "2"; echo "3"; } | tac)
+### expect
+3
+2
+1
+### end
+
+### process_subst_group_pipe_sort
+### bash_diff: requires /dev/fd/
+# { ... } | sort inside < <(...)
+while IFS= read -r line; do echo "$line"; done < <({ echo "c"; echo "a"; echo "b"; } | sort)
+### expect
+a
+b
+c
+### end


### PR DESCRIPTION
## Summary

- Fix group command `{ ... }` piped to another command producing no output inside process substitution `< <(...)`
- Root cause: `LeftBrace` and `RightBrace` tokens were missing from the process substitution parser's token reconstruction loop, silently dropping them
- Added 3 spec tests covering group+pipe, group+tac, group+sort inside process substitution

## What

The process substitution parser reconstructs command strings from tokens to re-parse them. The match block handled `Pipe`, `Semicolon`, `And`, `Or`, etc. but was missing `LeftBrace` and `RightBrace`. These fell through to the catch-all `_` branch which silently dropped them, turning `{ echo a; echo b; } | cat` into `echo a; echo b; | cat`.

## Test plan

- [x] 3 new spec tests: `process_subst_group_pipe`, `process_subst_group_pipe_tac`, `process_subst_group_pipe_sort`
- [x] All existing procsub tests still pass
- [x] Manual verification: `cat < <({ echo "line1"; echo "line2"; } | cat)` now outputs correctly
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] Full test suite green

Closes #947