### PR TITLE
fix(interpreter): contain ${var:?msg} error within subshell boundary

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1438,13 +1438,17 @@ impl Interpreter {
                 self.coproc_buffers = saved_coproc;
                 self.memory_budget = saved_memory_budget;
 
-                // Consume Exit control flow at subshell boundary — exit only
-                // terminates the subshell, not the parent shell.
-                if let Ok(ref mut res) = result
-                    && let ControlFlow::Exit(code) = res.control_flow
-                {
-                    res.exit_code = code;
-                    res.control_flow = ControlFlow::None;
+                // Consume Exit and Return control flow at subshell boundary —
+                // they only terminate the subshell, not the parent shell.
+                // Return is used by ${var:?msg} error handling and nounset errors.
+                if let Ok(ref mut res) = result {
+                    match res.control_flow {
+                        ControlFlow::Exit(code) | ControlFlow::Return(code) => {
+                            res.exit_code = code;
+                            res.control_flow = ControlFlow::None;
+                        }
+                        _ => {}
+                    }
                 }
 
                 result

--- a/crates/bashkit/tests/spec_cases/bash/subshell.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/subshell.test.sh
@@ -129,3 +129,11 @@ echo "$@"
 x y
 a b c
 ### end
+
+### parameter_error_in_subshell_contained
+# ${var:?msg} error in subshell should not kill parent
+(unset NOSUCHVAR; echo "${NOSUCHVAR:?gone}" 2>/dev/null)
+echo "survived: $?"
+### expect
+survived: 1
+### end


### PR DESCRIPTION
## Summary
- `${var:?msg}` errors used `ControlFlow::Return` which propagated through the subshell boundary, killing the parent shell
- Now both `ControlFlow::Exit` and `ControlFlow::Return` are consumed at the subshell boundary, matching real bash behavior

## Test plan
- [x] `parameter_error_in_subshell_contained` — verifies parent shell survives `${var:?msg}` in subshell
- [x] Smoke test via CLI confirms end-to-end behavior
- [x] All existing tests pass (199 tests, full suite)

Closes #961