### PR TITLE
fix(ci): pass --ref tag to publish workflow dispatches

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -395,14 +395,31 @@ jobs:
         run: ls -lh bashkit.*.node bashkit.*.wasm 2>/dev/null || true
         working-directory: crates/bashkit-js
 
+      - name: Determine npm dist-tag
+        id: dist-tag
+        working-directory: crates/bashkit-js
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$PKG_VERSION"
+
+          # Stable if triggered by a release tag, OR if workflow_dispatch
+          # and the version looks like a stable semver (no pre-release suffix).
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ "$PKG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Publishing stable release"
+          TAG="${{ steps.dist-tag.outputs.tag }}"
+          echo "Publishing with dist-tag: $TAG"
+          if [ "$TAG" = "latest" ]; then
             npm publish --provenance --access public
           else
-            echo "Publishing pre-release with 'next' tag"
-            npm publish --provenance --tag next --access public
+            npm publish --provenance --tag "$TAG" --access public
           fi
         working-directory: crates/bashkit-js
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,13 +72,19 @@ jobs:
           draft: false
           prerelease: false
 
+      # Note: the `release: [published]` event does NOT trigger other
+      # workflows when the release is created with GITHUB_TOKEN (GitHub
+      # prevents recursive workflow triggers). We must dispatch explicitly.
+      # Use --ref to set GITHUB_REF to the tag so publish-js correctly
+      # identifies stable releases.
       - name: Trigger publish workflows
-        run: |
-          gh workflow run publish.yml
-          gh workflow run publish-python.yml
-          gh workflow run publish-js.yml
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh workflow run publish.yml --ref "$TAG"
+          gh workflow run publish-python.yml --ref "$TAG"
+          gh workflow run publish-js.yml --ref "$TAG"
 
       - name: Trigger CLI binary builds for release tag
         env:


### PR DESCRIPTION
## Summary

- **release.yml**: Pass `--ref $TAG` to all `gh workflow run` calls so `GITHUB_REF` points to the release tag instead of `refs/heads/main`
- **publish-js.yml**: Add resilient dist-tag detection that falls back to checking `package.json` version format when `GITHUB_REF` isn't a tag

## Problem

npm `latest` tag has been stuck at 0.1.10 since v0.1.11. All subsequent versions (0.1.11–0.1.14) were published under the `next` dist-tag instead.

**Root cause**: `release.yml` dispatches publish workflows via `gh workflow run` without `--ref`. The `release: [published]` event doesn't fire because GitHub prevents recursive workflow triggers from `GITHUB_TOKEN`. Without `--ref`, `GITHUB_REF` defaults to `refs/heads/main`, and `publish-js.yml` classifies that as a pre-release → `--tag next`.

## Test plan

- [ ] Verify `release.yml` passes `--ref $TAG` to all three publish workflow dispatches
- [ ] Verify `publish-js.yml` determines `latest` tag when `GITHUB_REF` is a version tag
- [ ] Verify `publish-js.yml` falls back to `latest` when `package.json` has stable semver
- [ ] Ship v0.1.16 release to confirm npm `latest` tag updates correctly