### PR TITLE
fix(builtins): clear variable on read at EOF with no remaining data

### DIFF
--- a/crates/bashkit/src/builtins/read.rs
+++ b/crates/bashkit/src/builtins/read.rs
@@ -13,10 +13,7 @@ pub struct Read;
 impl Builtin for Read {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
         // Get the input to read from stdin
-        let input = match ctx.stdin {
-            Some(s) => s.to_string(),
-            None => return Ok(ExecResult::err("", 1)),
-        };
+        let input = ctx.stdin.map(|s| s.to_string());
 
         // Parse flags
         let mut raw_mode = false; // -r: don't interpret backslashes
@@ -81,6 +78,31 @@ impl Builtin for Read {
             }
         }
         let _ = prompt; // prompt is for interactive use, ignored in non-interactive
+
+        // EOF with no data: clear all target variables to empty and return 1.
+        // This prevents the common `while read line || [[ -n "$line" ]]`
+        // pattern from looping infinitely on the stale last value.
+        let input = match input {
+            Some(s) => s,
+            None => {
+                let var_names: Vec<&str> = if var_args.is_empty() {
+                    vec!["REPLY"]
+                } else {
+                    var_args
+                };
+                let mut result = ExecResult::err("", 1);
+                for var_name in &var_names {
+                    if is_internal_variable(var_name) {
+                        continue;
+                    }
+                    result.side_effects.push(BuiltinSideEffect::SetVariable {
+                        name: var_name.to_string(),
+                        value: String::new(),
+                    });
+                }
+                return Ok(result);
+            }
+        };
 
         // Extract input based on delimiter or nchars
         let line = if let Some(n) = nchars {

--- a/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
@@ -82,3 +82,33 @@ echo "$var"
 ### expect
 hel
 ### end
+
+### read_eof_clears_variable
+# read at EOF with no data should clear the variable
+printf "one\ntwo" | {
+  count=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    echo "$line"
+    count=$((count + 1))
+    [[ $count -gt 5 ]] && break
+  done
+}
+### expect
+one
+two
+### end
+
+### read_eof_partial_line
+# read returns 1 but captures partial line without trailing newline
+printf "complete\npartial" | {
+  lines=()
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lines+=("$line")
+    [[ ${#lines[@]} -gt 5 ]] && break
+  done
+  printf '%s\n' "${lines[@]}"
+}
+### expect
+complete
+partial
+### end


### PR DESCRIPTION
## Summary

- Fix `read` at EOF retaining the last value instead of clearing the variable
- When read reaches EOF with no data, now clears target variables to empty before returning 1
- Prevents the common `while read line || [[ -n "$line" ]]` pattern from infinite looping

## What

The `read` builtin returned `ExecResult::err("", 1)` on EOF without any `SetVariable` side effects, so the variable kept its previous value. Now the EOF path parses flag arguments first, then emits `SetVariable` side effects with empty values for all target variables.

## Test plan

- [x] New spec test: `read_eof_clears_variable` — verifies `printf "one\ntwo"` loop terminates
- [x] New spec test: `read_eof_partial_line` — verifies partial line without trailing newline is captured
- [x] All existing read-builtin spec tests pass
- [x] Manual smoke test confirms no infinite loop

Closes #953