### PR TITLE
chore: update cc exemption to 1.2.59 in cargo-vet config

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -155,7 +155,7 @@ version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.58"
+version = "1.2.59"
 criteria = "safe-to-deploy"
 
 [[exemptions.cesu8]]


### PR DESCRIPTION
## Summary

- Update `cc` crate exemption from 1.2.58 to 1.2.59 in `supply-chain/config.toml`
- Fixes `cargo vet` failure blocking all PRs