### PR TITLE
fix(interactive): flush stdout/stderr after streaming command output

### DIFF
--- a/crates/bashkit-cli/src/interactive.rs
+++ b/crates/bashkit-cli/src/interactive.rs
@@ -14,6 +14,7 @@ use rustyline::hint::{Hint, Hinter};
 use rustyline::validate::Validator;
 use rustyline::{Config, Context, Editor, Helper};
 use std::borrow::Cow;
+use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -505,9 +506,11 @@ pub async fn run(mut bash: bashkit::Bash) -> Result<i32> {
                     Box::new(|stdout, stderr| {
                         if !stdout.is_empty() {
                             print!("{stdout}");
+                            let _ = std::io::stdout().flush();
                         }
                         if !stderr.is_empty() {
                             eprint!("{stderr}");
+                            let _ = std::io::stderr().flush();
                         }
                     }),
                 )
@@ -732,6 +735,36 @@ mod tests {
         let mut bash = test_bash();
         let result = bash.exec("[ -t 0 ] && echo yes || echo no").await.unwrap();
         assert_eq!(result.stdout, "yes\n");
+    }
+
+    #[tokio::test]
+    async fn clear_command_streams_ansi_escape_codes() {
+        let mut bash = test_bash();
+        let chunks: Arc<std::sync::Mutex<Vec<String>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let chunks_cb = chunks.clone();
+        let result = bash
+            .exec_streaming(
+                "clear",
+                Box::new(move |stdout, _stderr| {
+                    if !stdout.is_empty() {
+                        chunks_cb.lock().unwrap().push(stdout.to_string());
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        let collected = chunks.lock().unwrap();
+        let output: String = collected.iter().cloned().collect();
+        assert!(
+            output.contains("\x1b[2J"),
+            "clear should emit ESC[2J: {output:?}"
+        );
+        assert!(
+            output.contains("\x1b[H"),
+            "clear should emit ESC[H: {output:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fix `clear` (and other commands producing output without trailing newlines) appearing delayed in interactive mode
- Root cause: `print!()`/`eprint!()` in the streaming callback are line-buffered on TTY — ANSI escape codes from `clear` (`\x1b[2J\x1b[H`, no newline) stayed buffered until rustyline's next prompt draw
- Add explicit `stdout().flush()` and `stderr().flush()` after each `print!()`/`eprint!()` in the streaming callback

## What changed

`crates/bashkit-cli/src/interactive.rs`:
- Added `use std::io::Write` import
- Added `std::io::stdout().flush()` after `print!()` in the `exec_streaming` callback
- Added `std::io::stderr().flush()` after `eprint!()` in the `exec_streaming` callback
- Added test `clear_command_streams_ansi_escape_codes` verifying `clear` produces expected ANSI escape sequences via streaming

## Why

Users reported that typing `clear` in interactive mode didn't clear the screen immediately — instead the screen cleared only when the *next* command was executed. This is because Rust's `print!()` macro uses line buffering when connected to a TTY, and the clear command's output contains no newline.

## Test plan

- [x] New test: `clear_command_streams_ansi_escape_codes` — verifies `clear` emits `ESC[2J` and `ESC[H` via `exec_streaming`
- [x] All 86 bashkit-cli tests pass
- [x] All 2363 bashkit lib tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Smoke test: `echo 'clear' | cargo run` emits correct ANSI codes
- [x] Audited codebase for similar unflushed `print!`/`eprint!` — only other occurrence is in `main.rs` one-shot mode where `process::exit()` follows immediately (OS flushes on exit)