### PR TITLE
fix(interpreter): exec < file redirects stdin for subsequent commands

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3643,14 +3643,17 @@ impl Interpreter {
         for redirect in redirects {
             match redirect.kind {
                 RedirectKind::Input => {
+                    let target_path = self.expand_word(&redirect.target).await?;
+                    let path = self.resolve_path(&target_path);
+                    let content = self.fs.read_file(&path).await?;
+                    let text = bytes_to_latin1_string(&content);
                     if let Some(fd) = redirect.fd {
-                        let target_path = self.expand_word(&redirect.target).await?;
-                        let path = self.resolve_path(&target_path);
-                        let content = self.fs.read_file(&path).await?;
-                        let text = bytes_to_latin1_string(&content);
                         let lines: Vec<String> =
                             text.lines().rev().map(|l| l.to_string()).collect();
                         self.coproc_buffers.insert(fd, lines);
+                    } else {
+                        // exec < file: redirect stdin for subsequent commands
+                        self.pipeline_stdin = Some(text);
                     }
                 }
                 RedirectKind::DupInput => {

--- a/crates/bashkit/tests/spec_cases/bash/exec-command.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/exec-command.test.sh
@@ -81,3 +81,13 @@ echo "after exec redirect"
 ### expect
 after exec redirect
 ### end
+
+### exec_stdin_redirect
+# exec < file should redirect stdin for subsequent commands
+echo "from file" > /tmp/exec_stdin_test.txt
+exec < /tmp/exec_stdin_test.txt
+read -r line
+echo "got: $line"
+### expect
+got: from file
+### end


### PR DESCRIPTION
## Summary
- When `exec < file` has no explicit fd, set `pipeline_stdin` to the file content so subsequent `read`/`cat` commands consume it
- Hoisted file-reading logic out of the fd check to share between named-fd and default-stdin paths

## Test plan
- [x] `exec_stdin_redirect` spec test — `exec < file` + `read` reads from file
- [x] Smoke test via CLI confirms end-to-end behavior
- [x] All existing exec and bash spec tests still pass

Closes #960