### PR TITLE
fix(ssh): replace derived Debug with manual impls that redact credentials

### DIFF
--- a/crates/bashkit/src/ssh/config.rs
+++ b/crates/bashkit/src/ssh/config.rs
@@ -47,7 +47,7 @@ pub const DEFAULT_PORT: u16 = 22;
 /// - Host allowlist is default-deny (empty blocks everything)
 /// - Keys are read from VFS only, never from host filesystem
 /// - All connections have timeouts to prevent hangs
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SshConfig {
     /// Host allowlist
     pub(crate) allowlist: SshAllowlist,
@@ -65,6 +65,29 @@ pub struct SshConfig {
     pub(crate) max_sessions: usize,
     /// Default port
     pub(crate) default_port: u16,
+}
+
+// THREAT[TM-INF-016]: Redact credentials in Debug output to prevent
+// passwords and private keys from leaking into logs, error messages, or LLM context.
+impl std::fmt::Debug for SshConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SshConfig")
+            .field("allowlist", &self.allowlist)
+            .field("default_user", &self.default_user)
+            .field(
+                "default_password",
+                &self.default_password.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "default_private_key",
+                &self.default_private_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("timeout", &self.timeout)
+            .field("max_response_bytes", &self.max_response_bytes)
+            .field("max_sessions", &self.max_sessions)
+            .field("default_port", &self.default_port)
+            .finish()
+    }
 }
 
 impl Default for SshConfig {
@@ -211,6 +234,23 @@ mod tests {
         assert_eq!(config.max_response_bytes, 5_000_000);
         assert_eq!(config.max_sessions, 3);
         assert_eq!(config.default_port, 2222);
+    }
+
+    #[test]
+    fn test_debug_redacts_credentials() {
+        let config = SshConfig::new()
+            .default_password("super_secret_password")
+            .default_private_key("-----BEGIN OPENSSH PRIVATE KEY-----");
+        let debug = format!("{:?}", config);
+        assert!(
+            !debug.contains("super_secret_password"),
+            "password leaked in Debug: {debug}"
+        );
+        assert!(
+            !debug.contains("BEGIN OPENSSH PRIVATE KEY"),
+            "private key leaked in Debug: {debug}"
+        );
+        assert!(debug.contains("[REDACTED]"), "REDACTED missing: {debug}");
     }
 
     #[test]

--- a/crates/bashkit/src/ssh/handler.rs
+++ b/crates/bashkit/src/ssh/handler.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 ///
 /// Fully resolved by the builtin before passing to the handler.
 /// The handler does NOT need to validate the host — that's already done.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SshTarget {
     /// Remote hostname or IP.
     pub host: String,
@@ -26,6 +26,22 @@ pub struct SshTarget {
     pub private_key: Option<String>,
     /// Optional password.
     pub password: Option<String>,
+}
+
+// THREAT[TM-INF-016]: Redact credentials in Debug output.
+impl std::fmt::Debug for SshTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SshTarget")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("user", &self.user)
+            .field(
+                "private_key",
+                &self.private_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
 }
 
 /// Output from a remote command execution.
@@ -125,4 +141,31 @@ pub trait SshHandler: Send + Sync {
         target: &SshTarget,
         remote_path: &str,
     ) -> std::result::Result<Vec<u8>, String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_redacts_credentials() {
+        let target = SshTarget {
+            host: "example.com".to_string(),
+            port: 22,
+            user: "admin".to_string(),
+            private_key: Some("-----BEGIN OPENSSH PRIVATE KEY-----".to_string()),
+            password: Some("super_secret".to_string()),
+        };
+        let debug = format!("{:?}", target);
+        assert!(!debug.contains("super_secret"), "password leaked: {debug}");
+        assert!(
+            !debug.contains("BEGIN OPENSSH PRIVATE KEY"),
+            "key leaked: {debug}"
+        );
+        assert!(debug.contains("[REDACTED]"), "REDACTED missing: {debug}");
+        assert!(
+            debug.contains("example.com"),
+            "host should be visible: {debug}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1189

- Replace `#[derive(Debug)]` with manual `Debug` impls for `SshConfig` and `SshTarget` that redact `default_password`, `default_private_key`, `private_key`, and `password` fields with `[REDACTED]`
- `BotAuthConfig` was already fixed in #1195
- Add tests verifying credentials don't appear in debug output

## Why

Formatting these structs with `{:?}` would dump plaintext passwords and private keys into logs, error messages, panic backtraces, and LLM context.

## Test plan

- [x] `test_debug_redacts_credentials` for `SshConfig` — verifies password and key are hidden
- [x] `test_debug_redacts_credentials` for `SshTarget` — verifies password and key are hidden, host is visible
- [x] All 2319 bashkit unit tests pass