### PR TITLE
fix(interpreter): remove exported vars from env on unset

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4794,6 +4794,7 @@ impl Interpreter {
                     continue;
                 }
                 self.variables.remove(&resolved);
+                self.env.remove(&resolved);
                 self.arrays.remove(&resolved);
                 self.assoc_arrays.remove(&resolved);
                 for frame in self.call_stack.iter_mut().rev() {

--- a/crates/bashkit/tests/spec_cases/bash/unset-exported-var.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/unset-exported-var.test.sh
@@ -1,0 +1,27 @@
+### unset_exported_variable
+# unset should remove exported vars completely
+export UNSET_TEST=value
+unset UNSET_TEST
+echo "${UNSET_TEST:-gone}"
+### expect
+gone
+### end
+
+### unset_then_check_defined
+### skip: [[ -v VAR ]] unary operator not yet implemented
+# unset var should not be -v defined
+export UNSET_DEF_TEST=x
+unset UNSET_DEF_TEST
+[[ -v UNSET_DEF_TEST ]] && echo "still set" || echo "unset"
+### expect
+unset
+### end
+
+### unset_regular_variable
+# unset non-exported var (verify no regression)
+REGULAR=hello
+unset REGULAR
+echo "${REGULAR:-gone}"
+### expect
+gone
+### end


### PR DESCRIPTION
## Summary

- `unset VAR` now also removes the variable from `self.env`, not just `self.variables`
- Previously, variable lookup fell back to `self.env`, so exported variables remained accessible after `unset`
- Added spec tests for unset of exported and regular variables

Closes #946