### PR TITLE
fix(logging): add runtime guard for unsafe logging methods

### DIFF
--- a/crates/bashkit/docs/logging.md
+++ b/crates/bashkit/docs/logging.md
@@ -130,10 +130,12 @@ Control characters are filtered, and newlines are escaped.
 
 ### Unsafe Options
 
-For debugging in **non-production** environments only:
+For debugging in **non-production** environments only. These methods require the
+`BASHKIT_UNSAFE_LOGGING=1` environment variable to take effect; without it they
+are no-ops that emit a warning:
 
-```rust
-# use bashkit::LogConfig;
+```rust,ignore
+// First: export BASHKIT_UNSAFE_LOGGING=1 in your shell
 // WARNING: May expose sensitive data
 let config = LogConfig::new()
     .unsafe_disable_redaction()  // Disable ALL redaction

--- a/crates/bashkit/src/logging_impl.rs
+++ b/crates/bashkit/src/logging_impl.rs
@@ -125,8 +125,16 @@ impl LogConfig {
     /// # Warning
     ///
     /// This may expose secrets in logs. Only use in trusted debugging environments.
+    /// Requires `BASHKIT_UNSAFE_LOGGING=1` environment variable; otherwise this is a no-op.
     pub fn unsafe_disable_redaction(mut self) -> Self {
-        self.redact_sensitive = false;
+        if std::env::var("BASHKIT_UNSAFE_LOGGING").as_deref() == Ok("1") {
+            eprintln!("WARNING: Log redaction disabled — secrets may appear in logs");
+            self.redact_sensitive = false;
+        } else {
+            eprintln!(
+                "WARNING: unsafe_disable_redaction() ignored — set BASHKIT_UNSAFE_LOGGING=1 to enable"
+            );
+        }
         self
     }
 
@@ -141,8 +149,16 @@ impl LogConfig {
     /// # Warning
     ///
     /// Scripts may contain embedded secrets, credentials, or sensitive data.
+    /// Requires `BASHKIT_UNSAFE_LOGGING=1` environment variable; otherwise this is a no-op.
     pub fn unsafe_log_scripts(mut self) -> Self {
-        self.log_script_content = true;
+        if std::env::var("BASHKIT_UNSAFE_LOGGING").as_deref() == Ok("1") {
+            eprintln!("WARNING: Script content logging enabled — secrets may appear in logs");
+            self.log_script_content = true;
+        } else {
+            eprintln!(
+                "WARNING: unsafe_log_scripts() ignored — set BASHKIT_UNSAFE_LOGGING=1 to enable"
+            );
+        }
         self
     }
 
@@ -411,9 +427,11 @@ mod tests {
         assert!(formatted.contains("2 lines"));
         assert!(!formatted.contains("echo"));
 
-        // With unsafe flag: log content
-        let config = config.unsafe_log_scripts();
+        // With unsafe flag: log content (requires env var)
+        unsafe { std::env::set_var("BASHKIT_UNSAFE_LOGGING", "1") };
+        let config = LogConfig::new().unsafe_log_scripts();
         let formatted = format_script_for_log(script, &config);
+        unsafe { std::env::remove_var("BASHKIT_UNSAFE_LOGGING") };
         assert!(formatted.contains("echo"));
     }
 
@@ -428,13 +446,35 @@ mod tests {
 
     #[test]
     fn test_disabled_redaction() {
+        unsafe { std::env::set_var("BASHKIT_UNSAFE_LOGGING", "1") };
         let config = LogConfig::new().unsafe_disable_redaction();
+        unsafe { std::env::remove_var("BASHKIT_UNSAFE_LOGGING") };
 
         // Should not redact when disabled
         assert!(!config.should_redact_env("PASSWORD"));
         assert_eq!(
             config.redact_url("https://user:pass@example.com").as_ref(),
             "https://user:pass@example.com"
+        );
+    }
+
+    #[test]
+    fn test_unsafe_methods_noop_without_env() {
+        // Ensure env var is NOT set
+        unsafe { std::env::remove_var("BASHKIT_UNSAFE_LOGGING") };
+
+        // unsafe_disable_redaction should be a no-op
+        let config = LogConfig::new().unsafe_disable_redaction();
+        assert!(
+            config.redact_sensitive,
+            "redact_sensitive should remain true without BASHKIT_UNSAFE_LOGGING=1"
+        );
+
+        // unsafe_log_scripts should be a no-op
+        let config = LogConfig::new().unsafe_log_scripts();
+        assert!(
+            !config.log_script_content,
+            "log_script_content should remain false without BASHKIT_UNSAFE_LOGGING=1"
         );
     }
 }

--- a/crates/bashkit/tests/logging_security_tests.rs
+++ b/crates/bashkit/tests/logging_security_tests.rs
@@ -442,7 +442,11 @@ mod redaction_tests {
         // Test for TM-LOG-002: Content shown only with explicit unsafe flag
         use bashkit::logging::format_script_for_log;
 
+        // Requires BASHKIT_UNSAFE_LOGGING=1 for unsafe_log_scripts to take effect
+        unsafe { std::env::set_var("BASHKIT_UNSAFE_LOGGING", "1") };
         let config = LogConfig::new().unsafe_log_scripts();
+        unsafe { std::env::remove_var("BASHKIT_UNSAFE_LOGGING") };
+
         let script = "echo hello";
 
         let formatted = format_script_for_log(script, &config);
@@ -628,7 +632,10 @@ mod disabled_redaction_tests {
     #[test]
     fn test_disabled_redaction_shows_secrets() {
         // Test that unsafe_disable_redaction actually disables redaction
+        // Requires BASHKIT_UNSAFE_LOGGING=1 for the method to take effect
+        unsafe { std::env::set_var("BASHKIT_UNSAFE_LOGGING", "1") };
         let config = LogConfig::new().unsafe_disable_redaction();
+        unsafe { std::env::remove_var("BASHKIT_UNSAFE_LOGGING") };
 
         // Env var redaction disabled
         assert!(


### PR DESCRIPTION
## Summary

Closes #1179

- `unsafe_disable_redaction()` and `unsafe_log_scripts()` now require `BASHKIT_UNSAFE_LOGGING=1` env var to take effect
- Without the env var, both methods are no-ops and emit a warning to stderr
- When the env var is set, a warning is still emitted confirming unsafe logging is active
- Updated docs/logging.md to document the env var requirement

## Test plan

- [x] `test_unsafe_methods_noop_without_env` — verifies both methods are no-ops without env var
- [x] `test_disabled_redaction` — verifies methods work with env var set
- [x] `test_script_formatting` — verifies script logging works with env var
- [x] All 8 unit tests and 26 integration tests pass