### PR TITLE
feat(js): expose additional execution limits for Python parity

### DIFF
--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -601,15 +601,7 @@ impl BashTool {
             builder = builder.hostname(hostname);
         }
 
-        let mut limits = ExecutionLimits::new();
-        if let Some(mc) = state.max_commands {
-            limits = limits.max_commands(mc as usize);
-        }
-        if let Some(mli) = state.max_loop_iterations {
-            limits = limits.max_loop_iterations(mli as usize);
-        }
-
-        builder.limits(limits).build()
+        builder.limits(build_limits(state)).build()
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds 10 new fields to `BashOptions` matching all `ExecutionLimits` fields: `maxTotalLoopIterations`, `maxFunctionDepth`, `timeoutMs`, `parserTimeoutMs`, `maxInputBytes`, `maxAstDepth`, `maxParserOperations`, `maxStdoutBytes`, `maxStderrBytes`, `captureFinalEnv`
- Updates `SharedState` and `build_bash` to wire all limits through construction and reset

Closes #1067