### PR TITLE
fix(date): parse RFC 2822 and RFC 3339 date strings in --date flag

### DIFF
--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -148,6 +148,16 @@ fn parse_base_date(s: &str, now: DateTime<Utc>) -> std::result::Result<DateTime<
         return local_naive_to_utc(dt, s);
     }
 
+    // Try RFC 2822: "Mon, 06 Apr 2026 12:00:00 +0000"
+    if let Ok(dt) = DateTime::parse_from_rfc2822(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+
+    // Try RFC 3339 / ISO 8601 with timezone: "2024-01-15T12:00:00+00:00"
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+
     Err(format!("date: invalid date '{}'", s))
 }
 
@@ -811,6 +821,31 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         let date = result.stdout.trim();
         assert_eq!(date.len(), 10);
+    }
+
+    // === --date with RFC 2822 input ===
+
+    #[tokio::test]
+    async fn test_date_parse_rfc2822_input() {
+        let result =
+            run_date(&["+%B %d, %Y", "--date=Mon, 06 Apr 2026 12:00:00 +0000"]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "April 06, 2026");
+    }
+
+    #[tokio::test]
+    async fn test_date_parse_rfc2822_epoch_output() {
+        let result =
+            run_date(&["+%s", "--date=Wed, 01 Jan 2020 00:00:00 +0000"]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "1577836800");
+    }
+
+    #[tokio::test]
+    async fn test_date_parse_rfc3339_input() {
+        let result = run_date(&["+%Y", "--date=2024-06-15T12:00:00+00:00"]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "2024");
     }
 
     // === -R (RFC 2822) tests ===

--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -827,16 +827,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_date_parse_rfc2822_input() {
-        let result =
-            run_date(&["+%B %d, %Y", "--date=Mon, 06 Apr 2026 12:00:00 +0000"]).await;
+        let result = run_date(&["+%B %d, %Y", "--date=Mon, 06 Apr 2026 12:00:00 +0000"]).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout.trim(), "April 06, 2026");
     }
 
     #[tokio::test]
     async fn test_date_parse_rfc2822_epoch_output() {
-        let result =
-            run_date(&["+%s", "--date=Wed, 01 Jan 2020 00:00:00 +0000"]).await;
+        let result = run_date(&["+%s", "--date=Wed, 01 Jan 2020 00:00:00 +0000"]).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout.trim(), "1577836800");
     }

--- a/crates/bashkit/tests/spec_cases/bash/date.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/date.test.sh
@@ -250,3 +250,17 @@ date -d 'yesterday + 12 hours' +%Y-%m-%d | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}
 ### expect
 valid
 ### end
+
+### date_rfc2822_input
+# Parse an RFC 2822 date string via --date
+date +"%B %d, %Y" --date="Mon, 06 Apr 2026 12:00:00 +0000"
+### expect
+April 06, 2026
+### end
+
+### date_rfc2822_input_epoch
+# Parse an RFC 2822 date string and output as epoch
+date +%s --date="Wed, 01 Jan 2020 00:00:00 +0000"
+### expect
+1577836800
+### end

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -152,7 +152,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | conditional.test.sh | 29 | `[[ ]]` conditionals, `=~` regex, BASH_REMATCH, glob `==`/`!=` |
 | control-flow.test.sh | 60 | if/elif/else, for, while, case `;;`/`;&`/`;;&`, select, trap ERR, `[[ =~ ]]` BASH_REMATCH, compound input redirects |
 | cuttr.test.sh | 39 | cut and tr commands, `-z` zero-terminated |
-| date.test.sh | 37 | format specifiers, `-d` relative/compound/epoch, `-R`, `-I`, `%N` (2 skipped) |
+| date.test.sh | 39 | format specifiers, `-d` relative/compound/epoch/RFC2822, `-R`, `-I`, `%N` (2 skipped) |
 | declare.test.sh | 23 | `declare`/`typeset`, `-i`, `-r`, `-x`, `-a`, `-p`, `-n` nameref, `-l`/`-u` case conversion |
 | df.test.sh | 3 | disk free reporting |
 | diff.test.sh | 6 | line diffs |


### PR DESCRIPTION
## Summary

- Add RFC 2822 parsing (`DateTime::parse_from_rfc2822`) to `parse_base_date()` so `date --date="Mon, 06 Apr 2026 12:00:00 +0000"` works
- Add RFC 3339 parsing (`DateTime::parse_from_rfc3339`) for timezone-aware ISO strings
- Both use chrono's built-in parsers — no custom parsing logic

## Why

`date +"%B %d, %Y" --date="Mon, 06 Apr 2026 12:00:00 +0000"` returned empty output because `parse_base_date` didn't recognize RFC 2822 format. This broke bashblog's timestamp formatting.

## Tests

- 3 unit tests: RFC 2822 format output, RFC 2822 epoch output, RFC 3339 input
- 2 spec tests: `date_rfc2822_input`, `date_rfc2822_input_epoch`
- All existing date tests continue to pass

Closes #1156