### PR TITLE
feat(builtins): add --help and --version support to all tools

### DIFF
--- a/crates/bashkit/src/builtins/archive.rs
+++ b/crates/bashkit/src/builtins/archive.rs
@@ -80,6 +80,13 @@ pub struct Tar;
 #[async_trait]
 impl Builtin for Tar {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: tar [OPTION]... [FILE]...\nCreate, extract, or list tar archives.\n\n  -c\tcreate archive\n  -x\textract archive\n  -t\tlist archive contents\n  -v\tverbose output\n  -f ARCHIVE\tarchive file name\n  -z\tfilter through gzip\n  -C DIR\tchange to directory DIR\n  -O\textract files to stdout\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("tar (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut create = false;
         let mut extract = false;
         let mut list = false;
@@ -752,6 +759,13 @@ pub struct Gzip;
 #[async_trait]
 impl Builtin for Gzip {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: gzip [OPTION]... [FILE]...\nCompress files.\n\n  -d\tdecompress\n  -k\tkeep original file\n  -f\tforce overwrite\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("gzip (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut decompress = false;
         let mut keep = false;
         let mut force = false;
@@ -912,6 +926,13 @@ pub struct Gunzip;
 #[async_trait]
 impl Builtin for Gunzip {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: gunzip [OPTION]... [FILE]...\nDecompress files.\n\n  -k\tkeep original file\n  -f\tforce overwrite\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("gunzip (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         // gunzip is equivalent to gzip -d
         let mut modified_args: Vec<String> = vec!["-d".to_string()];
         modified_args.extend(ctx.args.iter().cloned());

--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -3343,6 +3343,13 @@ impl Awk {
 #[async_trait]
 impl Builtin for Awk {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: awk [OPTION]... 'program' [FILE]...\nPattern scanning and processing language.\n\n  -F SEP\t\tuse SEP as field separator\n  -v var=val\tassign variable before execution\n  -f progfile\tread program from file\n  --csv, -k\tCSV mode (set field separator to comma)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("awk (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut program_str = String::new();
         let mut files: Vec<String> = Vec::new();
         let mut field_sep = " ".to_string();

--- a/crates/bashkit/src/builtins/base64.rs
+++ b/crates/bashkit/src/builtins/base64.rs
@@ -20,6 +20,13 @@ pub struct Base64;
 #[async_trait]
 impl Builtin for Base64 {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: base64 [OPTION]... [FILE]\nBase64 encode or decode FILE, or standard input.\n\n  -d, --decode\tdecode data\n  -w COLS, --wrap=COLS\twrap encoded lines after COLS characters (default 76)\n  -i, --ignore-garbage\twhen decoding, ignore non-alphabet characters\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("base64 (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut decode = false;
         let mut wrap = 76usize;
         let mut file: Option<String> = None;

--- a/crates/bashkit/src/builtins/bc.rs
+++ b/crates/bashkit/src/builtins/bc.rs
@@ -24,6 +24,13 @@ pub struct Bc;
 #[async_trait]
 impl Builtin for Bc {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: bc [OPTION]... [FILE]...\nArbitrary-precision calculator.\n\n  -l\tuse the predefined math library (scale=20, s, c, a, l, e, sqrt)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("bc (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut math_lib = false;
         let mut expr_args: Vec<&str> = Vec::new();
 

--- a/crates/bashkit/src/builtins/cat.rs
+++ b/crates/bashkit/src/builtins/cat.rs
@@ -13,6 +13,13 @@ pub struct Cat;
 #[async_trait]
 impl Builtin for Cat {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: cat [OPTION]... [FILE]...\nConcatenate FILE(s) to standard output.\n\n  -n\t\tnumber all output lines\n  -v\t\tuse ^ and M- notation\n  -e\t\tequivalent to -v (simplified)\n  -t\t\tequivalent to -v (simplified)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("cat (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut output = String::new();
         let mut show_nonprinting = false;
         let mut number_lines = false;

--- a/crates/bashkit/src/builtins/checksum.rs
+++ b/crates/bashkit/src/builtins/checksum.rs
@@ -21,6 +21,13 @@ pub struct Sha256sum;
 #[async_trait]
 impl Builtin for Md5sum {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: md5sum [FILE]...\nPrint MD5 checksums.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("md5sum (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         checksum_execute::<Md5>(&ctx, "md5sum").await
     }
 }
@@ -28,6 +35,13 @@ impl Builtin for Md5sum {
 #[async_trait]
 impl Builtin for Sha1sum {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: sha1sum [FILE]...\nPrint SHA1 checksums.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("sha1sum (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         checksum_execute::<Sha1>(&ctx, "sha1sum").await
     }
 }
@@ -35,6 +49,13 @@ impl Builtin for Sha1sum {
 #[async_trait]
 impl Builtin for Sha256sum {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: sha256sum [FILE]...\nPrint SHA256 checksums.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("sha256sum (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         checksum_execute::<Sha256>(&ctx, "sha256sum").await
     }
 }

--- a/crates/bashkit/src/builtins/column.rs
+++ b/crates/bashkit/src/builtins/column.rs
@@ -141,6 +141,13 @@ fn format_columns(text: &str) -> String {
 #[async_trait]
 impl Builtin for Column {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: column [OPTION]... [FILE]...\nColumnate lists.\n\n  -t\t\tcreate a table\n  -s SEP\tspecify input delimiter for -t mode\n  -o SEP\tspecify output delimiter for -t mode\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("column (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = parse_column_args(ctx.args);
 
         // Collect all input

--- a/crates/bashkit/src/builtins/comm.rs
+++ b/crates/bashkit/src/builtins/comm.rs
@@ -51,6 +51,13 @@ fn parse_comm_args(args: &[String]) -> (CommOptions, Vec<String>) {
 #[async_trait]
 impl Builtin for Comm {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: comm [OPTION]... FILE1 FILE2\nCompare two sorted files line by line.\n\n  -1\t\tsuppress column 1 (lines unique to FILE1)\n  -2\t\tsuppress column 2 (lines unique to FILE2)\n  -3\t\tsuppress column 3 (lines that appear in both files)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("comm (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = parse_comm_args(ctx.args);
 
         if files.len() < 2 {

--- a/crates/bashkit/src/builtins/curl.rs
+++ b/crates/bashkit/src/builtins/curl.rs
@@ -56,6 +56,13 @@ pub struct Curl;
 #[async_trait]
 impl Builtin for Curl {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: curl [OPTIONS] URL\nTransfer data from or to a server.\n\n  -s, --silent\tsilent mode\n  -o FILE\twrite output to FILE\n  -X METHOD\trequest method (GET, POST, PUT, DELETE, HEAD)\n  -d, --data DATA\tsend data in request body\n  -H, --header HEADER\tadd header (\"Name: Value\")\n  -I, --head\tfetch headers only\n  -f, --fail\tfail silently on HTTP errors\n  -L, --location\tfollow redirects\n  -w, --write-out FORMAT\twrite output format after transfer\n  --compressed\trequest and decompress compressed response\n  -u, --user USER:PASS\tbasic authentication\n  -A, --user-agent STRING\tcustom user agent\n  -e, --referer URL\treferer URL\n  -m, --max-time SECONDS\tmaximum time for operation\n  --connect-timeout SECONDS\tconnection timeout\n  -F, --form FIELD\tmultipart form data\n  -v, --verbose\tverbose output\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("curl 8.7.1 (bashkit)"),
+        ) {
+            return Ok(r);
+        }
         // Parse arguments
         let mut silent = false;
         let mut verbose = false;
@@ -820,6 +827,13 @@ pub struct Wget;
 #[async_trait]
 impl Builtin for Wget {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: wget [OPTIONS] URL\nDownload files from the web.\n\n  -q, --quiet\tquiet mode\n  -O FILE\twrite output to FILE (use '-' for stdout)\n  --spider\tdon't download, just check if URL exists\n  --header \"H: V\"\tadd custom header\n  -U, --user-agent STRING\tcustom user agent\n  --post-data DATA\tPOST data with request\n  -t, --tries NUM\tnumber of retries\n  -T, --timeout SECONDS\ttimeout for all operations\n  --connect-timeout SECONDS\tconnection timeout\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("GNU Wget 1.21 (bashkit)"),
+        ) {
+            return Ok(r);
+        }
         // Parse arguments
         let mut quiet = false;
         let mut output_file: Option<String> = None;

--- a/crates/bashkit/src/builtins/cuttr.rs
+++ b/crates/bashkit/src/builtins/cuttr.rs
@@ -31,6 +31,13 @@ enum CutMode {
 #[async_trait]
 impl Builtin for Cut {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: cut OPTION... [FILE]...\nPrint selected parts of lines from each FILE to standard output.\n\n  -d DELIM\t\tuse DELIM instead of TAB for field delimiter\n  -f FIELDS\t\tselect only these fields\n  -b BYTES\t\tselect only these bytes\n  -c CHARS\t\tselect only these characters\n  -s\t\t\tonly print lines containing delimiter\n  -z\t\t\tline delimiter is NUL, not newline\n  --complement\t\tcomplement the selection\n  --output-delimiter=STRING\tuse STRING as output delimiter\n  --help\t\tdisplay this help and exit\n  --version\t\toutput version information and exit\n",
+            Some("cut (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut delimiter = '\t';
         let mut spec = String::new();
         let mut mode = CutMode::Fields;
@@ -276,6 +283,13 @@ pub struct Tr;
 #[async_trait]
 impl Builtin for Tr {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: tr [OPTION]... SET1 [SET2]\nTranslate, squeeze, and/or delete characters from standard input.\n\n  -d\t\tdelete characters in SET1\n  -s\t\tsqueeze repeated output characters\n  -c, -C\tcomplement SET1\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("tr (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut delete = false;
         let mut squeeze = false;
         let mut complement = false;

--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -344,6 +344,13 @@ fn format_iso8601(dt: &DateTime<Utc>, utc: bool, precision: &str) -> String {
 #[async_trait]
 impl Builtin for Date {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: date [+FORMAT] [-u] [-R] [-I[TIMESPEC]] [-d STRING] [-r FILE]\nDisplay the current time in the given FORMAT, or set the system date.\n\n  +FORMAT\toutput date according to FORMAT\n  -d, --date=STRING\tdisplay time described by STRING\n  -r, --reference=FILE\tdisplay the last modification time of FILE\n  -u, --utc\tprint Coordinated Universal Time (UTC)\n  -R, --rfc-email\toutput RFC 2822 formatted date\n  -I[FMT], --iso-8601[=FMT]\toutput ISO 8601 date/time (FMT: date, hours, minutes, seconds)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("date (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut utc = false;
         let mut format_arg: Option<String> = None;
         let mut date_str: Option<String> = None;

--- a/crates/bashkit/src/builtins/diff.rs
+++ b/crates/bashkit/src/builtins/diff.rs
@@ -320,6 +320,13 @@ fn format_unified(file1: &str, file2: &str, diff: &[DiffLine<'_>]) -> String {
 #[async_trait]
 impl Builtin for Diff {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: diff [OPTION]... FILE1 FILE2\nCompare files line by line.\n\n  -u\t\toutput in unified format\n  -q, --brief\treport only when files differ\n  --help\t\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("diff (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = parse_diff_args(ctx.args);
 
         if files.len() < 2 {

--- a/crates/bashkit/src/builtins/disk.rs
+++ b/crates/bashkit/src/builtins/disk.rs
@@ -21,6 +21,28 @@ pub struct Du;
 #[async_trait]
 impl Builtin for Du {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        // NOTE: -h means "human readable" for du, so we cannot use check_help_version
+        // (which intercepts -h as help). Only check --help and --version explicitly.
+        for arg in ctx.args {
+            match arg.as_str() {
+                "--help" => {
+                    return Ok(ExecResult::ok(
+                        "Usage: du [-s] [-h] [FILE...]\n\
+                         Estimate file space usage.\n\n\
+                         \x20 -s\tdisplay only a total for each argument\n\
+                         \x20 -h\tprint sizes in human readable format\n\
+                         \x20 --help\tdisplay this help and exit\n\
+                         \x20 --version\toutput version information and exit\n"
+                            .to_string(),
+                    ));
+                }
+                "--version" => {
+                    return Ok(ExecResult::ok("du (bashkit) 0.1\n".to_string()));
+                }
+                s if !s.starts_with('-') => break,
+                _ => {}
+            }
+        }
         let mut summary_only = false;
         let mut human_readable = false;
         let mut paths: Vec<String> = Vec::new();
@@ -173,6 +195,27 @@ pub struct Df;
 #[async_trait]
 impl Builtin for Df {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        // NOTE: -h means "human readable" for df, so we cannot use check_help_version
+        // (which intercepts -h as help). Only check --help and --version explicitly.
+        for arg in ctx.args {
+            match arg.as_str() {
+                "--help" => {
+                    return Ok(ExecResult::ok(
+                        "Usage: df [-h]\n\
+                         Report file system disk space usage.\n\n\
+                         \x20 -h\tprint sizes in human readable format\n\
+                         \x20 --help\tdisplay this help and exit\n\
+                         \x20 --version\toutput version information and exit\n"
+                            .to_string(),
+                    ));
+                }
+                "--version" => {
+                    return Ok(ExecResult::ok("df (bashkit) 0.1\n".to_string()));
+                }
+                s if !s.starts_with('-') => break,
+                _ => {}
+            }
+        }
         let mut human_readable = false;
 
         for arg in ctx.args {

--- a/crates/bashkit/src/builtins/disk.rs
+++ b/crates/bashkit/src/builtins/disk.rs
@@ -21,27 +21,17 @@ pub struct Du;
 #[async_trait]
 impl Builtin for Du {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        // NOTE: -h means "human readable" for du, so we cannot use check_help_version
-        // (which intercepts -h as help). Only check --help and --version explicitly.
-        for arg in ctx.args {
-            match arg.as_str() {
-                "--help" => {
-                    return Ok(ExecResult::ok(
-                        "Usage: du [-s] [-h] [FILE...]\n\
-                         Estimate file space usage.\n\n\
-                         \x20 -s\tdisplay only a total for each argument\n\
-                         \x20 -h\tprint sizes in human readable format\n\
-                         \x20 --help\tdisplay this help and exit\n\
-                         \x20 --version\toutput version information and exit\n"
-                            .to_string(),
-                    ));
-                }
-                "--version" => {
-                    return Ok(ExecResult::ok("du (bashkit) 0.1\n".to_string()));
-                }
-                s if !s.starts_with('-') => break,
-                _ => {}
-            }
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: du [-s] [-h] [FILE...]\n\
+             Estimate file space usage.\n\n\
+             \x20 -s\tdisplay only a total for each argument\n\
+             \x20 -h\tprint sizes in human readable format\n\
+             \x20 --help\tdisplay this help and exit\n\
+             \x20 --version\toutput version information and exit\n",
+            Some("du (bashkit) 0.1"),
+        ) {
+            return Ok(r);
         }
         let mut summary_only = false;
         let mut human_readable = false;
@@ -195,26 +185,16 @@ pub struct Df;
 #[async_trait]
 impl Builtin for Df {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        // NOTE: -h means "human readable" for df, so we cannot use check_help_version
-        // (which intercepts -h as help). Only check --help and --version explicitly.
-        for arg in ctx.args {
-            match arg.as_str() {
-                "--help" => {
-                    return Ok(ExecResult::ok(
-                        "Usage: df [-h]\n\
-                         Report file system disk space usage.\n\n\
-                         \x20 -h\tprint sizes in human readable format\n\
-                         \x20 --help\tdisplay this help and exit\n\
-                         \x20 --version\toutput version information and exit\n"
-                            .to_string(),
-                    ));
-                }
-                "--version" => {
-                    return Ok(ExecResult::ok("df (bashkit) 0.1\n".to_string()));
-                }
-                s if !s.starts_with('-') => break,
-                _ => {}
-            }
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: df [-h]\n\
+             Report file system disk space usage.\n\n\
+             \x20 -h\tprint sizes in human readable format\n\
+             \x20 --help\tdisplay this help and exit\n\
+             \x20 --version\toutput version information and exit\n",
+            Some("df (bashkit) 0.1"),
+        ) {
+            return Ok(r);
         }
         let mut human_readable = false;
 

--- a/crates/bashkit/src/builtins/echo.rs
+++ b/crates/bashkit/src/builtins/echo.rs
@@ -12,6 +12,13 @@ pub struct Echo;
 #[async_trait]
 impl Builtin for Echo {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: echo [SHORT-OPTION]... [STRING]...\n  or:  echo LONG-OPTION\nEcho the STRING(s) to standard output.\n\n  -n\tdo not output the trailing newline\n  -e\tenable interpretation of backslash escapes\n  -E\tdisable interpretation of backslash escapes (default)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("echo (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut output = String::new();
         let mut add_newline = true;
         let mut interpret_escapes = false;

--- a/crates/bashkit/src/builtins/environ.rs
+++ b/crates/bashkit/src/builtins/environ.rs
@@ -19,6 +19,13 @@ pub struct Env;
 #[async_trait]
 impl Builtin for Env {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: env [-i] [NAME=VALUE]... [COMMAND [ARG]...]\nRun a command in a modified environment, or print the environment.\n\n  -i, --ignore-environment\tstart with an empty environment\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("env (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut ignore_env = false;
         let mut env_vars: Vec<(String, String)> = Vec::new();
         let mut command_start = 0;
@@ -83,6 +90,13 @@ pub struct Printenv;
 #[async_trait]
 impl Builtin for Printenv {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: printenv [VARIABLE...]\nPrint the values of the specified environment variable(s).\nIf no VARIABLE is specified, print all.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("printenv (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             // Print all environment variables
             let mut output = String::new();

--- a/crates/bashkit/src/builtins/expand.rs
+++ b/crates/bashkit/src/builtins/expand.rs
@@ -16,6 +16,13 @@ pub struct Expand;
 #[async_trait]
 impl Builtin for Expand {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: expand [OPTION]... [FILE]...\nConvert tabs to spaces.\n\n  -t N\tuse N characters as tab size (default 8)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("expand (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut tab_stops: Vec<usize> = vec![8];
         let mut files: Vec<&str> = Vec::new();
 
@@ -97,6 +104,13 @@ pub struct Unexpand;
 #[async_trait]
 impl Builtin for Unexpand {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: unexpand [OPTION]... [FILE]...\nConvert spaces to tabs.\n\n  -a, --all\tconvert all blanks, instead of just initial blanks\n  -t N\t\tuse N characters as tab size (default 8)\n  --help\t\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("unexpand (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut tab_stops: Vec<usize> = vec![8];
         let mut all = false;
         let mut files: Vec<&str> = Vec::new();

--- a/crates/bashkit/src/builtins/expr.rs
+++ b/crates/bashkit/src/builtins/expr.rs
@@ -21,6 +21,13 @@ pub struct Expr;
 #[async_trait]
 impl Builtin for Expr {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: expr EXPRESSION\n       expr OPTION\n\nPrint the value of EXPRESSION to standard output.\n\n  ARG1 + ARG2\tarithmetic sum\n  ARG1 - ARG2\tarithmetic difference\n  ARG1 * ARG2\tarithmetic product\n  ARG1 / ARG2\tarithmetic quotient\n  ARG1 % ARG2\tarithmetic remainder\n  ARG1 = ARG2\tcomparison equal\n  ARG1 != ARG2\tcomparison not equal\n  ARG1 < ARG2\tcomparison less than\n  ARG1 > ARG2\tcomparison greater than\n  ARG1 <= ARG2\tcomparison less or equal\n  ARG1 >= ARG2\tcomparison greater or equal\n  ARG1 | ARG2\tlogical or\n  ARG1 & ARG2\tlogical and\n  length STRING\tlength of STRING\n  substr STRING POS LEN\tsubstring of STRING\n  index STRING CHARS\tindex of first CHAR in STRING\n  match STRING REGEX\tanchored pattern match\n  STRING : REGEX\tanchored pattern match\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("expr (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err("expr: missing operand\n".to_string(), 2));
         }

--- a/crates/bashkit/src/builtins/fileops.rs
+++ b/crates/bashkit/src/builtins/fileops.rs
@@ -18,6 +18,14 @@ pub struct Mkdir;
 #[async_trait]
 impl Builtin for Mkdir {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: mkdir [OPTION]... DIRECTORY...\nCreate the DIRECTORY(ies), if they do not already exist.\n\n  -p\t\tno error if existing, make parent directories as needed\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("mkdir (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.is_empty() {
             return Ok(ExecResult::err("mkdir: missing operand\n".to_string(), 1));
         }
@@ -78,6 +86,14 @@ pub struct Rm;
 #[async_trait]
 impl Builtin for Rm {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: rm [OPTION]... [FILE]...\nRemove (unlink) the FILE(s).\n\n  -f\t\tignore nonexistent files and arguments, never prompt\n  -r, -R\tremove directories and their contents recursively\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("rm (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.is_empty() {
             return Ok(ExecResult::err("rm: missing operand\n".to_string(), 1));
         }
@@ -151,6 +167,14 @@ pub struct Cp;
 #[async_trait]
 impl Builtin for Cp {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: cp [OPTION]... SOURCE... DEST\nCopy SOURCE to DEST, or multiple SOURCE(s) to DIRECTORY.\n\n  -r, -R\tcopy directories recursively\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("cp (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.len() < 2 {
             return Ok(ExecResult::err("cp: missing file operand\n".to_string(), 1));
         }
@@ -219,6 +243,14 @@ pub struct Mv;
 #[async_trait]
 impl Builtin for Mv {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: mv [OPTION]... SOURCE... DEST\nRename SOURCE to DEST, or move SOURCE(s) to DIRECTORY.\n\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("mv (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.len() < 2 {
             return Ok(ExecResult::err("mv: missing file operand\n".to_string(), 1));
         }
@@ -286,6 +318,14 @@ pub struct Touch;
 #[async_trait]
 impl Builtin for Touch {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: touch [OPTION]... FILE...\nUpdate the access and modification times of each FILE to the current time.\nA FILE argument that does not exist is created empty.\n\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("touch (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.is_empty() {
             return Ok(ExecResult::err(
                 "touch: missing file operand\n".to_string(),
@@ -427,6 +467,14 @@ fn apply_symbolic_mode(mode_str: &str, current_mode: u32) -> Option<u32> {
 #[async_trait]
 impl Builtin for Chmod {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: chmod [OPTION]... MODE[,MODE]... FILE...\nChange the mode of each FILE to MODE.\nMODE can be octal (e.g., 755) or symbolic (e.g., u+x, a+r, go-w).\n\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("chmod (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.len() < 2 {
             return Ok(ExecResult::err("chmod: missing operand\n".to_string(), 1));
         }
@@ -498,6 +546,14 @@ pub struct Ln;
 #[async_trait]
 impl Builtin for Ln {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: ln [OPTION]... TARGET LINK_NAME\nCreate a link to TARGET with the name LINK_NAME.\n\n  -s\t\tmake symbolic links instead of hard links\n  -f\t\tremove existing destination files\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("ln (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut force = false;
         let mut files: Vec<&str> = Vec::new();
 
@@ -570,6 +626,14 @@ pub struct Chown;
 #[async_trait]
 impl Builtin for Chown {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: chown [OPTION]... OWNER[:GROUP] FILE...\nChange file owner and group.\n\n  -R, --recursive\toperate on files and directories recursively\n      --help\t\tdisplay this help and exit\n      --version\t\toutput version information and exit\n",
+            Some("chown (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut recursive = false;
         let mut positional: Vec<&str> = Vec::new();
 
@@ -616,6 +680,14 @@ pub struct Kill;
 #[async_trait]
 impl Builtin for Kill {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: kill [-s SIGNAL | -SIGNAL] PID...\nSend a signal to a process.\n\n  -s SIGNAL\tspecify the signal to send\n  -l, -L\tlist signal names\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("kill (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut pids: Vec<&str> = Vec::new();
 
         for arg in ctx.args {
@@ -658,6 +730,14 @@ pub struct Mktemp;
 #[async_trait]
 impl Builtin for Mktemp {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: mktemp [-d] [-p DIR] [-t] [TEMPLATE]\nCreate a temporary file or directory, safely, and print its name.\n\n  -d\t\tcreate a directory, not a file\n  -p DIR\tuse DIR as a prefix (default: /tmp)\n  -t\t\tinterpret TEMPLATE relative to a temporary directory\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("mktemp (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut create_dir = false;
         let mut prefix_dir = "/tmp".to_string();
         let mut template: Option<String> = None;

--- a/crates/bashkit/src/builtins/fold.rs
+++ b/crates/bashkit/src/builtins/fold.rs
@@ -19,6 +19,13 @@ pub struct Fold;
 #[async_trait]
 impl Builtin for Fold {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: fold [OPTION]... [FILE]...\nWrap each input line to fit in specified width.\n\n  -b\t\tcount bytes rather than columns\n  -s\t\tbreak at spaces\n  -w WIDTH\tuse WIDTH columns instead of 80\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("fold (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut width: usize = 80;
         let mut break_at_spaces = false;
         let mut files: Vec<&str> = Vec::new();

--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -371,6 +371,13 @@ fn bre_to_ere(pattern: &str) -> String {
 #[async_trait]
 impl Builtin for Grep {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: grep [OPTION]... PATTERN [FILE]...\nSearch for PATTERN in each FILE.\n\n  -i\t\t\tignore case distinctions\n  -v\t\t\tselect non-matching lines\n  -n\t\t\tprint line number with output lines\n  -c\t\t\tprint only a count of matching lines\n  -l\t\t\tprint only names of files with matches\n  -L\t\t\tprint only names of files without matches\n  -o\t\t\tshow only the matching part of lines\n  -q\t\t\tsuppress all normal output\n  -w\t\t\tmatch whole words only\n  -x\t\t\tmatch whole lines only\n  -m NUM\t\tstop after NUM matches\n  -E\t\t\textended regular expressions\n  -F\t\t\tfixed string matching\n  -P\t\t\tPerl-compatible regular expressions\n  -e PATTERN\t\tuse PATTERN for matching\n  -f FILE\t\tread patterns from FILE\n  -A NUM\t\tprint NUM lines of trailing context\n  -B NUM\t\tprint NUM lines of leading context\n  -C NUM\t\tprint NUM lines of output context\n  -H\t\t\talways print filename headers\n  -h\t\t\tsuppress filename headers\n  -b\t\t\tprint byte offset of matches\n  -a\t\t\ttreat binary files as text\n  -z\t\t\tuse NUL as line separator\n  -r\t\t\trecursive search\n  -s\t\t\tsuppress error messages\n  -Z\t\t\tprint NUL after filenames\n  --include=GLOB\tsearch only files matching GLOB\n  --exclude=GLOB\tskip files matching GLOB\n  --exclude-dir=GLOB\tskip directories matching GLOB\n  --color=WHEN\t\tcolor output (no-op)\n  --line-buffered\tline-buffered output (no-op)\n  --help\t\tdisplay this help and exit\n  --version\t\toutput version information and exit\n",
+            Some("grep (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut opts = GrepOptions::parse(ctx.args)?;
 
         // Load patterns from file if -f was specified

--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -22,6 +22,13 @@ pub struct Head;
 #[async_trait]
 impl Builtin for Head {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: head [OPTION]... [FILE]...\nPrint the first 10 lines of each FILE to standard output.\n\n  -n NUM\toutput the first NUM lines\n  -c NUM\toutput the first NUM bytes\n  -NUM\t\tshorthand for -n NUM\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("head (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (count, byte_mode, files) = parse_head_args(ctx.args, DEFAULT_LINES)?;
 
         let mut output = String::new();
@@ -88,6 +95,13 @@ pub struct Tail;
 #[async_trait]
 impl Builtin for Tail {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: tail [OPTION]... [FILE]...\nPrint the last 10 lines of each FILE to standard output.\n\n  -n NUM\toutput the last NUM lines\n  -n +NUM\toutput starting with line NUM\n  -NUM\t\tshorthand for -n NUM\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("tail (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (num_lines, from_start, files) = parse_tail_args(ctx.args, DEFAULT_LINES)?;
 
         let mut output = String::new();

--- a/crates/bashkit/src/builtins/hextools.rs
+++ b/crates/bashkit/src/builtins/hextools.rs
@@ -191,6 +191,13 @@ fn od_dump(data: &[u8], opts: &OdOptions) -> String {
 #[async_trait]
 impl Builtin for Od {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: od [OPTION]... [FILE]...\nDump files in octal and other formats.\n\n  -A RADIX\taddress radix: d (decimal), o (octal), x (hex), n (none)\n  -t TYPE\toutput type: o (octal), x (hex), d (decimal), c (char)\n  -N COUNT\tdump at most COUNT bytes\n  -j SKIP\tskip SKIP bytes from beginning\n  -x\tshorthand for -t x\n  -c\tshorthand for -t c\n  -d\tshorthand for -t d\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("od (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = match parse_od_args(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),
@@ -374,6 +381,13 @@ fn xxd_reverse(data: &[u8], plain: bool) -> Vec<u8> {
 #[async_trait]
 impl Builtin for Xxd {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: xxd [OPTIONS] [FILE]\nMake a hexdump or do the reverse.\n\n  -l LEN\tstop after LEN bytes\n  -s OFFSET\tstart at OFFSET bytes\n  -c COLS\tbytes per line (default: 16)\n  -g GROUP\tbytes per group (default: 2)\n  -p\tplain hex dump (no offsets, no ASCII)\n  -r\treverse: convert hexdump back to binary\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("xxd (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = match parse_xxd_args(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),
@@ -519,6 +533,13 @@ fn hexdump_dump(data: &[u8], opts: &HexdumpOptions) -> String {
 #[async_trait]
 impl Builtin for Hexdump {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: hexdump [OPTION]... [FILE]...\nDisplay file contents in hexadecimal.\n\n  -C\tcanonical hex+ASCII display\n  -n LENGTH\tinterpret only LENGTH bytes\n  -s OFFSET\tskip OFFSET bytes from beginning\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("hexdump (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = match parse_hexdump_args(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),

--- a/crates/bashkit/src/builtins/iconv.rs
+++ b/crates/bashkit/src/builtins/iconv.rs
@@ -226,6 +226,13 @@ fn decode_from(input: &[u8], encoding: &str) -> std::result::Result<String, Stri
 #[async_trait]
 impl Builtin for Iconv {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: iconv [OPTION]... [FILE]\nConvert text from one character encoding to another.\n\n  -f ENCODING\tconvert characters from ENCODING\n  -t ENCODING\tconvert characters to ENCODING (supports //TRANSLIT)\n  -l, --list\tlist known coded character sets\n  --help\t\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("iconv (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut from_enc: Option<String> = None;
         let mut to_enc: Option<String> = None;
         let mut file_arg: Option<String> = None;

--- a/crates/bashkit/src/builtins/inspect.rs
+++ b/crates/bashkit/src/builtins/inspect.rs
@@ -18,6 +18,13 @@ pub struct Less;
 #[async_trait]
 impl Builtin for Less {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: less [FILE]...\nView file contents (pager).\n\nIn bashkit, less behaves like cat (no interactive paging).\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("less (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         // less without args reads from stdin
         if ctx.args.is_empty() {
             if let Some(stdin) = ctx.stdin {
@@ -78,6 +85,13 @@ pub struct File;
 #[async_trait]
 impl Builtin for File {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: file FILE...\nDetermine file type.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("file (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err(
                 "file: missing file operand\n".to_string(),
@@ -236,6 +250,13 @@ pub struct Stat;
 #[async_trait]
 impl Builtin for Stat {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: stat [OPTION]... FILE...\nDisplay file status.\n\n  -c FORMAT, --format FORMAT\tuse specified format\n    %n\tfile name\n    %s\tsize in bytes\n    %a\toctal permissions\n    %A\thuman-readable permissions\n    %F\tfile type\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("stat (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut format: Option<String> = None;
         let mut files: Vec<&String> = Vec::new();
 

--- a/crates/bashkit/src/builtins/join.rs
+++ b/crates/bashkit/src/builtins/join.rs
@@ -24,6 +24,13 @@ struct JoinOptions {
 #[async_trait]
 impl Builtin for Join {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: join [OPTION]... FILE1 FILE2\nJoin lines of two sorted files on a common field.\n\n  -1 FIELD\tjoin on this FIELD of file 1\n  -2 FIELD\tjoin on this FIELD of file 2\n  -a FILENUM\talso print unpairable lines from file FILENUM\n  -e STRING\treplace missing input fields with STRING\n  -t CHAR\tuse CHAR as input and output field separator\n  --help\t\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("join (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut opts = JoinOptions {
             field1: 1,
             field2: 1,

--- a/crates/bashkit/src/builtins/jq.rs
+++ b/crates/bashkit/src/builtins/jq.rs
@@ -263,10 +263,31 @@ fn format_with_tabs(value: &serde_json::Value) -> String {
 #[async_trait]
 impl Builtin for Jq {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        // Check for --version flag first
+        // jq uses -h for help and -V for version (unlike GNU coreutils)
+        let help_text = "Usage: jq [OPTIONS...] FILTER [FILE...]\n\n\
+             \tjq is a command-line JSON processor.\n\n\
+             Options:\n\
+             \t-c, --compact-output\tcompact instead of pretty-printed output\n\
+             \t-r, --raw-output\toutput strings without escapes and quotes\n\
+             \t-R, --raw-input\t\tread each line as string instead of JSON\n\
+             \t-s, --slurp\t\tread entire input into a single array\n\
+             \t-n, --null-input\tuse null as the single input value\n\
+             \t-e, --exit-status\tset exit status code based on output\n\
+             \t-S, --sort-keys\t\tsort object keys in output\n\
+             \t-j, --join-output\tlike -r without trailing newline\n\
+             \t--tab\t\t\tuse tabs for indentation\n\
+             \t--indent N\t\tuse N spaces for indentation (default: 2)\n\
+             \t--arg name value\tset variable $name to string value\n\
+             \t--argjson name value\tset variable $name to JSON value\n\
+             \t--args\t\t\tremaining args are string arguments\n\
+             \t--jsonargs\t\tremaining args are JSON arguments\n\
+             \t-V, --version\t\toutput version information and exit\n\
+             \t-h, --help\t\toutput this help and exit\n";
         for arg in ctx.args {
-            if arg == "-V" || arg == "--version" {
-                return Ok(ExecResult::ok("jq-1.8\n".to_string()));
+            match arg.as_str() {
+                "-h" | "--help" => return Ok(ExecResult::ok(help_text.to_string())),
+                "-V" | "--version" => return Ok(ExecResult::ok("jq-1.8\n".to_string())),
+                _ => {}
             }
         }
 
@@ -1568,5 +1589,18 @@ mod tests {
                 .trim(),
             "42"
         );
+    }
+
+    #[tokio::test]
+    async fn test_jq_help() {
+        let result = run_jq_with_args(&["--help"], "").await.unwrap();
+        assert!(result.contains("Usage:"), "should contain usage info");
+        assert!(result.contains("jq"), "should mention jq");
+    }
+
+    #[tokio::test]
+    async fn test_jq_help_short() {
+        let result = run_jq_with_args(&["-h"], "").await.unwrap();
+        assert!(result.contains("Usage:"), "-h should also show help");
     }
 }

--- a/crates/bashkit/src/builtins/ls.rs
+++ b/crates/bashkit/src/builtins/ls.rs
@@ -41,6 +41,14 @@ pub struct Ls;
 #[async_trait]
 impl Builtin for Ls {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: ls [OPTION]... [FILE]...\nList directory contents.\n\n  -l\t\tuse a long listing format\n  -a\t\tdo not ignore entries starting with .\n  -h\t\thuman-readable sizes (with -l)\n  -1\t\tlist one file per line\n  -R\t\tlist subdirectories recursively\n  -t\t\tsort by modification time, newest first\n  -F, --classify\tappend indicator (/ for dirs, * for executables, @ for symlinks, | for FIFOs)\n  -C\t\tlist entries in columns\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("ls (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut opts = LsOptions {
             long: false,
             all: false,
@@ -701,6 +709,14 @@ fn build_find_exec_commands(
 #[async_trait]
 impl Builtin for Find {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: find [PATH...] [EXPRESSION]\nSearch for files in a directory hierarchy.\n\n  -name PATTERN\tmatch filename against PATTERN (supports * and ?)\n  -path PATTERN\tmatch full path against PATTERN\n  -type TYPE\tmatch file type: f (file), d (directory), l (link)\n  -maxdepth N\tdescend at most N levels\n  -mindepth N\tdo not apply tests at levels less than N\n  -print\t\tprint matching paths (default)\n  -printf FMT\tprint using format string (%f %p %P %s %m %M %y %d %T@)\n  -exec CMD {} \\;\texecute CMD for each match ({} = path)\n  -exec CMD {} +\texecute CMD once with all matches\n  -not, !\t\tnegate the next predicate\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("find (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let (search_paths, opts) = match parse_find_args(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(e),
@@ -1020,6 +1036,14 @@ pub struct Rmdir;
 #[async_trait]
 impl Builtin for Rmdir {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: rmdir [OPTION]... DIRECTORY...\nRemove empty directories.\n\n  -p\t\tremove DIRECTORY and its ancestors\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("rmdir (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.is_empty() {
             return Ok(ExecResult::err("rmdir: missing operand\n".to_string(), 1));
         }

--- a/crates/bashkit/src/builtins/mkfifo.rs
+++ b/crates/bashkit/src/builtins/mkfifo.rs
@@ -28,6 +28,14 @@ fn parse_mode(s: &str) -> Option<u32> {
 #[async_trait]
 impl Builtin for Mkfifo {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: mkfifo [OPTION]... NAME...\nCreate named pipes (FIFOs) with the given NAMEs.\n\n  -m MODE\tset file permission bits to MODE (default: 0666)\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("mkfifo (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         if ctx.args.is_empty() {
             return Ok(ExecResult::err("mkfifo: missing operand\n".to_string(), 1));
         }

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -253,6 +253,37 @@ pub(crate) async fn read_text_file(
     Ok(String::from_utf8_lossy(&content).into_owned())
 }
 
+/// Check args for `--help` and optionally `--version`.
+///
+/// Returns `Some(ExecResult)` when the flag is found, `None` otherwise.
+/// Call at the top of `execute()` to add standard help/version support.
+///
+/// Only matches long flags (`--help`, `--version`) because short flags
+/// `-h` and `-V` have different meanings in many tools (e.g. `sort -V`
+/// for version sort, `ls -h` for human-readable, `grep -h` to suppress
+/// filenames).  Tools that want `-h`/`-V` as aliases should handle them
+/// in their own `execute()` method.
+pub(crate) fn check_help_version(
+    args: &[String],
+    help_text: &str,
+    version: Option<&str>,
+) -> Option<ExecResult> {
+    for arg in args {
+        match arg.as_str() {
+            "--help" => return Some(ExecResult::ok(help_text.to_string())),
+            "--version" => {
+                if let Some(ver) = version {
+                    return Some(ExecResult::ok(format!("{ver}\n")));
+                }
+            }
+            // Stop checking after first non-flag argument
+            s if !s.starts_with('-') => break,
+            _ => {}
+        }
+    }
+    None
+}
+
 // Re-export ShellRef for internal builtins
 pub(crate) use crate::interpreter::ShellRef;
 

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -677,4 +677,41 @@ mod tests {
         assert_eq!(err.exit_code, 1);
         assert!(err.stderr.contains("cat: /tmp/missing.txt:"));
     }
+
+    #[test]
+    fn check_help_version_returns_help() {
+        let args = vec!["--help".to_string()];
+        let r = check_help_version(&args, "usage text\n", Some("v1.0"));
+        assert!(r.is_some());
+        assert_eq!(r.unwrap().stdout, "usage text\n");
+    }
+
+    #[test]
+    fn check_help_version_returns_version() {
+        let args = vec!["--version".to_string()];
+        let r = check_help_version(&args, "usage\n", Some("tool 1.0"));
+        assert!(r.is_some());
+        assert_eq!(r.unwrap().stdout, "tool 1.0\n");
+    }
+
+    #[test]
+    fn check_help_version_no_version_configured() {
+        let args = vec!["--version".to_string()];
+        let r = check_help_version(&args, "usage\n", None);
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn check_help_version_stops_at_non_flag() {
+        let args = vec!["file.txt".to_string(), "--help".to_string()];
+        let r = check_help_version(&args, "usage\n", None);
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn check_help_version_no_match() {
+        let args = vec!["-c".to_string(), "filter".to_string()];
+        let r = check_help_version(&args, "usage\n", Some("v1"));
+        assert!(r.is_none());
+    }
 }

--- a/crates/bashkit/src/builtins/nl.rs
+++ b/crates/bashkit/src/builtins/nl.rs
@@ -136,6 +136,13 @@ fn number_lines(text: &str, opts: &NlOptions, line_num: &mut usize) -> String {
 #[async_trait]
 impl Builtin for Nl {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: nl [OPTION]... [FILE]...\nNumber lines of files.\n\n  -b TYPE\tuse TYPE for numbering body lines (a=all, t=non-empty, n=none)\n  -i NUMBER\tline number increment\n  -n FORMAT\tinsert line numbers according to FORMAT (ln, rn, rz)\n  -s STRING\tadd STRING after line number\n  -v NUMBER\tfirst line number\n  -w NUMBER\tuse NUMBER columns for line numbers\n  --help\t\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("nl (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = match parse_nl_args(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),

--- a/crates/bashkit/src/builtins/numfmt.rs
+++ b/crates/bashkit/src/builtins/numfmt.rs
@@ -474,6 +474,13 @@ fn apply_printf_format(
 #[async_trait]
 impl Builtin for Numfmt {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: numfmt [OPTION]... [NUMBER]...\nReformat NUMBER(s), or the numbers from standard input.\n\n  --from=UNIT\tauto-scale input numbers to UNITs (none, si, iec, iec-i, auto)\n  --to=UNIT\tauto-scale output numbers to UNITs (none, si, iec, iec-i)\n  --suffix=SUFFIX\tadd SUFFIX to output numbers\n  --padding=N\tpad the output to N characters\n  --round=METHOD\tuse METHOD for rounding (up, down, from-zero, towards-zero, nearest)\n  --format=FORMAT\tuse printf-style FORMAT\n  --field=N\treplace the number in input field N (default 1)\n  -d, --delimiter=X\tuse X instead of whitespace for field delimiter\n  --help\t\t\tdisplay this help and exit\n  --version\t\toutput version information and exit\n",
+            Some("numfmt (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, operands) = match parse_options(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(ExecResult::err(e, 1)),

--- a/crates/bashkit/src/builtins/parallel.rs
+++ b/crates/bashkit/src/builtins/parallel.rs
@@ -182,6 +182,13 @@ fn build_command(template: &[String], args: &[String]) -> String {
 #[async_trait]
 impl Builtin for Parallel {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: parallel [OPTIONS] COMMAND ::: ARGS...\nRun commands in parallel.\n\n  -j NUM\tnumber of parallel jobs\n  --dry-run\tshow commands that would be run\n  --keep-order, -k\tkeep output in input order\n  --bar\tshow progress bar\n  -v\tverbose mode\n  :::\tdelimits the argument list\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("parallel (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err(
                 "parallel: usage: parallel [OPTIONS] COMMAND ::: ARGS...\n".to_string(),

--- a/crates/bashkit/src/builtins/paste.rs
+++ b/crates/bashkit/src/builtins/paste.rs
@@ -115,6 +115,13 @@ fn parse_delim_spec(spec: &str) -> Vec<char> {
 #[async_trait]
 impl Builtin for Paste {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: paste [OPTION]... [FILE]...\nMerge lines of files.\n\n  -d LIST\tuse LIST as delimiters\n  -s\t\tpaste one file at a time\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("paste (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = parse_paste_args(ctx.args);
 
         // Collect input sources

--- a/crates/bashkit/src/builtins/patch.rs
+++ b/crates/bashkit/src/builtins/patch.rs
@@ -289,6 +289,13 @@ fn apply_hunks(
 #[async_trait]
 impl Builtin for Patch {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: patch [OPTION]... [FILE]\nApply a unified diff patch to FILE(s).\n\n  -pNUM\tstrip NUM leading path components\n  --dry-run\tprint results without modifying files\n  -R, --reverse\treverse the patch\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("patch (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let opts = parse_patch_args(ctx.args);
 
         let input = match ctx.stdin {

--- a/crates/bashkit/src/builtins/path.rs
+++ b/crates/bashkit/src/builtins/path.rs
@@ -19,6 +19,13 @@ pub struct Basename;
 #[async_trait]
 impl Builtin for Basename {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: basename NAME [SUFFIX]\nPrint NAME with leading directory components removed.\nIf SUFFIX is specified, also remove a trailing SUFFIX.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("basename (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err(
                 "basename: missing operand\n".to_string(),
@@ -79,6 +86,13 @@ pub struct Dirname;
 #[async_trait]
 impl Builtin for Dirname {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: dirname NAME...\nOutput each NAME with its last non-slash component and trailing slashes removed.\nIf NAME contains no slashes, output '.' (current directory).\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("dirname (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err("dirname: missing operand\n".to_string(), 1));
         }
@@ -129,6 +143,13 @@ pub struct Realpath;
 #[async_trait]
 impl Builtin for Realpath {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: realpath [PATH...]\nPrint the resolved absolute pathname.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("realpath (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err(
                 "realpath: missing operand\n".to_string(),
@@ -165,6 +186,13 @@ pub struct Readlink;
 impl Builtin for Readlink {
     #[allow(clippy::collapsible_if)]
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: readlink [-f|-m|-e] FILE...\nPrint resolved symbolic links or canonical file names.\n\n  -f\tcanonicalize by following every symlink; all but last component must exist\n  -m\tcanonicalize without requiring components to exist\n  -e\tcanonicalize; all components must exist\n  -n\tdo not output the trailing newline\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("readlink (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::err(
                 "readlink: missing operand\n".to_string(),

--- a/crates/bashkit/src/builtins/pipeline.rs
+++ b/crates/bashkit/src/builtins/pipeline.rs
@@ -136,6 +136,13 @@ fn build_xargs_commands(opts: &XargsOptions, input: &str) -> Vec<SubCommand> {
 #[async_trait]
 impl Builtin for Xargs {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: xargs [OPTION]... [COMMAND [ARGS]...]\nBuild and execute command lines from standard input.\n\n  -I REPLACE\treplace REPLACE with input (implies -n 1)\n  -n MAX-ARGS\tuse at most MAX-ARGS arguments per command\n  -d DELIM\tuse DELIM as delimiter instead of whitespace\n  -0\tuse NUL as delimiter\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("xargs (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         // Validate arguments and return error for invalid input.
         // When no executor is available, output what commands would be run.
         let opts = match parse_xargs_args(ctx.args) {
@@ -197,6 +204,13 @@ pub struct Tee;
 #[async_trait]
 impl Builtin for Tee {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: tee [OPTION]... [FILE]...\nRead from standard input and write to standard output and files.\n\n  -a, --append\tappend to files instead of overwriting\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("tee (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut append = false;
         let mut files: Vec<String> = Vec::new();
 
@@ -247,6 +261,13 @@ pub struct Watch;
 #[async_trait]
 impl Builtin for Watch {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: watch [OPTION]... COMMAND\nExecute a program periodically, showing output.\n\n  -n SECONDS\tupdate interval (default: 2)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("watch (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut _interval: f64 = 2.0;
         let mut command_start: Option<usize> = None;
 

--- a/crates/bashkit/src/builtins/printf.rs
+++ b/crates/bashkit/src/builtins/printf.rs
@@ -12,6 +12,13 @@ pub struct Printf;
 #[async_trait]
 impl Builtin for Printf {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: printf FORMAT [ARGUMENT]...\n  or:  printf OPTION\nPrint ARGUMENT(s) according to FORMAT.\n\n  FORMAT controls the output, supports:\n    %s\tstring\n    %d, %i\tsigned integer\n    %u\tunsigned integer\n    %o\toctal\n    %x, %X\thexadecimal\n    %f, %e, %g\tfloating point\n    %c\tcharacter\n    %b\tstring with backslash escapes\n    %q\tshell-quoted string\n    \\n, \\t, \\\\, \\xHH, \\uHHHH, \\UHHHHHHHH\tescape sequences\n  -v VAR\tassign to shell variable VAR instead of printing\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("printf (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         if ctx.args.is_empty() {
             return Ok(ExecResult::ok(String::new()));
         }

--- a/crates/bashkit/src/builtins/rg.rs
+++ b/crates/bashkit/src/builtins/rg.rs
@@ -149,6 +149,13 @@ impl RgOptions {
 #[async_trait]
 impl Builtin for Rg {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: rg [OPTIONS] PATTERN [PATH...]\nRecursively search for a pattern.\n\n  -i\tcase insensitive\n  -n\tshow line numbers\n  -N, --no-line-number\tsuppress line numbers\n  -c\tcount matches\n  -l\tfiles with matches\n  -v\tinvert match\n  -w\tword boundary\n  -F\tfixed strings (literal)\n  -m NUM\tmax count per file\n  --no-filename\tsuppress filename\n  --color MODE\tcolor output (no-op)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("rg (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let opts = RgOptions::parse(ctx.args)?;
         let regex = opts.build_regex()?;
 

--- a/crates/bashkit/src/builtins/sed.rs
+++ b/crates/bashkit/src/builtins/sed.rs
@@ -769,6 +769,13 @@ fn count_commands(cmds: &[(Option<Address>, bool, SedCommand)]) -> usize {
 #[async_trait]
 impl Builtin for Sed {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: sed [OPTION]... {script} [FILE]...\nStream editor for filtering and transforming text.\n\n  -n\t\tsuppress automatic printing of pattern space\n  -i\t\tedit files in place\n  -E, -r\tuse extended regular expressions\n  -e script\tadd the script to the commands to be executed\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("sed (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let opts = SedOptions::parse(ctx.args)?;
 
         // Determine input

--- a/crates/bashkit/src/builtins/seq.rs
+++ b/crates/bashkit/src/builtins/seq.rs
@@ -20,6 +20,13 @@ pub struct Seq;
 #[async_trait]
 impl Builtin for Seq {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: seq [OPTION]... LAST\n  or:  seq [OPTION]... FIRST LAST\n  or:  seq [OPTION]... FIRST INCREMENT LAST\nPrint numbers from FIRST to LAST, in steps of INCREMENT.\n\n  -s STRING\tuse STRING to separate numbers (default: newline)\n  -w\tequalize width by padding with leading zeroes\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("seq (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut separator = "\n".to_string();
         let mut equal_width = false;
         let mut nums: Vec<String> = Vec::new();

--- a/crates/bashkit/src/builtins/sleep.rs
+++ b/crates/bashkit/src/builtins/sleep.rs
@@ -21,6 +21,13 @@ pub struct Sleep;
 #[async_trait]
 impl Builtin for Sleep {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: sleep SECONDS\nPause for SECONDS seconds.\nSECONDS may be a floating-point number. Maximum duration is 60 seconds.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("sleep (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let seconds = match ctx.args.first() {
             Some(arg) => match arg.parse::<f64>() {
                 Ok(s) if s < 0.0 => {

--- a/crates/bashkit/src/builtins/sortuniq.rs
+++ b/crates/bashkit/src/builtins/sortuniq.rs
@@ -314,6 +314,13 @@ fn month_ordinal(s: &str) -> u32 {
 #[async_trait]
 impl Builtin for Sort {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: sort [OPTION]... [FILE]...\nWrite sorted concatenation of all FILE(s) to standard output.\n\n  -f\t\tfold lower case to upper case characters\n  -n\t\tcompare according to string numerical value\n  -r\t\treverse the result of comparisons\n  -u\t\toutput only unique lines\n  -V\t\tnatural sort of version numbers\n  -t DELIM\tuse DELIM as field separator\n  -k KEYDEF\tsort via a key definition\n  -s\t\tstable sort\n  -c\t\tcheck for sorted input\n  -h\t\thuman numeric sort (1K, 2M, 3G)\n  -M\t\tmonth sort\n  -m\t\tmerge already sorted files\n  -o FILE\twrite output to FILE\n  -z\t\tline delimiter is NUL, not newline\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("sort (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut reverse = false;
         let mut numeric = false;
         let mut unique = false;
@@ -616,6 +623,13 @@ fn uniq_key(line: &str, skip_fields: usize, case_insensitive: bool) -> String {
 #[async_trait]
 impl Builtin for Uniq {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: uniq [OPTION]... [INPUT [OUTPUT]]\nFilter adjacent matching lines from INPUT, writing to OUTPUT.\n\n  -c\t\tprefix lines by the number of occurrences\n  -d\t\tonly print duplicate lines\n  -u\t\tonly print unique lines\n  -i\t\tignore differences in case when comparing\n  -f NUM\tavoid comparing the first NUM fields\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("uniq (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut count = false;
         let mut only_duplicates = false;
         let mut only_unique = false;

--- a/crates/bashkit/src/builtins/split.rs
+++ b/crates/bashkit/src/builtins/split.rs
@@ -20,6 +20,13 @@ pub struct Split;
 #[async_trait]
 impl Builtin for Split {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: split [OPTION]... [FILE [PREFIX]]\nSplit a file into pieces.\n\n  -l N\t\tput N lines per output file (default 1000)\n  -b N\t\tput N bytes per output file\n  -n N\t\tsplit into N files\n  -d, --numeric-suffixes\tuse numeric suffixes instead of alphabetic\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("split (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let mut lines_per_file: Option<usize> = None;
         let mut bytes_per_file: Option<usize> = None;
         let mut num_chunks: Option<usize> = None;

--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -134,6 +134,13 @@ fn extract_strings(data: &[u8], opts: &StringsOptions) -> String {
 #[async_trait]
 impl Builtin for Strings {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: strings [OPTION]... [FILE]...\nPrint the sequences of printable characters in files.\n\n  -a\t\tscan the whole file (default)\n  -n MIN\tprint sequences of at least MIN characters (default 4)\n  -t FORMAT\tprint the offset using FORMAT (d=decimal, o=octal, x=hex)\n  --help\t\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("strings (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let (opts, files) = match parse_strings_args(ctx.args) {
             Ok(v) => v,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),

--- a/crates/bashkit/src/builtins/system.rs
+++ b/crates/bashkit/src/builtins/system.rs
@@ -59,13 +59,12 @@ impl Default for Hostname {
 #[async_trait]
 impl Builtin for Hostname {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        // Check for -h or --help
-        if ctx.args.first().map(|s| s.as_str()) == Some("-h")
-            || ctx.args.first().map(|s| s.as_str()) == Some("--help")
-        {
-            return Ok(ExecResult::ok(
-                "hostname: display virtual hostname\nUsage: hostname\n",
-            ));
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: hostname\nDisplay the virtual hostname.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("hostname (bashkit) 0.1"),
+        ) {
+            return Ok(r);
         }
 
         // Ignore any attempts to set hostname
@@ -115,6 +114,14 @@ impl Default for Uname {
 #[async_trait]
 impl Builtin for Uname {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: uname [OPTION]...\nPrint virtual system information.\n\n  -a, --all\t\t\tprint all information\n  -s, --kernel-name\t\tprint the kernel name\n  -n, --nodename\t\tprint the network node hostname\n  -r, --kernel-release\t\tprint the kernel release\n  -v, --kernel-version\t\tprint the kernel version\n  -m, --machine\t\t\tprint the machine hardware name\n  -o, --operating-system\tprint the operating system\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("uname (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut show_all = false;
         let mut show_kernel = false;
         let mut show_nodename = false;
@@ -132,20 +139,6 @@ impl Builtin for Uname {
                 "-v" | "--kernel-version" => show_version = true,
                 "-m" | "--machine" => show_machine = true,
                 "-o" | "--operating-system" => show_os = true,
-                "-h" | "--help" => {
-                    return Ok(ExecResult::ok(
-                        "uname: print virtual system information\n\
-                         Usage: uname [OPTION]...\n\
-                         Options:\n\
-                         \t-a  print all information\n\
-                         \t-s  print kernel name\n\
-                         \t-n  print network node hostname\n\
-                         \t-r  print kernel release\n\
-                         \t-v  print kernel version\n\
-                         \t-m  print machine hardware name\n\
-                         \t-o  print operating system\n",
-                    ));
-                }
                 _ => {}
             }
         }
@@ -216,7 +209,14 @@ impl Default for Whoami {
 
 #[async_trait]
 impl Builtin for Whoami {
-    async fn execute(&self, _ctx: Context<'_>) -> Result<ExecResult> {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: whoami\nPrint the user name associated with the current effective user ID.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("whoami (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         Ok(ExecResult::ok(format!("{}\n", self.username)))
     }
 }
@@ -251,6 +251,14 @@ impl Default for Id {
 #[async_trait]
 impl Builtin for Id {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: id [OPTION]...\nPrint virtual user and group information.\n\n  -u, --user\tprint only the effective user ID\n  -g, --group\tprint only the effective group ID\n  -n, --name\tprint a name instead of a number (with -u or -g)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("id (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         // Check for specific flags
         for arg in ctx.args {
             match arg.as_str() {
@@ -263,16 +271,6 @@ impl Builtin for Id {
                 "-n" | "--name" => {
                     // -n is usually combined with -u or -g
                     continue;
-                }
-                "-h" | "--help" => {
-                    return Ok(ExecResult::ok(
-                        "id: print virtual user and group IDs\n\
-                         Usage: id [OPTION]\n\
-                         Options:\n\
-                         \t-u  print only the effective user ID\n\
-                         \t-g  print only the effective group ID\n\
-                         \t-n  print a name instead of a number (with -u or -g)\n",
-                    ));
                 }
                 _ => {}
             }

--- a/crates/bashkit/src/builtins/textrev.rs
+++ b/crates/bashkit/src/builtins/textrev.rs
@@ -51,6 +51,13 @@ pub struct Tac;
 #[async_trait]
 impl Builtin for Tac {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: tac [FILE]...\nConcatenate and print files in reverse.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("tac (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let raw = match read_input(&ctx).await {
             Ok(r) => r,
             Err(e) => return Ok(e),
@@ -87,6 +94,13 @@ pub struct Rev;
 #[async_trait]
 impl Builtin for Rev {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: rev [FILE]...\nReverse characters of each line.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("rev (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let raw = match read_input(&ctx).await {
             Ok(r) => r,
             Err(e) => return Ok(e),

--- a/crates/bashkit/src/builtins/timeout.rs
+++ b/crates/bashkit/src/builtins/timeout.rs
@@ -145,6 +145,13 @@ fn parse_timeout_args(
 #[async_trait]
 impl Builtin for Timeout {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: timeout [OPTION] DURATION COMMAND [ARG]...\nStart COMMAND, and kill it if still running after DURATION.\n\nDURATION may be: Ns (seconds), Nm (minutes), Nh (hours), Nd (days).\nDefault unit is seconds. Maximum timeout is 300 seconds.\n\n  -k DURATION\tsend KILL signal after DURATION if command still running\n  -s SIGNAL\tspecify the signal to send (ignored, always uses timeout)\n  --preserve-status\texit with the command's status even on timeout\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("timeout (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         // Validate arguments and return error for invalid input.
         // Actual command execution is handled by execution_plan().
         match parse_timeout_args(ctx.args) {

--- a/crates/bashkit/src/builtins/tree.rs
+++ b/crates/bashkit/src/builtins/tree.rs
@@ -35,6 +35,14 @@ struct TreeCounts {
 #[async_trait]
 impl Builtin for Tree {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: tree [OPTION]... [DIRECTORY]...\nList contents of directories in a tree-like format.\n\n  -a\t\tshow hidden files\n  -d\t\tlist directories only\n  -L level\tdescend only level directories deep\n  -I pattern\texclude files matching pattern\n  --noreport\tsuppress the file/directory count at the end\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            Some("tree (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
+
         let mut opts = TreeOptions {
             show_hidden: false,
             dirs_only: false,

--- a/crates/bashkit/src/builtins/wc.rs
+++ b/crates/bashkit/src/builtins/wc.rs
@@ -97,6 +97,13 @@ impl WcFlags {
 #[async_trait]
 impl Builtin for Wc {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: wc [OPTION]... [FILE]...\nPrint newline, word, and byte counts for each FILE.\n\n  -l, --lines\t\t\tprint the newline counts\n  -w, --words\t\t\tprint the word counts\n  -c, --bytes\t\t\tprint the byte counts\n  -m, --chars\t\t\tprint the character counts\n  -L, --max-line-length\t\tprint the maximum line length\n  --help\t\t\tdisplay this help and exit\n  --version\t\t\toutput version information and exit\n",
+            Some("wc (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let flags = WcFlags::parse(ctx.args);
 
         let files: Vec<_> = ctx

--- a/crates/bashkit/src/builtins/yes.rs
+++ b/crates/bashkit/src/builtins/yes.rs
@@ -20,6 +20,13 @@ const MAX_LINES: usize = 10_000;
 #[async_trait]
 impl Builtin for Yes {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: yes [STRING]\nRepeatedly output a line with STRING, or 'y'.\n\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("yes (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let text = if ctx.args.is_empty() {
             "y".to_string()
         } else {

--- a/crates/bashkit/src/builtins/zip_cmd.rs
+++ b/crates/bashkit/src/builtins/zip_cmd.rs
@@ -224,6 +224,13 @@ async fn collect_files_recursive(
 #[async_trait]
 impl Builtin for Zip {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: zip [OPTION]... ARCHIVE FILE...\nCreate zip archives.\n\n  -r\trecurse into directories\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("zip (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let opts = match parse_zip_args(ctx.args) {
             Ok(o) => o,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),
@@ -282,6 +289,13 @@ impl Builtin for Zip {
 #[async_trait]
 impl Builtin for Unzip {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if let Some(r) = super::check_help_version(
+            ctx.args,
+            "Usage: unzip [OPTION]... ARCHIVE\nExtract files from a zip archive.\n\n  -l\tlist contents\n  -d DIR\textract to directory\n  -o\toverwrite existing files\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            Some("unzip (bashkit) 0.1"),
+        ) {
+            return Ok(r);
+        }
         let opts = match parse_unzip_args(ctx.args) {
             Ok(o) => o,
             Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),

--- a/crates/bashkit/tests/spec_cases/bash/help-flag.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/help-flag.test.sh
@@ -1,4 +1,5 @@
 ### cat_help
+### bash_diff: bashkit custom help text differs from real coreutils
 # cat --help should show usage
 cat --help | head -1
 ### expect
@@ -6,6 +7,7 @@ Usage: cat [OPTION]... [FILE]...
 ### end
 
 ### grep_help
+### bash_diff: bashkit custom help text differs from real grep
 # grep --help should show usage
 grep --help | head -1
 ### expect
@@ -13,6 +15,7 @@ Usage: grep [OPTION]... PATTERN [FILE]...
 ### end
 
 ### sort_help
+### bash_diff: bashkit custom help text differs from real coreutils
 # sort --help should show usage
 sort --help | head -1
 ### expect
@@ -20,6 +23,7 @@ Usage: sort [OPTION]... [FILE]...
 ### end
 
 ### ls_help
+### bash_diff: bashkit custom help text differs from real coreutils
 # ls --help should show usage
 ls --help | head -1
 ### expect
@@ -27,6 +31,7 @@ Usage: ls [OPTION]... [FILE]...
 ### end
 
 ### date_help
+### bash_diff: bashkit custom help text differs from real coreutils
 # date --help should show usage
 date --help | head -1
 ### expect
@@ -34,6 +39,7 @@ Usage: date [+FORMAT] [-u] [-R] [-I[TIMESPEC]] [-d STRING] [-r FILE]
 ### end
 
 ### cat_version
+### bash_diff: bashkit reports its own version string
 # cat --version should output version info
 cat --version
 ### expect
@@ -41,6 +47,7 @@ cat (bashkit) 0.1
 ### end
 
 ### grep_version
+### bash_diff: bashkit reports its own version string
 # grep --version should output version info
 grep --version
 ### expect

--- a/crates/bashkit/tests/spec_cases/bash/help-flag.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/help-flag.test.sh
@@ -1,0 +1,48 @@
+### cat_help
+# cat --help should show usage
+cat --help | head -1
+### expect
+Usage: cat [OPTION]... [FILE]...
+### end
+
+### grep_help
+# grep --help should show usage
+grep --help | head -1
+### expect
+Usage: grep [OPTION]... PATTERN [FILE]...
+### end
+
+### sort_help
+# sort --help should show usage
+sort --help | head -1
+### expect
+Usage: sort [OPTION]... [FILE]...
+### end
+
+### ls_help
+# ls --help should show usage
+ls --help | head -1
+### expect
+Usage: ls [OPTION]... [FILE]...
+### end
+
+### date_help
+# date --help should show usage
+date --help | head -1
+### expect
+Usage: date [+FORMAT] [-u] [-R] [-I[TIMESPEC]] [-d STRING] [-r FILE]
+### end
+
+### cat_version
+# cat --version should output version info
+cat --version
+### expect
+cat (bashkit) 0.1
+### end
+
+### grep_version
+# grep --version should output version info
+grep --version
+### expect
+grep (bashkit) 0.1
+### end

--- a/specs/005-builtins.md
+++ b/specs/005-builtins.md
@@ -8,6 +8,15 @@ Implemented
 Bashkit provides a comprehensive set of built-in commands for script execution
 in a virtual environment. All builtins operate on the virtual filesystem.
 
+### Standard Flags
+
+All external-style builtins (non-shell-intrinsic commands) support `--help` and
+`--version` flags. The `check_help_version()` helper in `builtins/mod.rs`
+handles `--help` and `--version` (long flags only — short flags `-h`/`-V` are
+not handled by the helper since they have different meanings in many tools like
+`sort -V`, `ls -h`, `grep -h`). Tools where `-h`/`-V` genuinely mean
+help/version (e.g. `jq`) handle them directly in their `execute()` method.
+
 ### Builtin Categories
 
 #### Core Shell Builtins
@@ -86,7 +95,7 @@ execution → $PATH search → "command not found".
 - `grep` - Pattern matching (`-i`, `-v`, `-c`, `-n`, `-o`, `-l`, `-w`, `-E`, `-F`, `-P`, `-q`, `-m`, `-x`, `-A`, `-B`, `-C`, `-e`, `-f`, `-H`, `-h`, `-b`, `-a`, `-z`, `-r`)
 - `sed` - Stream editing (s/pat/repl/, d, p, a, i; `-E`, `-e`, `-i`, `-n`; nth occurrence, `!` negation)
 - `awk` - Text processing (print, -F, variables, `--csv`/`-k`, `\u` Unicode escapes)
-- `jq` - JSON processing (file arguments, `-s`, `-r`, `-c`, `-n`, `-S`, `-e`, `--tab`, `-j`, `--arg`, `--argjson`, `-V`/`--version`, combined short flags)
+- `jq` - JSON processing (file arguments, `-s`, `-r`, `-c`, `-n`, `-S`, `-e`, `--tab`, `-j`, `--arg`, `--argjson`, `-h`/`--help`, `-V`/`--version`, combined short flags)
 - `sort` - Sort lines (`-r`, `-n`, `-u`)
 - `uniq` - Filter duplicates (`-c`, `-d`, `-u`)
 - `cut` - Extract fields (`-d`, `-f`)


### PR DESCRIPTION
## Summary

- Add `check_help_version()` helper in `builtins/mod.rs` that handles `--help` and `--version` long flags (short flags `-h`/`-V` excluded since they have different meanings in many tools like `sort -V`, `ls -h`, `grep -h`)
- Add `--help` and `--version` support to ~80 builtin commands across all categories: text processing, file operations, path/system, data/archive, and pipeline tools
- Special handling for `jq` (supports `-h`/`-V` directly since those are genuine help/version flags for jq)
- Update `specs/005-builtins.md` documenting the standard flags convention

## Test plan

- [x] Unit tests for `check_help_version` helper (5 cases: help, version, no version configured, stops at non-flag, no match)
- [x] Integration spec tests verifying `--help`/`--version` for representative tools (cat, grep, sort, ls, date)
- [x] Tests marked `bash_diff` since help output intentionally differs from real bash
- [x] All 2371 unit tests pass
- [x] All 15 spec test suites pass (1974 bash specs, 99.9% pass rate)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Rebased on latest main