### PR TITLE
fix(date): resolve relative paths in date -r against CWD

### DIFF
--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use chrono::format::{Item, StrftimeItems};
 use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
-use super::{Builtin, Context};
+use super::{Builtin, Context, resolve_path};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
@@ -407,8 +407,9 @@ impl Builtin for Date {
         let dt_utc;
         if let Some(ref file) = ref_file {
             // -r / --reference: stat file to get modification time
-            let path = Path::new(file);
-            match ctx.fs.stat(path).await {
+            // Resolve relative paths against CWD (fix for issue #1225)
+            let path = resolve_path(ctx.cwd, file);
+            match ctx.fs.stat(&path).await {
                 Ok(meta) => {
                     dt_utc = meta.modified.into();
                     epoch_input = false;

--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -6,7 +6,6 @@
 //! caught and return graceful errors.
 
 use std::fmt::Write;
-use std::path::Path;
 
 use async_trait::async_trait;
 use chrono::format::{Item, StrftimeItems};

--- a/crates/bashkit/tests/spec_cases/bash/date.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/date.test.sh
@@ -264,3 +264,23 @@ date +%s --date="Wed, 01 Jan 2020 00:00:00 +0000"
 ### expect
 1577836800
 ### end
+
+### date_ref_relative_path
+# date -r should work with relative paths after cd (issue #1225)
+mkdir -p /tmp/datetest
+echo "test" > /tmp/datetest/myfile.txt
+cd /tmp/datetest
+date -r myfile.txt +%Y | grep -qE '^[0-9]{4}$' && echo "valid"
+### expect
+valid
+### end
+
+### date_ref_dot_relative_path
+# date -r should work with ./relative paths (issue #1225)
+mkdir -p /tmp/datetest2
+echo "test" > /tmp/datetest2/file.txt
+cd /tmp/datetest2
+date -r ./file.txt +%Y | grep -qE '^[0-9]{4}$' && echo "valid"
+### expect
+valid
+### end


### PR DESCRIPTION
## Summary

Closes #1225

- `date -r FILE` now uses `resolve_path(ctx.cwd, file)` to resolve relative paths against the interpreter's CWD, matching behavior of `cat`, `ls`, `stat`, and other builtins
- Previously used `Path::new(file)` which didn't resolve relative paths

## Test plan

- [x] `date_ref_relative_path` — `date -r myfile.txt` works after `cd`
- [x] `date_ref_dot_relative_path` — `date -r ./file.txt` works after `cd`
- [x] Existing `date -r` tests with absolute paths continue to pass