### PR TITLE
fix(interpreter): suppress DEBUG trap inside trap handlers

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -510,6 +510,9 @@ pub struct Interpreter {
     cancelled: Arc<AtomicBool>,
     /// Interceptor hooks registry (shared with Bash callers).
     hooks: crate::hooks::Hooks,
+    /// True while executing a trap handler. Suppresses recursive DEBUG trap
+    /// invocation to prevent amplification attacks (TM-DOS-035).
+    in_trap: bool,
     /// Deferred output process substitutions: after a command writes to the
     /// virtual file path, run these commands with the file content as stdin.
     /// Each entry is (virtual_path, commands_to_run).
@@ -845,6 +848,7 @@ impl Interpreter {
             pending_fd_targets: Vec::new(),
             cancelled: Arc::new(AtomicBool::new(false)),
             hooks: crate::hooks::Hooks::default(),
+            in_trap: false,
             deferred_proc_subs: Vec::new(),
             random_state: AtomicU32::new(random_seed),
         }
@@ -9002,6 +9006,11 @@ impl Interpreter {
     /// Run the DEBUG trap handler (fires before each simple command).
     /// Returns (stdout, stderr) from the trap handler.
     async fn run_debug_trap(&mut self) -> (String, String) {
+        // THREAT[TM-DOS-035]: Suppress DEBUG trap inside trap handlers to prevent
+        // recursive amplification (each trapped command firing more DEBUG traps).
+        if self.in_trap {
+            return (String::new(), String::new());
+        }
         if let Some(trap_cmd) = self.traps.get("DEBUG").cloned() {
             // THREAT[TM-DOS-030]: Propagate interpreter parser limits
             if let Ok(trap_script) = Parser::with_limits(
@@ -9011,9 +9020,11 @@ impl Interpreter {
             )
             .parse()
             {
+                self.in_trap = true;
                 let emit_before = self.output_emit_count;
-                if let Ok(trap_result) = self.execute_command_sequence(&trap_script.commands).await
-                {
+                let result = self.execute_command_sequence(&trap_script.commands).await;
+                self.in_trap = false;
+                if let Ok(trap_result) = result {
                     self.maybe_emit_output(&trap_result.stdout, &trap_result.stderr, emit_before);
                     return (trap_result.stdout, trap_result.stderr);
                 }
@@ -9032,9 +9043,11 @@ impl Interpreter {
             )
             .parse()
             {
+                self.in_trap = true;
                 let emit_before = self.output_emit_count;
-                if let Ok(trap_result) = self.execute_command_sequence(&trap_script.commands).await
-                {
+                let result = self.execute_command_sequence(&trap_script.commands).await;
+                self.in_trap = false;
+                if let Ok(trap_result) = result {
                     self.maybe_emit_output(&trap_result.stdout, &trap_result.stderr, emit_before);
                     stdout.push_str(&trap_result.stdout);
                     stderr.push_str(&trap_result.stderr);
@@ -10967,6 +10980,19 @@ echo "count=$COUNT"
         // DEBUG fires before: echo x (1), trap - DEBUG (2)
         // After removal: echo y, echo $count don't trigger
         assert_eq!(result.stdout, "x\ny\n2\n");
+    }
+
+    #[tokio::test]
+    async fn test_debug_trap_no_recursive_amplification() {
+        // THREAT[TM-DOS-035]: Commands inside the DEBUG trap handler must NOT
+        // trigger further DEBUG trap invocations (prevents N*M amplification).
+        let result = run_script(
+            r#"trap_count=0; trap '((trap_count++))' DEBUG; echo a; echo b; echo c; trap - DEBUG; echo $trap_count"#,
+        )
+        .await;
+        // DEBUG fires before: echo a (1), echo b (2), echo c (3), trap - DEBUG (4)
+        // The ((trap_count++)) inside the trap must NOT fire another DEBUG trap.
+        assert_eq!(result.stdout, "a\nb\nc\n4\n");
     }
 
     #[tokio::test]

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -259,6 +259,7 @@ max_ast_depth: 100,           // Parser recursion (TM-DOS-022)
 | TM-DOS-029 | Arithmetic overflow/panic | `$(( 2 ** -1 ))`, `$(( 1 << 64 ))`, `i64::MIN / -1` | — | **OPEN** |
 | TM-DOS-030 | Parser limit bypass via eval/source/trap | `eval`, `source`, trap handlers now use `Parser::with_limits()` | — | **FIXED** (2026-03 audit verified) |
 | TM-DOS-031 | ExtGlob exponential blowup | `+(a\|aa)` against long string causes O(n!) recursion in `glob_match_impl` | — | **OPEN** |
+| TM-DOS-035 | DEBUG trap recursive amplification | `trap 'a=1;b=2;...' DEBUG` amplifies N commands to N*M | Suppress DEBUG trap inside trap handlers (`in_trap` guard) | **FIXED** |
 | TM-DOS-032 | Tokio runtime exhaustion (Python) | Rapid `execute_sync()` calls each create new tokio runtime, exhausting OS threads | — | **OPEN** |
 | TM-DOS-033 | AWK unbounded loops | `BEGIN { while(1){} }` has no iteration limit in AWK interpreter | Timeout (30s) backstop | **PARTIAL** |
 | TM-DOS-051 | YAML parser unbounded recursion | `yaml get key` on deeply nested YAML input causes stack overflow in `parse_yaml_block`/`parse_yaml_map`/`parse_yaml_list` | `catch_unwind` (TM-INT-001) catches panic; no depth limit | **OPEN** |


### PR DESCRIPTION
## Summary\n\n- Add `in_trap` boolean guard to `Interpreter` struct\n- Skip DEBUG trap invocation when already executing inside a trap handler\n- Also guard ERR trap to prevent similar recursive amplification\n- Add TM-DOS-035 to threat model\n\n## Test plan\n\n- [x] `test_debug_trap_no_recursive_amplification` — trap commands don't trigger more traps\n- [x] Existing `test_debug_trap` and `test_debug_trap_removal` still pass\n- [x] `cargo clippy` and `cargo fmt` clean\n\nCloses #1170