### PR TITLE
docs: add contributing section to README and emphasize issues in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thanks for your interest in contributing to Bashkit!
 
+## How to Contribute
+
+The easiest and most valuable way to contribute is to [create an issue](https://github.com/everruns/bashkit/issues). Bug reports, feature requests, compatibility gaps, and questions all help us prioritize and improve bashkit. A well-described issue is often more impactful than a pull request.
+
+If you'd like to contribute code, read on.
+
 ## Setup
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -440,6 +440,10 @@ Bashkit is an independent implementation that draws design inspiration from seve
 
 No code was copied from any of these projects. See [NOTICE](NOTICE) for full details.
 
+## Contributing
+
+The best way to contribute is to [open an issue](https://github.com/everruns/bashkit/issues) — bug reports, feature requests, and questions all help improve bashkit. If you'd like to contribute code, see [CONTRIBUTING.md](CONTRIBUTING.md) for setup and workflow details.
+
 ## Ecosystem
 
 Bashkit is part of the [Everruns](https://everruns.com) ecosystem.


### PR DESCRIPTION
## What

Add a Contributing section to README.md and a "How to Contribute" section to CONTRIBUTING.md that highlights issue creation as the primary contribution path.

## Why

The README had no contributing section at all, so visitors had no guidance on how to help. Creating issues (bug reports, feature requests, questions) is the most valuable and accessible way to contribute — this change makes that clear upfront.

## Changes

- **README.md**: Added "Contributing" section above "Ecosystem" pointing to issues and linking CONTRIBUTING.md
- **CONTRIBUTING.md**: Added "How to Contribute" section at the top emphasizing issue creation before the code setup instructions