### PR TITLE
refactor(deps): simplify dependency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,8 +329,8 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "fail",
  "flate2",
- "futures",
- "globset",
+ "futures-core",
+ "futures-util",
  "insta",
  "jaq-core",
  "jaq-json",
@@ -369,7 +369,6 @@ dependencies = [
  "bashkit",
  "clap",
  "colored",
- "instant",
  "serde",
  "serde_json",
  "statrs",
@@ -1749,19 +1748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "globset"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,15 +2166,6 @@ dependencies = [
  "once_cell",
  "similar",
  "tempfile",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ categories = ["command-line-utilities", "parser-implementations"]
 # add them in their own Cargo.toml or via [target.'cfg(...)'.dependencies].
 tokio = { version = "1", features = ["sync", "macros", "io-util", "rt", "time"] }
 async-trait = "0.1"
-futures = "0.3"
+futures-core = "0.3"
+futures-util = "0.3"
 
 # Error handling
 thiserror = "2"
@@ -37,16 +38,8 @@ jaq-core = "3.0"
 jaq-std = "3.0"
 jaq-json = "2.0"
 
-# Text search (grep) - verified supports search_slice() for in-memory
-grep = "0.3"
-grep-regex = "0.1"
-grep-searcher = "0.1"
-
 # HTTP client (for curl and API calls)
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
-
-# Glob matching
-globset = "0.4"
 
 # Regex
 regex = "1"

--- a/crates/bashkit-bench/Cargo.toml
+++ b/crates/bashkit-bench/Cargo.toml
@@ -22,9 +22,6 @@ serde_json.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 
-# Timing
-instant = "0.1"
-
 # Statistics
 statrs = "0.18"
 

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -26,7 +26,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.1.9", features = ["http_client", "git"] }
+bashkit = { path = "../bashkit", version = "0.1.9", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-eval/Cargo.toml
+++ b/crates/bashkit-eval/Cargo.toml
@@ -15,7 +15,7 @@ name = "bashkit-eval"
 path = "src/main.rs"
 
 [dependencies]
-bashkit = { path = "../bashkit", features = ["scripted_tool"] }
+bashkit = { path = "../bashkit", features = ["scripted_tool", "jq"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bashkit-js/Cargo.toml
+++ b/crates/bashkit-js/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs"] }
+bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs", "jq"] }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 serde = { workspace = true }

--- a/crates/bashkit-python/Cargo.toml
+++ b/crates/bashkit-python/Cargo.toml
@@ -18,7 +18,7 @@ doc = false  # Python extension, no Rust docs needed
 [dependencies]
 # Bashkit core
 # realfs: always-on so Python callers can use mount_real_* APIs
-bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs"] }
+bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs", "jq"] }
 
 # PyO3 native extension
 pyo3 = { workspace = true }

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -17,7 +17,8 @@ readme = "../../README.md"
 # Async runtime
 tokio = { workspace = true }
 async-trait = { workspace = true }
-futures = { workspace = true }
+futures-core = { workspace = true }
+futures-util = { workspace = true }
 tower = { workspace = true }
 
 # Error handling
@@ -31,9 +32,6 @@ schemars = { workspace = true }
 
 # Regex
 regex = { workspace = true }
-
-# Glob matching
-globset = { workspace = true }
 
 # Date/Time
 chrono = { workspace = true }
@@ -51,10 +49,10 @@ fail = { workspace = true, optional = true }
 # URL parsing
 url = "2"
 
-# JSON processing (jq)
-jaq-core = { workspace = true }
-jaq-std = { workspace = true }
-jaq-json = { workspace = true }
+# JSON processing (jq) - optional, enabled with jq feature
+jaq-core = { workspace = true, optional = true }
+jaq-std = { workspace = true, optional = true }
+jaq-json = { workspace = true, optional = true }
 
 # Compression (for gzip/gunzip)
 flate2 = { workspace = true }
@@ -83,6 +81,9 @@ zapcode-core = { version = "1.5", optional = true }
 
 [features]
 default = []
+# Enable jq builtin via embedded jaq interpreter
+# Usage: cargo build --features jq
+jq = ["dep:jaq-core", "dep:jaq-std", "dep:jaq-json"]
 http_client = ["reqwest"]
 # Enable Ed25519 request signing per RFC 9421 / web-bot-auth profile
 bot-auth = ["http_client", "dep:ed25519-dalek", "dep:rand", "dep:zeroize"]

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -64,6 +64,7 @@ mod iconv;
 mod inspect;
 mod introspect;
 mod join;
+#[cfg(feature = "jq")]
 mod jq;
 mod json;
 mod log;
@@ -164,6 +165,7 @@ pub use iconv::Iconv;
 pub use inspect::{File, Less, Stat};
 pub use introspect::{Hash, Type, Which};
 pub use join::Join;
+#[cfg(feature = "jq")]
 pub use jq::Jq;
 pub use json::Json;
 pub use log::Log;

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 /// Monotonic counter for unique process substitution file paths
 static PROC_SUB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-use futures::FutureExt;
+use futures_util::FutureExt;
 
 use crate::builtins::{self, Builtin};
 #[cfg(feature = "failpoints")]
@@ -567,7 +567,6 @@ impl Interpreter {
             "times" => Times,
             "eval" => Eval,
             // Text processing
-            "jq" => Jq,
             "grep" => Grep,
             "sed" => Sed,
             "awk" => Awk,
@@ -694,6 +693,10 @@ impl Interpreter {
             "tomlq" => Tomlq,
             "yaml" => Yaml,
         );
+
+        // jq builtin (requires jq feature)
+        #[cfg(feature = "jq")]
+        builtins.insert("jq".to_string(), Box::new(builtins::Jq));
 
         // Custom-construction builtins that need parameters
 

--- a/crates/bashkit/src/network/client.rs
+++ b/crates/bashkit/src/network/client.rs
@@ -371,7 +371,7 @@ impl HttpClient {
     ///
     /// This streams the response to avoid allocating memory for oversized responses.
     async fn read_body_with_limit(&self, response: reqwest::Response) -> Result<Vec<u8>> {
-        use futures::StreamExt;
+        use futures_util::StreamExt;
 
         let mut body = Vec::new();
         let mut stream = response.bytes_stream();

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -41,7 +41,7 @@
 //!
 //! ```
 //! use bashkit::{BashTool, Tool};
-//! use futures::StreamExt;
+//! use futures_util::StreamExt;
 //!
 //! # tokio_test::block_on(async {
 //! let tool = BashTool::default();
@@ -64,7 +64,7 @@ use crate::builtins::Builtin;
 use crate::error::Error;
 use crate::{Bash, ExecResult, ExecutionLimits, OutputCallback};
 use async_trait::async_trait;
-use futures::Stream;
+use futures_core::Stream;
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
 use std::future::Future;
@@ -1382,7 +1382,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execution_stream_emits_output_chunks() {
-        use futures::StreamExt;
+        use futures_util::StreamExt;
 
         let tool = BashTool::default();
         let execution = tool

--- a/deny.toml
+++ b/deny.toml
@@ -31,9 +31,6 @@ exceptions = []
 [advisories]
 # Ignore unmaintained transitive dependencies we can't control
 ignore = [
-    # instant: transitive via bashkit-bench (dev/bench only)
-    # No security impact; bench-only dependency
-    "RUSTSEC-2024-0384",
     # paste: transitive via bashkit-bench -> statrs -> nalgebra -> simba
     # No security impact; bench-only dependency
     "RUSTSEC-2024-0436",

--- a/specs/012-maintenance.md
+++ b/specs/012-maintenance.md
@@ -29,6 +29,11 @@ dependency rot, or security gaps ship in a release.
 - No known CVEs in dependency tree
 - License and advisory checks pass (`deny.toml`)
 - Supply chain audit passes
+- Dependency tree analysis (`cargo tree --duplicates`, usage grep):
+  - No unused/dead dependencies in workspace or crate Cargo.toml files
+  - Single-builtin deps behind feature flags (not always-on)
+  - No full crates where a sub-crate suffices (e.g. `futures-util` vs `futures`)
+  - Duplicate transitive versions reviewed — fix or document why unfixable
 
 ### Security
 


### PR DESCRIPTION
## Summary

- Remove dead workspace deps: `grep`, `grep-regex`, `grep-searcher` (never used — grep builtin uses `regex` directly), `globset` (never imported in source)
- Remove unused `instant` from bashkit-bench (code uses `std::time::Instant`); also removes RUSTSEC-2024-0384 advisory from deny.toml
- Feature-gate `jaq-core`/`jaq-std`/`jaq-json` behind new `jq` feature flag (only used in `builtins/jq.rs`)
- Replace `futures` with `futures-core` + `futures-util` (drops 5 unused sub-crates)
- Add dependency tree analysis to maintenance checklist (`specs/012-maintenance.md`)

Minimal build (no features) drops from 227 to 173 dep lines (**-24%**).

## Test plan

- [x] `cargo check --all-targets --all-features` — clean
- [x] `cargo check -p bashkit --no-default-features` — clean (verifies jq gating)
- [x] `cargo test --all-features` — all pass (except pre-existing SSH integration test)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
