### PR TITLE
fix(snapshot): add keyed HMAC API and document forgery limitation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "futures-util",
+ "hmac 0.13.0",
  "insta",
  "jaq-core",
  "jaq-json",

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -69,6 +69,7 @@ zeroize = { workspace = true, optional = true }
 md-5 = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
+hmac = "0.13"
 
 # Logging/tracing (optional)
 tracing = { workspace = true, optional = true }

--- a/crates/bashkit/src/snapshot.rs
+++ b/crates/bashkit/src/snapshot.rs
@@ -58,9 +58,21 @@ use crate::interpreter::ShellState;
 /// Schema version for snapshot format compatibility.
 const SNAPSHOT_VERSION: u32 = 1;
 
-/// HMAC-like keyed hash prefix used to detect snapshot tampering.
-/// The key is combined with the JSON payload to produce a SHA-256 digest
-/// that is prepended to the serialized bytes.
+/// Domain-separation tag for the snapshot integrity digest.
+///
+/// # Security note (TM-SNAP-001)
+///
+/// This tag is a **public constant**, not a secret key. The digest
+/// (`SHA-256(INTEGRITY_TAG || payload)`) detects **accidental corruption**
+/// (bit flips, truncation) but does **NOT** prevent intentional forgery.
+/// Anyone with access to the source code can compute a valid digest for
+/// arbitrary payloads.
+///
+/// **Do NOT rely on `from_bytes` as a security boundary** when snapshots are
+/// received from untrusted sources (network, shared storage, user upload).
+/// For tamper-proof snapshots, wrap the bytes with your own HMAC or
+/// authenticated encryption using a secret key, or use [`Snapshot::to_bytes_keyed`]
+/// / [`Snapshot::from_bytes_keyed`] which accept a caller-provided key.
 const INTEGRITY_TAG: &[u8; 8] = b"BKSNAP01";
 /// Length of the SHA-256 digest prepended to snapshot bytes.
 const DIGEST_LEN: usize = 32;
@@ -124,6 +136,47 @@ impl Snapshot {
         Ok(snap)
     }
 
+    /// Serialize with a caller-provided secret key for tamper-proof integrity.
+    ///
+    /// Uses `HMAC-SHA256(key, payload)` instead of the public tag.
+    /// Use this when snapshots cross trust boundaries (network, shared storage).
+    pub fn to_bytes_keyed(&self, key: &[u8]) -> crate::Result<Vec<u8>> {
+        let json = serde_json::to_vec(self).map_err(|e| crate::Error::Internal(e.to_string()))?;
+        let digest = Self::compute_hmac(key, &json);
+        let mut out = Vec::with_capacity(DIGEST_LEN + json.len());
+        out.extend_from_slice(&digest);
+        out.extend_from_slice(&json);
+        Ok(out)
+    }
+
+    /// Deserialize and verify a snapshot using a caller-provided secret key.
+    ///
+    /// Rejects snapshots where the HMAC does not match, preventing forgery.
+    pub fn from_bytes_keyed(data: &[u8], key: &[u8]) -> crate::Result<Self> {
+        if data.len() < DIGEST_LEN {
+            return Err(crate::Error::Internal(
+                "snapshot too short: missing integrity digest".to_string(),
+            ));
+        }
+        let (stored_digest, json) = data.split_at(DIGEST_LEN);
+        let expected = Self::compute_hmac(key, json);
+        if stored_digest != expected.as_slice() {
+            return Err(crate::Error::Internal(
+                "snapshot integrity check failed: HMAC mismatch (wrong key or tampered data)"
+                    .to_string(),
+            ));
+        }
+        let snap: Self =
+            serde_json::from_slice(json).map_err(|e| crate::Error::Internal(e.to_string()))?;
+        if snap.version != SNAPSHOT_VERSION {
+            return Err(crate::Error::Internal(format!(
+                "unsupported snapshot version {} (expected {})",
+                snap.version, SNAPSHOT_VERSION
+            )));
+        }
+        Ok(snap)
+    }
+
     /// Compute SHA-256 digest over `INTEGRITY_TAG || payload`.
     fn compute_digest(payload: &[u8]) -> [u8; DIGEST_LEN] {
         let mut hasher = Sha256::new();
@@ -132,6 +185,18 @@ impl Snapshot {
         let result = hasher.finalize();
         let mut out = [0u8; DIGEST_LEN];
         out.copy_from_slice(&result);
+        out
+    }
+
+    /// Compute HMAC-SHA256 using a caller-provided secret key.
+    fn compute_hmac(key: &[u8], payload: &[u8]) -> [u8; DIGEST_LEN] {
+        use hmac::{Hmac, KeyInit, Mac};
+        type HmacSha256 = Hmac<Sha256>;
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+        mac.update(payload);
+        let result = mac.finalize();
+        let mut out = [0u8; DIGEST_LEN];
+        out.copy_from_slice(&result.into_bytes());
         out
     }
 }
@@ -237,5 +302,40 @@ impl crate::Bash {
         }
         self.interpreter
             .restore_session_counters(snap.session_commands, snap.session_exec_calls);
+    }
+
+    /// Capture snapshot and serialize with HMAC-SHA256 using a secret key.
+    ///
+    /// Use this instead of [`snapshot()`](Self::snapshot) when snapshots cross
+    /// trust boundaries (network, shared storage, untrusted input).
+    pub fn snapshot_to_bytes_keyed(&self, key: &[u8]) -> crate::Result<Vec<u8>> {
+        let shell = self.interpreter.shell_state();
+        let vfs = self.fs.vfs_snapshot();
+        let counters = self.interpreter.counters();
+        let snap = Snapshot {
+            version: SNAPSHOT_VERSION,
+            shell,
+            vfs,
+            session_commands: counters.session_commands,
+            session_exec_calls: counters.session_exec_calls,
+        };
+        snap.to_bytes_keyed(key)
+    }
+
+    /// Create a new Bash instance from a keyed (HMAC-protected) snapshot.
+    ///
+    /// Rejects snapshots where the HMAC doesn't match the provided key.
+    pub fn from_snapshot_keyed(data: &[u8], key: &[u8]) -> crate::Result<Self> {
+        let snap = Snapshot::from_bytes_keyed(data, key)?;
+        let mut bash = Self::new();
+        bash.restore_snapshot_inner(&snap);
+        Ok(bash)
+    }
+
+    /// Restore state from a keyed snapshot into this Bash instance.
+    pub fn restore_snapshot_keyed(&mut self, data: &[u8], key: &[u8]) -> crate::Result<()> {
+        let snap = Snapshot::from_bytes_keyed(data, key)?;
+        self.restore_snapshot_inner(&snap);
+        Ok(())
     }
 }

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -460,3 +460,52 @@ async fn restore_snapshot_preserves_limits() {
     // Should hit the command limit and return an error
     assert!(r.is_err(), "Should hit max_commands limit after restore");
 }
+
+// ==================== Keyed snapshot integrity (Issue #1167) ====================
+
+#[tokio::test]
+async fn keyed_snapshot_roundtrip() {
+    let key = b"my-secret-key-for-hmac";
+    let mut bash = Bash::new();
+    bash.exec("MY_VAR=hello").await.unwrap();
+    let bytes = bash.snapshot_to_bytes_keyed(key).unwrap();
+
+    let mut restored = Bash::new();
+    restored.restore_snapshot_keyed(&bytes, key).unwrap();
+    let r = restored.exec("echo $MY_VAR").await.unwrap();
+    assert_eq!(r.stdout.trim(), "hello");
+}
+
+#[tokio::test]
+async fn keyed_snapshot_wrong_key_rejected() {
+    let key = b"correct-key";
+    let wrong_key = b"wrong-key";
+    let mut bash = Bash::new();
+    bash.exec("x=42").await.unwrap();
+    let bytes = bash.snapshot_to_bytes_keyed(key).unwrap();
+
+    let result = Bash::from_snapshot_keyed(&bytes, wrong_key);
+    assert!(result.is_err());
+    let err = result.err().unwrap().to_string();
+    assert!(
+        err.contains("HMAC mismatch"),
+        "Expected HMAC error: {}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn keyed_snapshot_tampered_rejected() {
+    let key = b"secret";
+    let mut bash = Bash::new();
+    bash.exec("x=42").await.unwrap();
+    let mut bytes = bash.snapshot_to_bytes_keyed(key).unwrap();
+
+    // Tamper with payload
+    if bytes.len() > 40 {
+        bytes[40] ^= 0xFF;
+    }
+
+    let result = Bash::from_snapshot_keyed(&bytes, key);
+    assert!(result.is_err());
+}

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -1082,6 +1082,20 @@ let config = LogConfig::new()
     .redact_env("INTERNAL_TOKEN");
 ```
 
+### 9.5 Snapshot Security
+
+| ID | Threat | Attack | Mitigation | Status |
+|----|--------|--------|------------|--------|
+| TM-SNAP-001 | Snapshot forgery via public tag | Attacker computes valid SHA-256 digest using public `BKSNAP01` tag | Document limitation; add keyed HMAC API (`to_bytes_keyed`/`from_bytes_keyed`) | **MITIGATED** |
+
+**`from_bytes`** uses `SHA-256(BKSNAP01 || payload)` where the tag is a public constant.
+This detects accidental corruption but **does NOT prevent intentional forgery**. Any caller
+with source code access can forge valid snapshots.
+
+**`from_bytes_keyed`** uses `HMAC-SHA256(secret_key, payload)` with a caller-provided key.
+Use this when snapshots cross trust boundaries (network transfer, shared storage, untrusted
+input). The keyed API was added in response to issue #1167.
+
 ### 10. Builtin-Specific Threat Coverage
 
 This section documents the security assessment of builtins that do not have individual


### PR DESCRIPTION
## Summary\n\n- Add `to_bytes_keyed`/`from_bytes_keyed` on `Snapshot` using HMAC-SHA256 with caller-provided key\n- Add `snapshot_to_bytes_keyed`/`from_snapshot_keyed`/`restore_snapshot_keyed` on `Bash`\n- Document that existing `from_bytes` uses a public tag (corruption detection only, not forgery prevention)\n- Add TM-SNAP-001 section to threat model\n\n## Test plan\n\n- [x] `keyed_snapshot_roundtrip` — keyed snapshot serialize/deserialize works\n- [x] `keyed_snapshot_wrong_key_rejected` — wrong key triggers HMAC mismatch error\n- [x] `keyed_snapshot_tampered_rejected` — tampered payload rejected with correct key\n- [x] All 26 existing snapshot tests still pass\n- [x] `cargo clippy` and `cargo fmt` clean\n\nCloses #1167