### PR TITLE
feat(python): bump monty to 0.0.11, add datetime/json support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +562,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -657,6 +683,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1547,6 +1574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2397,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020ba671987d7444d251d3ee5340be1bf4606cd6c0b53e6f4066b5a1ee376b22"
+dependencies = [
+ "ahash",
+ "bitvec",
+ "lexical-parse-float",
+ "num-bigint",
+ "num-traits",
+ "pyo3",
+ "smallvec",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +2511,31 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
@@ -2621,14 +2694,17 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.8"
-source = "git+https://github.com/pydantic/monty?rev=e59c8fa#e59c8fa5229e38757ab0632d990b528aac395f35"
+version = "0.0.11"
+source = "git+https://github.com/pydantic/monty?rev=2e9df4b#2e9df4b508e8a9ac80f3a6a26ed680242d1f460d"
 dependencies = [
  "ahash",
+ "bytemuck",
+ "chrono",
  "fancy-regex",
  "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
+ "jiter",
  "libm",
  "num-bigint",
  "num-integer",
@@ -2640,6 +2716,7 @@ dependencies = [
  "ruff_text_size",
  "serde",
  "smallvec",
+ "speedate",
  "strum",
 ]
 
@@ -3684,6 +3761,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
+ "num-bigint",
+ "num-traits",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
@@ -3863,6 +3942,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -5014,6 +5099,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "speedate"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba069c070b5e213f2a094deb7e5ed50ecb092be36102a4f4042e8d2056d060e"
+dependencies = [
+ "lexical-parse-float",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5205,6 +5301,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -6351,6 +6453,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yansi"

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -76,7 +76,7 @@ hmac = "0.13"
 tracing = { workspace = true, optional = true }
 
 # Embedded Python interpreter (optional)
-monty = { git = "https://github.com/pydantic/monty", rev = "e59c8fa", optional = true }
+monty = { git = "https://github.com/pydantic/monty", rev = "2e9df4b", optional = true }
 
 # Embedded TypeScript interpreter (optional)
 zapcode-core = { version = "1.5", optional = true }

--- a/crates/bashkit/docs/python.md
+++ b/crates/bashkit/docs/python.md
@@ -187,7 +187,7 @@ Monty has no network primitives and no OsCall variants for network operations.
 **No classes.** Class definitions are not yet supported by Monty (planned upstream).
 
 **No third-party imports.** Only builtin modules (`sys`, `typing`, `os`, `pathlib`,
-`math`, `re`) are available. No `pip install`, no `import numpy`.
+`math`, `re`, `json`, `datetime`) are available. No `pip install`, no `import numpy`.
 
 **No `str.format()`.** Use f-strings instead: `f"value={x}"` not `"value={}".format(x)`.
 
@@ -201,6 +201,6 @@ All Python execution runs in a virtual environment:
 - **Resource limited** — allocation, time, memory, and recursion caps
 - **Path traversal safe** — `../..` is resolved by VFS path normalization
 
-See threat IDs TM-PY-001 through TM-PY-026 in the [threat model](./threat-model.md).
+See threat IDs TM-PY-001 through TM-PY-029 in the [threat model](./threat-model.md).
 
 [spec]: https://github.com/everruns/bashkit/blob/main/specs/011-python-builtin.md

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -772,45 +772,42 @@ fn handle_date_today() -> ExtFunctionResult {
 /// If tz is None, returns a naive datetime (no timezone info).
 /// If tz is a TimeZone, returns an aware datetime at that offset.
 fn handle_datetime_now(args: &[MontyObject]) -> ExtFunctionResult {
-    let now = chrono::Utc::now();
-    let (offset_seconds, tz_name) = match args.first() {
-        Some(MontyObject::TimeZone(tz)) => {
-            let offset = tz.offset_seconds;
-            let name = tz.name.clone();
-            (Some(offset), name)
-        }
-        _ => {
-            // No timezone → naive local datetime
-            let local = chrono::Local::now();
-            return ExtFunctionResult::Return(MontyObject::DateTime(MontyDateTime {
-                year: local.year(),
-                month: local.month() as u8,
-                day: local.day() as u8,
-                hour: local.hour() as u8,
-                minute: local.minute() as u8,
-                second: local.second() as u8,
-                microsecond: local.nanosecond() / 1000,
-                offset_seconds: None,
-                timezone_name: None,
-            }));
-        }
+    let tz = match args.first() {
+        Some(MontyObject::TimeZone(tz)) => Some(tz),
+        _ => None,
     };
 
-    // Aware datetime: apply the requested offset
-    let offset = chrono::FixedOffset::east_opt(offset_seconds.unwrap_or(0))
-        .unwrap_or(chrono::FixedOffset::east_opt(0).expect("UTC offset is always valid"));
-    let at_offset = now.with_timezone(&offset);
-    ExtFunctionResult::Return(MontyObject::DateTime(MontyDateTime {
-        year: at_offset.year(),
-        month: at_offset.month() as u8,
-        day: at_offset.day() as u8,
-        hour: at_offset.hour() as u8,
-        minute: at_offset.minute() as u8,
-        second: at_offset.second() as u8,
-        microsecond: at_offset.nanosecond() / 1000,
-        offset_seconds,
-        timezone_name: tz_name,
-    }))
+    if let Some(tz) = tz {
+        // Aware datetime at the requested offset
+        let offset = chrono::FixedOffset::east_opt(tz.offset_seconds)
+            .unwrap_or(chrono::FixedOffset::east_opt(0).expect("UTC offset is always valid"));
+        let dt = chrono::Utc::now().with_timezone(&offset);
+        ExtFunctionResult::Return(MontyObject::DateTime(MontyDateTime {
+            year: dt.year(),
+            month: dt.month() as u8,
+            day: dt.day() as u8,
+            hour: dt.hour() as u8,
+            minute: dt.minute() as u8,
+            second: dt.second() as u8,
+            microsecond: dt.nanosecond() / 1000,
+            offset_seconds: Some(tz.offset_seconds),
+            timezone_name: tz.name.clone(),
+        }))
+    } else {
+        // No timezone → naive local datetime
+        let dt = chrono::Local::now();
+        ExtFunctionResult::Return(MontyObject::DateTime(MontyDateTime {
+            year: dt.year(),
+            month: dt.month() as u8,
+            day: dt.day() as u8,
+            hour: dt.hour() as u8,
+            minute: dt.minute() as u8,
+            second: dt.second() as u8,
+            microsecond: dt.nanosecond() / 1000,
+            offset_seconds: None,
+            timezone_name: None,
+        }))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1547,6 +1544,37 @@ mod tests {
             &[
                 "-c",
                 "from datetime import datetime, timezone\ndt = datetime.now(timezone.utc)\nprint(dt.year > 2000)",
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "True");
+    }
+
+    #[tokio::test]
+    async fn test_datetime_attributes() {
+        // Verify datetime components are populated correctly
+        let r = run(
+            &[
+                "-c",
+                "from datetime import datetime\ndt = datetime.now()\nassert 1 <= dt.month <= 12\nassert 1 <= dt.day <= 31\nassert 0 <= dt.hour <= 23\nprint('ok')",
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "ok");
+    }
+
+    // --- json tests (Monty 0.0.9+) ---
+
+    #[tokio::test]
+    async fn test_json_dumps_loads() {
+        let r = run(
+            &[
+                "-c",
+                "import json\nd = {'a': 1, 'b': [2, 3]}\ns = json.dumps(d)\nprint(json.loads(s) == d)",
             ],
             None,
         )

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -15,10 +15,11 @@
 //! Supports: `python -c "code"`, `python script.py`, stdin piping.
 
 use async_trait::async_trait;
+use chrono::{Datelike, Timelike};
 use monty::{
-    ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject, MontyRun,
-    NameLookupResult, OsFunction, PrintWriter, ResourceLimits, RunProgress, dir_stat, file_stat,
-    symlink_stat,
+    ExcType, ExtFunctionResult, LimitedTracker, MontyDate, MontyDateTime, MontyException,
+    MontyObject, MontyRun, NameLookupResult, OsFunction, PrintWriter, ResourceLimits, RunProgress,
+    dir_stat, file_stat, symlink_stat,
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -496,10 +497,12 @@ async fn handle_os_call(
     cwd: &Path,
     env: &HashMap<String, String>,
 ) -> ExtFunctionResult {
-    // Environment access doesn't need a path
+    // Non-filesystem operations: env access, date/time
     match function {
         OsFunction::Getenv => return handle_getenv(args, env),
         OsFunction::GetEnviron => return handle_get_environ(env),
+        OsFunction::DateToday => return handle_date_today(),
+        OsFunction::DateTimeNow => return handle_datetime_now(args),
         _ => {}
     }
 
@@ -752,6 +755,62 @@ fn handle_get_environ(env: &HashMap<String, String>) -> ExtFunctionResult {
         })
         .collect();
     ExtFunctionResult::Return(MontyObject::dict(pairs))
+}
+
+/// Handle datetime.date.today() → current date from host system.
+fn handle_date_today() -> ExtFunctionResult {
+    let now = chrono::Local::now();
+    ExtFunctionResult::Return(MontyObject::Date(MontyDate {
+        year: now.year(),
+        month: now.month() as u8,
+        day: now.day() as u8,
+    }))
+}
+
+/// Handle datetime.datetime.now(tz=None) → current datetime from host system.
+///
+/// If tz is None, returns a naive datetime (no timezone info).
+/// If tz is a TimeZone, returns an aware datetime at that offset.
+fn handle_datetime_now(args: &[MontyObject]) -> ExtFunctionResult {
+    let now = chrono::Utc::now();
+    let (offset_seconds, tz_name) = match args.first() {
+        Some(MontyObject::TimeZone(tz)) => {
+            let offset = tz.offset_seconds;
+            let name = tz.name.clone();
+            (Some(offset), name)
+        }
+        _ => {
+            // No timezone → naive local datetime
+            let local = chrono::Local::now();
+            return ExtFunctionResult::Return(MontyObject::DateTime(MontyDateTime {
+                year: local.year(),
+                month: local.month() as u8,
+                day: local.day() as u8,
+                hour: local.hour() as u8,
+                minute: local.minute() as u8,
+                second: local.second() as u8,
+                microsecond: local.nanosecond() / 1000,
+                offset_seconds: None,
+                timezone_name: None,
+            }));
+        }
+    };
+
+    // Aware datetime: apply the requested offset
+    let offset = chrono::FixedOffset::east_opt(offset_seconds.unwrap_or(0))
+        .unwrap_or(chrono::FixedOffset::east_opt(0).expect("UTC offset is always valid"));
+    let at_offset = now.with_timezone(&offset);
+    ExtFunctionResult::Return(MontyObject::DateTime(MontyDateTime {
+        year: at_offset.year(),
+        month: at_offset.month() as u8,
+        day: at_offset.day() as u8,
+        hour: at_offset.hour() as u8,
+        minute: at_offset.minute() as u8,
+        second: at_offset.second() as u8,
+        microsecond: at_offset.nanosecond() / 1000,
+        offset_seconds,
+        timezone_name: tz_name,
+    }))
 }
 
 // ---------------------------------------------------------------------------
@@ -1450,5 +1509,49 @@ mod tests {
         .await;
         assert_eq!(r.exit_code, 0);
         assert_eq!(r.stdout.trim(), "1 2");
+    }
+
+    // --- datetime tests (Monty 0.0.11+) ---
+
+    #[tokio::test]
+    async fn test_date_today() {
+        let r = run(
+            &[
+                "-c",
+                "from datetime import date\nd = date.today()\nprint(d.year > 2000)",
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "True");
+    }
+
+    #[tokio::test]
+    async fn test_datetime_now_naive() {
+        let r = run(
+            &[
+                "-c",
+                "from datetime import datetime\ndt = datetime.now()\nprint(dt.year > 2000)",
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "True");
+    }
+
+    #[tokio::test]
+    async fn test_datetime_now_utc() {
+        let r = run(
+            &[
+                "-c",
+                "from datetime import datetime, timezone\ndt = datetime.now(timezone.utc)\nprint(dt.year > 2000)",
+            ],
+            None,
+        )
+        .await;
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "True");
     }
 }

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -1623,6 +1623,14 @@ DoS protections are silently removed. Fix: store original config and reapply.
 on nested Python dicts/lists with no depth counter. Deeply nested structures cause stack overflow.
 Fix: add depth counter, fail beyond 64 levels.
 
+| TM-PY-029 | Host clock information disclosure | `datetime.date.today()` / `datetime.datetime.now()` expose host system time and timezone | Intentional — required for correct datetime semantics | **ACCEPTED** |
+
+**TM-PY-029**: `crates/bashkit/src/builtins/python.rs` — `handle_date_today()` and
+`handle_datetime_now()` read the host system clock via `chrono::Local::now()` /
+`chrono::Utc::now()`. This exposes the host's current time and timezone offset to
+sandboxed Python code. Accepted as intentional: datetime operations require real time,
+and this information has low sensitivity. No filesystem or network access is granted.
+
 ### VFS Bridge Security Properties
 
 1. **No real filesystem access**: All Path operations go through BashKit's VFS.

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -112,7 +112,7 @@ Bashkit implements IEEE 1003.1-2024 Shell Command Language. See
 | Grep | 95 | Yes | 95 | 0 | -z, -r, -a, -b, -H, -h, -f, -P, --include, --exclude, binary detect, rg |
 | Sed | 78 | Yes | 78 | 0 | hold space, change, regex ranges, -E |
 | JQ | 121 | Yes | 120 | 1 | reduce, walk, regex funcs, --arg/--argjson, combined flags, input/inputs, env |
-| Python | 60 | Yes | 58 | 2 | embedded Python (Monty) |
+| Python | 60 | Yes | 58 | 2 | embedded Python (Monty 0.0.11); datetime, json, pathlib, os |
 | TypeScript | 44 | Yes | 42 | 2 | embedded TypeScript (ZapCode) |
 | **Total** | **2463** | **Yes** | **2435** | **28** | |
 

--- a/specs/011-python-builtin.md
+++ b/specs/011-python-builtin.md
@@ -122,7 +122,10 @@ Monty implements a subset of Python 3.12:
 - Exception handling: try/except/finally/raise
 - Property descriptors (`@property`) (since Monty 0.0.4)
 - Built-in functions: print, len, range, enumerate, zip, map, filter, sorted, reversed, sum, min, max, abs, round, int, float, str, bool, list, dict, tuple, set, type, isinstance, hasattr, getattr, id, repr, ord, chr, hex, oct, bin, all, any, input
-- Standard modules: sys, typing, math (~50 functions), re (regex), pathlib, os (getenv/environ)
+- Standard modules: sys, typing, math (~50 functions), re (regex), pathlib, os (getenv/environ), json, datetime
+- `datetime.date.today()`, `datetime.datetime.now()` with optional timezone (since Monty 0.0.11)
+- JSON: `json.dumps()`, `json.loads()` (since Monty 0.0.9)
+- Multi-module imports: `import a, b, c` (since Monty 0.0.10)
 - `TYPE_CHECKING` guard support (since Monty 0.0.4)
 
 **Not supported (Monty limitations):**
@@ -170,6 +173,8 @@ python3 -c "import os; print(os.getenv('HOME'))"
 - `Path.rename()` — move/rename
 - `Path.resolve()`, `Path.absolute()` — path resolution
 - `os.getenv()`, `os.environ` — environment variable access
+- `datetime.date.today()` — current date from host system
+- `datetime.datetime.now(tz=None)` — current datetime (naive or timezone-aware)
 
 **Architecture:**
 ```
@@ -179,6 +184,12 @@ Python code → Monty VM → OsCall(ReadText, path) → BashKit VFS → resume
 Monty pauses execution at filesystem operations, yields an `OsCall` event
 with the operation type and arguments, BashKit bridges it to the VFS, and
 resumes execution with the result (or a Python exception).
+
+> **Note:** Monty 0.0.10+ includes native filesystem mounting (`MountTable`,
+> `MountDir`, `MountMode`) that can handle file operations directly against
+> host directories. BashKit uses the OsCall bridge instead because our VFS is
+> in-memory and may not be backed by host directories. The native mount system
+> is suited for real-filesystem use cases where Monty is used standalone.
 
 ### Direct Integration
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -162,6 +162,10 @@ criteria = "safe-to-deploy"
 version = "2.11.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.bitvec]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.blake2]]
 version = "0.10.6"
 criteria = "safe-to-deploy"
@@ -200,6 +204,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bytemuck]]
 version = "1.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytemuck_derive]]
+version = "1.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.byteorder]]
@@ -626,6 +634,10 @@ criteria = "safe-to-deploy"
 version = "1.3.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.funty]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.futures]]
 version = "0.3.32"
 criteria = "safe-to-deploy"
@@ -942,6 +954,10 @@ criteria = "safe-to-deploy"
 version = "0.1.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.jiter]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.jni]]
 version = "0.21.1"
 criteria = "safe-to-deploy"
@@ -980,6 +996,18 @@ criteria = "safe-to-deploy"
 
 [[exemptions.leb128fmt]]
 version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-parse-float]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-parse-integer]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.lexical-util]]
+version = "1.0.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
@@ -1514,6 +1542,10 @@ criteria = "safe-to-deploy"
 version = "6.0.0"
 criteria = "safe-to-run"
 
+[[exemptions.radium]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.radix_trie]]
 version = "0.3.0"
 criteria = "safe-to-deploy"
@@ -1898,6 +1930,10 @@ criteria = "safe-to-deploy"
 version = "0.6.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.speedate]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.spin]]
 version = "0.9.8"
 criteria = "safe-to-deploy"
@@ -1968,6 +2004,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tabled_derive]]
 version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tap]]
+version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.target-lexicon]]
@@ -2472,6 +2512,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.writeable]]
 version = "0.6.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.wyz]]
+version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.yansi]]


### PR DESCRIPTION
## Summary

- Bump embedded Monty interpreter from 0.0.8 to 0.0.11
- Handle new `OsFunction::DateToday` and `OsFunction::DateTimeNow` variants, bridging `datetime.date.today()` and `datetime.datetime.now(tz)` to the host system clock via chrono
- Document Monty's new native filesystem mounting (`MountTable`, `MountDir`, `MountMode`) — BashKit continues using the OsCall bridge since our VFS is in-memory

## What changed

**Monty 0.0.9-0.0.11 brings:**
- `json` module (`json.dumps`, `json.loads`)
- `datetime` module (`date.today()`, `datetime.now()`)
- Multi-module imports (`import a, b, c`)
- Native filesystem mounting (not used by BashKit — see spec note)
- Various stdlib and performance improvements

**BashKit integration:**
- `handle_date_today()` — returns `MontyDate` from `chrono::Local::now()`
- `handle_datetime_now(args)` — returns naive `MontyDateTime` (local) or timezone-aware (at requested offset)
- Added TM-PY-029 to threat model for host clock disclosure (ACCEPTED — intentional for correct datetime semantics)
- Updated module lists in spec, docs, and implementation status

## Test plan

- [x] 58 unit tests pass (5 new: date_today, datetime_now_naive, datetime_now_utc, datetime_attributes, json_dumps_loads)
- [x] 129 integration tests pass
- [x] 113 security tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (no new warnings)
- [x] Rebased on latest main