### PR TITLE
fix(network): block requests to private IPs by default (SSRF protection)

### DIFF
--- a/crates/bashkit/src/network/allowlist.rs
+++ b/crates/bashkit/src/network/allowlist.rs
@@ -211,6 +211,21 @@ impl NetworkAllowlist {
             }
         };
 
+        // THREAT[TM-NET-002]: Block requests to private IPs in the hostname.
+        // If the hostname is a literal IP address, check it immediately.
+        if self.block_private_ips
+            && let Some(host) = parsed.host_str()
+            && let Ok(ip) = host.parse::<IpAddr>()
+            && is_private_ip(&ip)
+        {
+            return UrlMatch::Blocked {
+                reason: format!(
+                    "request to private/reserved IP {} blocked (SSRF protection)",
+                    ip
+                ),
+            };
+        }
+
         // Check against each pattern
         for pattern in &self.patterns {
             if self.matches_pattern(&parsed, pattern) {

--- a/crates/bashkit/src/network/allowlist.rs
+++ b/crates/bashkit/src/network/allowlist.rs
@@ -15,7 +15,35 @@
 //! - **TM-INF-010**: Data exfiltration → default-deny blocks unauthorized destinations
 
 use std::collections::HashSet;
+use std::net::IpAddr;
 use url::Url;
+
+/// Check if an IP address is in a private/reserved range.
+///
+/// Blocks: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+/// 169.254.0.0/16, 0.0.0.0, ::1, fd00::/8, fe80::/10, ::
+///
+/// # Security (TM-NET-002, TM-NET-004)
+///
+/// Used to prevent SSRF attacks where an allowed hostname resolves
+/// to an internal/cloud metadata IP address.
+pub fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()                    // 127.0.0.0/8
+                || v4.is_private()              // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+                || v4.is_link_local()           // 169.254.0.0/16
+                || v4.is_unspecified()          // 0.0.0.0
+                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 (CGNAT)
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()                    // ::1
+                || v6.is_unspecified()          // ::
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // fd00::/8 (unique local)
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        }
+    }
+}
 
 /// Redact credentials from a URL for safe inclusion in error messages.
 /// Replaces `user:pass@` in the authority with `***@`.
@@ -59,7 +87,7 @@ fn redact_url(url: &str) -> String {
 /// - **Host**: Must match exactly (no wildcards)
 /// - **Port**: Must match (defaults apply: 443 for https, 80 for http)
 /// - **Path**: Pattern path is treated as a prefix
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct NetworkAllowlist {
     /// URL patterns that are allowed
     /// Format: "scheme://host[:port][/path]"
@@ -68,6 +96,20 @@ pub struct NetworkAllowlist {
 
     /// If true, allow all URLs (dangerous - use only for testing)
     allow_all: bool,
+
+    /// THREAT[TM-NET-002/004]: Block requests to private/reserved IP ranges.
+    /// Default: true. Prevents SSRF via DNS rebinding.
+    block_private_ips: bool,
+}
+
+impl Default for NetworkAllowlist {
+    fn default() -> Self {
+        Self {
+            patterns: HashSet::new(),
+            allow_all: false,
+            block_private_ips: true,
+        }
+    }
 }
 
 /// Result of matching a URL against the allowlist
@@ -97,7 +139,28 @@ impl NetworkAllowlist {
         Self {
             patterns: HashSet::new(),
             allow_all: true,
+            block_private_ips: true,
         }
+    }
+
+    /// Block requests to private/reserved IP ranges (default: true).
+    ///
+    /// When enabled, requests to hostnames that resolve to private IPs
+    /// (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+    /// 169.254.0.0/16, ::1, fd00::/8, fe80::/10) are blocked.
+    ///
+    /// # Security (TM-NET-002, TM-NET-004)
+    ///
+    /// Prevents SSRF via DNS rebinding where an allowed hostname
+    /// resolves to an internal IP address.
+    pub fn block_private_ips(mut self, block: bool) -> Self {
+        self.block_private_ips = block;
+        self
+    }
+
+    /// Returns whether private IP blocking is enabled.
+    pub fn is_blocking_private_ips(&self) -> bool {
+        self.block_private_ips
     }
 
     /// Add a URL pattern to the allowlist.
@@ -432,5 +495,59 @@ mod tests {
             allowlist.check("https://example.com/apix"),
             UrlMatch::Blocked { .. }
         ));
+    }
+
+    // === Private IP tests (TM-NET-002/004) ===
+
+    #[test]
+    fn test_is_private_ip_loopback() {
+        assert!(is_private_ip(&"127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"127.0.0.2".parse().unwrap()));
+        assert!(is_private_ip(&"::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_rfc1918() {
+        assert!(is_private_ip(&"10.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"10.255.255.255".parse().unwrap()));
+        assert!(is_private_ip(&"172.16.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"172.31.255.255".parse().unwrap()));
+        assert!(is_private_ip(&"192.168.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"192.168.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_link_local() {
+        assert!(is_private_ip(&"169.254.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"169.254.169.254".parse().unwrap())); // AWS metadata
+    }
+
+    #[test]
+    fn test_is_private_ip_public() {
+        assert!(!is_private_ip(&"8.8.8.8".parse().unwrap()));
+        assert!(!is_private_ip(&"1.1.1.1".parse().unwrap()));
+        assert!(!is_private_ip(&"203.0.113.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v6() {
+        assert!(is_private_ip(&"::1".parse().unwrap()));
+        assert!(is_private_ip(&"fd00::1".parse().unwrap()));
+        assert!(is_private_ip(&"fe80::1".parse().unwrap()));
+        assert!(!is_private_ip(
+            &"2001:db8::1".parse::<std::net::IpAddr>().unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_block_private_ips_default_true() {
+        let al = NetworkAllowlist::new();
+        assert!(al.is_blocking_private_ips());
+    }
+
+    #[test]
+    fn test_block_private_ips_disabled() {
+        let al = NetworkAllowlist::new().block_private_ips(false);
+        assert!(!al.is_blocking_private_ips());
     }
 }

--- a/crates/bashkit/src/network/client.rs
+++ b/crates/bashkit/src/network/client.rs
@@ -20,7 +20,7 @@ use reqwest::Client;
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use super::allowlist::{NetworkAllowlist, UrlMatch};
+use super::allowlist::{NetworkAllowlist, UrlMatch, is_private_ip};
 use crate::error::{Error, Result};
 
 /// Default maximum response body size (10 MB)
@@ -260,6 +260,42 @@ impl HttpClient {
         self.request_with_headers(method, url, body, &[]).await
     }
 
+    /// THREAT[TM-NET-002/004]: Pre-resolve DNS and block private IPs.
+    async fn check_private_ip(&self, url: &str) -> Result<()> {
+        let parsed = match url::Url::parse(url) {
+            Ok(p) => p,
+            Err(_) => return Ok(()),
+        };
+        let Some(host) = parsed.host_str() else {
+            return Ok(());
+        };
+        if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+            if is_private_ip(&ip) {
+                return Err(Error::Network(format!(
+                    "access denied: {} is a private IP (SSRF protection)",
+                    host
+                )));
+            }
+        } else {
+            let port = parsed
+                .port()
+                .unwrap_or(if parsed.scheme() == "https" { 443 } else { 80 });
+            let addr = format!("{}:{}", host, port);
+            if let Ok(addrs) = tokio::net::lookup_host(&addr).await {
+                for a in addrs {
+                    if is_private_ip(&a.ip()) {
+                        return Err(Error::Network(format!(
+                            "access denied: {} resolves to private IP {} (SSRF protection)",
+                            host,
+                            a.ip()
+                        )));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Make an HTTP request with custom headers.
     ///
     /// # Security
@@ -283,6 +319,12 @@ impl HttpClient {
             UrlMatch::Invalid { reason } => {
                 return Err(Error::Network(format!("invalid URL: {}", reason)));
             }
+        }
+
+        // THREAT[TM-NET-002/004]: Pre-resolve DNS and block private IPs
+        // to prevent SSRF via DNS rebinding.
+        if self.allowlist.is_blocking_private_ips() {
+            self.check_private_ip(url).await?;
         }
 
         // Compute bot-auth signing headers (transparent, non-blocking)

--- a/crates/bashkit/tests/network_security_tests.rs
+++ b/crates/bashkit/tests/network_security_tests.rs
@@ -118,6 +118,64 @@ mod allowlist {
 }
 
 // =============================================================================
+// 1b. PRIVATE IP BLOCKING (SSRF PROTECTION)
+// =============================================================================
+
+mod private_ip_blocking {
+    use bashkit::NetworkAllowlist;
+
+    #[test]
+    fn threat_private_ip_loopback_blocked() {
+        let allowlist = NetworkAllowlist::new().allow("http://127.0.0.1:8080");
+        assert!(
+            !allowlist.is_allowed("http://127.0.0.1:8080/"),
+            "Requests to 127.0.0.1 should be blocked by default"
+        );
+    }
+
+    #[test]
+    fn threat_private_ip_link_local_blocked() {
+        let allowlist = NetworkAllowlist::new().allow("http://169.254.169.254");
+        assert!(
+            !allowlist.is_allowed("http://169.254.169.254/latest/meta-data/"),
+            "Requests to 169.254.169.254 (cloud metadata) should be blocked"
+        );
+    }
+
+    #[test]
+    fn threat_private_ip_rfc1918_blocked() {
+        let allowlist = NetworkAllowlist::new().allow("http://10.0.0.1");
+        assert!(!allowlist.is_allowed("http://10.0.0.1/"));
+
+        let allowlist = NetworkAllowlist::new().allow("http://172.16.0.1");
+        assert!(!allowlist.is_allowed("http://172.16.0.1/"));
+
+        let allowlist = NetworkAllowlist::new().allow("http://192.168.1.1");
+        assert!(!allowlist.is_allowed("http://192.168.1.1/"));
+    }
+
+    #[test]
+    fn private_ip_blocking_can_be_disabled() {
+        let allowlist = NetworkAllowlist::new()
+            .block_private_ips(false)
+            .allow("http://127.0.0.1:8080");
+        assert!(
+            allowlist.is_allowed("http://127.0.0.1:8080/"),
+            "Private IP should be allowed when blocking is disabled"
+        );
+    }
+
+    #[test]
+    fn public_ip_is_allowed() {
+        let allowlist = NetworkAllowlist::new().allow("http://8.8.8.8");
+        assert!(
+            allowlist.is_allowed("http://8.8.8.8/"),
+            "Public IPs should be allowed when in allowlist"
+        );
+    }
+}
+
+// =============================================================================
 // 2. NETWORK NOT CONFIGURED TESTS
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Closes #1176

- `is_private_ip()` checks all private/reserved ranges: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 100.64.0.0/10, ::1, fd00::/8, fe80::/10
- `NetworkAllowlist::block_private_ips(bool)` builder method (default: true)
- HTTP client pre-resolves DNS via `tokio::net::lookup_host()` and blocks private IPs before connecting
- Direct IP URLs (e.g. `http://127.0.0.1`) are also checked

## Test plan

- [x] `test_is_private_ip_loopback` — 127.x and ::1
- [x] `test_is_private_ip_rfc1918` — 10.x, 172.16-31.x, 192.168.x
- [x] `test_is_private_ip_link_local` — 169.254.x including AWS metadata
- [x] `test_is_private_ip_public` — 8.8.8.8, 1.1.1.1 not blocked
- [x] `test_is_private_ip_v6` — ::1, fd00::, fe80::
- [x] `test_block_private_ips_default_true`
- [x] `test_block_private_ips_disabled`