### PR TITLE
chore: pre-release maintenance pass (2026-04-14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Awesomely fast virtual sandbox with bash and file system. Written in Rust.
 
 - **Secure by default** - No process spawning, no filesystem access, no network access unless explicitly enabled. [250+ threats](specs/006-threat-model.md) analyzed and mitigated
 - **POSIX compliant** - Substantial IEEE 1003.1-2024 Shell Command Language compliance
-- **Sandboxed, in-process execution** - All 156 commands reimplemented in Rust, no `fork`/`exec`
+- **Sandboxed, in-process execution** - All 160 commands reimplemented in Rust, no `fork`/`exec`
 - **Virtual filesystem** - InMemoryFs, OverlayFs, MountableFs with optional RealFs backend (`realfs` feature)
 - **Resource limits** - Command count, loop iterations, function depth, output size, filesystem size, parser fuel
 - **Network allowlist** - HTTP access denied by default, per-domain control
@@ -109,7 +109,7 @@ assert_eq!(output.result["stdout"], "hello\nworld\n");
   </a>
 </div>
 
-## Built-in Commands (150)
+## Built-in Commands (160)
 
 | Category | Commands |
 |----------|----------|
@@ -407,7 +407,7 @@ Bashkit is built for running untrusted scripts from AI agents and users. Securit
 
 | Layer | Protection |
 |-------|------------|
-| **No process spawning** | All 156 commands are reimplemented in Rust — no `fork`, `exec`, or shell escape |
+| **No process spawning** | All 160 commands are reimplemented in Rust — no `fork`, `exec`, or shell escape |
 | **Virtual filesystem** | Scripts see an in-memory FS by default; no host filesystem access unless explicitly mounted |
 | **Network allowlist** | HTTP access is denied by default; each domain must be explicitly allowed |
 | **Resource limits** | Configurable caps on commands (10K), loop iterations (100K), function depth (100), output (10MB), input (10MB) |

--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -13,7 +13,7 @@ deno add npm:@everruns/bashkit  # Deno
 ## Features
 
 - **Sandboxed execution** — all commands run in-process with a virtual filesystem, no containers needed
-- **156 built-in commands** — echo, cat, grep, sed, awk, jq, curl, find, and more
+- **160 built-in commands** — echo, cat, grep, sed, awk, jq, curl, find, and more
 - **Full bash syntax** — variables, pipelines, redirects, loops, functions, arrays
 - **Resource limits** — protect against infinite loops and runaway scripts
 - **Sync and async APIs** — `executeSync()` and `execute()` (Promise-based)

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -15,7 +15,7 @@ print(result.stdout)  # Hello, World!
 ## Features
 
 - **Sandboxed execution** — all commands run in-process with a virtual filesystem, no containers needed
-- **156 built-in commands** — echo, cat, grep, sed, awk, jq, curl, find, and more
+- **160 built-in commands** — echo, cat, grep, sed, awk, jq, curl, find, and more
 - **Full bash syntax** — variables, pipelines, redirects, loops, functions, arrays
 - **Resource limits** — protect against infinite loops and runaway scripts
 - **Framework integrations** — LangChain, PydanticAI, and Deep Agents
@@ -203,7 +203,7 @@ print(result.stdout)  # Alice
 ## Features
 
 - **Sandboxed, in-process execution**: All commands run in isolation with a virtual filesystem
-- **150 built-in commands**: echo, cat, grep, sed, awk, jq, curl, find, and more
+- **160 built-in commands**: echo, cat, grep, sed, awk, jq, curl, find, and more
 - **Full bash syntax**: Variables, pipelines, redirects, loops, functions, arrays
 - **Resource limits**: Protect against infinite loops and runaway scripts
 

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -15,7 +15,7 @@
 //! - **Experimental: Git** - Virtual git operations on the VFS (`git` feature)
 //! - **Experimental: Python** - Embedded Python via [Monty](https://github.com/pydantic/monty) (`python` feature)
 //!
-//! # Built-in Commands (156)
+//! # Built-in Commands (160)
 //!
 //! | Category | Commands |
 //! |----------|----------|
@@ -37,7 +37,7 @@
 //! | Structured data | `json`, `csv`, `yaml`, `tomlq`, `semver` |
 //! | Network | `curl`, `wget`, `http` (requires [`NetworkAllowlist`])
 //! | Arithmetic | `bc` |
-//! | Experimental | `python`, `python3` (requires `python` feature), `git` (requires `git` feature)
+//! | Experimental | `python`, `python3` (requires `python` feature), `git` (requires `git` feature), `ts`, `typescript`, `node`, `deno`, `bun` (requires `typescript` feature), `ssh`, `scp`, `sftp` (requires `ssh` feature)
 //!
 //! # Shell Features
 //!
@@ -382,8 +382,8 @@
 //! - [`custom_builtins_guide`] - Creating custom builtins
 //! - [`compatibility_scorecard`] - Feature parity tracking
 //! - [`live_mounts_guide`] - Live mount/unmount on running instances
-//! - [`python_guide`] - Embedded Python (Monty) guide (requires `python` feature)
-//! - [`logging_guide`] - Structured logging with security (requires `logging` feature)
+//! - `python_guide` - Embedded Python (Monty) guide (requires `python` feature)
+//! - `logging_guide` - Structured logging with security (requires `logging` feature)
 //!
 //! # Resources
 //!
@@ -843,7 +843,7 @@ impl Bash {
     /// `on_error`) and frozen at build time.
     ///
     /// HTTP hooks (`before_http`, `after_http`) live on the
-    /// [`HttpClient`] and are set via
+    /// `HttpClient` (requires `http_client` feature) and are set via
     /// the builder as well.
     pub fn hooks(&self) -> &hooks::Hooks {
         self.interpreter.hooks()

--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -309,31 +309,23 @@ struct DiscoverBuiltin {
 }
 
 impl DiscoverBuiltin {
-    fn filter_tools(&self, args: &[String]) -> (Vec<&ToolDefSnapshot>, bool) {
-        let json_mode = args.iter().any(|a| a == "--json");
-
-        if args.iter().any(|a| a == "--categories") {
-            return (Vec::new(), json_mode);
-        }
-
+    fn filter_tools(&self, args: &[String]) -> Vec<&ToolDefSnapshot> {
         if let Some(pos) = args.iter().position(|a| a == "--category") {
             let cat = args.get(pos + 1).map(|s| s.as_str()).unwrap_or("");
-            let filtered: Vec<&ToolDefSnapshot> = self
+            return self
                 .tools
                 .iter()
                 .filter(|t| t.category.as_deref() == Some(cat))
                 .collect();
-            return (filtered, json_mode);
         }
 
         if let Some(pos) = args.iter().position(|a| a == "--tag") {
             let tag = args.get(pos + 1).map(|s| s.as_str()).unwrap_or("");
-            let filtered: Vec<&ToolDefSnapshot> = self
+            return self
                 .tools
                 .iter()
                 .filter(|t| t.tags.iter().any(|tg| tg == tag))
                 .collect();
-            return (filtered, json_mode);
         }
 
         if let Some(pos) = args.iter().position(|a| a == "--search") {
@@ -341,7 +333,7 @@ impl DiscoverBuiltin {
                 .get(pos + 1)
                 .map(|s| s.to_lowercase())
                 .unwrap_or_default();
-            let filtered: Vec<&ToolDefSnapshot> = self
+            return self
                 .tools
                 .iter()
                 .filter(|t| {
@@ -349,10 +341,9 @@ impl DiscoverBuiltin {
                         || t.description.to_lowercase().contains(&keyword)
                 })
                 .collect();
-            return (filtered, json_mode);
         }
 
-        (self.tools.iter().collect(), json_mode)
+        self.tools.iter().collect()
     }
 }
 
@@ -395,7 +386,7 @@ impl Builtin for DiscoverBuiltin {
                     ExecResult::ok(out)
                 }
             } else {
-                let (filtered, _) = self.filter_tools(args);
+                let filtered = self.filter_tools(args);
 
                 if json_mode {
                     let arr: Vec<serde_json::Value> = filtered

--- a/deny.toml
+++ b/deny.toml
@@ -37,9 +37,9 @@ ignore = [
     # atomic-polyfill: transitive via monty -> postcard -> heapless
     # Unmaintained but no security vulnerability; upstream dep we can't control
     "RUSTSEC-2023-0089",
-    # rsa: Marvin timing attack — transitive via russh-keys -> ssh-key -> rsa
-    # Only used for RSA key parsing; no direct timing attack exposure
-    "RUSTSEC-2023-0071",
+    # rand: unsoundness with custom logger using rand::rng() (RUSTSEC-2026-0097)
+    # Transitive via russh, statrs, proptest, reqwest; we don't use custom loggers
+    "RUSTSEC-2026-0097",
 ]
 
 [bans]

--- a/specs/005-builtins.md
+++ b/specs/005-builtins.md
@@ -6,7 +6,7 @@ Implemented
 ## Decision
 
 Bashkit provides built-in commands for script execution in a virtual environment.
-All builtins operate on the virtual filesystem. For the complete list of 156
+All builtins operate on the virtual filesystem. For the complete list of 160
 builtins and per-command details, see `specs/009-implementation-status.md`.
 
 ### Standard Flags

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -274,15 +274,15 @@ Features that may be added in the future (not intentionally excluded):
 
 ### Implemented
 
-**148 core builtins + 8 feature-gated = 156 total**
+**148 core builtins + 12 feature-gated = 160 total**
 
 `echo`, `printf`, `cat`, `nl`, `cd`, `pwd`, `true`, `false`, `exit`, `test`, `[`,
 `export`, `set`, `unset`, `local`, `source`, `.`, `read`, `shift`, `break`,
-`continue`, `return`, `grep`, `sed`, `awk`, `jq`, `sleep`, `head`, `tail`,
+`continue`, `return`, `grep`, `sed`, `awk`, `sleep`, `head`, `tail`,
 `basename`, `dirname`, `realpath`, `readlink`, `mkdir`, `mktemp`, `mkfifo`, `rm`, `cp`, `mv`,
 `touch`, `chmod`, `chown`, `ln`, `wc`,
 `sort`, `uniq`, `cut`, `tr`, `paste`, `column`, `diff`, `comm`, `date`,
-`wait`, `curl`, `wget`, `timeout`, `command`, `getopts`,
+`wait`, `curl`, `wget`, `timeout`, `command`, `exec`, `getopts`,
 `type`, `which`, `hash`, `declare`, `typeset`, `let`, `kill`, `shopt`,
 `trap`, `caller`, `mapfile`, `readarray`, `seq`, `tac`, `rev`, `yes`, `expr`,
 `time` (keyword), `whoami`, `hostname`, `uname`, `id`, `ls`, `rmdir`, `find`, `xargs`, `tee`,
@@ -296,7 +296,9 @@ Features that may be added in the future (not intentionally excluded):
 `compgen`, `csv`, `fc`, `help`, `http`, `iconv`, `json`,
 `numfmt`, `parallel`, `patch`, `rg`, `template`, `tomlq`, `yaml`, `zip`, `unzip`,
 `alias`, `unalias`,
+`jq` (requires `jq` feature),
 `git` (requires `git` feature, see [010-git-support.md](010-git-support.md)),
+`ssh`, `scp`, `sftp` (requires `ssh` feature, see [015-ssh-support.md](015-ssh-support.md)),
 `python`, `python3` (requires `python` feature, see [011-python-builtin.md](011-python-builtin.md)),
 `ts`, `typescript`, `node`, `deno`, `bun` (requires `typescript` feature, see [016-zapcode-runtime.md](016-zapcode-runtime.md))
 

--- a/specs/017-request-signing.md
+++ b/specs/017-request-signing.md
@@ -1,5 +1,8 @@
 # 017 — Transparent Request Signing (bot-auth)
 
+## Status
+Implemented
+
 > Ed25519 request signing for all outbound HTTP requests per RFC 9421 / web-bot-auth profile.
 
 ## Problem


### PR DESCRIPTION
## Summary

- Update command counts from 156 to 160 across all docs (README, lib.rs, Python/JS READMEs, specs) to reflect ssh/scp/sftp, jq feature-gated builtins, and exec
- Move jq from core to feature-gated list in spec 009; add ssh/scp/sftp and exec
- Fix rustdoc broken links to feature-gated modules (python_guide, logging_guide, HttpClient)
- Update deny.toml: remove stale RUSTSEC-2023-0071, add RUSTSEC-2026-0097
- Add missing Status header to spec 017 (request-signing)
- Simplify DiscoverBuiltin::filter_tools() — remove unused json_mode return value and unreachable --categories branch

## What changed

**Documentation drift fixes:** The actual builtin count is 148 core + 12 feature-gated = 160 total. Docs referenced 150 or 156 in various places due to additions of ssh/scp/sftp (ssh feature), jq (jq feature), and exec (interpreter-level) that were never reflected in docs.

**Rustdoc fixes:** Three broken doc links — `python_guide` and `logging_guide` are behind feature gates so `[`link`]` syntax fails without the feature; `HttpClient` requires `http_client` feature.

**Advisory cleanup:** RUSTSEC-2023-0071 (rsa Marvin attack) no longer matches any crate in the dependency tree. Added RUSTSEC-2026-0097 (rand unsoundness with custom loggers) — transitive, no impact on bashkit.

**Code simplification:** `DiscoverBuiltin::filter_tools()` returned an unused `json_mode` bool and had an unreachable `--categories` early-return (the caller handles categories before calling this function).

## Test plan

- [x] `cargo test` — 2,347 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` — clean
- [x] `cargo deny check` — passes
- [x] Scripted tool example runs end-to-end
- [x] All non-feature-gated examples verified