### PR TITLE
feat(bench): add gbash and gbash-server benchmark runners

### DIFF
--- a/crates/bashkit-bench/README.md
+++ b/crates/bashkit-bench/README.md
@@ -11,6 +11,8 @@ Benchmark tool for comparing bashkit against bash and just-bash across multiple 
 | `bashkit-js` | persistent child | Node.js + @everruns/bashkit, warm interpreter |
 | `bashkit-py` | persistent child | Python + bashkit package, warm interpreter |
 | `bash` | subprocess | /bin/bash, new process per run |
+| `gbash` | subprocess | gbash binary (Go), new process per run |
+| `gbash-server` | persistent child | gbash JSON-RPC server, warm interpreter |
 | `just-bash` | subprocess | just-bash CLI, new process per run |
 | `just-bash-inproc` | persistent child | Node.js + just-bash library, warm interpreter |
 
@@ -117,6 +119,8 @@ cargo run -p bashkit-bench --release -- --list
 | `bashkit-js` | `cd crates/bashkit-js && npm install && npm run build` |
 | `bashkit-py` | `maturin build --release && pip install target/wheels/bashkit-*.whl` |
 | `bash` | Pre-installed on most systems |
+| `gbash` | `go install github.com/ewhauser/gbash/cmd/gbash@latest` |
+| `gbash-server` | Same as gbash (uses JSON-RPC server mode) |
 | `just-bash` | `npm install -g just-bash` |
 | `just-bash-inproc` | Same as just-bash (uses library API) |
 

--- a/crates/bashkit-bench/scripts/gbash-server-runner.py
+++ b/crates/bashkit-bench/scripts/gbash-server-runner.py
@@ -1,0 +1,130 @@
+# Persistent gbash server benchmark runner
+# Starts gbash --server on a Unix socket, bridges JSON-RPC to the
+# stdin/stdout JSON lines protocol used by PersistentChild.
+#
+# Each benchmark creates a fresh session for isolation.
+#
+# Protocol: read JSON lines from stdin, write JSON lines to stdout
+# Each request: {"script": "..."}
+# Each response: {"stdout": "...", "stderr": "...", "exitCode": 0}
+# Sends {"ready": true} on startup
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def find_gbash():
+    home = os.environ.get("HOME", "")
+    candidates = [
+        os.path.join(home, "go/bin/gbash"),
+        os.path.join(os.environ.get("GOPATH", ""), "bin/gbash"),
+        "/usr/local/bin/gbash",
+        "/usr/bin/gbash",
+    ]
+    for path in candidates:
+        if path and os.path.isfile(path):
+            return path
+    # Try PATH
+    import shutil
+
+    found = shutil.which("gbash")
+    if found:
+        return found
+    return None
+
+
+def rpc_call(sock, method, params=None):
+    req = {"jsonrpc": "2.0", "method": method, "id": 1}
+    if params:
+        req["params"] = params
+    sock.sendall((json.dumps(req) + "\n").encode())
+    data = b""
+    while b"\n" not in data:
+        chunk = sock.recv(65536)
+        if not chunk:
+            raise ConnectionError("gbash server closed connection")
+        data += chunk
+    return json.loads(data.decode())
+
+
+def main():
+    gbash_path = find_gbash()
+    if not gbash_path:
+        sys.stderr.write("gbash not found\n")
+        sys.exit(1)
+
+    sock_path = os.path.join(tempfile.mkdtemp(), "gbash-bench.sock")
+
+    proc = subprocess.Popen(
+        [gbash_path, "--server", "--socket", sock_path, "--session-ttl", "10m"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    # Wait for socket to appear
+    for _ in range(50):
+        if os.path.exists(sock_path):
+            break
+        time.sleep(0.1)
+    else:
+        sys.stderr.write("gbash server did not start\n")
+        proc.kill()
+        sys.exit(1)
+
+    # Signal ready
+    sys.stdout.write(json.dumps({"ready": True}) + "\n")
+    sys.stdout.flush()
+
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                req = json.loads(line)
+                script = req["script"]
+
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(sock_path)
+
+                # Create session
+                create_resp = rpc_call(sock, "session.create")
+                session_id = create_resp["result"]["session"]["session_id"]
+
+                # Execute script
+                exec_resp = rpc_call(
+                    sock,
+                    "session.exec",
+                    {"session_id": session_id, "script": script},
+                )
+                result = exec_resp.get("result", {})
+
+                resp = {
+                    "stdout": result.get("stdout", ""),
+                    "stderr": result.get("stderr", ""),
+                    "exitCode": result.get("exit_code", -1),
+                }
+
+                sock.close()
+            except Exception as e:
+                resp = {"stdout": "", "stderr": str(e), "exitCode": 1}
+
+            sys.stdout.write(json.dumps(resp) + "\n")
+            sys.stdout.flush()
+    finally:
+        proc.terminate()
+        proc.wait()
+        try:
+            os.unlink(sock_path)
+            os.rmdir(os.path.dirname(sock_path))
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/bashkit-bench/src/main.rs
+++ b/crates/bashkit-bench/src/main.rs
@@ -26,8 +26,8 @@ mod runners;
 
 use cases::BenchCase;
 use runners::{
-    BashRunner, BashkitCliRunner, BashkitJsRunner, BashkitPyRunner, BashkitRunner,
-    JustBashInprocRunner, JustBashRunner, Runner,
+    BashRunner, BashkitCliRunner, BashkitJsRunner, BashkitPyRunner, BashkitRunner, GbashRunner,
+    GbashServerRunner, JustBashInprocRunner, JustBashRunner, Runner,
 };
 
 /// Number of prewarm cases to run before actual benchmarks
@@ -45,7 +45,7 @@ struct Args {
     #[arg(long)]
     moniker: Option<String>,
 
-    /// Runners to use (comma-separated: bashkit,bashkit-cli,bashkit-js,bashkit-py,bash,just-bash,just-bash-inproc)
+    /// Runners to use (comma-separated: bashkit,bashkit-cli,bashkit-js,bashkit-py,bash,gbash,gbash-server,just-bash,just-bash-inproc)
     #[arg(long, default_value = "bashkit,bash")]
     runners: String,
 
@@ -260,6 +260,8 @@ async fn main() -> Result<()> {
             "bashkit-js" => BashkitJsRunner::create().await,
             "bashkit-py" => BashkitPyRunner::create().await,
             "bash" => BashRunner::create().await,
+            "gbash" => GbashRunner::create().await,
+            "gbash-server" => GbashServerRunner::create().await,
             "just-bash" => JustBashRunner::create().await,
             "just-bash-inproc" => JustBashInprocRunner::create().await,
             _ => {
@@ -695,6 +697,8 @@ fn generate_markdown_report(report: &BenchReport) -> String {
     );
     md.push_str("| bashkit-py | persistent child | Python + bashkit package, warm interpreter |\n");
     md.push_str("| bash | subprocess | /bin/bash, new process per run |\n");
+    md.push_str("| gbash | subprocess | gbash binary (Go), new process per run |\n");
+    md.push_str("| gbash-server | persistent child | gbash JSON-RPC server, warm interpreter |\n");
     md.push_str("| just-bash | subprocess | just-bash CLI, new process per run |\n");
     md.push_str(
         "| just-bash-inproc | persistent child | Node.js + just-bash library, warm interpreter |\n",

--- a/crates/bashkit-bench/src/runners.rs
+++ b/crates/bashkit-bench/src/runners.rs
@@ -8,6 +8,7 @@
 // - bashkit-js: in-process via Node.js + @everruns/bashkit (persistent child)
 // - bashkit-py: in-process via Python + bashkit package (persistent child)
 // - bash: out-of-process via /bin/bash (subprocess per run)
+// - gbash: out-of-process via gbash binary (subprocess per run)
 // - just-bash: out-of-process via just-bash CLI (subprocess per run)
 // - just-bash-inproc: in-process via Node.js + just-bash library (persistent child)
 
@@ -25,6 +26,8 @@ pub enum Runner {
     BashkitJs(PersistentChild),
     BashkitPy(PersistentChild),
     NativeBash(String),
+    Gbash(String),
+    GbashServer(PersistentChild),
     JustBash(String),
     JustBashInproc(PersistentChild),
 }
@@ -37,6 +40,8 @@ impl Runner {
             Runner::BashkitJs(_) => "bashkit-js",
             Runner::BashkitPy(_) => "bashkit-py",
             Runner::NativeBash(_) => "bash",
+            Runner::Gbash(_) => "gbash",
+            Runner::GbashServer(_) => "gbash-server",
             Runner::JustBash(_) => "just-bash",
             Runner::JustBashInproc(_) => "just-bash-inproc",
         }
@@ -49,6 +54,8 @@ impl Runner {
             Runner::BashkitJs(child) => child.run(script).await,
             Runner::BashkitPy(child) => child.run(script).await,
             Runner::NativeBash(path) => run_subprocess(path, &["-c"], script).await,
+            Runner::Gbash(path) => run_subprocess(path, &["-c"], script).await,
+            Runner::GbashServer(child) => child.run(script).await,
             Runner::JustBash(path) => run_just_bash_subprocess(path, script).await,
             Runner::JustBashInproc(child) => child.run(script).await,
         }
@@ -174,6 +181,70 @@ async fn which_bash() -> Result<String> {
     }
 
     anyhow::bail!("bash not found")
+}
+
+// === Gbash (out-of-process) ===
+
+pub struct GbashRunner;
+
+impl GbashRunner {
+    pub async fn create() -> Result<Runner> {
+        let path = which_gbash().await?;
+        Ok(Runner::Gbash(path))
+    }
+}
+
+async fn which_gbash() -> Result<String> {
+    // Try common Go binary locations
+    if let Ok(home) = std::env::var("HOME") {
+        let gobin = format!("{}/go/bin/gbash", home);
+        if Path::new(&gobin).exists() {
+            return Ok(gobin);
+        }
+    }
+
+    if let Ok(gopath) = std::env::var("GOPATH") {
+        let gobin = format!("{}/bin/gbash", gopath);
+        if Path::new(&gobin).exists() {
+            return Ok(gobin);
+        }
+    }
+
+    for path in &["/usr/local/bin/gbash", "/usr/bin/gbash"] {
+        if Path::new(path).exists() {
+            return Ok(path.to_string());
+        }
+    }
+
+    let output = Command::new("which").arg("gbash").output().await?;
+    if output.status.success() {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Ok(path);
+        }
+    }
+
+    anyhow::bail!(
+        "gbash not found (install via: go install github.com/ewhauser/gbash/cmd/gbash@latest)"
+    )
+}
+
+// === Gbash server (persistent child via JSON-RPC) ===
+
+pub struct GbashServerRunner;
+
+impl GbashServerRunner {
+    pub async fn create() -> Result<Runner> {
+        let script_path = scripts_dir().join("gbash-server-runner.py");
+        if !script_path.exists() {
+            anyhow::bail!(
+                "gbash-server runner script not found at {}",
+                script_path.display()
+            );
+        }
+        let child = PersistentChild::spawn("python3", &[script_path.to_str().unwrap()]).await?;
+        Ok(Runner::GbashServer(child))
+    }
 }
 
 // === Just-bash (out-of-process) ===


### PR DESCRIPTION
## Summary

- Add `gbash` subprocess runner (cold start, new Go process per run)
- Add `gbash-server` persistent child runner (JSON-RPC server on Unix socket, warm interpreter)
- Python wrapper script bridges gbash's JSON-RPC protocol to the PersistentChild stdin/stdout JSON lines protocol

## Why

gbash is a Go-based sandboxed bash runtime for AI agents. Adding it to the benchmark suite enables direct performance comparison across all three runtimes (bashkit/Rust, gbash/Go, just-bash/TypeScript) in both subprocess and persistent execution models.

## Smoke test results

| Runner | startup_echo (ms) | Execution model |
|--------|-------------------|-----------------|
| bashkit | 0.086 | in-process |
| gbash-server | 1.86 | persistent child |
| bash | 9.14 | subprocess |
| gbash | 17.58 | subprocess |

- 96 benchmarks tested across all categories
- 100% output match on all supported commands
- Expected errors on `awk` (6) and `jq` (5) cases — gbash sandboxes unknown commands (exit 127)

## Test plan

- [x] `cargo test --all-features` — all 2564+ tests pass (pre-existing ssh_supabase failure unrelated)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p bashkit-bench` clean (pre-existing warnings in bashkit lib only)
- [x] `ruff check` and `ruff format --check` on Python wrapper
- [x] Smoke tested both runners across startup, variables, arithmetic, control, strings, arrays, pipes, tools, complex, large categories