### PR TITLE
feat(cli): add cargo-binstall metadata

### DIFF
--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -13,6 +13,10 @@ categories.workspace = true
 description = "Command line interface for Bashkit virtual bash interpreter"
 readme = "../../README.md"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/bashkit-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+
 [[bin]]
 name = "bashkit"
 path = "src/main.rs"


### PR DESCRIPTION
## Summary

- Adds `[package.metadata.binstall]` to `bashkit-cli` so `cargo binstall bashkit-cli` uses explicit `pkg-url` pointing at GitHub release assets instead of heuristic fallback
- Verified: `cargo binstall bashkit-cli` installs `bashkit` binary from `bashkit-{target}.tar.gz` release assets

## Test plan

- [x] `cargo binstall bashkit-cli --no-confirm` installs successfully
- [x] `bashkit --version` returns expected version
- [x] `cargo check -p bashkit-cli` passes
