### PR TITLE
fix(ci): update python3-dll-a cargo-vet exemption to 0.2.15

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1255,7 +1255,7 @@ version = "0.28.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.python3-dll-a]]
-version = "0.2.14"
+version = "0.2.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-error]]


### PR DESCRIPTION
## Summary

- `python3-dll-a` was bumped from 0.2.14 to 0.2.15 but the cargo-vet exemption in `supply-chain/config.toml` was not updated
- This causes the Audit job (`cargo vet --locked`) to fail on every CI run, blocking all PRs from merging
- Updates the exemption version to 0.2.15

## Test plan

- [x] `cargo vet --locked` passes locally (544 exempted, 3 fully audited)
- [ ] CI Audit job passes on this PR