### PR TITLE
fix(interpreter): forward piped stdin to bash script/command child

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2680,7 +2680,16 @@ impl Interpreter {
         self.insert_variable_checked("OPTIND".to_string(), "1".to_string());
         self.variables.remove("_OPTCHAR_IDX");
 
+        // Forward piped stdin to child when executing a script file or -c command
+        let saved_stdin = self.pipeline_stdin.take();
+        if script_file.is_some() || is_command_mode {
+            self.pipeline_stdin = stdin.clone();
+        }
+
         let result = self.execute(&script).await;
+
+        // Restore stdin
+        self.pipeline_stdin = saved_stdin;
 
         // Restore state
         if let Some(val) = saved_optind {

--- a/crates/bashkit/tests/spec_cases/bash/bash-stdin-pipe.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/bash-stdin-pipe.test.sh
@@ -1,0 +1,22 @@
+### bash_builtin_stdin_pipe_to_script
+# echo | bash script.sh should forward stdin
+echo 'echo "got: $(cat)"' > /tmp/stdin_test.sh
+echo "hello" | bash /tmp/stdin_test.sh
+### expect
+got: hello
+### end
+
+### bash_builtin_stdin_pipe_to_c
+# echo | bash -c 'cat' should forward stdin
+echo "piped" | bash -c 'cat'
+### expect
+piped
+### end
+
+### bash_builtin_stdin_read
+# echo | bash script.sh with read builtin
+echo 'read -r line; echo "line: $line"' > /tmp/read_test.sh
+echo "test input" | bash /tmp/read_test.sh
+### expect
+line: test input
+### end


### PR DESCRIPTION
## Summary
- Forward `stdin` as `pipeline_stdin` when executing scripts via `bash script.sh` or `bash -c`
- Save/restore previous `pipeline_stdin` state around child execution

## Test plan
- [x] Spec tests: 3 cases (pipe to script, pipe to -c, pipe with read)
- [x] Full test suite passes

Closes #941