### PR TITLE
fix(interpreter): set BASH_SOURCE[0] when running bash /path/script.sh

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2686,7 +2686,19 @@ impl Interpreter {
             self.pipeline_stdin = stdin.clone();
         }
 
+        // Set BASH_SOURCE for script file execution
+        if let Some(ref file) = script_file {
+            self.bash_source_stack.push(file.clone());
+            self.update_bash_source();
+        }
+
         let result = self.execute(&script).await;
+
+        // Restore BASH_SOURCE
+        if script_file.is_some() {
+            self.bash_source_stack.pop();
+            self.update_bash_source();
+        }
 
         // Restore stdin
         self.pipeline_stdin = saved_stdin;

--- a/crates/bashkit/tests/spec_cases/bash/bash-source-var.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/bash-source-var.test.sh
@@ -1,0 +1,15 @@
+### bash_source_in_executed_script
+# BASH_SOURCE[0] should equal script path when run via bash
+echo 'echo "${BASH_SOURCE[0]}"' > /tmp/bsrc_test.sh
+bash /tmp/bsrc_test.sh
+### expect
+/tmp/bsrc_test.sh
+### end
+
+### bash_source_dirname_pattern
+# Common pattern: find script's own directory
+echo 'echo "$(dirname "${BASH_SOURCE[0]}")"' > /tmp/bsrc_dir.sh
+bash /tmp/bsrc_dir.sh
+### expect
+/tmp
+### end


### PR DESCRIPTION
## Summary
- Push script file path onto `bash_source_stack` before executing via `bash /path/script.sh`
- Pop after execution completes

## Test plan
- [x] Spec tests: BASH_SOURCE[0] value, dirname pattern
- [x] Full test suite passes

Closes #942