### PR TITLE
fix(audit): update semver exemption to 1.0.28

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1227,7 +1227,7 @@ version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.semver]]
-version = "1.0.27"
+version = "1.0.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.seq-macro]]


### PR DESCRIPTION
## Summary

- `semver` crate updated to 1.0.28 in `Cargo.lock` but `cargo-vet` exemption still referenced 1.0.27, causing the Audit CI job to fail
- Updates the exemption in `supply-chain/config.toml` from 1.0.27 → 1.0.28

## Test plan

- [ ] CI Audit job (`cargo vet --locked`) passes
- [ ] No other unvetted dependencies