### PR TITLE
fix(ci): update x86_64-apple-darwin runner from deprecated macos-13

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -26,7 +26,7 @@ jobs:
             runner: macos-latest
             archive: bashkit-aarch64-apple-darwin.tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             archive: bashkit-x86_64-apple-darwin.tar.gz
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest

--- a/specs/008-release-process.md
+++ b/specs/008-release-process.md
@@ -185,7 +185,7 @@ The CI workflows handle this automatically on GitHub Release.
 | OS | Target | Runner |
 |----|--------|--------|
 | macOS | aarch64-apple-darwin | macos-latest |
-| macOS | x86_64-apple-darwin | macos-13 |
+| macOS | x86_64-apple-darwin | macos-latest |
 | Linux | x86_64-unknown-linux-gnu | ubuntu-latest |
 
 #### Homebrew


### PR DESCRIPTION
## Summary
- Updates `x86_64-apple-darwin` CLI binary build runner from deprecated `macos-13` to `macos-latest`
- Updates the runner table in `specs/008-release-process.md` to match
- Cross-compilation works since the Rust toolchain step already adds the `x86_64-apple-darwin` target

Closes #1153

## Test plan
- [ ] CI passes on this PR
- [ ] Next release dispatch of `cli-binaries.yml` builds all three targets successfully