### PR TITLE
fix(mcp): add request rate limiting for MCP tool calls

### DIFF
--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -101,7 +101,11 @@ struct Args {
 #[derive(Subcommand, Debug)]
 enum SubCmd {
     /// Run as MCP (Model Context Protocol) server
-    Mcp,
+    Mcp {
+        /// Maximum tool call requests per minute (0 = unlimited)
+        #[arg(long, default_value_t = 0)]
+        max_requests_per_minute: u32,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -187,7 +191,7 @@ fn configure_bash(args: &Args, mode: CliMode) -> bashkit::BashBuilder {
 }
 
 fn cli_mode(args: &Args) -> CliMode {
-    if matches!(args.subcommand, Some(SubCmd::Mcp)) {
+    if matches!(args.subcommand, Some(SubCmd::Mcp { .. })) {
         CliMode::Mcp
     } else if args.command.is_some() {
         CliMode::Command
@@ -296,11 +300,20 @@ fn run_interactive(args: Args, mode: CliMode) -> Result<i32> {
 }
 
 fn run_mcp(args: Args, mode: CliMode) -> Result<()> {
+    let max_rpm = match &args.subcommand {
+        Some(SubCmd::Mcp {
+            max_requests_per_minute,
+        }) => *max_requests_per_minute,
+        _ => 0,
+    };
     Builder::new_multi_thread()
         .enable_all()
         .build()
         .context("Failed to build MCP runtime")?
-        .block_on(mcp::run(move || build_bash(&args, mode)))
+        .block_on(mcp::run_with_rate_limit(
+            move || build_bash(&args, mode),
+            max_rpm,
+        ))
 }
 
 fn run_oneshot(args: Args, mode: CliMode) -> Result<RunOutput> {

--- a/crates/bashkit-cli/src/mcp.rs
+++ b/crates/bashkit-cli/src/mcp.rs
@@ -135,6 +135,11 @@ pub struct McpServer {
     cumulative_commands: u64,
     /// Cumulative session exec call count across all MCP tool calls.
     cumulative_exec_calls: u64,
+    /// Rate limiter: max tool-call requests per minute (0 = unlimited).
+    // THREAT[TM-DOS-036]: Prevent resource exhaustion from rapid MCP requests.
+    max_requests_per_minute: u32,
+    /// Timestamps of recent tool-call requests for rate limiting.
+    request_timestamps: Vec<std::time::Instant>,
     #[cfg(feature = "scripted_tool")]
     scripted_tools: Vec<bashkit::ScriptedTool>,
 }
@@ -148,9 +153,18 @@ impl McpServer {
             bash_factory: Box::new(bash_factory),
             cumulative_commands: 0,
             cumulative_exec_calls: 0,
+            max_requests_per_minute: 0,
+            request_timestamps: Vec::new(),
             #[cfg(feature = "scripted_tool")]
             scripted_tools: Vec::new(),
         }
+    }
+
+    /// Set the maximum number of tool-call requests per minute.
+    /// 0 means unlimited.
+    pub fn max_requests_per_minute(mut self, limit: u32) -> Self {
+        self.max_requests_per_minute = limit;
+        self
     }
 
     /// Register a ScriptedTool. It will appear in `tools/list` and route
@@ -196,6 +210,13 @@ impl McpServer {
     }
 
     async fn handle_request(&mut self, request: JsonRpcRequest) -> JsonRpcResponse {
+        // THREAT[TM-DOS-036]: Rate-limit tools/call to prevent resource exhaustion.
+        if request.method == "tools/call"
+            && let Some(err) = self.check_rate_limit()
+        {
+            return JsonRpcResponse::error(request.id, -32000, err);
+        }
+
         match request.method.as_str() {
             "initialize" => Self::handle_initialize(request.id),
             "initialized" => JsonRpcResponse::success(request.id, serde_json::Value::Null),
@@ -204,6 +225,26 @@ impl McpServer {
             "shutdown" => JsonRpcResponse::success(request.id, serde_json::Value::Null),
             _ => JsonRpcResponse::error(request.id, -32601, "Method not found".to_string()),
         }
+    }
+
+    /// Check rate limit. Returns an error message if exceeded, None if OK.
+    fn check_rate_limit(&mut self) -> Option<String> {
+        if self.max_requests_per_minute == 0 {
+            return None;
+        }
+        let now = std::time::Instant::now();
+        let window = std::time::Duration::from_secs(60);
+        // Remove timestamps older than 1 minute
+        self.request_timestamps
+            .retain(|t| now.duration_since(*t) < window);
+        if self.request_timestamps.len() >= self.max_requests_per_minute as usize {
+            return Some(format!(
+                "Rate limit exceeded: max {} requests per minute",
+                self.max_requests_per_minute
+            ));
+        }
+        self.request_timestamps.push(now);
+        None
     }
 
     fn handle_initialize(id: serde_json::Value) -> JsonRpcResponse {
@@ -390,8 +431,18 @@ impl McpServer {
 }
 
 /// Run the MCP server with a factory that produces configured `Bash` instances.
+#[allow(dead_code)] // Public API; used by external callers / tests
 pub async fn run(bash_factory: impl Fn() -> bashkit::Bash + Send + 'static) -> Result<()> {
     let mut server = McpServer::new(bash_factory);
+    server.run().await
+}
+
+/// Run the MCP server with rate limiting.
+pub async fn run_with_rate_limit(
+    bash_factory: impl Fn() -> bashkit::Bash + Send + 'static,
+    max_requests_per_minute: u32,
+) -> Result<()> {
+    let mut server = McpServer::new(bash_factory).max_requests_per_minute(max_requests_per_minute);
     server.run().await
 }
 
@@ -773,5 +824,94 @@ mod tests {
             let text = call_result["content"][0]["text"].as_str().expect("text");
             assert!(text.contains("hello MCP"));
         }
+    }
+
+    // THREAT[TM-DOS-036]: Rate limiting tests
+
+    #[tokio::test]
+    async fn test_rate_limit_blocks_excess_requests() {
+        let mut server = McpServer::new(bashkit::Bash::new).max_requests_per_minute(2);
+
+        // First two requests should succeed
+        for i in 1..=2 {
+            let req = JsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!(i),
+                method: "tools/call".to_string(),
+                params: serde_json::json!({
+                    "name": "bash",
+                    "arguments": { "script": "echo ok" }
+                }),
+            };
+            let resp = server.handle_request(req).await;
+            assert!(resp.error.is_none(), "request {i} should succeed");
+        }
+
+        // Third request should be rate-limited
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(3),
+            method: "tools/call".to_string(),
+            params: serde_json::json!({
+                "name": "bash",
+                "arguments": { "script": "echo should_fail" }
+            }),
+        };
+        let resp = server.handle_request(req).await;
+        let err = resp.error.expect("should be rate limited");
+        assert_eq!(err.code, -32000);
+        assert!(err.message.contains("Rate limit exceeded"));
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_zero_means_unlimited() {
+        let mut server = McpServer::new(bashkit::Bash::new).max_requests_per_minute(0);
+
+        for i in 1..=10 {
+            let req = JsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!(i),
+                method: "tools/call".to_string(),
+                params: serde_json::json!({
+                    "name": "bash",
+                    "arguments": { "script": "echo ok" }
+                }),
+            };
+            let resp = server.handle_request(req).await;
+            assert!(
+                resp.error.is_none(),
+                "request {i} should succeed with no limit"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_does_not_block_non_tool_calls() {
+        let mut server = McpServer::new(bashkit::Bash::new).max_requests_per_minute(1);
+
+        // Use the one allowed tool call
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(1),
+            method: "tools/call".to_string(),
+            params: serde_json::json!({
+                "name": "bash",
+                "arguments": { "script": "echo ok" }
+            }),
+        };
+        server.handle_request(req).await;
+
+        // tools/list should still work even though tool call limit is reached
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::json!(2),
+            method: "tools/list".to_string(),
+            params: serde_json::json!({}),
+        };
+        let resp = server.handle_request(req).await;
+        assert!(
+            resp.error.is_none(),
+            "tools/list should not be rate-limited"
+        );
     }
 }


### PR DESCRIPTION
## Summary\n\n- Add `--max-requests-per-minute` CLI flag for MCP subcommand (0 = unlimited, default)\n- Track tool/call timestamps in sliding 1-minute window\n- Return JSON-RPC error -32000 when rate limit exceeded\n- Non-tool methods (tools/list, initialize, shutdown) bypass rate limit\n\n## Test plan\n\n- [x] `test_rate_limit_blocks_excess_requests` — 3rd request blocked at limit=2\n- [x] `test_rate_limit_zero_means_unlimited` — 10 rapid requests succeed at limit=0\n- [x] `test_rate_limit_does_not_block_non_tool_calls` — tools/list works after limit reached\n- [x] `cargo clippy` and `cargo fmt` clean\n\nCloses #1168