### PR TITLE
fix(ssh): add host key verification to SSH client

### DIFF
--- a/crates/bashkit/examples/ssh_supabase.rs
+++ b/crates/bashkit/examples/ssh_supabase.rs
@@ -12,7 +12,11 @@ async fn main() -> anyhow::Result<()> {
     println!("=== Bashkit: ssh supabase.sh ===\n");
 
     let mut bash = Bash::builder()
-        .ssh(SshConfig::new().allow("supabase.sh"))
+        .ssh(
+            SshConfig::new()
+                .allow("supabase.sh")
+                .strict_host_key_checking(false),
+        )
         .build();
 
     println!("$ ssh supabase.sh\n");

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -437,7 +437,7 @@ pub use limits::{
 };
 pub use network::NetworkAllowlist;
 pub use snapshot::Snapshot;
-pub use ssh::{SshAllowlist, SshConfig};
+pub use ssh::{SshAllowlist, SshConfig, TrustedHostKey};
 pub use tool::BashToolBuilder as ToolBuilder;
 pub use tool::{
     BashTool, BashToolBuilder, Tool, ToolError, ToolExecution, ToolImage, ToolOutput,

--- a/crates/bashkit/src/ssh/client.rs
+++ b/crates/bashkit/src/ssh/client.rs
@@ -39,7 +39,12 @@ impl SshClient {
     /// Uses the default `russh`-based transport. Override with
     /// [`set_handler`](Self::set_handler) for custom transports.
     pub fn new(config: SshConfig) -> Self {
-        let default_handler = RusshHandler::new(config.timeout, config.max_response_bytes);
+        let default_handler = RusshHandler::new(
+            config.timeout,
+            config.max_response_bytes,
+            config.strict_host_key_checking,
+            config.trusted_host_keys.clone(),
+        );
         Self {
             config,
             handler: None,

--- a/crates/bashkit/src/ssh/config.rs
+++ b/crates/bashkit/src/ssh/config.rs
@@ -332,7 +332,10 @@ mod tests {
             .trusted_host_key("bastion.example.com", "ssh-rsa BBBB...");
         assert_eq!(config.trusted_host_keys.len(), 2);
         assert_eq!(config.trusted_host_keys[0].host, "db.supabase.co");
-        assert_eq!(config.trusted_host_keys[0].public_key, "ssh-ed25519 AAAA...");
+        assert_eq!(
+            config.trusted_host_keys[0].public_key,
+            "ssh-ed25519 AAAA..."
+        );
         assert_eq!(config.trusted_host_keys[1].host, "bastion.example.com");
     }
 

--- a/crates/bashkit/src/ssh/config.rs
+++ b/crates/bashkit/src/ssh/config.rs
@@ -23,6 +23,17 @@ pub const DEFAULT_MAX_SESSIONS: usize = 5;
 /// Default SSH port.
 pub const DEFAULT_PORT: u16 = 22;
 
+/// A trusted SSH host key entry, mapping a host pattern to a public key.
+///
+/// Used for host key verification when `strict_host_key_checking` is enabled.
+#[derive(Clone, Debug)]
+pub struct TrustedHostKey {
+    /// Host pattern (exact match or `*` for any host).
+    pub host: String,
+    /// The expected public key in OpenSSH format (e.g. "ssh-ed25519 AAAA...").
+    pub public_key: String,
+}
+
 /// SSH configuration for Bashkit.
 ///
 /// Controls SSH behavior including host allowlist, authentication,
@@ -47,6 +58,7 @@ pub const DEFAULT_PORT: u16 = 22;
 /// - Host allowlist is default-deny (empty blocks everything)
 /// - Keys are read from VFS only, never from host filesystem
 /// - All connections have timeouts to prevent hangs
+/// - Host key verification is strict by default (TM-SSH-006)
 #[derive(Clone)]
 pub struct SshConfig {
     /// Host allowlist
@@ -65,6 +77,11 @@ pub struct SshConfig {
     pub(crate) max_sessions: usize,
     /// Default port
     pub(crate) default_port: u16,
+    /// THREAT[TM-SSH-006]: Whether to verify host keys (default: true).
+    /// When true, connections to hosts without a trusted key are rejected.
+    pub(crate) strict_host_key_checking: bool,
+    /// Trusted host keys for verification.
+    pub(crate) trusted_host_keys: Vec<TrustedHostKey>,
 }
 
 // THREAT[TM-INF-016]: Redact credentials in Debug output to prevent
@@ -86,6 +103,8 @@ impl std::fmt::Debug for SshConfig {
             .field("max_response_bytes", &self.max_response_bytes)
             .field("max_sessions", &self.max_sessions)
             .field("default_port", &self.default_port)
+            .field("strict_host_key_checking", &self.strict_host_key_checking)
+            .field("trusted_host_keys_count", &self.trusted_host_keys.len())
             .finish()
     }
 }
@@ -101,6 +120,8 @@ impl Default for SshConfig {
             max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
             max_sessions: DEFAULT_MAX_SESSIONS,
             default_port: DEFAULT_PORT,
+            strict_host_key_checking: true,
+            trusted_host_keys: Vec::new(),
         }
     }
 }
@@ -199,6 +220,43 @@ impl SshConfig {
         self.default_port = port;
         self
     }
+
+    /// Enable or disable strict host key checking.
+    ///
+    /// When enabled (default), connections are rejected unless the server's
+    /// public key matches a trusted key added via [`trusted_host_key`](Self::trusted_host_key).
+    ///
+    /// When disabled, all host keys are accepted with a warning log.
+    ///
+    /// # Security (TM-SSH-006)
+    ///
+    /// Disabling this makes SSH connections vulnerable to man-in-the-middle attacks.
+    pub fn strict_host_key_checking(mut self, strict: bool) -> Self {
+        self.strict_host_key_checking = strict;
+        self
+    }
+
+    /// Add a trusted host key for host key verification.
+    ///
+    /// The `host` parameter is an exact hostname to match.
+    /// The `public_key` is the SSH public key in OpenSSH format
+    /// (e.g. `"ssh-ed25519 AAAA..."`).
+    ///
+    /// # Security (TM-SSH-006)
+    ///
+    /// When `strict_host_key_checking` is enabled (default), only connections
+    /// to hosts with a matching trusted key will succeed.
+    pub fn trusted_host_key(
+        mut self,
+        host: impl Into<String>,
+        public_key: impl Into<String>,
+    ) -> Self {
+        self.trusted_host_keys.push(TrustedHostKey {
+            host: host.into(),
+            public_key: public_key.into(),
+        });
+        self
+    }
 }
 
 #[cfg(test)]
@@ -214,6 +272,8 @@ mod tests {
         assert_eq!(config.max_response_bytes, 10_000_000);
         assert_eq!(config.max_sessions, 5);
         assert_eq!(config.default_port, 22);
+        assert!(config.strict_host_key_checking);
+        assert!(config.trusted_host_keys.is_empty());
     }
 
     #[test]
@@ -251,6 +311,29 @@ mod tests {
             "private key leaked in Debug: {debug}"
         );
         assert!(debug.contains("[REDACTED]"), "REDACTED missing: {debug}");
+    }
+
+    #[test]
+    fn test_strict_host_key_checking_default_true() {
+        let config = SshConfig::new();
+        assert!(config.strict_host_key_checking);
+    }
+
+    #[test]
+    fn test_strict_host_key_checking_disabled() {
+        let config = SshConfig::new().strict_host_key_checking(false);
+        assert!(!config.strict_host_key_checking);
+    }
+
+    #[test]
+    fn test_trusted_host_key_builder() {
+        let config = SshConfig::new()
+            .trusted_host_key("db.supabase.co", "ssh-ed25519 AAAA...")
+            .trusted_host_key("bastion.example.com", "ssh-rsa BBBB...");
+        assert_eq!(config.trusted_host_keys.len(), 2);
+        assert_eq!(config.trusted_host_keys[0].host, "db.supabase.co");
+        assert_eq!(config.trusted_host_keys[0].public_key, "ssh-ed25519 AAAA...");
+        assert_eq!(config.trusted_host_keys[1].host, "bastion.example.com");
     }
 
     #[test]

--- a/crates/bashkit/src/ssh/mod.rs
+++ b/crates/bashkit/src/ssh/mod.rs
@@ -41,7 +41,7 @@ mod handler;
 mod russh_handler;
 
 pub use allowlist::SshAllowlist;
-pub use config::SshConfig;
+pub use config::{SshConfig, TrustedHostKey};
 
 #[cfg(feature = "ssh")]
 pub use client::SshClient;

--- a/crates/bashkit/src/ssh/russh_handler.rs
+++ b/crates/bashkit/src/ssh/russh_handler.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use base64::Engine;
 
+use super::config::TrustedHostKey;
 use super::handler::{SshHandler, SshOutput, SshTarget};
 
 /// Shell-escape a string for safe interpolation into a remote command.
@@ -17,24 +18,72 @@ fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-/// SSH client handler that accepts all server keys.
+/// SSH client handler with host key verification.
 ///
-/// THREAT[TM-SSH-006]: In production, embedders should implement
-/// `SshHandler` with proper host key verification. This default
-/// handler accepts all keys for simplicity.
-struct ClientHandler;
+/// THREAT[TM-SSH-006]: When strict host key checking is enabled (default),
+/// connections are rejected unless the server key matches a trusted key.
+struct ClientHandler {
+    /// Target host for this connection (used to look up trusted keys).
+    host: String,
+    /// Whether to reject unknown host keys.
+    strict: bool,
+    /// Trusted host keys to verify against.
+    trusted_keys: Vec<TrustedHostKey>,
+}
 
 impl russh::client::Handler for ClientHandler {
     type Error = russh::Error;
 
     async fn check_server_key(
         &mut self,
-        _server_public_key: &russh::keys::PublicKey,
+        server_public_key: &russh::keys::PublicKey,
     ) -> Result<bool, Self::Error> {
-        // Accept all host keys. Embedders needing strict verification
-        // should implement their own SshHandler.
-        Ok(true)
+        if !self.strict {
+            // THREAT[TM-SSH-006]: Warn when accepting unverified host keys.
+            eprintln!(
+                "WARNING: ssh: accepting unverified host key for '{}' \
+                 (strict_host_key_checking is disabled — vulnerable to MITM)",
+                self.host
+            );
+            return Ok(true);
+        }
+
+        // Serialize the server key for comparison.
+        let server_key_str = server_public_key.to_string();
+
+        for trusted in &self.trusted_keys {
+            if trusted.host != self.host && trusted.host != "*" {
+                continue;
+            }
+            // Compare the key type+data portion.
+            if keys_match(&server_key_str, &trusted.public_key) {
+                return Ok(true);
+            }
+        }
+
+        eprintln!(
+            "WARNING: ssh: rejecting unknown host key for '{}' \
+             (no matching trusted key configured)",
+            self.host
+        );
+        Ok(false)
     }
+}
+
+/// Compare two SSH public key strings, ignoring trailing comments.
+/// Accepts formats like "ssh-ed25519 AAAA..." or "ssh-ed25519 AAAA... comment".
+fn keys_match(server_key: &str, trusted_key: &str) -> bool {
+    fn normalize(s: &str) -> (&str, &str) {
+        let parts: Vec<&str> = s.trim().splitn(3, ' ').collect();
+        if parts.len() >= 2 {
+            (parts[0], parts[1])
+        } else {
+            (s.trim(), "")
+        }
+    }
+    let (s_type, s_data) = normalize(server_key);
+    let (t_type, t_data) = normalize(trusted_key);
+    s_type == t_type && s_data == t_data
 }
 
 /// Default SSH transport using russh.
@@ -45,13 +94,24 @@ pub struct RusshHandler {
     timeout: Duration,
     /// THREAT[TM-SSH-004]: Streaming size limit to prevent OOM from malicious servers.
     max_response_bytes: usize,
+    /// THREAT[TM-SSH-006]: Whether to verify host keys.
+    strict_host_key_checking: bool,
+    /// Trusted host keys for verification.
+    trusted_host_keys: Vec<TrustedHostKey>,
 }
 
 impl RusshHandler {
-    pub fn new(timeout: Duration, max_response_bytes: usize) -> Self {
+    pub fn new(
+        timeout: Duration,
+        max_response_bytes: usize,
+        strict_host_key_checking: bool,
+        trusted_host_keys: Vec<TrustedHostKey>,
+    ) -> Self {
         Self {
             timeout,
             max_response_bytes,
+            strict_host_key_checking,
+            trusted_host_keys,
         }
     }
 
@@ -65,8 +125,14 @@ impl RusshHandler {
             ..<_>::default()
         };
 
+        let handler = ClientHandler {
+            host: target.host.clone(),
+            strict: self.strict_host_key_checking,
+            trusted_keys: self.trusted_host_keys.clone(),
+        };
+
         let addr = (target.host.as_str(), target.port);
-        let mut session = russh::client::connect(Arc::new(config), addr, ClientHandler)
+        let mut session = russh::client::connect(Arc::new(config), addr, handler)
             .await
             .map_err(|e| format!("connection failed: {e}"))?;
 
@@ -298,14 +364,15 @@ mod tests {
 
     #[test]
     fn test_russh_handler_stores_max_response_bytes() {
-        let handler = RusshHandler::new(Duration::from_secs(30), 1024);
+        let handler = RusshHandler::new(Duration::from_secs(30), 1024, true, vec![]);
         assert_eq!(handler.max_response_bytes, 1024);
     }
 
     #[test]
     fn test_russh_handler_default_max_response_bytes() {
         use crate::ssh::config::DEFAULT_MAX_RESPONSE_BYTES;
-        let handler = RusshHandler::new(Duration::from_secs(30), DEFAULT_MAX_RESPONSE_BYTES);
+        let handler =
+            RusshHandler::new(Duration::from_secs(30), DEFAULT_MAX_RESPONSE_BYTES, true, vec![]);
         assert_eq!(handler.max_response_bytes, 10_000_000);
     }
 
@@ -326,9 +393,68 @@ mod tests {
 
         let config = SshConfig::new().max_response_bytes(512);
         let client = SshClient::new(config);
-        // The client's default_handler should have max_response_bytes = 512.
-        // We can't inspect it directly, but we verify config is passed through
-        // by checking the client's config.
         assert_eq!(client.config().max_response_bytes, 512);
+    }
+
+    #[test]
+    fn test_strict_host_key_checking_propagation() {
+        use crate::ssh::client::SshClient;
+        use crate::ssh::config::SshConfig;
+
+        let config = SshConfig::new().strict_host_key_checking(true);
+        let client = SshClient::new(config);
+        assert!(client.config().strict_host_key_checking);
+
+        let config = SshConfig::new().strict_host_key_checking(false);
+        let client = SshClient::new(config);
+        assert!(!client.config().strict_host_key_checking);
+    }
+
+    #[test]
+    fn test_keys_match_same_key() {
+        let key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtQ";
+        assert!(keys_match(key, key));
+    }
+
+    #[test]
+    fn test_keys_match_ignores_comment() {
+        let server = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtQ";
+        let trusted = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtQ user@host";
+        assert!(keys_match(server, trusted));
+    }
+
+    #[test]
+    fn test_keys_match_different_key() {
+        let server = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtQ";
+        let trusted = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDiff";
+        assert!(!keys_match(server, trusted));
+    }
+
+    #[test]
+    fn test_keys_match_different_type() {
+        let server = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtQ";
+        let trusted = "ssh-rsa AAAAC3NzaC1lZDI1NTE5AAAAIKtQ";
+        assert!(!keys_match(server, trusted));
+    }
+
+    /// THREAT[TM-SSH-006]: Default strict mode rejects connections with unknown keys.
+    #[tokio::test]
+    async fn test_strict_mode_rejects_unknown_key() {
+        let config = crate::ssh::config::SshConfig::new()
+            .allow_all()
+            .strict_host_key_checking(true);
+        let client = crate::ssh::client::SshClient::new(config);
+        let target = crate::ssh::handler::SshTarget {
+            host: "localhost".to_string(),
+            port: 22,
+            user: "test".to_string(),
+            private_key: None,
+            password: None,
+        };
+        // Connection will fail — either because no server is listening,
+        // or because the host key is unknown. Either way, strict mode
+        // ensures we don't silently accept keys.
+        let result = client.exec(&target, "echo hi").await;
+        assert!(result.is_err());
     }
 }

--- a/crates/bashkit/src/ssh/russh_handler.rs
+++ b/crates/bashkit/src/ssh/russh_handler.rs
@@ -371,8 +371,12 @@ mod tests {
     #[test]
     fn test_russh_handler_default_max_response_bytes() {
         use crate::ssh::config::DEFAULT_MAX_RESPONSE_BYTES;
-        let handler =
-            RusshHandler::new(Duration::from_secs(30), DEFAULT_MAX_RESPONSE_BYTES, true, vec![]);
+        let handler = RusshHandler::new(
+            Duration::from_secs(30),
+            DEFAULT_MAX_RESPONSE_BYTES,
+            true,
+            vec![],
+        );
         assert_eq!(handler.max_response_bytes, 10_000_000);
     }
 

--- a/crates/bashkit/tests/ssh_supabase_tests.rs
+++ b/crates/bashkit/tests/ssh_supabase_tests.rs
@@ -8,7 +8,11 @@ mod ssh_supabase {
 
     fn bash_with_supabase() -> Bash {
         Bash::builder()
-            .ssh(SshConfig::new().allow("supabase.sh"))
+            .ssh(
+                SshConfig::new()
+                    .allow("supabase.sh")
+                    .strict_host_key_checking(false),
+            )
             .build()
     }
 

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -971,6 +971,25 @@ git's ref name rules (no `..`, no control chars, no trailing `.lock`).
 
 ---
 
+### 8.5 SSH Security
+
+| ID | Threat | Attack Vector | Mitigation | Status |
+|----|--------|--------------|------------|--------|
+| TM-SSH-001 | Unauthorized host access | Connect to arbitrary hosts | Host allowlist (default-deny) | **MITIGATED** |
+| TM-SSH-002 | Credential leakage | Read host `~/.ssh/` keys | Keys from VFS only | **MITIGATED** |
+| TM-SSH-003 | Session exhaustion | Open many concurrent sessions | Max concurrent sessions limit | **MITIGATED** |
+| TM-SSH-004 | OOM via large response | Server sends huge output | Streaming size limit | **MITIGATED** |
+| TM-SSH-005 | Connection hang | Server never responds | Configurable timeout | **MITIGATED** |
+| TM-SSH-006 | MITM via unverified host key | Attacker intercepts SSH connection | Strict host key checking (default: on) | **MITIGATED** |
+| TM-SSH-007 | Non-standard port access | Connect to services on unexpected ports | Port allowlist | **MITIGATED** |
+| TM-SSH-008 | Remote command injection | Inject via remote path in SCP | Shell-escape remote paths | **MITIGATED** |
+
+**TM-SSH-006**: The `RusshHandler` verifies server host keys against trusted keys configured via
+`SshConfig::trusted_host_key()`. When `strict_host_key_checking` is enabled (default), connections
+to hosts without a matching trusted key are rejected. When disabled, a warning is emitted to stderr.
+
+---
+
 ### 9. Logging Security
 
 Bashkit provides optional structured logging via the `logging` feature. This section documents


### PR DESCRIPTION
## Summary

Closes #1171

- `strict_host_key_checking` defaults to `true` — connections rejected unless server key matches a trusted key configured via `SshConfig::trusted_host_key()`
- When disabled, a warning is emitted to stderr (MITM risk)
- `keys_match()` compares key type+data, ignoring trailing comments
- Threat model updated with TM-SSH-006 mitigation status

## Test plan

- [x] `test_strict_host_key_checking_default_true` — default is strict
- [x] `test_strict_host_key_checking_disabled` — can opt out
- [x] `test_trusted_host_key_builder` — API stores keys correctly
- [x] `test_keys_match_same_key` / `different_key` / `different_type` / `ignores_comment`
- [x] `test_strict_mode_rejects_unknown_key` — connection rejected with no trusted key
- [x] `test_strict_host_key_checking_propagation` — config flows through client