### PR TITLE
feat(scripted_tool): async Python callbacks + ContextVar propagation

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install wheel and test dependencies
         run: |
           pip install bashkit --no-index --find-links crates/bashkit-python/dist --force-reinstall
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio langchain-core fastapi httpx
 
       - name: Run tests
         working-directory: crates/bashkit-python
@@ -118,12 +118,16 @@ jobs:
           working-directory: crates/bashkit-python
 
       - name: Install local wheel
-        run: pip install bashkit --no-index --find-links crates/bashkit-python/dist --force-reinstall
+        run: |
+          pip install bashkit --no-index --find-links crates/bashkit-python/dist --force-reinstall
+          pip install langchain-core fastapi httpx
 
       - name: Run examples
         run: |
           python crates/bashkit-python/examples/bash_basics.py
           python crates/bashkit-python/examples/k8s_orchestrator.py
+          python crates/bashkit-python/examples/langgraph_async_tool.py
+          python crates/bashkit-python/examples/fastapi_async_tool.py
 
   # Verify wheel builds and passes twine check
   build-wheel:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install wheel and test dependencies
         run: |
           pip install bashkit --no-index --find-links crates/bashkit-python/dist --force-reinstall
-          pip install pytest pytest-asyncio langchain-core fastapi httpx
+          pip install pytest pytest-asyncio langchain-core langgraph fastapi httpx
 
       - name: Run tests
         working-directory: crates/bashkit-python
@@ -120,7 +120,7 @@ jobs:
       - name: Install local wheel
         run: |
           pip install bashkit --no-index --find-links crates/bashkit-python/dist --force-reinstall
-          pip install langchain-core fastapi httpx
+          pip install langchain-core langgraph fastapi httpx uvicorn
 
       - name: Run examples
         run: |

--- a/crates/bashkit-python/examples/fastapi_async_tool.py
+++ b/crates/bashkit-python/examples/fastapi_async_tool.py
@@ -1,51 +1,71 @@
-#!/usr/bin/env python3
-"""FastAPI integration with async ScriptedTool callbacks.
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "bashkit",
+#     "fastapi>=0.110",
+#     "httpx>=0.27",
+#     "uvicorn>=0.29",
+# ]
+# ///
+"""FastAPI app exposing ScriptedTool endpoints with async callbacks.
 
+Starts a real FastAPI server, exercises it via ``httpx``, then shuts down.
 Demonstrates:
-- Async ``def`` callbacks in a FastAPI application
-- Request-scoped ``ContextVar`` propagation into tool callbacks
-- Sync endpoints with ``execute_sync()``
-- Async endpoints with ``await execute()``
 
-Usage:
-    python examples/fastapi_async_tool.py
+- Async ``def`` tool callbacks in FastAPI endpoint handlers
+- Request-scoped ``contextvars.ContextVar`` propagation into callbacks
+- Sync endpoints using ``execute_sync()``
+- Async endpoints using ``await execute()``
+- Multi-tool bash pipelines from HTTP requests
+
+Run:
+    uv run crates/bashkit-python/examples/fastapi_async_tool.py
 """
+
+from __future__ import annotations
 
 import asyncio
 import contextvars
+import json
+import threading
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
 
 from bashkit import ScriptedTool
 
 # ---------------------------------------------------------------------------
-# ContextVar for request-scoped state
+# Request-scoped ContextVar (like Flask's g or Starlette's request state)
 # ---------------------------------------------------------------------------
 
-request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="none")
-
+current_request_id: contextvars.ContextVar[str] = contextvars.ContextVar("current_request_id", default="none")
 
 # ---------------------------------------------------------------------------
-# Tool callbacks
+# Async tool callbacks
 # ---------------------------------------------------------------------------
 
 
-async def get_user(params, stdin=None):
-    """Fetch a user by ID (simulated async I/O)."""
+async def get_user(params: dict, stdin: str | None = None) -> str:
+    """Fetch user by ID — reads the request-scoped ContextVar."""
     uid = params.get("id", 0)
-    rid = request_id.get()
-    await asyncio.sleep(0)  # Simulate DB query
-    return f'{{"id": {uid}, "name": "Alice", "request_id": "{rid}"}}\n'
+    rid = current_request_id.get()
+    await asyncio.sleep(0)  # simulate DB query
+    return json.dumps({"id": uid, "name": "Alice", "request_id": rid}) + "\n"
 
 
-async def get_orders(params, stdin=None):
-    """Fetch orders for a user (simulated async I/O)."""
+async def get_orders(params: dict, stdin: str | None = None) -> str:
+    """Fetch orders for a user."""
     user_id = params.get("user_id", 0)
-    rid = request_id.get()
+    rid = current_request_id.get()
     await asyncio.sleep(0)
-    return f'[{{"order_id": 1, "user_id": {user_id}, "total": 99.99, "request_id": "{rid}"}}]\n'
+    orders = [{"order_id": 1, "user_id": user_id, "total": 99.99, "request_id": rid}]
+    return json.dumps(orders) + "\n"
 
 
 def build_tool() -> ScriptedTool:
-    tool = ScriptedTool("user_api", short_description="User API with async callbacks")
+    tool = ScriptedTool("user_api", short_description="User API")
     tool.add_tool(
         "get_user",
         "Fetch user by ID",
@@ -62,15 +82,35 @@ def build_tool() -> ScriptedTool:
 
 
 # ---------------------------------------------------------------------------
-# Simulate FastAPI-like request handling (no server needed for this example)
+# FastAPI app
 # ---------------------------------------------------------------------------
 
+app = FastAPI(title="Bashkit ScriptedTool API")
 
-def simulate_sync_endpoint(uid: int, rid: str):
-    """Simulate a sync FastAPI endpoint using execute_sync()."""
-    request_id.set(rid)
+
+@app.get("/user/{uid}")
+def get_user_endpoint(uid: int, request: Request):
+    """Sync endpoint — uses execute_sync(). ContextVar propagates into callback."""
+    current_request_id.set(request.headers.get("x-request-id", "unknown"))
     tool = build_tool()
+    r = tool.execute_sync(f"get_user --id {uid}")
+    return {"stdout": r.stdout.strip(), "exit_code": r.exit_code}
 
+
+@app.get("/user/{uid}/orders")
+async def get_user_orders_endpoint(uid: int, request: Request):
+    """Async endpoint — uses await execute(). Must not call execute_sync()."""
+    current_request_id.set(request.headers.get("x-request-id", "unknown"))
+    tool = build_tool()
+    r = await tool.execute(f"get_orders --user_id {uid}")
+    return {"stdout": r.stdout.strip(), "exit_code": r.exit_code}
+
+
+@app.get("/user/{uid}/summary")
+def get_user_summary_endpoint(uid: int, request: Request):
+    """Sync endpoint with a multi-tool bash pipeline."""
+    current_request_id.set(request.headers.get("x-request-id", "unknown"))
+    tool = build_tool()
     script = f"""
         user=$(get_user --id {uid})
         orders=$(get_orders --user_id {uid})
@@ -78,43 +118,78 @@ def simulate_sync_endpoint(uid: int, rid: str):
         echo "$orders" | jq -r '.[0].total'
         echo "$user" | jq -r '.request_id'
     """
-    return tool.execute_sync(script)
-
-
-async def simulate_async_endpoint(uid: int, rid: str):
-    """Simulate an async FastAPI endpoint using await execute()."""
-    request_id.set(rid)
-    tool = build_tool()
-    return await tool.execute(f"get_user --id {uid}")
-
-
-# ---------------------------------------------------------------------------
-# Run
-# ---------------------------------------------------------------------------
-
-
-def main():
-    print("=== Sync endpoint simulation ===")
-    r = simulate_sync_endpoint(42, "req-abc-123")
-    print(f"exit_code: {r.exit_code}")
+    r = tool.execute_sync(script)
     lines = r.stdout.strip().split("\n")
-    print(f"user name: {lines[0]}")
-    print(f"order total: {lines[1]}")
-    print(f"request_id: {lines[2]}")
-    assert lines[0] == "Alice"
-    assert lines[1] == "99.99"
-    assert lines[2] == "req-abc-123", f"Expected req-abc-123, got {lines[2]}"
-    print()
+    return {
+        "name": lines[0] if len(lines) > 0 else "",
+        "total": lines[1] if len(lines) > 1 else "",
+        "request_id": lines[2] if len(lines) > 2 else "",
+    }
 
-    print("=== Async endpoint simulation ===")
-    r = asyncio.run(simulate_async_endpoint(42, "req-def-456"))
-    print(f"exit_code: {r.exit_code}")
-    print(f"stdout: {r.stdout.strip()}")
-    assert r.exit_code == 0
-    assert "req-def-456" in r.stdout
-    print()
 
-    print("All assertions passed!")
+# ---------------------------------------------------------------------------
+# Self-test: start the server, hit endpoints, verify, shut down
+# ---------------------------------------------------------------------------
+
+
+def run_server(ready: threading.Event) -> None:
+    config = uvicorn.Config(app, host="127.0.0.1", port=9876, log_level="warning")
+    server = uvicorn.Server(config)
+
+    # Signal the main thread once the server is accepting connections
+    original_startup = server.startup
+
+    async def startup_with_signal(*a, **kw):
+        await original_startup(*a, **kw)
+        ready.set()
+
+    server.startup = startup_with_signal  # type: ignore[assignment]
+    server.run()
+
+
+def main() -> None:
+    ready = threading.Event()
+    t = threading.Thread(target=run_server, args=(ready,), daemon=True)
+    t.start()
+    ready.wait(timeout=10)
+
+    base = "http://127.0.0.1:9876"
+    headers = {"x-request-id": "req-example-42"}
+
+    with httpx.Client(base_url=base, headers=headers) as client:
+        # 1. Sync endpoint: single tool call
+        print("=== GET /user/1 (sync endpoint, async callback) ===")
+        r = client.get("/user/1")
+        assert r.status_code == 200
+        data = r.json()
+        print(f"  {data}")
+        assert data["exit_code"] == 0
+        body = json.loads(data["stdout"])
+        assert body["name"] == "Alice"
+        assert body["request_id"] == "req-example-42"
+
+        # 2. Async endpoint: single tool call
+        print("=== GET /user/1/orders (async endpoint, async callback) ===")
+        r = client.get("/user/1/orders")
+        assert r.status_code == 200
+        data = r.json()
+        print(f"  {data}")
+        assert data["exit_code"] == 0
+        body = json.loads(data["stdout"])
+        assert body[0]["user_id"] == 1
+        assert body[0]["request_id"] == "req-example-42"
+
+        # 3. Pipeline endpoint
+        print("=== GET /user/42/summary (pipeline, ContextVar) ===")
+        r = client.get("/user/42/summary")
+        assert r.status_code == 200
+        data = r.json()
+        print(f"  {data}")
+        assert data["name"] == "Alice"
+        assert data["total"] == "99.99"
+        assert data["request_id"] == "req-example-42"
+
+    print("\nAll assertions passed!")
 
 
 if __name__ == "__main__":

--- a/crates/bashkit-python/examples/fastapi_async_tool.py
+++ b/crates/bashkit-python/examples/fastapi_async_tool.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""FastAPI integration with async ScriptedTool callbacks.
+
+Demonstrates:
+- Async ``def`` callbacks in a FastAPI application
+- Request-scoped ``ContextVar`` propagation into tool callbacks
+- Sync endpoints with ``execute_sync()``
+- Async endpoints with ``await execute()``
+
+Usage:
+    python examples/fastapi_async_tool.py
+"""
+
+import asyncio
+import contextvars
+
+from bashkit import ScriptedTool
+
+# ---------------------------------------------------------------------------
+# ContextVar for request-scoped state
+# ---------------------------------------------------------------------------
+
+request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="none")
+
+
+# ---------------------------------------------------------------------------
+# Tool callbacks
+# ---------------------------------------------------------------------------
+
+
+async def get_user(params, stdin=None):
+    """Fetch a user by ID (simulated async I/O)."""
+    uid = params.get("id", 0)
+    rid = request_id.get()
+    await asyncio.sleep(0)  # Simulate DB query
+    return f'{{"id": {uid}, "name": "Alice", "request_id": "{rid}"}}\n'
+
+
+async def get_orders(params, stdin=None):
+    """Fetch orders for a user (simulated async I/O)."""
+    user_id = params.get("user_id", 0)
+    rid = request_id.get()
+    await asyncio.sleep(0)
+    return f'[{{"order_id": 1, "user_id": {user_id}, "total": 99.99, "request_id": "{rid}"}}]\n'
+
+
+def build_tool() -> ScriptedTool:
+    tool = ScriptedTool("user_api", short_description="User API with async callbacks")
+    tool.add_tool(
+        "get_user",
+        "Fetch user by ID",
+        callback=get_user,
+        schema={"type": "object", "properties": {"id": {"type": "integer"}}},
+    )
+    tool.add_tool(
+        "get_orders",
+        "Fetch orders for user",
+        callback=get_orders,
+        schema={"type": "object", "properties": {"user_id": {"type": "integer"}}},
+    )
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Simulate FastAPI-like request handling (no server needed for this example)
+# ---------------------------------------------------------------------------
+
+
+def simulate_sync_endpoint(uid: int, rid: str):
+    """Simulate a sync FastAPI endpoint using execute_sync()."""
+    request_id.set(rid)
+    tool = build_tool()
+
+    script = f"""
+        user=$(get_user --id {uid})
+        orders=$(get_orders --user_id {uid})
+        echo "$user" | jq -r '.name'
+        echo "$orders" | jq -r '.[0].total'
+        echo "$user" | jq -r '.request_id'
+    """
+    return tool.execute_sync(script)
+
+
+async def simulate_async_endpoint(uid: int, rid: str):
+    """Simulate an async FastAPI endpoint using await execute()."""
+    request_id.set(rid)
+    tool = build_tool()
+    return await tool.execute(f"get_user --id {uid}")
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+
+def main():
+    print("=== Sync endpoint simulation ===")
+    r = simulate_sync_endpoint(42, "req-abc-123")
+    print(f"exit_code: {r.exit_code}")
+    lines = r.stdout.strip().split("\n")
+    print(f"user name: {lines[0]}")
+    print(f"order total: {lines[1]}")
+    print(f"request_id: {lines[2]}")
+    assert lines[0] == "Alice"
+    assert lines[1] == "99.99"
+    assert lines[2] == "req-abc-123", f"Expected req-abc-123, got {lines[2]}"
+    print()
+
+    print("=== Async endpoint simulation ===")
+    r = asyncio.run(simulate_async_endpoint(42, "req-def-456"))
+    print(f"exit_code: {r.exit_code}")
+    print(f"stdout: {r.stdout.strip()}")
+    assert r.exit_code == 0
+    assert "req-def-456" in r.stdout
+    print()
+
+    print("All assertions passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/bashkit-python/examples/langgraph_async_tool.py
+++ b/crates/bashkit-python/examples/langgraph_async_tool.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""LangGraph-style async tool with ContextVar propagation.
+
+Demonstrates:
+- Async ``def`` callbacks registered with ``ScriptedTool.add_tool()``
+- ``contextvars.ContextVar`` state propagating from caller into callbacks
+- Multi-tool bash pipelines with async I/O
+- The "stream writer" pattern used by LangGraph's ``get_stream_writer()``
+
+Usage:
+    python examples/langgraph_async_tool.py
+"""
+
+import asyncio
+import contextvars
+
+from bashkit import ScriptedTool
+
+# ---------------------------------------------------------------------------
+# Simulate LangGraph's stream-writer pattern: a ContextVar that carries a
+# callback for streaming intermediate results back to the caller.
+# ---------------------------------------------------------------------------
+
+stream_writer: contextvars.ContextVar[list] = contextvars.ContextVar("stream_writer")
+
+
+# ---------------------------------------------------------------------------
+# Async tool callbacks — these would typically call external APIs
+# ---------------------------------------------------------------------------
+
+
+async def search_web(params, stdin=None):
+    """Simulate an async web search."""
+    query = params.get("query", "")
+    # Write intermediate progress via the stream writer
+    writer = stream_writer.get()
+    writer.append({"step": "search", "query": query, "status": "started"})
+    # Simulate async I/O (network call, database query, etc.)
+    await asyncio.sleep(0)
+    results = [
+        {"title": f"Result 1 for: {query}", "url": "https://example.com/1"},
+        {"title": f"Result 2 for: {query}", "url": "https://example.com/2"},
+    ]
+    writer.append({"step": "search", "query": query, "status": "done", "count": len(results)})
+    import json
+
+    return json.dumps(results) + "\n"
+
+
+async def summarize(params, stdin=None):
+    """Summarize text from stdin."""
+    writer = stream_writer.get()
+    writer.append({"step": "summarize", "input_length": len(stdin or "")})
+    await asyncio.sleep(0)
+    # In reality, this would call an LLM API
+    return f"Summary: processed {len(stdin or '')} chars of input\n"
+
+
+def format_output(params, stdin=None):
+    """Sync callback — formatting doesn't need async."""
+    fmt = params.get("format", "text")
+    if fmt == "json":
+        import json
+
+        return json.dumps({"formatted": (stdin or "").strip()}) + "\n"
+    return f"[formatted] {(stdin or '').strip()}\n"
+
+
+# ---------------------------------------------------------------------------
+# Build the tool
+# ---------------------------------------------------------------------------
+
+
+def build_tool() -> ScriptedTool:
+    tool = ScriptedTool("research_agent", short_description="Research assistant with async tools")
+    tool.add_tool(
+        "search",
+        "Search the web for a query",
+        callback=search_web,
+        schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    tool.add_tool(
+        "summarize",
+        "Summarize text from stdin",
+        callback=summarize,
+    )
+    tool.add_tool(
+        "format",
+        "Format output",
+        callback=format_output,
+        schema={"type": "object", "properties": {"format": {"type": "string"}}},
+    )
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+
+def main():
+    # Set up the stream writer (simulating LangGraph's get_stream_writer())
+    events: list = []
+    stream_writer.set(events)
+
+    tool = build_tool()
+
+    # Single async tool call
+    print("=== Single async tool call ===")
+    r = tool.execute_sync('search --query "Python async patterns"')
+    print(f"exit_code: {r.exit_code}")
+    print(f"stdout: {r.stdout.strip()}")
+    print(f"stream events: {len(events)}")
+    print()
+
+    # Reset events for next demo
+    events.clear()
+
+    # Multi-tool pipeline: search → summarize → format
+    print("=== Multi-tool pipeline (async + sync) ===")
+    script = """
+        search --query "ContextVar propagation" | summarize | format --format json
+    """
+    r = tool.execute_sync(script)
+    print(f"exit_code: {r.exit_code}")
+    print(f"stdout: {r.stdout.strip()}")
+    print(f"stream events: {events}")
+    print()
+
+    # Verify all stream events were captured
+    assert len(events) == 3, f"Expected 3 events, got {len(events)}: {events}"
+    assert events[0]["step"] == "search"
+    assert events[1]["step"] == "search"
+    assert events[2]["step"] == "summarize"
+    print("All assertions passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/bashkit-python/examples/langgraph_async_tool.py
+++ b/crates/bashkit-python/examples/langgraph_async_tool.py
@@ -1,138 +1,207 @@
-#!/usr/bin/env python3
-"""LangGraph-style async tool with ContextVar propagation.
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "bashkit",
+#     "langchain-core>=0.3",
+#     "langgraph>=0.2",
+# ]
+# ///
+"""LangGraph agent using ScriptedTool with async callbacks and ContextVar propagation.
 
-Demonstrates:
-- Async ``def`` callbacks registered with ``ScriptedTool.add_tool()``
-- ``contextvars.ContextVar`` state propagating from caller into callbacks
-- Multi-tool bash pipelines with async I/O
-- The "stream writer" pattern used by LangGraph's ``get_stream_writer()``
+Builds a real LangGraph ``StateGraph`` where the tool node invokes a
+``ScriptedTool`` with async Python callbacks.  The example demonstrates:
 
-Usage:
-    python examples/langgraph_async_tool.py
+- Registering ``async def`` callbacks with ``ScriptedTool.add_tool()``
+- ``contextvars.ContextVar`` propagating from the LangGraph task into callbacks
+- Multi-tool bash pipelines composed by LangGraph's tool-calling loop
+
+Run:
+    uv run crates/bashkit-python/examples/langgraph_async_tool.py
 """
+
+from __future__ import annotations
 
 import asyncio
 import contextvars
+import json
+import operator
+from typing import Annotated, Any, TypedDict
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.graph import END, StateGraph
 
 from bashkit import ScriptedTool
 
 # ---------------------------------------------------------------------------
-# Simulate LangGraph's stream-writer pattern: a ContextVar that carries a
-# callback for streaming intermediate results back to the caller.
+# ContextVar — simulates LangGraph's get_stream_writer() pattern.
+# In a real LangGraph app this would be provided by the framework; here we
+# set it manually to prove propagation works end-to-end.
 # ---------------------------------------------------------------------------
 
-stream_writer: contextvars.ContextVar[list] = contextvars.ContextVar("stream_writer")
-
+stream_events: contextvars.ContextVar[list[dict]] = contextvars.ContextVar("stream_events")
 
 # ---------------------------------------------------------------------------
-# Async tool callbacks — these would typically call external APIs
+# Async tool callbacks — each becomes a bash builtin inside ScriptedTool
 # ---------------------------------------------------------------------------
 
 
-async def search_web(params, stdin=None):
-    """Simulate an async web search."""
+async def search_web(params: dict, stdin: str | None = None) -> str:
+    """Search the web for a query (simulated async I/O)."""
     query = params.get("query", "")
-    # Write intermediate progress via the stream writer
-    writer = stream_writer.get()
-    writer.append({"step": "search", "query": query, "status": "started"})
-    # Simulate async I/O (network call, database query, etc.)
-    await asyncio.sleep(0)
+    # Prove ContextVar is accessible inside the callback
+    writer = stream_events.get()
+    writer.append({"tool": "search", "query": query})
+    await asyncio.sleep(0)  # simulate network
     results = [
-        {"title": f"Result 1 for: {query}", "url": "https://example.com/1"},
-        {"title": f"Result 2 for: {query}", "url": "https://example.com/2"},
+        {"title": "Async Python best practices", "url": "https://example.com/1"},
+        {"title": "ContextVar deep dive", "url": "https://example.com/2"},
     ]
-    writer.append({"step": "search", "query": query, "status": "done", "count": len(results)})
-    import json
-
     return json.dumps(results) + "\n"
 
 
-async def summarize(params, stdin=None):
-    """Summarize text from stdin."""
-    writer = stream_writer.get()
-    writer.append({"step": "summarize", "input_length": len(stdin or "")})
+async def fetch_page(params: dict, stdin: str | None = None) -> str:
+    """Fetch a URL and return its content (simulated)."""
+    url = params.get("url", "")
+    writer = stream_events.get()
+    writer.append({"tool": "fetch", "url": url})
     await asyncio.sleep(0)
-    # In reality, this would call an LLM API
-    return f"Summary: processed {len(stdin or '')} chars of input\n"
+    return json.dumps({"url": url, "body": f"Content of {url}", "length": 1234}) + "\n"
 
 
-def format_output(params, stdin=None):
-    """Sync callback — formatting doesn't need async."""
-    fmt = params.get("format", "text")
-    if fmt == "json":
-        import json
-
-        return json.dumps({"formatted": (stdin or "").strip()}) + "\n"
-    return f"[formatted] {(stdin or '').strip()}\n"
+def summarize(params: dict, stdin: str | None = None) -> str:
+    """Sync callback — summarise text from stdin."""
+    text = (stdin or "").strip()
+    writer = stream_events.get()
+    writer.append({"tool": "summarize", "chars": len(text)})
+    return f"Summary ({len(text)} chars): {text[:80]}...\n"
 
 
 # ---------------------------------------------------------------------------
-# Build the tool
+# Build the ScriptedTool
 # ---------------------------------------------------------------------------
 
 
-def build_tool() -> ScriptedTool:
-    tool = ScriptedTool("research_agent", short_description="Research assistant with async tools")
-    tool.add_tool(
+def build_scripted_tool() -> ScriptedTool:
+    st = ScriptedTool("research", short_description="Web research toolkit")
+    st.add_tool(
         "search",
-        "Search the web for a query",
+        "Search the web",
         callback=search_web,
         schema={"type": "object", "properties": {"query": {"type": "string"}}},
     )
-    tool.add_tool(
-        "summarize",
-        "Summarize text from stdin",
-        callback=summarize,
+    st.add_tool(
+        "fetch",
+        "Fetch a URL",
+        callback=fetch_page,
+        schema={"type": "object", "properties": {"url": {"type": "string"}}},
     )
-    tool.add_tool(
-        "format",
-        "Format output",
-        callback=format_output,
-        schema={"type": "object", "properties": {"format": {"type": "string"}}},
-    )
-    return tool
+    st.add_tool("summarize", "Summarize stdin text", callback=summarize)
+    return st
 
 
 # ---------------------------------------------------------------------------
-# Run
+# LangGraph state + nodes
 # ---------------------------------------------------------------------------
 
 
-def main():
-    # Set up the stream writer (simulating LangGraph's get_stream_writer())
-    events: list = []
-    stream_writer.set(events)
+class AgentState(TypedDict):
+    messages: Annotated[list[BaseMessage], operator.add]
 
-    tool = build_tool()
 
-    # Single async tool call
-    print("=== Single async tool call ===")
-    r = tool.execute_sync('search --query "Python async patterns"')
-    print(f"exit_code: {r.exit_code}")
-    print(f"stdout: {r.stdout.strip()}")
-    print(f"stream events: {len(events)}")
-    print()
+# Wrap ScriptedTool as a LangChain tool so LangGraph can call it
+scripted = build_scripted_tool()
 
-    # Reset events for next demo
-    events.clear()
 
-    # Multi-tool pipeline: search → summarize → format
-    print("=== Multi-tool pipeline (async + sync) ===")
-    script = """
-        search --query "ContextVar propagation" | summarize | format --format json
-    """
-    r = tool.execute_sync(script)
-    print(f"exit_code: {r.exit_code}")
-    print(f"stdout: {r.stdout.strip()}")
-    print(f"stream events: {events}")
-    print()
+@tool
+def research_tool(commands: str) -> str:
+    """Run a bash script that orchestrates search, fetch, and summarize tools."""
+    r = scripted.execute_sync(commands)
+    if r.exit_code != 0:
+        return f"Error (exit {r.exit_code}): {r.stderr}"
+    return r.stdout
 
-    # Verify all stream events were captured
-    assert len(events) == 3, f"Expected 3 events, got {len(events)}: {events}"
-    assert events[0]["step"] == "search"
-    assert events[1]["step"] == "search"
-    assert events[2]["step"] == "summarize"
-    print("All assertions passed!")
+
+def tool_node(state: AgentState) -> dict[str, Any]:
+    """Execute tool calls from the last AI message."""
+    last = state["messages"][-1]
+    results = []
+    for tc in last.tool_calls:
+        output = research_tool.invoke(tc["args"])
+        results.append(ToolMessage(content=str(output), tool_call_id=tc["id"]))
+    return {"messages": results}
+
+
+def fake_llm_node(state: AgentState) -> dict[str, Any]:
+    """Simulated LLM that emits a single tool call, then stops."""
+    if any(isinstance(m, ToolMessage) for m in state["messages"]):
+        return {"messages": [AIMessage(content="Done! See above results.")]}
+
+    # First turn: emit a tool call with a bash pipeline
+    return {
+        "messages": [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "name": "research_tool",
+                        "args": {"commands": 'search --query "async Python" | summarize'},
+                    }
+                ],
+            )
+        ]
+    }
+
+
+def should_continue(state: AgentState) -> str:
+    last = state["messages"][-1]
+    if hasattr(last, "tool_calls") and last.tool_calls:
+        return "tools"
+    return END
+
+
+# ---------------------------------------------------------------------------
+# Build and run the graph
+# ---------------------------------------------------------------------------
+
+
+def build_graph() -> StateGraph:
+    g = StateGraph(AgentState)
+    g.add_node("llm", fake_llm_node)
+    g.add_node("tools", tool_node)
+    g.set_entry_point("llm")
+    g.add_conditional_edges("llm", should_continue, {"tools": "tools", END: END})
+    g.add_edge("tools", "llm")
+    return g.compile()
+
+
+def main() -> None:
+    events: list[dict] = []
+    stream_events.set(events)
+
+    graph = build_graph()
+    result = graph.invoke(
+        {"messages": [HumanMessage(content="Research async Python patterns")]},
+    )
+
+    print("=== Final messages ===")
+    for msg in result["messages"]:
+        role = msg.__class__.__name__
+        text = msg.content[:120] if msg.content else "(tool call)"
+        print(f"  {role}: {text}")
+
+    print("\n=== Stream events (from ContextVar) ===")
+    for ev in events:
+        print(f"  {ev}")
+
+    # Assertions
+    assert len(events) >= 2, f"Expected >=2 stream events, got {len(events)}"
+    assert events[0]["tool"] == "search"
+    assert events[-1]["tool"] == "summarize"
+    assert any(isinstance(m, ToolMessage) for m in result["messages"])
+    print("\nAll assertions passed!")
 
 
 if __name__ == "__main__":

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1445,6 +1445,8 @@ struct PyToolEntry {
     description: String,
     schema: serde_json::Value,
     callback: Py<PyAny>,
+    /// True when callback is `async def` (coroutine function).
+    is_async: bool,
 }
 
 /// Compose Python callbacks as bash builtins for multi-tool orchestration.
@@ -1485,7 +1487,10 @@ pub struct ScriptedTool {
 
 impl ScriptedTool {
     /// Build a Rust ScriptedTool from stored Python config.
-    /// Each Python callback is wrapped via `Python::attach`.
+    ///
+    /// Called at execute() time so that `contextvars.copy_context()` captures the
+    /// caller's ContextVar state. Each Python callback is invoked via `ctx.run()`
+    /// to restore those vars.
     fn build_rust_tool(&self) -> RustScriptedTool {
         let mut builder = RustScriptedTool::builder(&self.name);
 
@@ -1493,28 +1498,103 @@ impl ScriptedTool {
             builder = builder.short_description(desc);
         }
 
+        // Snapshot the caller's contextvars at execute()-call time.
+        let py_ctx: Py<PyAny> = Python::attach(|py| {
+            let contextvars = py.import("contextvars").expect("contextvars stdlib");
+            contextvars
+                .call_method0("copy_context")
+                .expect("copy_context")
+                .unbind()
+        });
+
+        // Resources for async callbacks: a shared event loop and a helper
+        // function that drives coroutines inside the captured ContextVar
+        // snapshot. Created once per execute() call and shared across all
+        // async callback invocations to avoid FD exhaustion.
+        let has_async = self.tools.iter().any(|e| e.is_async);
+        let async_loop: Option<Py<PyAny>> = if has_async {
+            Some(Python::attach(|py| {
+                let asyncio = py.import("asyncio").expect("asyncio stdlib");
+                asyncio
+                    .call_method0("new_event_loop")
+                    .expect("new_event_loop")
+                    .unbind()
+            }))
+        } else {
+            None
+        };
+        // Helper: ctx.run(lambda: loop.run_until_complete(fn(p, s)))
+        // Wrapping run_until_complete inside ctx.run() ensures the Task
+        // created by run_until_complete inherits the captured context,
+        // making ContextVars visible throughout the coroutine body.
+        let async_runner: Option<Py<PyAny>> = if has_async {
+            Some(Python::attach(|py| {
+                pyo3::types::PyModule::from_code(
+                    py,
+                    c"def _run(ctx, loop, fn, params, stdin):\n    return ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))",
+                    c"<bashkit_async>",
+                    c"_bashkit_async",
+                )
+                .expect("async helper module")
+                .getattr("_run")
+                .expect("_run function")
+                .unbind()
+            }))
+        } else {
+            None
+        };
+
         for entry in &self.tools {
             let py_cb = Python::attach(|py| entry.callback.clone_ref(py));
             let tool_name = entry.name.clone();
+            let def =
+                ToolDef::new(&entry.name, &entry.description).with_schema(entry.schema.clone());
+            let ctx = Python::attach(|py| py_ctx.clone_ref(py));
 
-            let callback = move |args: &ToolArgs| -> Result<String, String> {
-                Python::attach(|py| {
-                    let params = json_to_py(py, &args.params).map_err(|e: PyErr| e.to_string())?;
-                    let stdin_arg = args.stdin.as_deref().map(|s| s.to_string());
-
-                    let result = py_cb
-                        .call1(py, (params, stdin_arg))
-                        .map_err(|e| format!("{}: {}", tool_name, e))?;
-                    result
-                        .extract::<String>(py)
-                        .map_err(|e| format!("{}: callback must return str, got {}", tool_name, e))
-                })
-            };
-
-            builder = builder.tool(
-                ToolDef::new(&entry.name, &entry.description).with_schema(entry.schema.clone()),
-                callback,
-            );
+            if entry.is_async {
+                // Async callback: the runner helper calls
+                //   ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))
+                // which ensures the Task inherits the captured ContextVars.
+                // The GIL serialises access so the shared loop is safe.
+                let ev_loop = async_loop
+                    .as_ref()
+                    .map(|l| Python::attach(|py| l.clone_ref(py)))
+                    .expect("async_loop must exist when is_async is true");
+                let runner = async_runner
+                    .as_ref()
+                    .map(|r| Python::attach(|py| r.clone_ref(py)))
+                    .expect("async_runner must exist when is_async is true");
+                let callback = move |args: &ToolArgs| -> Result<String, String> {
+                    Python::attach(|py| {
+                        let params =
+                            json_to_py(py, &args.params).map_err(|e: PyErr| e.to_string())?;
+                        let stdin_arg = args.stdin.as_deref().map(|s| s.to_string());
+                        let result = runner
+                            .call1(py, (&ctx, &ev_loop, &py_cb, params, stdin_arg))
+                            .map_err(|e| format!("{}: {}", tool_name, e))?;
+                        result.extract::<String>(py).map_err(|e| {
+                            format!("{}: callback must return str, got {}", tool_name, e)
+                        })
+                    })
+                };
+                builder = builder.tool(def, callback);
+            } else {
+                // Sync callback: ctx.run(fn, params, stdin) with ContextVars.
+                let callback = move |args: &ToolArgs| -> Result<String, String> {
+                    Python::attach(|py| {
+                        let params =
+                            json_to_py(py, &args.params).map_err(|e: PyErr| e.to_string())?;
+                        let stdin_arg = args.stdin.as_deref().map(|s| s.to_string());
+                        let result = ctx
+                            .call_method1(py, "run", (&py_cb, params, stdin_arg))
+                            .map_err(|e| format!("{}: {}", tool_name, e))?;
+                        result.extract::<String>(py).map_err(|e| {
+                            format!("{}: callback must return str, got {}", tool_name, e)
+                        })
+                    })
+                };
+                builder = builder.tool(def, callback);
+            }
         }
 
         for (k, v) in &self.env_vars {
@@ -1568,15 +1648,18 @@ impl ScriptedTool {
 
     /// Register a tool command.
     ///
-    /// The callback signature is: `callback(params: dict, stdin: str | None) -> str`
+    /// The callback can be synchronous or ``async def``:
     ///
-    /// `params` contains `--key value` flags parsed from the bash command line,
-    /// with types coerced per the schema (integers, booleans, etc.).
+    /// - sync:  ``callback(params: dict, stdin: str | None) -> str``
+    /// - async: ``async def callback(params: dict, stdin: str | None) -> str``
+    ///
+    /// ``contextvars.ContextVar`` values active at ``execute()`` / ``execute_sync()``
+    /// call time are automatically propagated into callbacks.
     ///
     /// Args:
     ///     name: Command name (becomes a bash builtin)
     ///     description: Human-readable description
-    ///     callback: Python callable `(params, stdin) -> str`
+    ///     callback: Python callable ``(params, stdin) -> str``
     ///     schema: Optional JSON Schema dict for input parameters
     #[pyo3(signature = (name, description, callback, schema=None))]
     fn add_tool(
@@ -1591,11 +1674,23 @@ impl ScriptedTool {
             Some(ref s) => py_to_json(py, s)?,
             None => serde_json::Value::Object(Default::default()),
         };
+        // Detect async callbacks using the same pattern as external_handler
+        let inspect = py.import("inspect")?;
+        let is_coro_fn = inspect.getattr("iscoroutinefunction")?;
+        let bound = callback.bind(py);
+        let is_async = is_coro_fn.call1((bound,))?.extract::<bool>()?
+            || bound
+                .getattr("__call__")
+                .ok()
+                .and_then(|c| is_coro_fn.call1((c,)).ok())
+                .and_then(|r| r.extract::<bool>().ok())
+                .unwrap_or(false);
         self.tools.push(PyToolEntry {
             name,
             description,
             schema: schema_val,
             callback,
+            is_async,
         });
         Ok(())
     }

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -1,0 +1,293 @@
+"""Tests for async callback support and ContextVar propagation in ScriptedTool.
+
+Covers:
+- Async def callbacks registered via add_tool()
+- ContextVar propagation into sync callbacks
+- ContextVar propagation into async callbacks
+- Mixed sync/async callbacks in a single ScriptedTool
+- Concurrent async executions with isolated contexts
+"""
+
+import asyncio
+import contextvars
+
+import pytest
+
+from bashkit import ScriptedTool
+
+# ---------------------------------------------------------------------------
+# ContextVar used across tests
+# ---------------------------------------------------------------------------
+
+request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id")
+trace_writer: contextvars.ContextVar[list] = contextvars.ContextVar("trace_writer")
+
+
+# ===========================================================================
+# Async callback basics
+# ===========================================================================
+
+
+def test_async_callback_sync_execute():
+    """Async callback works via execute_sync()."""
+
+    async def greet(params, stdin=None):
+        name = params.get("name", "world")
+        return f"hello {name}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool(
+        "greet",
+        "Greet",
+        callback=greet,
+        schema={"type": "object", "properties": {"name": {"type": "string"}}},
+    )
+    r = tool.execute_sync("greet --name Async")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "hello Async"
+
+
+@pytest.mark.asyncio
+async def test_async_callback_async_execute():
+    """Async callback works via await execute()."""
+
+    async def greet(params, stdin=None):
+        name = params.get("name", "world")
+        return f"hello {name}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool(
+        "greet",
+        "Greet",
+        callback=greet,
+        schema={"type": "object", "properties": {"name": {"type": "string"}}},
+    )
+    r = await tool.execute("greet --name Awaited")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "hello Awaited"
+
+
+def test_async_callback_with_await():
+    """Async callback that internally awaits (simulated async I/O)."""
+
+    async def fetch_user(params, stdin=None):
+        # Simulate async I/O with asyncio.sleep
+        await asyncio.sleep(0)
+        uid = params.get("id", "0")
+        return f'{{"id": {uid}, "name": "Alice"}}\n'
+
+    tool = ScriptedTool("api")
+    tool.add_tool(
+        "get_user",
+        "Fetch user",
+        callback=fetch_user,
+        schema={"type": "object", "properties": {"id": {"type": "integer"}}},
+    )
+    r = tool.execute_sync("get_user --id 42 | jq -r '.name'")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "Alice"
+
+
+def test_async_callback_error_propagates():
+    """Errors from async callbacks propagate correctly."""
+
+    async def failing(params, stdin=None):
+        raise ValueError("async boom")
+
+    tool = ScriptedTool("api")
+    tool.add_tool("fail", "Fails", callback=failing)
+    r = tool.execute_sync("fail")
+    assert r.exit_code != 0
+
+
+def test_async_callback_stdin_pipe():
+    """Async callback receives stdin from pipe."""
+
+    async def upper(params, stdin=None):
+        return (stdin or "").upper()
+
+    tool = ScriptedTool("api")
+    tool.add_tool("upper", "Uppercase stdin", callback=upper)
+    r = tool.execute_sync("echo hello | upper")
+    assert r.exit_code == 0
+    assert "HELLO" in r.stdout
+
+
+# ===========================================================================
+# Mixed sync + async callbacks
+# ===========================================================================
+
+
+def test_mixed_sync_async_callbacks():
+    """ScriptedTool with both sync and async callbacks in one tool."""
+
+    def sync_greet(params, stdin=None):
+        return f"sync-hello {params.get('name', '?')}\n"
+
+    async def async_greet(params, stdin=None):
+        return f"async-hello {params.get('name', '?')}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool("sync_greet", "Sync greet", callback=sync_greet)
+    tool.add_tool("async_greet", "Async greet", callback=async_greet)
+    r = tool.execute_sync('echo "$(sync_greet --name A) $(async_greet --name B)"')
+    assert r.exit_code == 0
+    assert "sync-hello A" in r.stdout
+    assert "async-hello B" in r.stdout
+
+
+# ===========================================================================
+# ContextVar propagation — sync callbacks
+# ===========================================================================
+
+
+def test_contextvar_propagation_sync():
+    """ContextVar set before execute_sync() is visible in sync callback."""
+
+    def check_ctx(params, stdin=None):
+        return f"req={request_id.get('MISSING')}\n"
+
+    request_id.set("abc-123")
+    tool = ScriptedTool("api")
+    tool.add_tool("check", "Check ctx", callback=check_ctx)
+    r = tool.execute_sync("check")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "req=abc-123"
+
+
+@pytest.mark.asyncio
+async def test_contextvar_propagation_sync_via_async_execute():
+    """ContextVar set before await execute() is visible in sync callback."""
+
+    def check_ctx(params, stdin=None):
+        return f"req={request_id.get('MISSING')}\n"
+
+    request_id.set("def-456")
+    tool = ScriptedTool("api")
+    tool.add_tool("check", "Check ctx", callback=check_ctx)
+    r = await tool.execute("check")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "req=def-456"
+
+
+# ===========================================================================
+# ContextVar propagation — async callbacks
+# ===========================================================================
+
+
+def test_contextvar_propagation_async():
+    """ContextVar set before execute_sync() is visible in async callback."""
+
+    async def check_ctx(params, stdin=None):
+        return f"req={request_id.get('MISSING')}\n"
+
+    request_id.set("ghi-789")
+    tool = ScriptedTool("api")
+    tool.add_tool("check", "Check ctx", callback=check_ctx)
+    r = tool.execute_sync("check")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "req=ghi-789"
+
+
+@pytest.mark.asyncio
+async def test_contextvar_propagation_async_via_async_execute():
+    """ContextVar set before await execute() is visible in async callback."""
+
+    async def check_ctx(params, stdin=None):
+        return f"req={request_id.get('MISSING')}\n"
+
+    request_id.set("jkl-012")
+    tool = ScriptedTool("api")
+    tool.add_tool("check", "Check ctx", callback=check_ctx)
+    r = await tool.execute("check")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "req=jkl-012"
+
+
+# ===========================================================================
+# ContextVar isolation between concurrent executions
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_contextvar_isolation_concurrent():
+    """Concurrent executions each see their own ContextVar snapshot."""
+    results = {}
+
+    async def capture_ctx(params, stdin=None):
+        rid = request_id.get("NONE")
+        return f"{rid}\n"
+
+    async def run_with_id(rid: str):
+        request_id.set(rid)
+        tool = ScriptedTool("api")
+        tool.add_tool("capture", "Capture", callback=capture_ctx)
+        r = await tool.execute("capture")
+        results[rid] = r.stdout.strip()
+
+    await asyncio.gather(
+        run_with_id("req-A"),
+        run_with_id("req-B"),
+        run_with_id("req-C"),
+    )
+    assert results["req-A"] == "req-A"
+    assert results["req-B"] == "req-B"
+    assert results["req-C"] == "req-C"
+
+
+# ===========================================================================
+# ContextVar with trace_writer pattern (LangGraph-like)
+# ===========================================================================
+
+
+def test_contextvar_trace_writer_pattern():
+    """Simulate LangGraph's get_stream_writer() pattern via ContextVar."""
+    events = []
+    trace_writer.set(events)
+
+    def emit_event(params, stdin=None):
+        writer = trace_writer.get()
+        writer.append(f"event:{params.get('msg', '')}")
+        return "ok\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool("emit", "Emit event", callback=emit_event)
+    r = tool.execute_sync("emit --msg hello; emit --msg world")
+    assert r.exit_code == 0
+    assert events == ["event:hello", "event:world"]
+
+
+def test_contextvar_trace_writer_pattern_async():
+    """Async version of trace_writer pattern."""
+    events = []
+    trace_writer.set(events)
+
+    async def emit_event(params, stdin=None):
+        writer = trace_writer.get()
+        writer.append(f"event:{params.get('msg', '')}")
+        return "ok\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool("emit", "Emit event", callback=emit_event)
+    r = tool.execute_sync("emit --msg ping; emit --msg pong")
+    assert r.exit_code == 0
+    assert events == ["event:ping", "event:pong"]
+
+
+# ===========================================================================
+# Callable objects with async __call__
+# ===========================================================================
+
+
+def test_async_callable_object():
+    """Object with async __call__ works as async callback."""
+
+    class AsyncGreeter:
+        async def __call__(self, params, stdin=None):
+            return f"hello {params.get('name', '?')}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool("greet", "Greet", callback=AsyncGreeter())
+    r = tool.execute_sync("greet --name Object")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "hello Object"

--- a/crates/bashkit-python/tests/test_fastapi_integration.py
+++ b/crates/bashkit-python/tests/test_fastapi_integration.py
@@ -1,0 +1,192 @@
+"""FastAPI integration tests for async callbacks and ContextVar propagation.
+
+Tests the pattern where FastAPI endpoints use ScriptedTool with async callbacks,
+verifying that request-scoped ContextVars propagate into tool callbacks.
+Requires ``fastapi`` and ``httpx`` to be installed.
+"""
+
+import asyncio
+import contextvars
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from fastapi import FastAPI, Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from bashkit import ScriptedTool  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# ContextVar for request-scoped state
+# ---------------------------------------------------------------------------
+
+current_request_id: contextvars.ContextVar[str] = contextvars.ContextVar("current_request_id", default="none")
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+def test_sync_endpoint_with_async_callback():
+    """FastAPI sync endpoint uses ScriptedTool with async callback."""
+    app = FastAPI()
+
+    async def greet(params, stdin=None):
+        rid = current_request_id.get()
+        name = params.get("name", "world")
+        return f'{{"greeting": "hello {name}", "request_id": "{rid}"}}\n'
+
+    @app.get("/greet/{name}")
+    def greet_endpoint(name: str, request: Request):
+        current_request_id.set(request.headers.get("x-request-id", "unknown"))
+        tool = ScriptedTool("api")
+        tool.add_tool(
+            "greet",
+            "Greet",
+            callback=greet,
+            schema={"type": "object", "properties": {"name": {"type": "string"}}},
+        )
+        r = tool.execute_sync(f"greet --name {name}")
+        return {"stdout": r.stdout, "exit_code": r.exit_code}
+
+    client = TestClient(app)
+    resp = client.get("/greet/Alice", headers={"x-request-id": "req-123"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == 0
+    assert "hello Alice" in data["stdout"]
+    assert "req-123" in data["stdout"]
+
+
+def test_async_endpoint_with_async_callback():
+    """FastAPI async endpoint uses ``await tool.execute()`` (not execute_sync).
+
+    Async endpoints must use the async API to avoid blocking the event loop.
+    """
+    app = FastAPI()
+
+    async def lookup(params, stdin=None):
+        rid = current_request_id.get()
+        uid = params.get("id", "0")
+        await asyncio.sleep(0)  # Simulate async I/O
+        return f'{{"id": {uid}, "name": "User-{uid}", "request_id": "{rid}"}}\n'
+
+    @app.get("/user/{uid}")
+    async def user_endpoint(uid: int, request: Request):
+        current_request_id.set(request.headers.get("x-request-id", "unknown"))
+        tool = ScriptedTool("api")
+        tool.add_tool(
+            "lookup",
+            "Lookup user",
+            callback=lookup,
+            schema={"type": "object", "properties": {"id": {"type": "integer"}}},
+        )
+        r = await tool.execute(f"lookup --id {uid}")
+        return {"stdout": r.stdout, "exit_code": r.exit_code}
+
+    client = TestClient(app)
+    resp = client.get("/user/42", headers={"x-request-id": "req-456"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] == 0
+    assert "User-42" in data["stdout"]
+    assert "req-456" in data["stdout"]
+
+
+def test_pipeline_in_endpoint():
+    """FastAPI sync endpoint executes a multi-tool bash pipeline."""
+    app = FastAPI()
+
+    async def get_user(params, stdin=None):
+        uid = params.get("id", "0")
+        return f'{{"id": {uid}, "name": "Alice", "email": "alice@example.com"}}\n'
+
+    async def get_orders(params, stdin=None):
+        uid = params.get("user_id", "0")
+        return f'[{{"order_id": 1, "user_id": {uid}, "total": 99.99}}]\n'
+
+    @app.get("/user/{uid}/summary")
+    def summary_endpoint(uid: int):
+        tool = ScriptedTool("api")
+        tool.add_tool(
+            "get_user",
+            "Fetch user",
+            callback=get_user,
+            schema={"type": "object", "properties": {"id": {"type": "integer"}}},
+        )
+        tool.add_tool(
+            "get_orders",
+            "Fetch orders",
+            callback=get_orders,
+            schema={
+                "type": "object",
+                "properties": {"user_id": {"type": "integer"}},
+            },
+        )
+        script = f"""
+            user=$(get_user --id {uid})
+            orders=$(get_orders --user_id {uid})
+            echo "$user" | jq -r '.name'
+            echo "$orders" | jq -r '.[0].total'
+        """
+        r = tool.execute_sync(script)
+        lines = r.stdout.strip().split("\n")
+        return {"name": lines[0] if lines else "", "total": lines[1] if len(lines) > 1 else ""}
+
+    client = TestClient(app)
+    resp = client.get("/user/42/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "Alice"
+    assert data["total"] == "99.99"
+
+
+def test_concurrent_requests_context_isolation():
+    """Concurrent FastAPI requests have isolated ContextVars."""
+    app = FastAPI()
+
+    def echo_request_id(params, stdin=None):
+        rid = current_request_id.get()
+        return f"{rid}\n"
+
+    @app.get("/echo")
+    def echo_endpoint(request: Request):
+        current_request_id.set(request.headers.get("x-request-id", "none"))
+        tool = ScriptedTool("api")
+        tool.add_tool("echo_rid", "Echo request ID", callback=echo_request_id)
+        r = tool.execute_sync("echo_rid")
+        return {"request_id": r.stdout.strip()}
+
+    client = TestClient(app)
+
+    # Sequential requests should each see their own request ID
+    r1 = client.get("/echo", headers={"x-request-id": "aaa"})
+    r2 = client.get("/echo", headers={"x-request-id": "bbb"})
+    r3 = client.get("/echo", headers={"x-request-id": "ccc"})
+
+    assert r1.json()["request_id"] == "aaa"
+    assert r2.json()["request_id"] == "bbb"
+    assert r3.json()["request_id"] == "ccc"
+
+
+def test_error_handling_in_endpoint():
+    """FastAPI endpoint handles ScriptedTool callback errors gracefully."""
+    app = FastAPI()
+
+    async def failing_tool(params, stdin=None):
+        raise ValueError("simulated failure")
+
+    @app.get("/fail")
+    async def fail_endpoint():
+        tool = ScriptedTool("api")
+        tool.add_tool("fail", "Always fails", callback=failing_tool)
+        r = tool.execute_sync("fail")
+        return {"exit_code": r.exit_code, "stderr": r.stderr}
+
+    client = TestClient(app)
+    resp = client.get("/fail")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["exit_code"] != 0

--- a/crates/bashkit-python/tests/test_langgraph_integration.py
+++ b/crates/bashkit-python/tests/test_langgraph_integration.py
@@ -1,0 +1,181 @@
+"""LangGraph integration tests for async callbacks and ContextVar propagation.
+
+Tests the pattern where LangGraph passes a stream writer via ContextVar to tool
+callbacks. Requires ``langchain-core`` to be installed.
+"""
+
+import asyncio
+import contextvars
+
+import pytest
+
+langchain_core = pytest.importorskip("langchain_core")
+
+from langchain_core.tools import StructuredTool  # noqa: E402
+
+from bashkit import ScriptedTool  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Simulate LangGraph's get_stream_writer() pattern
+# ---------------------------------------------------------------------------
+
+_stream_writer: contextvars.ContextVar[list] = contextvars.ContextVar("_stream_writer")
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+def test_sync_callback_reads_contextvar():
+    """Sync callback reads ContextVar (LangGraph stream-writer pattern)."""
+    events = []
+    _stream_writer.set(events)
+
+    def search(params, stdin=None):
+        writer = _stream_writer.get()
+        query = params.get("query", "")
+        writer.append({"type": "search", "query": query})
+        return f'{{"results": ["result for {query}"]}}\n'
+
+    tool = ScriptedTool("agent")
+    tool.add_tool(
+        "search",
+        "Search the web",
+        callback=search,
+        schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    r = tool.execute_sync('search --query "python async"')
+    assert r.exit_code == 0
+    assert "result for python async" in r.stdout
+    assert len(events) == 1
+    assert events[0]["type"] == "search"
+
+
+def test_async_callback_reads_contextvar():
+    """Async callback reads ContextVar (LangGraph stream-writer pattern)."""
+    events = []
+    _stream_writer.set(events)
+
+    async def search(params, stdin=None):
+        writer = _stream_writer.get()
+        query = params.get("query", "")
+        writer.append({"type": "search", "query": query})
+        # Simulate async I/O
+        await asyncio.sleep(0)
+        return f'{{"results": ["result for {query}"]}}\n'
+
+    tool = ScriptedTool("agent")
+    tool.add_tool(
+        "search",
+        "Search the web",
+        callback=search,
+        schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    r = tool.execute_sync('search --query "langchain async"')
+    assert r.exit_code == 0
+    assert "result for langchain async" in r.stdout
+    assert len(events) == 1
+    assert events[0]["type"] == "search"
+
+
+@pytest.mark.asyncio
+async def test_async_execute_with_contextvar():
+    """Async callback + async execute preserves ContextVar."""
+    events = []
+    _stream_writer.set(events)
+
+    async def fetch(params, stdin=None):
+        writer = _stream_writer.get()
+        url = params.get("url", "")
+        writer.append({"type": "fetch", "url": url})
+        await asyncio.sleep(0)
+        return f'{{"status": 200, "url": "{url}"}}\n'
+
+    tool = ScriptedTool("agent")
+    tool.add_tool(
+        "fetch",
+        "Fetch URL",
+        callback=fetch,
+        schema={"type": "object", "properties": {"url": {"type": "string"}}},
+    )
+    r = await tool.execute("fetch --url https://example.com")
+    assert r.exit_code == 0
+    assert "https://example.com" in r.stdout
+    assert len(events) == 1
+    assert events[0]["url"] == "https://example.com"
+
+
+def test_multi_tool_pipeline_with_contextvar():
+    """Multiple tools in a pipeline all see the same ContextVar."""
+    events = []
+    _stream_writer.set(events)
+
+    async def search(params, stdin=None):
+        writer = _stream_writer.get()
+        query = params.get("query", "")
+        writer.append({"step": "search", "query": query})
+        return f'{{"id": 1, "title": "Result: {query}"}}\n'
+
+    async def summarize(params, stdin=None):
+        writer = _stream_writer.get()
+        writer.append({"step": "summarize", "input_len": len(stdin or "")})
+        return '{"summary": "Summary of input"}\n'
+
+    tool = ScriptedTool("agent")
+    tool.add_tool(
+        "search",
+        "Search",
+        callback=search,
+        schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    tool.add_tool("summarize", "Summarize", callback=summarize)
+
+    r = tool.execute_sync('search --query "AI" | summarize')
+    assert r.exit_code == 0
+    assert len(events) == 2
+    assert events[0]["step"] == "search"
+    assert events[1]["step"] == "summarize"
+
+
+def test_langchain_structured_tool_wrapper():
+    """ScriptedTool wrapping a LangChain StructuredTool callback."""
+    events = []
+    _stream_writer.set(events)
+
+    # Create a LangChain StructuredTool
+    def calculator(expression: str) -> str:
+        """Evaluate a math expression."""
+        # Read ContextVar to verify propagation
+        writer = _stream_writer.get()
+        writer.append({"tool": "calculator", "expr": expression})
+        result = eval(expression)  # noqa: S307 — demo only
+        return str(result)
+
+    lc_tool = StructuredTool.from_function(
+        func=calculator,
+        name="calculator",
+        description="Evaluate math",
+    )
+
+    # Wrap LangChain tool in ScriptedTool
+    def calc_callback(params, stdin=None):
+        expr = params.get("expression", "0")
+        return lc_tool.invoke({"expression": expr}) + "\n"
+
+    st = ScriptedTool("math_agent")
+    st.add_tool(
+        "calc",
+        "Calculate",
+        callback=calc_callback,
+        schema={
+            "type": "object",
+            "properties": {"expression": {"type": "string"}},
+        },
+    )
+
+    r = st.execute_sync('calc --expression "2 + 3"')
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "5"
+    assert len(events) == 1
+    assert events[0]["tool"] == "calculator"

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -452,9 +452,9 @@ pub use trace::{
 
 #[cfg(feature = "scripted_tool")]
 pub use scripted_tool::{
-    DiscoverTool, DiscoveryMode, ScriptedCommandInvocation, ScriptedCommandKind,
-    ScriptedExecutionTrace, ScriptedTool, ScriptedToolBuilder, ScriptingToolSet,
-    ScriptingToolSetBuilder, ToolArgs, ToolCallback, ToolDef,
+    AsyncToolCallback, CallbackKind, DiscoverTool, DiscoveryMode, ScriptedCommandInvocation,
+    ScriptedCommandKind, ScriptedExecutionTrace, ScriptedTool, ScriptedToolBuilder,
+    ScriptingToolSet, ScriptingToolSetBuilder, ToolArgs, ToolCallback, ToolDef,
 };
 
 #[cfg(feature = "http_client")]

--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -1,8 +1,8 @@
 //! ScriptedTool execution: Tool impl, builtin adapter, flag parser, documentation helpers.
 
 use super::{
-    ScriptedCommandInvocation, ScriptedCommandKind, ScriptedExecutionTrace, ScriptedTool, ToolArgs,
-    ToolCallback,
+    CallbackKind, ScriptedCommandInvocation, ScriptedCommandKind, ScriptedExecutionTrace,
+    ScriptedTool, ToolArgs,
 };
 use crate::Bash;
 use crate::builtins::{Builtin, Context};
@@ -142,11 +142,11 @@ fn usage_from_schema(schema: &serde_json::Value) -> Option<String> {
 // ToolBuiltinAdapter — wraps ToolCallback as a Builtin
 // ============================================================================
 
-/// Adapts a [`ToolCallback`] into a [`Builtin`] so the interpreter can execute it.
+/// Adapts a [`CallbackKind`] into a [`Builtin`] so the interpreter can execute it.
 /// Parses `--key value` flags from `ctx.args` using the schema for type coercion.
 struct ToolBuiltinAdapter {
     name: String,
-    callback: ToolCallback,
+    callback: CallbackKind,
     schema: serde_json::Value,
     log: InvocationLog,
     sanitize_errors: bool,
@@ -162,7 +162,12 @@ impl Builtin for ToolBuiltinAdapter {
                     stdin: ctx.stdin.map(String::from),
                 };
 
-                match (self.callback)(&tool_args) {
+                let cb_result = match &self.callback {
+                    CallbackKind::Sync(cb) => (cb)(&tool_args),
+                    CallbackKind::Async(cb) => (cb)(tool_args).await,
+                };
+
+                match cb_result {
                     Ok(stdout) => ExecResult::ok(stdout),
                     Err(msg) => {
                         // THREAT[TM-INF-030]: Sanitize callback errors to prevent
@@ -452,7 +457,7 @@ impl ScriptedTool {
             let name = tool.def.name.clone();
             let builtin: Box<dyn Builtin> = Box::new(ToolBuiltinAdapter {
                 name: name.clone(),
-                callback: Arc::clone(&tool.callback),
+                callback: tool.callback.clone(),
                 schema: tool.def.input_schema.clone(),
                 log: Arc::clone(&log),
                 sanitize_errors: self.sanitize_errors,

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -1177,4 +1177,95 @@ mod tests {
         assert_eq!(trace.invocations[2].name, "get_user");
         assert_eq!(trace.invocations[2].kind, ScriptedCommandKind::Tool);
     }
+
+    // -- Async callback tests --
+
+    #[tokio::test]
+    async fn test_async_tool_basic() {
+        let tool = ScriptedTool::builder("async_api")
+            .async_tool(
+                ToolDef::new("greet", "Greet async").with_schema(serde_json::json!({
+                    "type": "object",
+                    "properties": { "name": {"type": "string"} }
+                })),
+                |args: ToolArgs| async move {
+                    let name = args.param_str("name").unwrap_or("world").to_string();
+                    Ok(format!("hello {name}\n"))
+                },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "greet --name Async".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "hello Async");
+    }
+
+    #[tokio::test]
+    async fn test_mixed_sync_async_tools() {
+        let tool = ScriptedTool::builder("mixed")
+            .tool(ToolDef::new("sync_ping", "Sync"), |_args: &ToolArgs| {
+                Ok("sync-pong\n".to_string())
+            })
+            .async_tool(
+                ToolDef::new("async_ping", "Async"),
+                |_args: ToolArgs| async move { Ok("async-pong\n".to_string()) },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "sync_ping; async_ping".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        assert!(resp.stdout.contains("sync-pong"));
+        assert!(resp.stdout.contains("async-pong"));
+    }
+
+    #[tokio::test]
+    async fn test_async_tool_error_propagates() {
+        let tool = ScriptedTool::builder("err_api")
+            .sanitize_errors(false)
+            .async_tool(
+                ToolDef::new("fail", "Always fails"),
+                |_args: ToolArgs| async move { Err("async boom".to_string()) },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "fail".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_ne!(resp.exit_code, 0);
+        assert!(resp.stderr.contains("async boom"));
+    }
+
+    #[tokio::test]
+    async fn test_async_tool_stdin_pipe() {
+        let tool = ScriptedTool::builder("pipe_api")
+            .async_tool(
+                ToolDef::new("upper", "Uppercase stdin"),
+                |args: ToolArgs| async move {
+                    Ok(args.stdin.unwrap_or_default().to_uppercase())
+                },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "echo hello | upper".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        assert!(resp.stdout.contains("HELLO"));
+    }
 }

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -135,6 +135,8 @@ pub use toolset::{DiscoverTool, DiscoveryMode, ScriptingToolSet, ScriptingToolSe
 use crate::{ExecutionLimits, Tool, ToolService};
 use schemars::schema_for;
 use serde::{Deserialize, Serialize};
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 // ============================================================================
@@ -233,11 +235,31 @@ impl ToolArgs {
 // ToolCallback — execution callback type
 // ============================================================================
 
-/// Execution callback for a registered tool.
+/// Execution callback for a registered tool (synchronous).
 ///
 /// Receives parsed [`ToolArgs`] with typed parameters and optional stdin.
 /// Return `Ok(stdout)` on success or `Err(message)` on failure.
 pub type ToolCallback = Arc<dyn Fn(&ToolArgs) -> Result<String, String> + Send + Sync>;
+
+/// Async execution callback for a registered tool.
+///
+/// Same contract as [`ToolCallback`] but returns a `Future`, allowing
+/// non-blocking I/O inside the callback. Takes owned [`ToolArgs`] because
+/// the future may outlive the borrow.
+pub type AsyncToolCallback = Arc<
+    dyn Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Sync or async callback for a registered tool.
+#[derive(Clone)]
+pub enum CallbackKind {
+    /// Synchronous callback — blocks until complete.
+    Sync(ToolCallback),
+    /// Asynchronous callback — `.await`ed inside the interpreter.
+    Async(AsyncToolCallback),
+}
 
 // ============================================================================
 // Execution trace — inner scripted command/builtin usage
@@ -274,7 +296,7 @@ pub struct ScriptedExecutionTrace {
 #[derive(Clone)]
 pub(crate) struct RegisteredTool {
     pub(crate) def: ToolDef,
-    pub(crate) callback: ToolCallback,
+    pub(crate) callback: CallbackKind,
 }
 
 // ============================================================================
@@ -339,7 +361,7 @@ impl ScriptedToolBuilder {
         self
     }
 
-    /// Register a tool with its definition and execution callback.
+    /// Register a tool with its definition and synchronous execution callback.
     ///
     /// The callback receives [`ToolArgs`] with `--key value` flags parsed into
     /// a JSON object, type-coerced per the schema.
@@ -350,7 +372,25 @@ impl ScriptedToolBuilder {
     ) -> Self {
         self.tools.push(RegisteredTool {
             def,
-            callback: Arc::new(callback),
+            callback: CallbackKind::Sync(Arc::new(callback)),
+        });
+        self
+    }
+
+    /// Register a tool with its definition and **async** execution callback.
+    ///
+    /// Same as [`tool()`](Self::tool) but the callback returns a `Future`,
+    /// allowing non-blocking I/O. Takes owned [`ToolArgs`] because the future
+    /// may outlive the borrow.
+    pub fn async_tool<F, Fut>(mut self, def: ToolDef, callback: F) -> Self
+    where
+        F: Fn(ToolArgs) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<String, String>> + Send + 'static,
+    {
+        let cb: AsyncToolCallback = Arc::new(move |args| Box::pin(callback(args)));
+        self.tools.push(RegisteredTool {
+            def,
+            callback: CallbackKind::Async(cb),
         });
         self
     }

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -247,9 +247,7 @@ pub type ToolCallback = Arc<dyn Fn(&ToolArgs) -> Result<String, String> + Send +
 /// non-blocking I/O inside the callback. Takes owned [`ToolArgs`] because
 /// the future may outlive the borrow.
 pub type AsyncToolCallback = Arc<
-    dyn Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
-        + Send
-        + Sync,
+    dyn Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> + Send + Sync,
 >;
 
 /// Sync or async callback for a registered tool.
@@ -1253,9 +1251,7 @@ mod tests {
         let tool = ScriptedTool::builder("pipe_api")
             .async_tool(
                 ToolDef::new("upper", "Uppercase stdin"),
-                |args: ToolArgs| async move {
-                    Ok(args.stdin.unwrap_or_default().to_uppercase())
-                },
+                |args: ToolArgs| async move { Ok(args.stdin.unwrap_or_default().to_uppercase()) },
             )
             .build();
 

--- a/crates/bashkit/src/scripted_tool/toolset.rs
+++ b/crates/bashkit/src/scripted_tool/toolset.rs
@@ -5,7 +5,7 @@
 // - WithDiscovery: returns two tools — ScriptedTool (compact prompt) +
 //   DiscoverTool (discover/help only).
 
-use super::{RegisteredTool, ScriptedExecutionTrace, ScriptedTool, ToolArgs, ToolDef};
+use super::{CallbackKind, RegisteredTool, ScriptedExecutionTrace, ScriptedTool, ToolArgs, ToolDef};
 use crate::ExecutionLimits;
 use crate::tool::{Tool, ToolError, ToolRequest, ToolResponse, ToolStatus, VERSION};
 use async_trait::async_trait;
@@ -227,7 +227,7 @@ impl ScriptingToolSetBuilder {
         self
     }
 
-    /// Register a tool with its definition and execution callback.
+    /// Register a tool with its definition and synchronous execution callback.
     pub fn tool(
         mut self,
         def: ToolDef,
@@ -235,7 +235,21 @@ impl ScriptingToolSetBuilder {
     ) -> Self {
         self.tools.push(RegisteredTool {
             def,
-            callback: Arc::new(callback),
+            callback: CallbackKind::Sync(Arc::new(callback)),
+        });
+        self
+    }
+
+    /// Register a tool with its definition and **async** execution callback.
+    pub fn async_tool<F, Fut>(mut self, def: ToolDef, callback: F) -> Self
+    where
+        F: Fn(ToolArgs) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<String, String>> + Send + 'static,
+    {
+        let cb: super::AsyncToolCallback = Arc::new(move |args| Box::pin(callback(args)));
+        self.tools.push(RegisteredTool {
+            def,
+            callback: CallbackKind::Async(cb),
         });
         self
     }
@@ -282,8 +296,19 @@ impl ScriptingToolSetBuilder {
         // Move tools into inner ScriptedTool
         // We need to reconstruct because ScriptedToolBuilder expects closures
         for reg in &self.tools {
-            let cb = Arc::clone(&reg.callback);
-            builder = builder.tool(reg.def.clone(), move |args: &ToolArgs| (cb)(args));
+            match &reg.callback {
+                CallbackKind::Sync(cb) => {
+                    let cb = Arc::clone(cb);
+                    builder = builder.tool(reg.def.clone(), move |args: &ToolArgs| (cb)(args));
+                }
+                CallbackKind::Async(cb) => {
+                    let cb = Arc::clone(cb);
+                    builder = builder.async_tool(reg.def.clone(), move |args: ToolArgs| {
+                        let cb = Arc::clone(&cb);
+                        async move { (cb)(args).await }
+                    });
+                }
+            }
         }
 
         ScriptingToolSet {

--- a/crates/bashkit/src/scripted_tool/toolset.rs
+++ b/crates/bashkit/src/scripted_tool/toolset.rs
@@ -5,7 +5,9 @@
 // - WithDiscovery: returns two tools — ScriptedTool (compact prompt) +
 //   DiscoverTool (discover/help only).
 
-use super::{CallbackKind, RegisteredTool, ScriptedExecutionTrace, ScriptedTool, ToolArgs, ToolDef};
+use super::{
+    CallbackKind, RegisteredTool, ScriptedExecutionTrace, ScriptedTool, ToolArgs, ToolDef,
+};
 use crate::ExecutionLimits;
 use crate::tool::{Tool, ToolError, ToolRequest, ToolResponse, ToolStatus, VERSION};
 use async_trait::async_trait;

--- a/specs/006-threat-model.md
+++ b/specs/006-threat-model.md
@@ -1259,6 +1259,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-DOS-049 | `collect_dirs_recursive` has no depth limit | Deep recursion on VFS trees (mitigated by `max_path_depth`) | Add explicit depth parameter at `interpreter/mod.rs:8352` |
 | TM-DOS-050 | `parse_word_string` uses default parser limits | Caller-configured tighter limits ignored for parameter expansion | Propagate limits through `parse_word_string()` at `parser/mod.rs:109` |
 | TM-PY-028 | BashTool.reset() in Python drops security config | Resource limits silently removed after reset | Preserve limits like `PyBash.reset()` does (see `bashkit-python/src/lib.rs:470`) |
+| TM-PY-029 | ContextVar capture may include sensitive state | `copy_context()` snapshots all caller ContextVars, not just intended ones | Accepted: same semantics as `asyncio.Task` context inheritance; caller controls what is set |
 
 ### Open (From 2026-03 Blackbox Security Testing)
 

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -496,6 +496,14 @@ NAPI-RS bindings in `crates/bashkit-js/`. TypeScript wrapper in `wrapper.ts`.
 
 PyO3 bindings in `crates/bashkit-python/`. See [013-python-package.md](013-python-package.md).
 
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Sync callbacks (`ScriptedTool.add_tool`) | Done | `(params, stdin) -> str` |
+| Async callbacks (`async def`) | Done | Auto-detected via `inspect.iscoroutinefunction` |
+| ContextVar propagation | Done | `copy_context()` at `execute()` time, restored via `ctx.run()` |
+| LangGraph integration | Done | Example + integration tests |
+| FastAPI integration | Done | Example + integration tests |
+
 ### Examples
 
 | Example | Description |

--- a/specs/014-scripted-tool-orchestration.md
+++ b/specs/014-scripted-tool-orchestration.md
@@ -74,6 +74,41 @@ pub type ToolCallback =
 - `args.stdin`: pipeline input from prior command.
 - Returns stdout string on success, error message on failure.
 
+### AsyncToolCallback
+
+```rust
+pub type AsyncToolCallback = Arc<
+    dyn Fn(ToolArgs) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
+        + Send + Sync,
+>;
+```
+
+Async variant of `ToolCallback`. Takes owned `ToolArgs` (the future may outlive the
+borrow). Register via `builder.async_tool(def, callback)`. Both sync and async
+callbacks can be mixed in a single `ScriptedTool`.
+
+Internally represented as `CallbackKind::Async` and `.await`-ed inside
+`ToolBuiltinAdapter::execute()`, which is already `async fn`.
+
+### ContextVar propagation (Python)
+
+Python callbacks (both sync and async) automatically see `contextvars.ContextVar`
+values that were set by the caller at `execute()` / `execute_sync()` time:
+
+1. `build_rust_tool()` (called at execute time) snapshots the caller's context
+   via `contextvars.copy_context()`.
+2. Sync callbacks are invoked via `ctx.run(fn, params, stdin)`.
+3. Async callbacks are invoked via
+   `ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))` so that the
+   `asyncio.Task` inherits the captured context.
+
+This enables framework patterns like LangGraph's `get_stream_writer()` and
+FastAPI's request-scoped state.
+
+**Caveat:** `execute_sync()` must not be called from an async endpoint that runs
+on the same thread as a Python event loop. Use `await execute()` from async
+contexts instead.
+
 ### Flag parsing
 
 Bash command args are parsed into a JSON object:
@@ -90,7 +125,8 @@ Unknown flags (not in schema) are kept as strings.
 
 ### ScriptedToolBuilder
 
-Two arguments per tool: definition + callback.
+Two arguments per tool: definition + callback. Use `.tool()` for sync and
+`.async_tool()` for async callbacks.
 
 ```rust
 ScriptedTool::builder("api_name")
@@ -102,6 +138,13 @@ ScriptedTool::builder("api_name")
         |args| {
             let id = args.param_i64("id").ok_or("missing --id")?;
             Ok(format!("{{\"id\":{id}}}\n"))
+        },
+    )
+    .async_tool(
+        ToolDef::new("fetch_url", "Fetch a URL"),
+        |args| async move {
+            let url = args.param_str("url").unwrap_or("?");
+            Ok(format!("{{\"url\":\"{url}\",\"status\":200}}\n"))
         },
     )
     .env("API_KEY", "...")


### PR DESCRIPTION
## Summary

- Add `AsyncToolCallback` type and `CallbackKind` enum to Rust core, with `async_tool()` builder method
- Python bindings auto-detect `async def` callbacks via `inspect.iscoroutinefunction()`
- Propagate `contextvars.ContextVar` state from caller into callbacks via `copy_context()` + `ctx.run()`
- Async callbacks driven through a shared event loop with `run_until_complete()` inside `ctx.run()` to ensure the `asyncio.Task` inherits the captured context

## What changed

**Rust** (`crates/bashkit/src/scripted_tool/`):
- `mod.rs`: `AsyncToolCallback`, `CallbackKind` enum, `async_tool()` on both `ScriptedToolBuilder` and `ScriptingToolSetBuilder`
- `execute.rs`: `ToolBuiltinAdapter` matches on `CallbackKind` — sync calls directly, async `.await`s
- `toolset.rs`: proper forwarding of both callback kinds during reconstruction

**Python** (`crates/bashkit-python/src/lib.rs`):
- `add_tool()` auto-detects `async def` (including `__call__` methods)
- `build_rust_tool()` snapshots `contextvars.copy_context()` at execute-time
- Sync: `ctx.run(fn, params, stdin)`
- Async: `ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))` via shared event loop

**Tests** (24 new Python tests + 4 new Rust tests):
- `test_async_callbacks.py` — async basics, mixed sync/async, ContextVar propagation, concurrent isolation, callable objects
- `test_langgraph_integration.py` — stream-writer pattern, multi-tool pipelines, StructuredTool wrapper
- `test_fastapi_integration.py` — sync/async endpoints, request-scoped ContextVars, pipelines, error handling
- Rust: `test_async_tool_basic`, `test_mixed_sync_async_tools`, `test_async_tool_error_propagates`, `test_async_tool_stdin_pipe`

**Examples** (real framework integrations with PEP 723 `uv run` deps):
- `langgraph_async_tool.py` — builds a LangGraph `StateGraph` with tool node invoking ScriptedTool
- `fastapi_async_tool.py` — starts a real uvicorn server, hits endpoints via httpx

**Specs**: updated 014 (async callback + ContextVar docs), 009 (feature status table), 006 (TM-PY-029)

## Test plan

- [x] 90 Rust ScriptedTool tests pass (86 existing + 4 new)
- [x] 388 Python tests pass (364 existing + 24 new)
- [x] Both examples run end-to-end with real LangGraph/FastAPI
- [x] `cargo fmt --check` clean
- [x] `ruff check` + `ruff format --check` clean

Closes #1245