### PR TITLE
fix(network): add .no_proxy() to prevent host proxy env leakage

### DIFF
--- a/crates/bashkit/src/network/client.rs
+++ b/crates/bashkit/src/network/client.rs
@@ -14,6 +14,7 @@
 //! - **TM-NET-012**: Chunked encoding bomb → streaming size check
 //! - **TM-NET-013**: Gzip/compression bomb → auto-decompression disabled
 //! - **TM-NET-014**: DNS rebind via redirect → manual redirect requires allowlist check
+//! - **TM-NET-015**: Host proxy leakage → `.no_proxy()` ignores host `HTTP_PROXY`/`HTTPS_PROXY`
 
 use reqwest::Client;
 use std::sync::OnceLock;
@@ -593,6 +594,9 @@ fn build_client(
         .no_gzip()
         .no_brotli()
         .no_deflate()
+        // THREAT[TM-NET-015]: Ignore host proxy env vars (HTTP_PROXY, HTTPS_PROXY, ALL_PROXY)
+        // to prevent sandboxed HTTP traffic from being redirected through a host proxy
+        .no_proxy()
         .build()
         .map_err(|e| e.to_string())
 }
@@ -708,6 +712,14 @@ mod tests {
         let result = usize::try_from(large).unwrap_or(usize::MAX);
         // Should never silently become a smaller value
         assert!(result >= large.min(usize::MAX as u64) as usize);
+    }
+
+    #[test]
+    fn test_build_client_uses_no_proxy() {
+        // Verify build_client succeeds — the .no_proxy() call ensures
+        // host HTTP_PROXY/HTTPS_PROXY env vars are ignored (TM-NET-015).
+        let client = build_client(Duration::from_secs(30), None);
+        assert!(client.is_ok(), "build_client should succeed with no_proxy");
     }
 
     // Note: Integration tests that actually make network requests

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -615,6 +615,7 @@ allowlist.allow("https://api.example.com");
 | TM-NET-012 | Chunked encoding bomb | Infinite chunked response | Response size limit (streaming) | **MITIGATED** |
 | TM-NET-013 | Gzip bomb / Zip bomb | 10KB gzip → 10GB decompressed | Auto-decompression disabled | **MITIGATED** |
 | TM-NET-014 | DNS rebind via redirect | Redirect to rebinded IP | Manual redirect requires allowlist check | **MITIGATED** |
+| TM-NET-015 | Host proxy leakage | `HTTP_PROXY`/`HTTPS_PROXY` env vars route sandboxed traffic through host proxy | `.no_proxy()` on reqwest builder | **MITIGATED** |
 | TM-NET-018 | JSON body injection | `http POST url name='x","admin":true'` via unescaped string formatting | Use `serde_json` for JSON construction | **MITIGATED** |
 | TM-NET-019 | Query param injection | `http GET url q=='foo&admin=true'` injects extra params | URL-encode via `url::form_urlencoded` | **MITIGATED** |
 | TM-NET-020 | Form body injection | `http --form POST url user='x&role=admin'` injects extra fields | URL-encode via `url::form_urlencoded` | **MITIGATED** |
@@ -640,6 +641,9 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 .no_gzip()
 .no_brotli()
 .no_deflate()
+
+// Ignore host proxy env vars (TM-NET-015)
+.no_proxy()
 
 // Response size checked during streaming (TM-NET-008, TM-NET-012)
 async fn read_body_with_limit(&self, response: Response) -> Result<Vec<u8>> {
@@ -1290,6 +1294,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | HTTP connect timeout | TM-NET-009 | `network/client.rs` | Yes |
 | HTTP read timeout | TM-NET-010 | `network/client.rs` | Yes |
 | No auto-redirect | TM-NET-011, TM-NET-014 | `network/client.rs` | Yes |
+| No host proxy | TM-NET-015 | `network/client.rs` | Yes |
 | Log value redaction | TM-LOG-001 to TM-LOG-004 | `logging.rs` | Yes |
 | Log injection prevention | TM-LOG-005, TM-LOG-006 | `logging.rs` | Yes |
 | Log value truncation | TM-LOG-007, TM-LOG-008 | `logging.rs` | Yes |


### PR DESCRIPTION
## Summary

Closes #1188

- Add `.no_proxy()` to the reqwest client builder to prevent sandboxed HTTP traffic from being routed through host-configured proxy servers (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` env vars)
- Add `TM-NET-015` threat entry to threat model and mitigation summary table
- Add `test_build_client_uses_no_proxy` test

## Why

By default, reqwest reads proxy environment variables from the host process. This means all sandboxed HTTP requests could be redirected through an attacker-controlled proxy, leaking authorization headers, API keys, and request bodies — even when the destination URL passes the allowlist.

## Test plan

- [x] `test_build_client_uses_no_proxy` verifies the client builder succeeds with `.no_proxy()`
- [x] All 2313 bashkit unit tests pass
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean