### PR TITLE
fix(parser): treat escaped dollar \\$ in double quotes as literal

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -416,7 +416,14 @@ impl<'a> Lexer<'a> {
                                 '\n' => {
                                     self.advance();
                                 }
-                                '"' | '\\' | '$' | '`' => {
+                                '$' => {
+                                    // Use NUL sentinel so parse_word() treats this
+                                    // as a literal '$' rather than a variable expansion.
+                                    word.push('\x00');
+                                    word.push('$');
+                                    self.advance();
+                                }
+                                '"' | '\\' | '`' => {
                                     word.push(next);
                                     self.advance();
                                 }
@@ -512,7 +519,14 @@ impl<'a> Lexer<'a> {
                                     // \<newline> is line continuation: discard both
                                     self.advance();
                                 }
-                                '"' | '\\' | '$' | '`' => {
+                                '$' => {
+                                    // Use NUL sentinel so parse_word() treats this
+                                    // as a literal '$' rather than a variable expansion.
+                                    word.push('\x00');
+                                    word.push('$');
+                                    self.advance();
+                                }
+                                '"' | '\\' | '`' => {
                                     word.push(next);
                                     self.advance();
                                 }
@@ -568,7 +582,12 @@ impl<'a> Lexer<'a> {
                                     '\n' => {
                                         self.advance();
                                     }
-                                    '"' | '\\' | '$' | '`' => {
+                                    '$' => {
+                                        word.push('\x00');
+                                        word.push('$');
+                                        self.advance();
+                                    }
+                                    '"' | '\\' | '`' => {
                                         word.push(next);
                                         self.advance();
                                     }
@@ -937,7 +956,12 @@ impl<'a> Lexer<'a> {
                             self.advance();
                             if let Some(next) = self.peek_char() {
                                 match next {
-                                    '"' | '\\' | '$' | '`' => {
+                                    '$' => {
+                                        content.push('\x00');
+                                        content.push('$');
+                                        self.advance();
+                                    }
+                                    '"' | '\\' | '`' => {
                                         content.push(next);
                                         self.advance();
                                     }
@@ -1108,7 +1132,14 @@ impl<'a> Lexer<'a> {
                                 // \<newline> is line continuation: discard both
                                 self.advance();
                             }
-                            '"' | '\\' | '$' | '`' => {
+                            '$' => {
+                                // Use NUL sentinel so parse_word() treats this
+                                // as a literal '$' rather than a variable expansion.
+                                content.push('\x00');
+                                content.push('$');
+                                self.advance();
+                            }
+                            '"' | '\\' | '`' => {
                                 content.push(next);
                                 self.advance();
                             }
@@ -1332,7 +1363,12 @@ impl<'a> Lexer<'a> {
                     self.advance();
                     if let Some(esc) = self.peek_char() {
                         match esc {
-                            '"' | '\\' | '$' | '`' => {
+                            '$' => {
+                                content.push('\x00');
+                                content.push('$');
+                                self.advance();
+                            }
+                            '"' | '\\' | '`' => {
                                 content.push(esc);
                                 self.advance();
                             }

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -2539,7 +2539,12 @@ impl<'a> Parser<'a> {
         let mut current = String::new();
 
         while let Some(ch) = chars.next() {
-            if ch == '$' {
+            if ch == '\x00' {
+                // NUL sentinel from lexer: next char is a literal (escaped in source).
+                if let Some(literal_ch) = chars.next() {
+                    current.push(literal_ch);
+                }
+            } else if ch == '$' {
                 // Flush current literal
                 if !current.is_empty() {
                     parts.push(WordPart::Literal(std::mem::take(&mut current)));

--- a/crates/bashkit/tests/spec_cases/bash/blackbox-exploration.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/blackbox-exploration.test.sh
@@ -1370,11 +1370,10 @@ say "hello"
 ### end
 
 ### escaped_dollar
-### bash_diff: echo "\$HOME" — bashkit expands the variable instead of treating \$ as literal (#668)
-# Escaped dollar sign — bash: "$HOME", bashkit: "/home/sandbox"
+# Escaped dollar sign — bash treats \$ in double quotes as literal $
 echo "\$HOME"
 ### expect
-/home/sandbox
+$HOME
 ### end
 
 ### escaped_backtick


### PR DESCRIPTION
## Summary

- Fix `\$` inside double quotes expanding as variable instead of literal `$`
- Root cause: lexer correctly converts `\$` to `$` but `parse_word()` re-interprets it as variable expansion
- Used sentinel character to distinguish escaped dollars from genuine expansion markers

## Test plan

- [x] New spec tests: `backslash_dollar_in_double_quotes`, `backslash_dollar_with_text`, `backslash_dollar_set_u`, `backslash_dollar_in_assignment`
- [x] No regressions in existing spec tests
- [x] clippy + fmt clean

Closes #948