### PR TITLE
fix(parser): enforce subst depth limit in unquoted cmdsub

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -682,11 +682,34 @@ impl<'a> Lexer<'a> {
                             }
                         }
                     } else {
-                        // Command substitution $(...) - track nested parens
+                        // THREAT[TM-DOS]: Track substitution nesting depth to
+                        // enforce max_subst_depth consistently in both quoted
+                        // and unquoted contexts (issue #996).
                         let mut depth = 1;
+                        let mut subst_depth = 1usize;
                         while let Some(c) = self.peek_char() {
                             word.push(c);
                             self.advance();
+                            if c == '$' && self.peek_char() == Some('(') {
+                                subst_depth += 1;
+                                if subst_depth > self.max_subst_depth {
+                                    // Depth limit exceeded — consume remaining
+                                    // parens and stop nesting deeper.
+                                    while let Some(ic) = self.peek_char() {
+                                        word.push(ic);
+                                        self.advance();
+                                        if ic == '(' {
+                                            depth += 1;
+                                        } else if ic == ')' {
+                                            depth -= 1;
+                                            if depth == 0 {
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    break;
+                                }
+                            }
                             if c == '(' {
                                 depth += 1;
                             } else if c == ')' {

--- a/crates/bashkit/tests/spec_cases/bash/cmdsub_depth_unquoted.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/cmdsub_depth_unquoted.test.sh
@@ -1,0 +1,26 @@
+# Command substitution depth limit in unquoted context
+# Regression tests for issue #996
+
+### shallow_cmdsub_unquoted
+# Shallow command substitution in unquoted context works
+x=$(echo hello)
+echo $x
+### expect
+hello
+### end
+
+### nested_cmdsub_unquoted
+# Nested command substitution in unquoted context works
+x=$(echo $(echo nested))
+echo $x
+### expect
+nested
+### end
+
+### cmdsub_depth_3_unquoted
+# Three levels of nesting works
+x=$(echo $(echo $(echo deep)))
+echo $x
+### expect
+deep
+### end


### PR DESCRIPTION
## Summary
- Enforce `max_subst_depth` in unquoted `$()` context in `read_word`, matching the limit already enforced in double-quoted strings
- Defense-in-depth: prevents deeply nested `$()` from bypassing depth limit

Closes #996

## Test plan
- [x] New spec tests: `cmdsub_depth_unquoted.test.sh` with 3 cases
- [x] Existing `parse_incomplete_command_sub` test still passes
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` clean