### PR TITLE
test(interpreter): add regression tests for bash -c exported variable visibility

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/bash-c-exports.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/bash-c-exports.test.sh
@@ -1,0 +1,23 @@
+### bash_c_sees_exported_vars
+# bash -c should inherit exported variables
+export TEST_EXPORT_VAR="visible"
+bash -c 'echo "$TEST_EXPORT_VAR"'
+### expect
+visible
+### end
+
+### bash_c_assigns_from_export
+# bash -c can assign from exported vars
+export TEST_ASSIGN_VAR="value"
+bash -c 'x=$TEST_ASSIGN_VAR; echo "x=$x"'
+### expect
+x=value
+### end
+
+### bash_c_multiple_exports
+# bash -c sees multiple exports
+export A1=one A2=two
+bash -c 'echo "$A1 $A2"'
+### expect
+one two
+### end


### PR DESCRIPTION
## Summary
- The reported behavior (bash -c not seeing exports) appears fixed on current main
- Add regression spec tests to prevent future regressions

## Test plan
- [x] Spec tests: 3 cases covering exported var access in bash -c
- [x] All tests pass

Closes #943