### PR TITLE
fix(builtins): produce empty JSON string for jq -Rs with empty stdin

### DIFF
--- a/crates/bashkit/src/builtins/jq.rs
+++ b/crates/bashkit/src/builtins/jq.rs
@@ -412,7 +412,8 @@ impl Builtin for Jq {
         };
 
         // If no input and not null_input mode, return empty
-        if input.trim().is_empty() && !null_input {
+        // (but not for -Rs: raw_input+slurp should produce "" for empty stdin)
+        if input.trim().is_empty() && !null_input && !(raw_input && slurp) {
             return Ok(ExecResult::ok(String::new()));
         }
 
@@ -1359,6 +1360,13 @@ mod tests {
         .unwrap();
         assert!(result.contains("a,b,c"));
         assert!(result.contains("1,2,3"));
+    }
+
+    #[tokio::test]
+    async fn test_jq_raw_input_slurp_empty_stdin() {
+        // -Rs on empty stdin should produce "" (empty JSON string), not nothing
+        let result = run_jq_with_args(&["-Rs", "."], "").await.unwrap();
+        assert_eq!(result.trim(), "\"\"");
     }
 
     // --- Process env pollution tests (issue #410) ---

--- a/crates/bashkit/tests/spec_cases/jq/jq.test.sh
+++ b/crates/bashkit/tests/spec_cases/jq/jq.test.sh
@@ -1000,3 +1000,17 @@ printf 'a,b\n1,2\n' | jq -Rs 'split("\n") | map(select(length>0))'
   "1,2"
 ]
 ### end
+
+### jq_raw_slurp_empty_stdin
+# jq -Rs on empty stdin should produce empty JSON string
+printf '' | jq -Rs '.'
+### expect
+""
+### end
+
+### jq_raw_slurp_normal
+# jq -Rs on normal input (no regression)
+printf 'hello' | jq -Rs '.'
+### expect
+"hello"
+### end


### PR DESCRIPTION
## Summary

- Fix `jq -Rs '.'` producing no output on empty stdin instead of `""`
- Root cause: early return when `input.trim().is_empty()` fired before the `-Rs` code path could create an empty string value
- Added `&& !(raw_input && slurp)` guard so `-Rs` with empty stdin proceeds to create `Val::from("")`

## Test plan

- [x] New spec test: `jq_raw_slurp_empty_stdin` — verifies `printf '' | jq -Rs '.'` outputs `""`
- [x] New spec test: `jq_raw_slurp_normal` — regression test for non-empty input
- [x] All 121 existing jq spec tests pass
- [x] Full spec test suite green

Closes #952