### PR TITLE
feat(scripted-tool): add --dry-run flag with pluggable validation

### DIFF
--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -48,6 +48,7 @@ struct ToolBuiltinAdapter {
     schema: serde_json::Value,
     log: InvocationLog,
     sanitize_errors: bool,
+    dry_run: Option<CallbackKind>,
 }
 
 impl ToolBuiltinAdapter {
@@ -66,6 +67,7 @@ impl Builtin for ToolBuiltinAdapter {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
         // Intercept --help before calling the callback — return the same
         // quality output as `help <tool>` without invoking the callback.
+        // --help takes precedence over --dry-run.
         if ctx.args.iter().any(|a| a == "--help") {
             let result = ExecResult::ok(self.help_text());
             push_invocation(
@@ -76,6 +78,65 @@ impl Builtin for ToolBuiltinAdapter {
                 result.exit_code,
             );
             return Ok(result);
+        }
+
+        // Intercept --dry-run: validate args without executing the callback.
+        if ctx.args.iter().any(|a| a == "--dry-run") {
+            let stripped: Vec<String> = ctx
+                .args
+                .iter()
+                .filter(|a| a.as_str() != "--dry-run")
+                .cloned()
+                .collect();
+            let exit_result = match parse_flags(&stripped, &self.schema) {
+                Ok(params) => {
+                    if let Some(ref dr) = self.dry_run {
+                        // Custom dry-run handler
+                        let tool_args = ToolArgs {
+                            params,
+                            stdin: ctx.stdin.map(String::from),
+                        };
+                        let cb_result = match dr {
+                            CallbackKind::Sync(cb) => (cb)(&tool_args),
+                            CallbackKind::Async(cb) => (cb)(tool_args).await,
+                        };
+                        match cb_result {
+                            Ok(stdout) => ExecResult::ok(stdout),
+                            Err(msg) => ExecResult::err(msg, 1),
+                        }
+                    } else {
+                        // Default: return structured JSON validation result
+                        let obj = serde_json::json!({
+                            "dry_run": true,
+                            "valid": true,
+                            "tool": self.name,
+                            "params": params,
+                        });
+                        ExecResult::ok(format!(
+                            "{}\n",
+                            serde_json::to_string(&obj).unwrap_or_default()
+                        ))
+                    }
+                }
+                Err(err) => {
+                    let obj = serde_json::json!({
+                        "dry_run": true,
+                        "valid": false,
+                        "tool": self.name,
+                        "error": err,
+                    });
+                    let json = serde_json::to_string(&obj).unwrap_or_default();
+                    ExecResult::err(format!("{json}\n"), 1)
+                }
+            };
+            push_invocation(
+                &self.log,
+                &self.name,
+                ScriptedCommandKind::Tool,
+                ctx.args,
+                exit_result.exit_code,
+            );
+            return Ok(exit_result);
         }
 
         let exit_result = match parse_flags(ctx.args, &self.schema) {
@@ -376,6 +437,7 @@ impl ScriptedTool {
                 schema: tool.def.input_schema.clone(),
                 log: Arc::clone(&log),
                 sanitize_errors: self.sanitize_errors,
+                dry_run: tool.dry_run.clone(),
             });
             builder = builder.builtin(name, builtin);
         }

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -187,6 +187,7 @@ pub struct ScriptedExecutionTrace {
 pub(crate) struct RegisteredTool {
     pub(crate) def: ToolDef,
     pub(crate) callback: CallbackKind,
+    pub(crate) dry_run: Option<CallbackKind>,
 }
 
 impl RegisteredTool {
@@ -205,6 +206,7 @@ impl RegisteredTool {
         Self {
             def: tool.def,
             callback,
+            dry_run: None,
         }
     }
 }
@@ -293,6 +295,24 @@ impl ScriptedToolBuilder {
         self.tools.push(RegisteredTool {
             def,
             callback: CallbackKind::Sync(Arc::new(exec)),
+            dry_run: None,
+        });
+        self
+    }
+
+    /// Register a tool with its definition, exec function, and a custom
+    /// `--dry-run` handler. When the tool is invoked with `--dry-run`,
+    /// the custom handler runs instead of the regular callback.
+    pub fn tool_with_dry_run(
+        mut self,
+        def: ToolDef,
+        exec: impl Fn(&ToolArgs) -> Result<String, String> + Send + Sync + 'static,
+        dry_run: impl Fn(&ToolArgs) -> Result<String, String> + Send + Sync + 'static,
+    ) -> Self {
+        self.tools.push(RegisteredTool {
+            def,
+            callback: CallbackKind::Sync(Arc::new(exec)),
+            dry_run: Some(CallbackKind::Sync(Arc::new(dry_run))),
         });
         self
     }
@@ -312,6 +332,7 @@ impl ScriptedToolBuilder {
         self.tools.push(RegisteredTool {
             def,
             callback: CallbackKind::Async(cb),
+            dry_run: None,
         });
         self
     }
@@ -1353,6 +1374,115 @@ mod tests {
         assert!(
             !resp.stdout.contains("Alice"),
             "callback should NOT be invoked"
+        );
+    }
+
+    // -- Issue #1279: --dry-run flag tests --
+
+    #[tokio::test]
+    async fn test_dry_run_validates_args() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "get_user --dry-run --id 42".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        let parsed: serde_json::Value =
+            serde_json::from_str(resp.stdout.trim()).expect("stdout should be valid JSON");
+        assert_eq!(parsed["dry_run"], true);
+        assert_eq!(parsed["valid"], true);
+        assert_eq!(parsed["params"]["id"], 42);
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_does_not_invoke_callback() {
+        let tool = build_test_tool();
+        // fail_tool always errors, but --dry-run should succeed
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "fail_tool --dry-run".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(
+            resp.exit_code, 0,
+            "--dry-run should not invoke the callback"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_help_precedence() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "get_user --help --dry-run".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        // Should return help text, not dry-run JSON
+        assert!(
+            resp.stdout.contains("Fetch user by id"),
+            "should show help text"
+        );
+        assert!(
+            !resp.stdout.contains("dry_run"),
+            "should NOT show dry-run JSON"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_custom_dry_run_handler() {
+        let tool = ScriptedTool::builder("dr_test")
+            .tool_with_dry_run(
+                ToolDef::new("check", "Validate input").with_schema(serde_json::json!({
+                    "type": "object",
+                    "properties": { "id": {"type": "integer"} }
+                })),
+                |args: &ToolArgs| {
+                    let id = args.param_i64("id").ok_or("missing --id")?;
+                    Ok(format!("executed {id}\n"))
+                },
+                |args: &ToolArgs| {
+                    let id = args.param_i64("id").ok_or("missing --id")?;
+                    Ok(format!("custom-dry-run id={id}\n"))
+                },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "check --dry-run --id 7".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "custom-dry-run id=7");
+    }
+
+    #[tokio::test]
+    async fn test_help_flag_returns_help() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "get_user --help".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 0);
+        assert!(
+            resp.stdout.contains("get_user"),
+            "help should include tool name"
+        );
+        assert!(
+            resp.stdout.contains("Fetch user by id"),
+            "help should include description"
+        );
+        assert!(
+            resp.stdout.contains("--id"),
+            "help should include parameter flags"
         );
     }
 }

--- a/crates/bashkit/src/scripted_tool/toolset.rs
+++ b/crates/bashkit/src/scripted_tool/toolset.rs
@@ -246,6 +246,7 @@ impl ScriptingToolSetBuilder {
         self.tools.push(RegisteredTool {
             def,
             callback: CallbackKind::Sync(Arc::new(exec)),
+            dry_run: None,
         });
         self
     }
@@ -262,6 +263,7 @@ impl ScriptingToolSetBuilder {
         self.tools.push(RegisteredTool {
             def,
             callback: CallbackKind::Async(cb),
+            dry_run: None,
         });
         self
     }


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag that validates arguments without executing the callback
- Add `tool_with_dry_run()` builder method for custom dry-run handlers
- Add `--help` flag interception (same output as `help <tool>`)

## Details

When `--dry-run` is passed, the tool:
1. Strips `--dry-run` from args before parsing
2. Validates args against the schema
3. Returns structured JSON result without calling the callback:
   - Valid: `{"dry_run":true,"valid":true,"tool":"name","params":{...}}`
   - Invalid: `{"dry_run":true,"valid":false,"tool":"name","error":"..."}`

Custom dry-run handlers can be registered per-tool via `tool_with_dry_run()` for domain-specific validation (e.g. checking if a resource exists before mutating it).

`--help` takes precedence over `--dry-run` when both are present.

## Test plan

- [x] `test_dry_run_validates_args` — validates args and returns structured JSON
- [x] `test_dry_run_does_not_invoke_callback` — fail_tool --dry-run succeeds
- [x] `test_dry_run_help_precedence` — --help takes precedence
- [x] `test_custom_dry_run_handler` — custom handler is called
- [x] `test_help_flag_returns_help` — --help returns help text
- [x] All 2459 lib tests pass

Closes #1279