### PR TITLE
docs: add GitHub links to PyPI metadata and Everruns ecosystem section

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -232,6 +232,10 @@ Returns the bashkit version string.
 | Windows | x86_64 |
 | WASM | wasm32-wasip1-threads |
 
+## Part of Everruns
+
+Bashkit is part of the [Everruns](https://github.com/everruns) ecosystem — tools and runtimes for building reliable AI agents. See the [bashkit monorepo](https://github.com/everruns/bashkit) for the Rust core, Python package (`bashkit`), and more.
+
 ## License
 
 MIT

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -261,6 +261,10 @@ Convenience wrapper for AI agents. Inherits all execution methods from `Bash`, p
 
 Bashkit is built on top of [Bashkit core](https://github.com/everruns/bashkit), a bash interpreter written in Rust. The Python package provides a native extension for fast, sandboxed execution without spawning subprocesses or containers.
 
+## Part of Everruns
+
+Bashkit is part of the [Everruns](https://github.com/everruns) ecosystem — tools and runtimes for building reliable AI agents. See the [bashkit monorepo](https://github.com/everruns/bashkit) for the Rust core, Node.js package (`@everruns/bashkit`), and more.
+
 ## License
 
 MIT

--- a/crates/bashkit-python/pyproject.toml
+++ b/crates/bashkit-python/pyproject.toml
@@ -25,6 +25,12 @@ classifiers = [
     "Topic :: Security",
 ]
 
+[project.urls]
+Homepage = "https://github.com/everruns/bashkit"
+Repository = "https://github.com/everruns/bashkit"
+Issues = "https://github.com/everruns/bashkit/issues"
+Changelog = "https://github.com/everruns/bashkit/releases"
+
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.3", "langchain-anthropic>=0.3"]
 deepagents = ["deepagents>=0.3.11", "langchain-anthropic>=0.3"]


### PR DESCRIPTION
## What

- Add `[project.urls]` to `pyproject.toml` so PyPI sidebar shows GitHub repo, issues, and changelog links
- Add "Part of Everruns" section to both Python and Node README files

## Why

The PyPI page for `bashkit` has no link back to the GitHub repo, making it harder for users to find source code, report issues, or discover the broader ecosystem.

## How

- Added `[project.urls]` with Homepage, Repository, Issues, and Changelog entries to `crates/bashkit-python/pyproject.toml`
- Added ecosystem section to `crates/bashkit-python/README.md` (mentions Node package)
- Added ecosystem section to `crates/bashkit-js/README.md` (mentions Python package)

## Test plan

- [x] `cargo test --all-features` — all pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `ruff check` and `ruff format --check` — clean
- [ ] Verify PyPI sidebar after next publish