### PR TITLE
fix(expansion): handle mixed literal+quoted var in ${var#pattern}

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7086,9 +7086,13 @@ impl Interpreter {
         if operand.is_empty() {
             return String::new();
         }
+        // Strip double/single quotes from operand before parsing.
+        // In patterns like ${var#./"$other"}, the quotes suppress globbing
+        // but should not appear as literal characters in the expanded result.
+        let stripped = Self::strip_operand_quotes(operand);
         // THREAT[TM-DOS-050]: Propagate caller-configured limits to word parsing
         let word = Parser::parse_word_string_with_limits(
-            operand,
+            &stripped,
             self.limits.max_ast_depth,
             self.limits.max_parser_operations,
         );
@@ -7126,6 +7130,36 @@ impl Interpreter {
                 }
                 // TODO: handle CommandSubstitution etc. in sync operand expansion
                 _ => {}
+            }
+        }
+        result
+    }
+
+    /// Strip unescaped double-quote pairs from operand strings.
+    /// In patterns like `${var#./"$other"}`, the `"` around `$other` suppress
+    /// globbing but should not appear as literal characters in the pattern.
+    /// Escaped quotes (`\"`) and NUL-sentinel-marked chars (`\x00"`) are kept.
+    fn strip_operand_quotes(operand: &str) -> String {
+        let mut result = String::with_capacity(operand.len());
+        let chars: Vec<char> = operand.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            if chars[i] == '\x00' && i + 1 < chars.len() {
+                // NUL sentinel: next char is literal (from lexer escape processing)
+                result.push(chars[i]);
+                result.push(chars[i + 1]);
+                i += 2;
+            } else if chars[i] == '\\' && i + 1 < chars.len() && chars[i + 1] == '"' {
+                // Escaped double quote \" → literal " (keep both for parse_word)
+                result.push(chars[i]);
+                result.push(chars[i + 1]);
+                i += 2;
+            } else if chars[i] == '"' {
+                // Unescaped double quote: skip it (strip the quote character)
+                i += 1;
+            } else {
+                result.push(chars[i]);
+                i += 1;
             }
         }
         result

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -3117,6 +3117,17 @@ fn
     }
 
     #[tokio::test]
+    async fn test_param_remove_prefix_mixed_pattern() {
+        let mut bash = Bash::new();
+        // ${var#./"$other"} - pattern mixing literal and quoted variable
+        let result = bash
+            .exec(r#"i="./tag_hello.tmp.html"; prefix_tags="tag_"; echo ${i#./"$prefix_tags"}"#)
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "hello.tmp.html\n");
+    }
+
+    #[tokio::test]
     async fn test_param_remove_suffix() {
         let mut bash = Bash::new();
         // ${var%pattern} - remove shortest suffix

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1428,7 +1428,14 @@ impl<'a> Lexer<'a> {
                                 content.push('$');
                                 self.advance();
                             }
-                            '"' | '\\' | '`' => {
+                            '"' => {
+                                // Use NUL sentinel so strip_operand_quotes()
+                                // can distinguish literal " from quoting "
+                                content.push('\x00');
+                                content.push('"');
+                                self.advance();
+                            }
+                            '\\' | '`' => {
                                 content.push(esc);
                                 self.advance();
                             }


### PR DESCRIPTION
## Summary

- `${var#./"$other_var"}` now correctly strips the prefix when the pattern mixes literals and quoted variables
- Added `strip_operand_quotes()` to remove unescaped double quotes from operand strings before expansion
- Modified lexer to use NUL sentinel for escaped quotes (`\"`) inside `${...}` to distinguish literal `"` from quoting `"`

## Test plan

- [x] `${i#./"$prefix_tags"}` correctly strips `./tag_` prefix
- [x] All 15 spec test suites pass (no regressions)
- [x] `cargo clippy` clean

Closes #1161