### PR TITLE
fix(interpreter): filter SHOPT_ variables from set/declare output

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -290,7 +290,8 @@ fn is_dev_null(path: &Path) -> bool {
 /// THREAT[TM-INJ-009,TM-INJ-016]: Check if a variable name is an internal marker.
 /// Used by builtins and interpreter to block user assignment to internal prefixes.
 pub(crate) fn is_internal_variable(name: &str) -> bool {
-    name.starts_with("_NAMEREF_")
+    name.starts_with("SHOPT_")
+        || name.starts_with("_NAMEREF_")
         || name.starts_with("_READONLY_")
         || name.starts_with("_UPPER_")
         || name.starts_with("_LOWER_")

--- a/crates/bashkit/tests/security_audit_pocs.rs
+++ b/crates/bashkit/tests/security_audit_pocs.rs
@@ -258,6 +258,53 @@ mod internal_variable_leak {
             result.stdout.trim()
         );
     }
+
+    /// TM-INF-017: `set` must not expose SHOPT_ internal variables.
+    #[tokio::test]
+    async fn security_audit_set_hides_shopt_vars() {
+        let mut bash = Bash::builder().build();
+
+        // Enable some shell options so SHOPT_ vars exist internally
+        let result = bash
+            .exec(
+                r#"
+                set -e
+                set -o pipefail
+                set | grep -E "^SHOPT_"
+            "#,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result.stdout.trim().is_empty(),
+            "`set` must filter SHOPT_ internal variables from output. Got:\n{}",
+            result.stdout.trim()
+        );
+    }
+
+    /// TM-INF-017: `declare -p` must not expose SHOPT_ internal variables.
+    #[tokio::test]
+    async fn security_audit_declare_p_hides_shopt_vars() {
+        let mut bash = Bash::builder().build();
+
+        let result = bash
+            .exec(
+                r#"
+                set -e
+                set -o pipefail
+                declare -p | grep -E "SHOPT_"
+            "#,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result.stdout.trim().is_empty(),
+            "`declare -p` must filter SHOPT_ internal variables. Got:\n{}",
+            result.stdout.trim()
+        );
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes #1186

- Add `SHOPT_` prefix to `is_internal_variable()` filter to prevent implementation fingerprinting
- `SHOPT_*` variables (e.g. `SHOPT_e`, `SHOPT_pipefail`) are internal bookkeeping and should not appear in `set` or `declare -p` output

## Test plan

- [x] `security_audit_set_hides_shopt_vars` — verifies `set` output has no `SHOPT_` variables
- [x] `security_audit_declare_p_hides_shopt_vars` — verifies `declare -p` output has no `SHOPT_` variables
- [x] All 4 `internal_variable_leak` security tests pass