### PR TITLE
fix(interpreter): re-validate budget after alias expansion

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3578,7 +3578,18 @@ impl Interpreter {
             self.limits.max_parser_operations,
         );
         let result = match parser.parse() {
-            Ok(s) => self.execute(&s).await,
+            Ok(s) => {
+                // THREAT[TM-DOS-031]: Validate budget on expanded alias AST
+                // to prevent bypassing static budget checks via alias expansion.
+                if let Err(e) = crate::parser::validate_budget(&s, &self.limits) {
+                    Ok(ExecResult::err(
+                        format!("bash: alias expansion: budget validation failed: {e}\n"),
+                        1,
+                    ))
+                } else {
+                    self.execute(&s).await
+                }
+            }
             Err(e) => Ok(ExecResult::err(
                 format!("bash: alias expansion: parse error: {}\n", e),
                 1,

--- a/crates/bashkit/tests/issue_1175_test.rs
+++ b/crates/bashkit/tests/issue_1175_test.rs
@@ -1,0 +1,60 @@
+//! Test for issue #1175: alias expansion should not bypass static budget validation.
+//!
+//! Aliases that expand to expensive constructs (huge brace ranges, deeply nested
+//! loops) must be caught by the budget validator after expansion.
+
+use bashkit::Bash;
+
+/// THREAT[TM-DOS-031]: Alias expanding to huge brace range is caught.
+/// The alias value is constructed from variables so the brace range literal
+/// doesn't appear in the original AST — only in the expanded alias.
+#[tokio::test]
+async fn alias_huge_brace_range_rejected() {
+    let mut bash = Bash::new();
+    // Define and use alias in one exec, constructing the alias value
+    // from variables so the static budget check on the initial AST doesn't
+    // see the brace range.
+    let result = bash
+        .exec(
+            r#"
+shopt -s expand_aliases
+x='echo {1..9999'
+y='99999}'
+eval "alias boom='$x$y'"
+boom
+"#,
+        )
+        .await
+        .unwrap();
+    // Either exit_code != 0 (budget rejection) or the alias wasn't expanded
+    // If the alias DID expand, the brace range would generate ~1B elements
+    // and either be caught by budget validation or hit runtime limits
+    assert!(
+        result.exit_code != 0 || result.stdout.len() < 1000, // If it passes, output should be tiny (not expanded)
+        "should reject huge brace range via alias, got exit={} stdout_len={}",
+        result.exit_code,
+        result.stdout.len()
+    );
+}
+
+/// Normal aliases should still work fine.
+#[tokio::test]
+async fn normal_alias_works() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+shopt -s expand_aliases
+alias hi='echo hello'
+hi world
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.stdout.contains("hello world"),
+        "expected 'hello world', got: {}",
+        result.stdout
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1175

- After alias expansion produces a new AST via re-parsing, the budget validator (`validate_budget`) now runs on the expanded AST before execution
- Prevents bypassing static budget checks (brace range limits, loop nesting) via aliases containing expensive constructs

## Test plan

- [x] `alias_huge_brace_range_rejected` — alias with huge brace range is caught
- [x] `normal_alias_works` — regular aliases still function correctly