### PR TITLE
fix(cli): install custom panic hook to suppress backtrace information disclosure

### DIFF
--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -161,7 +161,27 @@ fn apply_real_mounts(
     builder
 }
 
+/// Format a panic payload into a sanitized error message.
+// THREAT[TM-INF-021]: No file paths, line numbers, or dependency versions in output.
+fn format_panic_message(payload: &dyn std::any::Any) -> String {
+    let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unexpected error".to_string()
+    };
+    format!("bashkit: internal error: {msg}")
+}
+
 fn main() -> Result<()> {
+    // THREAT[TM-INF-021]: Suppress stack backtraces to prevent information disclosure.
+    // Custom panic hook emits a sanitized message without file paths, line numbers,
+    // or dependency versions that could be exploited by attackers.
+    std::panic::set_hook(Box::new(|info| {
+        eprintln!("{}", format_panic_message(info.payload()));
+    }));
+
     let args = Args::parse();
 
     match cli_mode(&args) {
@@ -409,5 +429,30 @@ mod tests {
 
         let content = std::fs::read_to_string(dir.path().join("r.txt")).unwrap();
         assert_eq!(content, "result\n");
+    }
+
+    #[test]
+    fn panic_message_str_payload() {
+        let msg = format_panic_message(&"something went wrong" as &dyn std::any::Any);
+        assert_eq!(msg, "bashkit: internal error: something went wrong");
+        assert!(!msg.contains(".rs:"));
+        assert!(!msg.contains("cargo"));
+    }
+
+    #[test]
+    fn panic_message_string_payload() {
+        let payload = String::from("Formatting argument out of range");
+        let msg = format_panic_message(&payload as &dyn std::any::Any);
+        assert_eq!(
+            msg,
+            "bashkit: internal error: Formatting argument out of range"
+        );
+    }
+
+    #[test]
+    fn panic_message_unknown_payload() {
+        let payload = 42i32;
+        let msg = format_panic_message(&payload as &dyn std::any::Any);
+        assert_eq!(msg, "bashkit: internal error: unexpected error");
     }
 }

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -406,6 +406,7 @@ All execution stays within the virtual interpreter — no OS subprocess is spawn
 | TM-INF-016 | Internal state in error messages | `std::io::Error`, reqwest errors, Debug-formatted errors leak host paths/IPs/TLS info | `sanitize_error_message()` strips paths/IPs/TLS; `Error::network_sanitized()` wraps reqwest | **FIXED** |
 | TM-INF-019 | `envsubst` exposes all env vars | `envsubst` substitutes `$VAR`/`${VAR}` from `ctx.env` — scripts can probe any env var | Same as TM-INF-001 (caller controls env) | **CALLER RISK** |
 | TM-INF-020 | `template` exposes env vars via `{{var}}` | Template builtin looks up variables from env as fallback after shell vars and JSON data | Same as TM-INF-001 (caller controls env) | **CALLER RISK** |
+| TM-INF-021 | Stack backtrace information disclosure | Panics leak internal source paths, dependency versions, and function names via stderr | Custom panic hook suppresses backtraces in CLI | **MITIGATED** |
 
 **TM-INF-013**: The jq builtin (`builtins/jq.rs:414-421`) calls `std::env::set_var()` to expose
 shell variables to jaq's `env` function. This also makes host process env vars (API keys, tokens)


### PR DESCRIPTION
## Summary

- Install a custom panic hook in CLI `main()` that shows only the panic message
- No file paths, line numbers, dependency versions, or function names leaked to stderr
- Added TM-INF-021 threat model entry

## What & Why

Panics (e.g., from precision overflow in printf, resource limit exceeded) dumped full Rust stack backtraces to stderr, exposing internal source paths, cargo registry paths, and dependency versions. The custom hook replaces this with a clean `bashkit: internal error: <message>` format.

## Tests Added

- `panic_message_str_payload` — &str payload formatting
- `panic_message_string_payload` — String payload formatting  
- `panic_message_unknown_payload` — unknown payload fallback

Closes #1004