### PR TITLE
fix(builtins): filter internal markers from Python os.environ

### DIFF
--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -316,8 +316,17 @@ impl Builtin for Python {
 
         // Merge env and variables so exported vars (set via `export`) are visible
         // to Python's os.getenv(). Variables override env (bash semantics).
+        // THREAT[TM-INF]: Filter internal markers and SHOPT_* to prevent
+        // information disclosure via os.environ (issue #999).
         let mut merged_env = ctx.env.clone();
-        merged_env.extend(ctx.variables.iter().map(|(k, v)| (k.clone(), v.clone())));
+        merged_env.extend(
+            ctx.variables
+                .iter()
+                .filter(|(k, _)| {
+                    !crate::interpreter::is_internal_variable(k) && !k.starts_with("SHOPT_")
+                })
+                .map(|(k, v)| (k.clone(), v.clone())),
+        );
 
         run_python(
             &code,

--- a/crates/bashkit/tests/spec_cases/python/env_leak.test.sh
+++ b/crates/bashkit/tests/spec_cases/python/env_leak.test.sh
@@ -1,0 +1,25 @@
+# Python environment variable filtering
+# Regression tests for issue #999
+
+### readonly_marker_not_visible
+# Internal _READONLY_ marker should not be visible in Python
+readonly x=1
+python3 -c "import os; print(os.getenv('_READONLY_x', 'none'))"
+### expect
+none
+### end
+
+### user_variable_still_visible
+# Regular user variables should still be accessible from Python
+MY_VAR=hello
+python3 -c "import os; print(os.getenv('MY_VAR', 'missing'))"
+### expect
+hello
+### end
+
+### shopt_not_visible
+# SHOPT_ variables should not be visible in Python
+python3 -c "import os; shopt_vars = [k for k in os.environ if k.startswith('SHOPT_')]; print(len(shopt_vars))"
+### expect
+0
+### end


### PR DESCRIPTION
## Summary
- Filter internal variable markers (`_READONLY_*`, `_NAMEREF_*`, `_INTEGER_*`, etc.) and `SHOPT_*` from the environment passed to Python builtin
- Prevents information disclosure of internal shell state via `os.environ`

Closes #999

## Test plan
- [x] New spec tests: `env_leak.test.sh` with 3 cases (readonly marker hidden, user vars visible, SHOPT filtered)
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` clean