### PR TITLE
ci(node): add TypeScript type-check job to JS workflow

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -34,6 +34,34 @@ env:
   DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
 jobs:
+  typecheck:
+    name: TypeScript type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: crates/bashkit-js
+
+      - name: Build native binding (generates type declarations)
+        run: npm run build
+        working-directory: crates/bashkit-js
+
+      - name: Type-check (including tests)
+        run: npx tsc --noEmit -p tsconfig.check.json
+        working-directory: crates/bashkit-js
+
   build-and-test:
     name: ${{ matrix.runtime }} ${{ matrix.version }}
     runs-on: ubuntu-latest
@@ -166,11 +194,15 @@ jobs:
   js-check:
     name: JS Check
     if: always()
-    needs: [build-and-test]
+    needs: [typecheck, build-and-test]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed
         run: |
+          if [[ "${{ needs.typecheck.result }}" != "success" ]]; then
+            echo "TypeScript type-check failed"
+            exit 1
+          fi
           if [[ "${{ needs.build-and-test.result }}" != "success" ]]; then
             echo "JS build/test failed"
             exit 1

--- a/crates/bashkit-js/tsconfig.check.json
+++ b/crates/bashkit-js/tsconfig.check.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": true
+  },
+  "include": [
+    "wrapper.ts",
+    "langchain.ts",
+    "anthropic.ts",
+    "openai.ts",
+    "ai.ts",
+    "__test__/**/*.spec.ts"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Add `typecheck` job to `.github/workflows/js.yml` that runs `tsc --noEmit`
- Create `tsconfig.check.json` that extends `tsconfig.json` to also cover test files (`__test__/*.spec.ts`)
- Add typecheck job to `js-check` gate for branch protection

## Details

The Node CI now mirrors the Python CI pattern of having a dedicated lint/type-check job. The typecheck job:
- Sets up Node.js 22 and Rust toolchain (needed for NAPI type generation)
- Builds the native binding to generate `index.d.cts` type declarations
- Runs `tsc --noEmit -p tsconfig.check.json`
- Is required by the `js-check` gate job

## Test plan

- [x] Job definition is valid YAML
- [x] `tsconfig.check.json` extends base config and includes test files
- [x] Job added to gate/required-checks

Closes #1268