### PR TITLE
fix(date): preserve spaces in format string from variable expansion

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -11010,4 +11010,23 @@ cat /tmp/test_fd.txt"#,
             "fd3 → stdout, fd1 → file"
         );
     }
+
+    // Regression: date +"$var" must not word-split format when var contains spaces
+    // https://github.com/everruns/bashkit/issues/1203
+    #[tokio::test]
+    async fn test_date_format_var_with_spaces_no_split() {
+        // Use -u -d @0 for deterministic output (1970-01-01 UTC)
+        let result = run_script(r#"fmt="%Y %m %d"; date -u -d @0 +"$fmt""#).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "1970 01 01");
+    }
+
+    // Mixed-quoting: prefix"$var" must stay one word (no IFS split)
+    #[tokio::test]
+    async fn test_mixed_quote_prefix_var_no_split() {
+        // prefix"$var" should produce one argument, not be split at spaces
+        let result = run_script(r#"v="a b c"; echo prefix"$v""#).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "prefixa b c");
+    }
 }

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -398,6 +398,7 @@ impl<'a> Lexer<'a> {
 
     fn read_word_starting_with(&mut self, prefix: &str) -> Option<Token> {
         let mut word = prefix.to_string();
+        let mut has_quoted_expansion = false;
         // Use the same logic as read_word but with pre-seeded content
         while let Some(ch) = self.peek_char() {
             if ch == '"' || ch == '\'' {
@@ -435,6 +436,19 @@ impl<'a> Lexer<'a> {
                             }
                             continue;
                         }
+                    }
+                    // Track quoted expansions for IFS-split suppression
+                    if c == '$' && quote_char == '"' {
+                        word.push(c);
+                        self.advance();
+                        if self.peek_char().is_some_and(|nc| {
+                            nc.is_ascii_alphanumeric()
+                                || nc == '_'
+                                || matches!(nc, '{' | '(' | '?' | '#' | '@' | '*' | '!' | '$' | '-')
+                        }) {
+                            has_quoted_expansion = true;
+                        }
+                        continue;
                     }
                     word.push(c);
                     self.advance();
@@ -488,11 +502,20 @@ impl<'a> Lexer<'a> {
                 break;
             }
         }
-        Some(Token::Word(word))
+        if has_quoted_expansion {
+            Some(Token::QuotedWord(word))
+        } else {
+            Some(Token::Word(word))
+        }
     }
 
     fn read_word(&mut self) -> Option<Token> {
         let mut word = String::new();
+        // Track whether any double-quoted segment contained a variable/command
+        // expansion.  When true the whole token is promoted to QuotedWord so
+        // the interpreter suppresses IFS field splitting — matching POSIX
+        // behaviour for words like  +"$fmt"  or  prefix"$var"suffix.
+        let mut has_quoted_expansion = false;
 
         while let Some(ch) = self.peek_char() {
             // Handle quoted strings within words (e.g., a="Hello" or VAR="value")
@@ -544,6 +567,15 @@ impl<'a> Lexer<'a> {
                     if c == '$' && quote_char == '"' {
                         word.push(c);
                         self.advance();
+                        // Mark that this word contains a quoted expansion so IFS
+                        // splitting is suppressed (e.g. +"$fmt" stays one field).
+                        if self.peek_char().is_some_and(|nc| {
+                            nc.is_ascii_alphanumeric()
+                                || nc == '_'
+                                || matches!(nc, '{' | '(' | '?' | '#' | '@' | '*' | '!' | '$' | '-')
+                        }) {
+                            has_quoted_expansion = true;
+                        }
                         if self.peek_char() == Some('(') {
                             word.push('(');
                             self.advance();
@@ -920,6 +952,11 @@ impl<'a> Lexer<'a> {
 
         if word.is_empty() {
             None
+        } else if has_quoted_expansion {
+            // A double-quoted segment contained a variable/command expansion.
+            // Promote to QuotedWord so the interpreter suppresses IFS field
+            // splitting, matching POSIX behaviour for  +"$fmt"  etc.
+            Some(Token::QuotedWord(word))
         } else {
             Some(Token::Word(word))
         }


### PR DESCRIPTION
## Summary
- Fix word-splitting of `date +"$var"` when the variable contains spaces
- Root cause: lexer produced `Token::Word` for mixed-quoted words like `+"$fmt"`, causing IFS field splitting on expansion
- Fix promotes tokens with double-quoted variable/command expansions from `Token::Word` to `Token::QuotedWord`, suppressing field splitting (matches POSIX behavior)

Closes #1203

## Test plan
- [x] `test_date_format_var_with_spaces_no_split` — verifies `date +"$fmt"` with spaces produces correct output
- [x] `test_mixed_quote_prefix_var_no_split` — verifies generic `prefix"$var"` pattern preserves spaces
- [x] Full test suite (2051 tests) passes with no regressions