### PR TITLE
fix(touch): update mtimes for existing paths

### DIFF
--- a/crates/bashkit/src/builtins/fileops.rs
+++ b/crates/bashkit/src/builtins/fileops.rs
@@ -1,7 +1,11 @@
 //! File operation builtins - mkdir, rm, cp, mv, touch, chmod
+// Decision: touch delegates mtime changes to the filesystem layer so `touch`
+// and `touch -t` stay consistent across in-memory, overlay, and realfs backends.
 
 use async_trait::async_trait;
+use chrono::{Datelike, Local, LocalResult, NaiveDate, TimeZone};
 use std::path::Path;
+use std::time::SystemTime;
 
 use super::{Builtin, Context, resolve_path};
 use crate::error::Result;
@@ -315,12 +319,71 @@ impl Builtin for Mv {
 /// Usage: touch FILE...
 pub struct Touch;
 
+fn parse_touch_timestamp(raw: &str) -> std::result::Result<SystemTime, String> {
+    let (main, seconds) = match raw.split_once('.') {
+        Some((main, seconds)) => {
+            if seconds.len() != 2 || !seconds.chars().all(|ch| ch.is_ascii_digit()) {
+                return Err(format!("touch: invalid date format '{}'\n", raw));
+            }
+            let seconds = seconds
+                .parse::<u32>()
+                .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?;
+            (main, seconds)
+        }
+        None => (raw, 0),
+    };
+
+    if !main.chars().all(|ch| ch.is_ascii_digit()) {
+        return Err(format!("touch: invalid date format '{}'\n", raw));
+    }
+
+    let year = match main.len() {
+        8 => Local::now().year(),
+        10 => {
+            let yy = main[0..2]
+                .parse::<i32>()
+                .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?;
+            if yy >= 69 { 1900 + yy } else { 2000 + yy }
+        }
+        12 => main[0..4]
+            .parse::<i32>()
+            .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?,
+        _ => return Err(format!("touch: invalid date format '{}'\n", raw)),
+    };
+
+    let offset = main.len() - 8;
+    let month = main[offset..offset + 2]
+        .parse::<u32>()
+        .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?;
+    let day = main[offset + 2..offset + 4]
+        .parse::<u32>()
+        .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?;
+    let hour = main[offset + 4..offset + 6]
+        .parse::<u32>()
+        .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?;
+    let minute = main[offset + 6..offset + 8]
+        .parse::<u32>()
+        .map_err(|_| format!("touch: invalid date format '{}'\n", raw))?;
+
+    let naive = NaiveDate::from_ymd_opt(year, month, day)
+        .and_then(|date| date.and_hms_opt(hour, minute, seconds))
+        .ok_or_else(|| format!("touch: invalid date format '{}'\n", raw))?;
+
+    let local = match Local.from_local_datetime(&naive) {
+        LocalResult::Single(dt) => dt,
+        LocalResult::Ambiguous(dt, _) => dt,
+        LocalResult::None => return Err(format!("touch: invalid date format '{}'\n", raw)),
+    };
+
+    Ok(local.into())
+}
+
 #[async_trait]
 impl Builtin for Touch {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
         if let Some(r) = super::check_help_version(
             ctx.args,
-            "Usage: touch [OPTION]... FILE...\nUpdate the access and modification times of each FILE to the current time.\nA FILE argument that does not exist is created empty.\n\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
+            "Usage: touch [OPTION]... FILE...\nUpdate the access and modification times of each FILE to the current time.\nA FILE argument that does not exist is created empty.\n\n  -t STAMP\tuse [[CC]YY]MMDDhhmm[.ss] instead of current time\n      --help\tdisplay this help and exit\n      --version\toutput version information and exit\n",
             Some("touch (bashkit) 0.1"),
         ) {
             return Ok(r);
@@ -333,20 +396,66 @@ impl Builtin for Touch {
             ));
         }
 
-        for file in ctx.args.iter().filter(|a| !a.starts_with('-')) {
-            let path = resolve_path(ctx.cwd, file);
-
-            // Check if file exists
-            if !ctx.fs.exists(&path).await.unwrap_or(false) {
-                // Create empty file
-                if let Err(e) = ctx.fs.write_file(&path, &[]).await {
+        let mut files = Vec::new();
+        let mut target_time = SystemTime::now();
+        let mut i = 0;
+        while i < ctx.args.len() {
+            let arg = &ctx.args[i];
+            if arg == "-t" {
+                i += 1;
+                if i >= ctx.args.len() {
                     return Ok(ExecResult::err(
-                        format!("touch: cannot touch '{}': {}\n", file, e),
+                        "touch: option requires an argument -- 't'\n".to_string(),
                         1,
                     ));
                 }
+                match parse_touch_timestamp(&ctx.args[i]) {
+                    Ok(parsed) => target_time = parsed,
+                    Err(err) => return Ok(ExecResult::err(err, 1)),
+                }
+            } else if let Some(stamp) = arg.strip_prefix("-t")
+                && !stamp.is_empty()
+            {
+                match parse_touch_timestamp(stamp) {
+                    Ok(parsed) => target_time = parsed,
+                    Err(err) => return Ok(ExecResult::err(err, 1)),
+                }
+            } else if arg.starts_with('-') {
+                return Ok(ExecResult::err(
+                    format!("touch: invalid option -- '{}'\n", arg),
+                    1,
+                ));
+            } else {
+                files.push(arg);
             }
-            // For existing files, we would update mtime but VFS doesn't track it in a modifiable way
+            i += 1;
+        }
+
+        if files.is_empty() {
+            return Ok(ExecResult::err(
+                "touch: missing file operand\n".to_string(),
+                1,
+            ));
+        }
+
+        for file in files {
+            let path = resolve_path(ctx.cwd, file);
+
+            if !ctx.fs.exists(&path).await.unwrap_or(false)
+                && let Err(e) = ctx.fs.write_file(&path, &[]).await
+            {
+                return Ok(ExecResult::err(
+                    format!("touch: cannot touch '{}': {}\n", file, e),
+                    1,
+                ));
+            }
+
+            if let Err(e) = ctx.fs.set_modified_time(&path, target_time).await {
+                return Ok(ExecResult::err(
+                    format!("touch: cannot touch '{}': {}\n", file, e),
+                    1,
+                ));
+            }
         }
 
         Ok(ExecResult::ok(String::new()))
@@ -816,6 +925,7 @@ impl Builtin for Mktemp {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{DateTime, Datelike, Local, Timelike};
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -912,6 +1022,78 @@ mod tests {
         let result = Touch.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 0);
         assert!(fs.exists(&cwd.join("newfile.txt")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_touch_t_sets_existing_file_mtime() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+        let file = cwd.join("existing.txt");
+        fs.write_file(&file, b"content").await.unwrap();
+
+        let args = vec![
+            "-t".to_string(),
+            "202604061200.00".to_string(),
+            "existing.txt".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Touch.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+
+        let metadata = fs.stat(&file).await.unwrap();
+        let modified: DateTime<Local> = metadata.modified.into();
+        assert_eq!(modified.year(), 2026);
+        assert_eq!(modified.month(), 4);
+        assert_eq!(modified.day(), 6);
+        assert_eq!(modified.hour(), 12);
+        assert_eq!(modified.minute(), 0);
+        assert_eq!(modified.second(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_touch_t_rejects_invalid_timestamp() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec![
+            "-t".to_string(),
+            "not-a-timestamp".to_string(),
+            "existing.txt".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs,
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Touch.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid date format"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/help.rs
+++ b/crates/bashkit/src/builtins/help.rs
@@ -260,7 +260,7 @@ const BUILTINS: &[CmdInfo] = &[
     CmdInfo {
         name: "touch",
         category: "files",
-        usage: "touch FILE...",
+        usage: "touch [-t STAMP] FILE...",
         description: "Create/update files",
     },
     CmdInfo {

--- a/crates/bashkit/src/fs/backend.rs
+++ b/crates/bashkit/src/fs/backend.rs
@@ -94,6 +94,7 @@
 
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use super::limits::{FsLimits, FsUsage};
 use super::traits::{DirEntry, Metadata};
@@ -192,6 +193,11 @@ pub trait FsBackend: Send + Sync {
 
     /// Change file permissions.
     async fn chmod(&self, path: &Path, mode: u32) -> Result<()>;
+
+    /// Set the last modification time for a file or directory.
+    async fn set_modified_time(&self, _path: &Path, _time: SystemTime) -> Result<()> {
+        Err(std::io::Error::other("set_modified_time not supported").into())
+    }
 
     /// Get storage usage statistics.
     fn usage(&self) -> FsUsage {

--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -1602,6 +1602,26 @@ impl FileSystem for InMemoryFs {
             None => Err(IoError::new(ErrorKind::NotFound, "not found").into()),
         }
     }
+
+    async fn set_modified_time(&self, path: &Path, time: SystemTime) -> Result<()> {
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+        let path = Self::normalize_path(path);
+        let mut entries = self.entries.write().unwrap();
+
+        match entries.get_mut(&path) {
+            Some(FsEntry::File { metadata, .. })
+            | Some(FsEntry::LazyFile { metadata, .. })
+            | Some(FsEntry::Directory { metadata })
+            | Some(FsEntry::Symlink { metadata, .. })
+            | Some(FsEntry::Fifo { metadata, .. }) => {
+                metadata.modified = time;
+                Ok(())
+            }
+            None => Err(IoError::new(ErrorKind::NotFound, "not found").into()),
+        }
+    }
 }
 
 #[async_trait]

--- a/crates/bashkit/src/fs/mountable.rs
+++ b/crates/bashkit/src/fs/mountable.rs
@@ -12,6 +12,7 @@ use std::collections::BTreeMap;
 use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
+use std::time::SystemTime;
 
 use super::limits::{FsLimits, FsUsage};
 use super::traits::{DirEntry, FileSystem, FileSystemExt, FileType, Metadata};
@@ -480,6 +481,12 @@ impl FileSystem for MountableFs {
         self.validate_path(path)?;
         let (fs, resolved) = self.resolve(path);
         fs.chmod(&resolved, mode).await
+    }
+
+    async fn set_modified_time(&self, path: &Path, time: SystemTime) -> Result<()> {
+        self.validate_path(path)?;
+        let (fs, resolved) = self.resolve(path);
+        fs.set_modified_time(&resolved, time).await
     }
 }
 

--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -36,6 +36,7 @@ use std::collections::HashSet;
 use std::io::{Error as IoError, ErrorKind};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
+use std::time::SystemTime;
 
 use super::limits::{FsLimits, FsUsage};
 use super::memory::InMemoryFs;
@@ -849,6 +850,59 @@ impl FileSystem for OverlayFs {
             }
 
             return self.upper.chmod(&path, mode).await;
+        }
+
+        Err(IoError::new(ErrorKind::NotFound, "not found").into())
+    }
+
+    async fn set_modified_time(&self, path: &Path, time: SystemTime) -> Result<()> {
+        self.limits
+            .validate_path(path)
+            .map_err(|e| IoError::other(e.to_string()))?;
+        let path = Self::normalize_path(path);
+
+        if self.is_whiteout(&path) {
+            return Err(IoError::new(ErrorKind::NotFound, "not found").into());
+        }
+
+        if self.upper.exists(&path).await.unwrap_or(false) {
+            return self.upper.set_modified_time(&path, time).await;
+        }
+
+        if self.lower.exists(&path).await.unwrap_or(false) {
+            let stat = self.lower.stat(&path).await?;
+
+            match stat.file_type {
+                FileType::File | FileType::Fifo => {
+                    let content = self.lower.read_file(&path).await?;
+                    self.check_write_limits(content.len())?;
+                    if let Some(parent) = path.parent()
+                        && !self.upper.exists(parent).await.unwrap_or(false)
+                    {
+                        self.upper.mkdir(parent, true).await?;
+                    }
+                    self.upper.write_file(&path, &content).await?;
+                    self.hide_lower_file(stat.size);
+                }
+                FileType::Directory => {
+                    self.check_dir_limits()?;
+                    self.upper.mkdir(&path, true).await?;
+                    self.hide_lower_dir();
+                }
+                FileType::Symlink => {
+                    let target = self.lower.read_link(&path).await?;
+                    self.check_write_limits(0)?;
+                    if let Some(parent) = path.parent()
+                        && !self.upper.exists(parent).await.unwrap_or(false)
+                    {
+                        self.upper.mkdir(parent, true).await?;
+                    }
+                    self.upper.symlink(&target, &path).await?;
+                    self.hide_lower_file(0);
+                }
+            }
+
+            return self.upper.set_modified_time(&path, time).await;
         }
 
         Err(IoError::new(ErrorKind::NotFound, "not found").into())

--- a/crates/bashkit/src/fs/posix.rs
+++ b/crates/bashkit/src/fs/posix.rs
@@ -50,6 +50,7 @@ use async_trait::async_trait;
 use std::io::Error as IoError;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use super::backend::FsBackend;
 use super::limits::{FsLimits, FsUsage};
@@ -256,6 +257,11 @@ impl<B: FsBackend + 'static> FileSystem for PosixFs<B> {
     async fn chmod(&self, path: &Path, mode: u32) -> Result<()> {
         let path = Self::normalize(path);
         self.backend.chmod(&path, mode).await
+    }
+
+    async fn set_modified_time(&self, path: &Path, time: SystemTime) -> Result<()> {
+        let path = Self::normalize(path);
+        self.backend.set_modified_time(&path, time).await
     }
 }
 

--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -478,6 +478,14 @@ impl FsBackend for RealFs {
         Ok(())
     }
 
+    async fn set_modified_time(&self, path: &Path, time: SystemTime) -> Result<()> {
+        self.check_writable()?;
+        let real = self.resolve(path)?;
+        let file = std::fs::File::open(&real)?;
+        file.set_modified(time)?;
+        Ok(())
+    }
+
     fn usage(&self) -> FsUsage {
         // Could walk the real directory, but that's expensive. Return zeros.
         FsUsage::default()

--- a/crates/bashkit/src/fs/traits.rs
+++ b/crates/bashkit/src/fs/traits.rs
@@ -367,6 +367,11 @@ pub trait FileSystem: FileSystemExt {
     /// Returns an error if the path does not exist.
     async fn chmod(&self, path: &Path, mode: u32) -> Result<()>;
 
+    /// Set the last modification time for a file or directory.
+    async fn set_modified_time(&self, _path: &Path, _time: SystemTime) -> Result<()> {
+        Err(std::io::Error::other("set_modified_time not supported").into())
+    }
+
     /// Returns a reference to this filesystem as a [`SearchCapable`](super::SearchCapable)
     /// implementation, if supported.
     ///

--- a/crates/bashkit/tests/spec_cases/bash/fileops.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/fileops.test.sh
@@ -178,6 +178,15 @@ echo $?
 0
 ### end
 
+### touch_t_sets_file_mtime
+# touch -t should set the file mtime
+echo "test" > /tmp/touch_timestamp.txt
+touch -t 202604061200.00 /tmp/touch_timestamp.txt
+date -r /tmp/touch_timestamp.txt +%Y%m%d%H%M.%S
+### expect
+202604061200.00
+### end
+
 ### mktemp_creates_file
 # mktemp creates a temp file and prints its path
 f=$(mktemp)


### PR DESCRIPTION
## What
- teach touch to update mtimes for existing files and directories instead of silently doing nothing
- add touch -t timestamp parsing for [[CC]YY]MMDDhhmm[.ss]
- route mtime updates through the filesystem layer so in-memory, mountable, overlay, posix, and realfs backends all behave consistently
- cover the fix with builtin tests and a bash spec case

## Why
- touch -t TIMESTAMP FILE exited successfully but left the original mtime unchanged, which breaks workflows that preserve timestamps after rebuilding files

## How
- add set_modified_time to the filesystem traits and backend wrappers
- use it from touch for both the default current-time path and the explicit -t path
- keep the end-to-end behavior exercised through the bash spec suite and CLI smoke test

## Tests
- cargo test touch_t_ --package bashkit --features http_client
- cargo test bash_spec_tests --test spec_tests --package bashkit --features http_client -- --nocapture
- target/debug/bashkit -c "echo test > /tmp/touch_timestamp.txt && touch -t 202604061200.00 /tmp/touch_timestamp.txt && date -r /tmp/touch_timestamp.txt +%Y%m%d%H%M.%S"

Closes #1157