### PR TITLE
fix(bashkit-js): bump langsmith 0.5.16 → 0.5.18

### DIFF
--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -2976,16 +2976,6 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/console-table-printer": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
-      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "simple-wcswidth": "^1.1.2"
-      }
-    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -3713,17 +3703,14 @@
       "license": "MIT"
     },
     "node_modules/langsmith": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.16.tgz",
-      "integrity": "sha512-nSsSnTo3gjg1dnb48vb8i582zyjvtPbn+EpR6P1pNELb+4Hb4R3nt7LDy+Tl1ltw73vPGfJQtUWOl28irI1b5w==",
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
+      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.6.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
+        "p-queue": "6.6.2",
+        "uuid": "10.0.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -4410,13 +4397,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/simple-wcswidth": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
-      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "5.1.0",


### PR DESCRIPTION
## Summary

- Bumps transitive `langsmith` dependency from 0.5.16 to 0.5.18 in `crates/bashkit-js/package-lock.json`
- Resolves moderate severity Dependabot alert on langsmith 0.5.16 (transitive via `@langchain/core`)

## Test plan

- [ ] CI passes (lockfile-only change, no code changes)