### PR TITLE
chore: update semver exemption to 1.0.28 in cargo-vet config

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1227,7 +1227,7 @@ version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.semver]]
-version = "1.0.27"
+version = "1.0.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.seq-macro]]


### PR DESCRIPTION
## Summary

- Update `semver` crate exemption from 1.0.27 to 1.0.28 in `supply-chain/config.toml`
- Fixes `cargo vet` failure blocking all PRs