### PR TITLE
fix(bench): enable jq feature and fix expected outputs for jq bench cases

### DIFF
--- a/crates/bashkit-bench/Cargo.toml
+++ b/crates/bashkit-bench/Cargo.toml
@@ -15,7 +15,7 @@ name = "bashkit-bench"
 path = "src/main.rs"
 
 [dependencies]
-bashkit = { path = "../bashkit" }
+bashkit = { path = "../bashkit", features = ["jq"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "process"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/bashkit-bench/src/cases.rs
+++ b/crates/bashkit-bench/src/cases.rs
@@ -677,14 +677,14 @@ fn tool_cases() -> Vec<BenchCase> {
             "Jq filter array",
             r#"echo '[1,2,3,4,5]' | jq '[.[] | select(. > 2)]'"#,
         )
-        .with_expected("[3, 4, 5]\n"),
+        .with_expected("[\n  3,\n  4,\n  5\n]\n"),
         BenchCase::new(
             "tool_jq_map",
             Category::Tools,
             "Jq map",
             r#"echo '[1,2,3]' | jq '[.[] * 2]'"#,
         )
-        .with_expected("[2, 4, 6]\n"),
+        .with_expected("[\n  2,\n  4,\n  6\n]\n"),
     ]
 }
 


### PR DESCRIPTION
## Summary

- Enable `jq` feature flag on the `bashkit` dependency in `bashkit-bench`, so the in-process bashkit runner has the jq builtin available
- Fix expected outputs for `tool_jq_filter` and `tool_jq_map` to match jq's pretty-printed array format

## Why

All 5 jq benchmarks (plus `complex_json_transform`) were reporting `[10 errors]` on every run. The root cause was that `bashkit-bench/Cargo.toml` depended on `bashkit` without `features = ["jq"]`, so the jq builtin was simply absent from the in-process runner. Additionally, two expected output strings used compact array format (`[3, 4, 5]`) instead of jq's actual pretty-printed output.

## How

1. Added `features = ["jq"]` to the bashkit dependency in `crates/bashkit-bench/Cargo.toml`
2. Updated `tool_jq_filter` expected from `[3, 4, 5]\n` to pretty-printed format
3. Updated `tool_jq_map` expected from `[2, 4, 6]\n` to pretty-printed format

## Test plan

- [x] `just bench-category tools` — all 5 jq benchmarks pass with ✓, 0 errors
- [x] `just bench-category complex` — `complex_json_transform` passes with ✓
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — all tests pass (only pre-existing ssh_supabase env-dependent failure)