### PR TITLE
fix(git): sanitize control characters in git output

### DIFF
--- a/crates/bashkit/src/builtins/git.rs
+++ b/crates/bashkit/src/builtins/git.rs
@@ -196,7 +196,7 @@ async fn git_config(
             }
         }
         None => {
-            // Get config
+            // Get config — value already sanitized by config_get (TM-GIT-015)
             match git_client.config_get(&ctx.fs, ctx.cwd, key).await {
                 Ok(Some(value)) => Ok(ExecResult::ok(format!("{}\n", value))),
                 Ok(None) => Ok(ExecResult::ok(String::new())),

--- a/crates/bashkit/src/git/client.rs
+++ b/crates/bashkit/src/git/client.rs
@@ -181,12 +181,13 @@ impl GitClient {
                 continue;
             }
 
-            // Check for key = value in the right section
+            // Check for key = value in the right section.
+            // Sanitize returned value to strip control characters (TM-GIT-015).
             if in_section
                 && let Some((k, v)) = line.split_once('=')
                 && k.trim().to_lowercase() == name
             {
-                return Ok(Some(v.trim().to_string()));
+                return Ok(Some(super::sanitize_git_output(v.trim())));
             }
         }
 
@@ -640,12 +641,18 @@ impl GitClient {
     }
 
     /// Format git log output.
+    ///
+    /// Author names and commit messages are sanitized to strip control
+    /// characters (TM-GIT-015).
     pub fn format_log(&self, entries: &[GitLogEntry]) -> String {
         let mut output = String::new();
 
         for entry in entries {
             output.push_str(&format!("commit {}\n", entry.hash));
-            output.push_str(&format!("Author: {}\n", entry.author));
+            output.push_str(&format!(
+                "Author: {}\n",
+                super::sanitize_git_output(&entry.author)
+            ));
 
             // Format timestamp
             if let Some(dt) = chrono::DateTime::from_timestamp(entry.timestamp, 0) {
@@ -656,7 +663,8 @@ impl GitClient {
             }
 
             output.push('\n');
-            for line in entry.message.lines() {
+            let sanitized_msg = super::sanitize_git_output(&entry.message);
+            for line in sanitized_msg.lines() {
                 output.push_str(&format!("    {}\n", line));
             }
             output.push('\n');
@@ -666,16 +674,25 @@ impl GitClient {
     }
 
     /// Format git status output.
+    ///
+    /// Branch names and file paths are sanitized to strip control
+    /// characters (TM-GIT-015).
     pub fn format_status(&self, status: &GitStatus) -> String {
         let mut output = String::new();
 
-        output.push_str(&format!("On branch {}\n", status.branch));
+        output.push_str(&format!(
+            "On branch {}\n",
+            super::sanitize_git_output(&status.branch)
+        ));
 
         if !status.staged.is_empty() {
             output.push_str("\nChanges to be committed:\n");
             output.push_str("  (use \"git restore --staged <file>...\" to unstage)\n");
             for file in &status.staged {
-                output.push_str(&format!("\tnew file:   {}\n", file));
+                output.push_str(&format!(
+                    "\tnew file:   {}\n",
+                    super::sanitize_git_output(file)
+                ));
             }
         }
 
@@ -683,7 +700,10 @@ impl GitClient {
             output.push_str("\nChanges not staged for commit:\n");
             output.push_str("  (use \"git add <file>...\" to update what will be committed)\n");
             for file in &status.modified {
-                output.push_str(&format!("\tmodified:   {}\n", file));
+                output.push_str(&format!(
+                    "\tmodified:   {}\n",
+                    super::sanitize_git_output(file)
+                ));
             }
         }
 
@@ -691,7 +711,7 @@ impl GitClient {
             output.push_str("\nUntracked files:\n");
             output.push_str("  (use \"git add <file>...\" to include in what will be committed)\n");
             for file in &status.untracked {
-                output.push_str(&format!("\t{}\n", file));
+                output.push_str(&format!("\t{}\n", super::sanitize_git_output(file)));
             }
         }
 
@@ -1247,13 +1267,16 @@ impl GitClient {
     }
 
     /// Format branch list output.
+    ///
+    /// Branch names are sanitized to strip control characters (TM-GIT-015).
     pub fn format_branch_list(&self, branches: &[Branch]) -> String {
         let mut output = String::new();
         for branch in branches {
+            let name = super::sanitize_git_output(&branch.name);
             if branch.current {
-                output.push_str(&format!("* {}\n", branch.name));
+                output.push_str(&format!("* {}\n", name));
             } else {
-                output.push_str(&format!("  {}\n", branch.name));
+                output.push_str(&format!("  {}\n", name));
             }
         }
         output
@@ -1292,7 +1315,10 @@ impl GitClient {
             let file_path = repo_path.join(path);
             if fs.exists(&file_path).await? {
                 let content = fs.read_file(&file_path).await?;
-                return Ok(String::from_utf8_lossy(&content).to_string());
+                // Sanitize file content from VFS (TM-GIT-015)
+                return Ok(super::sanitize_git_output(&String::from_utf8_lossy(
+                    &content,
+                )));
             }
             return Err(Error::Internal(format!(
                 "fatal: path '{}' does not exist",
@@ -1401,9 +1427,13 @@ impl GitClient {
                         let head_content = fs.read_file(&git_dir.join("HEAD")).await?;
                         let head = String::from_utf8_lossy(&head_content);
                         if let Some(branch) = head.trim().strip_prefix("ref: refs/heads/") {
-                            output.push_str(&format!("{}\n", branch));
+                            // Sanitize branch name from HEAD ref (TM-GIT-015)
+                            output.push_str(&format!("{}\n", super::sanitize_git_output(branch)));
                         } else {
-                            output.push_str(&format!("{}\n", head.trim()));
+                            output.push_str(&format!(
+                                "{}\n",
+                                super::sanitize_git_output(head.trim())
+                            ));
                         }
                     }
                 }
@@ -1415,15 +1445,18 @@ impl GitClient {
                         let ref_path = git_dir.join(format!("refs/heads/{}", branch));
                         if fs.exists(&ref_path).await? {
                             let hash = fs.read_file(&ref_path).await?;
-                            output
-                                .push_str(&format!("{}\n", String::from_utf8_lossy(&hash).trim()));
+                            // Sanitize hash read from ref file (TM-GIT-015)
+                            output.push_str(&format!(
+                                "{}\n",
+                                super::sanitize_git_output(String::from_utf8_lossy(&hash).trim())
+                            ));
                         } else {
                             return Err(Error::Internal(
                                 "fatal: ambiguous argument 'HEAD': unknown revision".to_string(),
                             ));
                         }
                     } else {
-                        output.push_str(&format!("{}\n", head.trim()));
+                        output.push_str(&format!("{}\n", super::sanitize_git_output(head.trim())));
                     }
                 }
                 arg => {
@@ -1431,7 +1464,11 @@ impl GitClient {
                     let ref_path = git_dir.join(format!("refs/heads/{}", arg));
                     if fs.exists(&ref_path).await? {
                         let hash = fs.read_file(&ref_path).await?;
-                        output.push_str(&format!("{}\n", String::from_utf8_lossy(&hash).trim()));
+                        // Sanitize hash read from ref file (TM-GIT-015)
+                        output.push_str(&format!(
+                            "{}\n",
+                            super::sanitize_git_output(String::from_utf8_lossy(&hash).trim())
+                        ));
                     } else {
                         return Err(Error::Internal(format!(
                             "fatal: ambiguous argument '{}': unknown revision",
@@ -1576,7 +1613,13 @@ impl GitClient {
             let content = String::from_utf8_lossy(&content);
             for (i, line) in content.lines().enumerate() {
                 if line.contains(pattern) {
-                    output.push_str(&format!("{}:{}:{}\n", file, i + 1, line));
+                    // Sanitize file path and line content (TM-GIT-015)
+                    output.push_str(&format!(
+                        "{}:{}:{}\n",
+                        super::sanitize_git_output(file),
+                        i + 1,
+                        super::sanitize_git_output(line)
+                    ));
                 }
             }
         }

--- a/crates/bashkit/src/git/mod.rs
+++ b/crates/bashkit/src/git/mod.rs
@@ -53,3 +53,108 @@ pub use config::GitConfig;
 
 #[cfg(feature = "git")]
 pub use client::GitClient;
+
+/// THREAT[TM-GIT-015]: Sanitize git output to prevent terminal injection.
+///
+/// Strips ANSI escape sequences, null bytes, and dangerous C0/C1 control
+/// characters from strings before they reach interpreter stdout. Preserves
+/// tab (0x09), newline (0x0a), and carriage return (0x0d).
+pub(crate) fn sanitize_git_output(s: &str) -> String {
+    use regex::Regex;
+    use std::sync::LazyLock;
+
+    // Match ANSI escape sequences: ESC [ <params> <final byte>
+    // Also matches OSC sequences: ESC ] ... BEL
+    // Also matches two-char ESC sequences (e.g. ESC H)
+    static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[^\[\]].?")
+            .expect("ANSI regex is valid")
+    });
+
+    let stripped = ANSI_RE.replace_all(s, "");
+
+    stripped
+        .chars()
+        .filter(|&ch| {
+            // Allow printable ASCII + common whitespace
+            if ch == '\t' || ch == '\n' || ch == '\r' {
+                return true;
+            }
+            // Remove C0 control chars (0x00-0x1f) except the three above
+            if (ch as u32) <= 0x1f {
+                return false;
+            }
+            // Remove DEL
+            if ch as u32 == 0x7f {
+                return false;
+            }
+            // Remove C1 control chars (0x80-0x9f)
+            if (0x80..=0x9f).contains(&(ch as u32)) {
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_git_output;
+
+    #[test]
+    fn test_strips_ansi_escape_sequences() {
+        let input = "main\x1b[31mPWNED\x1b[0m";
+        assert_eq!(sanitize_git_output(input), "mainPWNED");
+    }
+
+    #[test]
+    fn test_strips_null_bytes() {
+        let input = "hello\x00world";
+        assert_eq!(sanitize_git_output(input), "helloworld");
+    }
+
+    #[test]
+    fn test_strips_c0_control_chars() {
+        // 0x01 (SOH), 0x02 (STX), 0x07 (BEL), 0x08 (BS)
+        let input = "a\x01b\x02c\x07d\x08e";
+        assert_eq!(sanitize_git_output(input), "abcde");
+    }
+
+    #[test]
+    fn test_preserves_tab_newline_cr() {
+        let input = "line1\n\tindented\r\nline2";
+        assert_eq!(sanitize_git_output(input), "line1\n\tindented\r\nline2");
+    }
+
+    #[test]
+    fn test_strips_c1_control_chars() {
+        // 0x80, 0x9b (CSI), 0x9f
+        let input = format!("a{}b{}c{}d", '\u{0080}', '\u{009b}', '\u{009f}');
+        assert_eq!(sanitize_git_output(&input), "abcd");
+    }
+
+    #[test]
+    fn test_strips_del() {
+        let input = "hello\x7fworld";
+        assert_eq!(sanitize_git_output(input), "helloworld");
+    }
+
+    #[test]
+    fn test_complex_ansi_injection() {
+        // Simulates a crafted branch name with multiple escape sequences
+        let input = "\x1b[2J\x1b[Hfake-prompt$ rm -rf /\x1b[0m";
+        assert_eq!(sanitize_git_output(input), "fake-prompt$ rm -rf /");
+    }
+
+    #[test]
+    fn test_passthrough_normal_text() {
+        let input = "feature/my-branch-123";
+        assert_eq!(sanitize_git_output(input), "feature/my-branch-123");
+    }
+
+    #[test]
+    fn test_unicode_preserved() {
+        let input = "日本語ブランチ";
+        assert_eq!(sanitize_git_output(input), "日本語ブランチ");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `sanitize_git_output()` function in `git/mod.rs` that strips ANSI escape sequences, null bytes, DEL, and C0/C1 control characters while preserving tab, newline, and carriage return
- Applies sanitization to all git output paths: `format_branch_list()`, `format_log()`, `format_status()`, `config_get()`, `grep()`, `rev_parse()`, and `show()`
- Adds 9 unit tests covering ANSI injection, null bytes, C0/C1 chars, DEL, Unicode preservation, and passthrough of normal text

Fixes #1187 (TM-GIT-015)

## Test plan

- [x] `cargo test -p bashkit --lib git::tests` — all 9 sanitization tests pass
- [x] `cargo test -p bashkit --features git` — full test suite passes (95 passed)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p bashkit --features git -- -D warnings` — no new warnings (pre-existing dead code in curl.rs)