### PR TITLE
feat(python): add direct VFS convenience methods

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -84,6 +84,21 @@ bash = Bash(
 from bashkit import Bash
 
 bash = Bash()
+bash.mkdir("/data", recursive=True)
+bash.write_file("/data/config.json", '{"debug": true}\n')
+assert bash.read_file("/data/config.json") == '{"debug": true}\n'
+assert bash.ls("/data") == ["config.json"]
+assert bash.glob("/data/*.json") == ["/data/config.json"]
+
+# The same convenience methods exist on BashTool()
+```
+
+### FileSystem Accessor
+
+```python
+from bashkit import Bash
+
+bash = Bash()
 fs = bash.fs()
 fs.mkdir("/data", recursive=True)
 fs.write_file("/data/blob.bin", b"\x00\x01hello")

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -424,6 +424,58 @@ class Bash:
         """
         ...
 
+    def read_file(self, path: str) -> str:
+        """Read a VFS file as UTF-8 text."""
+        ...
+
+    def write_file(self, path: str, content: str) -> None:
+        """Write UTF-8 text into the VFS."""
+        ...
+
+    def append_file(self, path: str, content: str) -> None:
+        """Append UTF-8 text to a VFS file."""
+        ...
+
+    def mkdir(self, path: str, recursive: bool = False) -> None:
+        """Create a directory in the VFS."""
+        ...
+
+    def exists(self, path: str) -> bool:
+        """Return whether a VFS path exists."""
+        ...
+
+    def remove(self, path: str, recursive: bool = False) -> None:
+        """Remove a VFS file or directory."""
+        ...
+
+    def stat(self, path: str) -> dict[str, Any]:
+        """Return metadata for a VFS path."""
+        ...
+
+    def chmod(self, path: str, mode: int) -> None:
+        """Change VFS permissions for a path."""
+        ...
+
+    def symlink(self, target: str, link: str) -> None:
+        """Create a symlink in the VFS."""
+        ...
+
+    def read_link(self, path: str) -> str:
+        """Return the symlink target for a VFS path."""
+        ...
+
+    def read_dir(self, path: str) -> list[dict[str, Any]]:
+        """Return directory entries with metadata."""
+        ...
+
+    def ls(self, path: str = ".") -> list[str]:
+        """Return entry names for a directory, or an empty list if it is missing."""
+        ...
+
+    def glob(self, pattern: str) -> list[str]:
+        """Return file paths matching a safe glob pattern."""
+        ...
+
     def fs(self) -> FileSystem:
         """Return a live filesystem handle.
 
@@ -701,6 +753,58 @@ class BashTool:
             >>> result.exit_code  # file is gone
             1
         """
+        ...
+
+    def read_file(self, path: str) -> str:
+        """Read a VFS file as UTF-8 text."""
+        ...
+
+    def write_file(self, path: str, content: str) -> None:
+        """Write UTF-8 text into the VFS."""
+        ...
+
+    def append_file(self, path: str, content: str) -> None:
+        """Append UTF-8 text to a VFS file."""
+        ...
+
+    def mkdir(self, path: str, recursive: bool = False) -> None:
+        """Create a directory in the VFS."""
+        ...
+
+    def exists(self, path: str) -> bool:
+        """Return whether a VFS path exists."""
+        ...
+
+    def remove(self, path: str, recursive: bool = False) -> None:
+        """Remove a VFS file or directory."""
+        ...
+
+    def stat(self, path: str) -> dict[str, Any]:
+        """Return metadata for a VFS path."""
+        ...
+
+    def chmod(self, path: str, mode: int) -> None:
+        """Change VFS permissions for a path."""
+        ...
+
+    def symlink(self, target: str, link: str) -> None:
+        """Create a symlink in the VFS."""
+        ...
+
+    def read_link(self, path: str) -> str:
+        """Return the symlink target for a VFS path."""
+        ...
+
+    def read_dir(self, path: str) -> list[dict[str, Any]]:
+        """Return directory entries with metadata."""
+        ...
+
+    def ls(self, path: str = ".") -> list[str]:
+        """Return entry names for a directory, or an empty list if it is missing."""
+        ...
+
+    def glob(self, pattern: str) -> list[str]:
+        """Return file paths matching a safe glob pattern."""
         ...
 
     def fs(self) -> FileSystem:

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -243,6 +243,241 @@ impl FileSystemHandle {
     }
 }
 
+fn with_live_fs<T, F, Fut>(rt: &Arc<Runtime>, inner: &Arc<Mutex<Bash>>, f: F) -> PyResult<T>
+where
+    F: FnOnce(Arc<dyn FileSystem>) -> Fut,
+    Fut: Future<Output = PyResult<T>>,
+{
+    let inner = inner.clone();
+    rt.block_on(async move {
+        let fs = {
+            let bash = inner.lock().await;
+            bash.fs()
+        };
+        f(fs).await
+    })
+}
+
+fn read_text_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+) -> PyResult<String> {
+    with_live_fs(rt, inner, move |fs| async move {
+        let bytes = fs
+            .read_file(Path::new(&path))
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        String::from_utf8(bytes).map_err(|e| PyRuntimeError::new_err(format!("Invalid UTF-8: {e}")))
+    })
+}
+
+fn write_text_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+    content: String,
+) -> PyResult<()> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.write_file(Path::new(&path), content.as_bytes())
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn append_text_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+    content: String,
+) -> PyResult<()> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.append_file(Path::new(&path), content.as_bytes())
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn mkdir_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+    recursive: bool,
+) -> PyResult<()> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.mkdir(Path::new(&path), recursive)
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn remove_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+    recursive: bool,
+) -> PyResult<()> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.remove(Path::new(&path), recursive)
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn exists_via_live_fs(rt: &Arc<Runtime>, inner: &Arc<Mutex<Bash>>, path: String) -> PyResult<bool> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.exists(Path::new(&path))
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn stat_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+) -> PyResult<FsMetadata> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.stat(Path::new(&path))
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn chmod_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+    mode: u32,
+) -> PyResult<()> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.chmod(Path::new(&path), mode)
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn symlink_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    target: String,
+    link: String,
+) -> PyResult<()> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.symlink(Path::new(&target), Path::new(&link))
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn read_link_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+) -> PyResult<String> {
+    with_live_fs(rt, inner, move |fs| async move {
+        let target = fs
+            .read_link(Path::new(&path))
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        Ok(target.display().to_string())
+    })
+}
+
+fn read_dir_via_live_fs(
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    path: String,
+) -> PyResult<Vec<FsDirEntry>> {
+    with_live_fs(rt, inner, move |fs| async move {
+        fs.read_dir(Path::new(&path))
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+    })
+}
+
+fn is_safe_glob_pattern(pattern: &str) -> bool {
+    pattern.chars().all(|ch| {
+        ch.is_ascii_alphanumeric()
+            || matches!(ch, '*' | '?' | '[' | ']' | '.' | '_' | '-' | '/' | ' ')
+    })
+}
+
+fn glob_match_path(value: &str, pattern: &str) -> bool {
+    let mut value_chars = value.chars().peekable();
+    let mut pattern_chars = pattern.chars().peekable();
+
+    loop {
+        match (pattern_chars.peek(), value_chars.peek()) {
+            (None, None) => return true,
+            (None, Some(_)) => return false,
+            (Some('*'), _) => {
+                pattern_chars.next();
+                if pattern_chars.peek().is_none() {
+                    return true;
+                }
+                while value_chars.peek().is_some() {
+                    let remaining_value: String = value_chars.clone().collect();
+                    let remaining_pattern: String = pattern_chars.clone().collect();
+                    if glob_match_path(&remaining_value, &remaining_pattern) {
+                        return true;
+                    }
+                    value_chars.next();
+                }
+                let remaining_pattern: String = pattern_chars.collect();
+                return glob_match_path("", &remaining_pattern);
+            }
+            (Some('?'), Some(_)) => {
+                pattern_chars.next();
+                value_chars.next();
+            }
+            (Some('?'), None) => return false,
+            (Some(p), Some(v)) => {
+                if *p == *v {
+                    pattern_chars.next();
+                    value_chars.next();
+                } else {
+                    return false;
+                }
+            }
+            (Some(_), None) => return false,
+        }
+    }
+}
+
+fn normalize_find_path(path: &str) -> String {
+    if let Some(stripped) = path.strip_prefix("//") {
+        format!("/{}", stripped)
+    } else {
+        path.to_string()
+    }
+}
+
+fn glob_via_bash(rt: &Arc<Runtime>, inner: &Arc<Mutex<Bash>>, pattern: String) -> Vec<String> {
+    if !is_safe_glob_pattern(&pattern) {
+        return Vec::new();
+    }
+
+    let inner = inner.clone();
+    let command = "find / -type f 2>/dev/null".to_string();
+    let result = rt.block_on(async move {
+        let mut bash = inner.lock().await;
+        bash.exec(&command).await
+    });
+
+    match result {
+        Ok(exec) if exec.exit_code == 0 => exec
+            .stdout
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(normalize_find_path)
+            .filter(|line| glob_match_path(line, &pattern))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 #[pyclass(name = "FileSystem")]
 struct PyFileSystem {
     inner: FileSystemHandle,
@@ -964,6 +1199,77 @@ impl PyBash {
         })
     }
 
+    fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn write_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| write_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    fn append_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| append_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn mkdir(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| mkdir_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn exists(&self, py: Python<'_>, path: String) -> PyResult<bool> {
+        py.detach(|| exists_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn remove(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| remove_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn stat(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let metadata = py.detach(|| stat_via_live_fs(&self.rt, &self.inner, path))?;
+        metadata_to_pydict(py, &metadata)
+    }
+
+    fn chmod(&self, py: Python<'_>, path: String, mode: u32) -> PyResult<()> {
+        py.detach(|| chmod_via_live_fs(&self.rt, &self.inner, path, mode))
+    }
+
+    fn symlink(&self, py: Python<'_>, target: String, link: String) -> PyResult<()> {
+        py.detach(|| symlink_via_live_fs(&self.rt, &self.inner, target, link))
+    }
+
+    fn read_link(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_link_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn read_dir(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let entries = py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path))?;
+        let items: Vec<Py<PyAny>> = entries
+            .iter()
+            .map(|entry| dir_entry_to_pydict(py, entry))
+            .collect::<PyResult<_>>()?;
+        Ok(PyList::new(py, &items)?.into_any().unbind())
+    }
+
+    #[pyo3(signature = (path=".".to_string()))]
+    fn ls(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let names = match py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path)) {
+            Ok(entries) => entries
+                .into_iter()
+                .map(|entry| entry.name)
+                .collect::<Vec<_>>(),
+            Err(_) => Vec::new(),
+        };
+        Ok(PyList::new(py, names)?.into_any().unbind())
+    }
+
+    fn glob(&self, py: Python<'_>, pattern: String) -> PyResult<Py<PyAny>> {
+        let matches = py.detach(|| -> PyResult<Vec<String>> {
+            Ok(glob_via_bash(&self.rt, &self.inner, pattern))
+        })?;
+        Ok(PyList::new(py, matches)?.into_any().unbind())
+    }
+
     /// Return a live filesystem handle backed by the current interpreter.
     ///
     /// Each operation on the returned handle acquires the interpreter lock,
@@ -1346,6 +1652,77 @@ impl BashTool {
                 Ok(())
             })
         })
+    }
+
+    fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn write_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| write_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    fn append_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| append_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn mkdir(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| mkdir_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn exists(&self, py: Python<'_>, path: String) -> PyResult<bool> {
+        py.detach(|| exists_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn remove(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| remove_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn stat(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let metadata = py.detach(|| stat_via_live_fs(&self.rt, &self.inner, path))?;
+        metadata_to_pydict(py, &metadata)
+    }
+
+    fn chmod(&self, py: Python<'_>, path: String, mode: u32) -> PyResult<()> {
+        py.detach(|| chmod_via_live_fs(&self.rt, &self.inner, path, mode))
+    }
+
+    fn symlink(&self, py: Python<'_>, target: String, link: String) -> PyResult<()> {
+        py.detach(|| symlink_via_live_fs(&self.rt, &self.inner, target, link))
+    }
+
+    fn read_link(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_link_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn read_dir(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let entries = py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path))?;
+        let items: Vec<Py<PyAny>> = entries
+            .iter()
+            .map(|entry| dir_entry_to_pydict(py, entry))
+            .collect::<PyResult<_>>()?;
+        Ok(PyList::new(py, &items)?.into_any().unbind())
+    }
+
+    #[pyo3(signature = (path=".".to_string()))]
+    fn ls(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let names = match py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path)) {
+            Ok(entries) => entries
+                .into_iter()
+                .map(|entry| entry.name)
+                .collect::<Vec<_>>(),
+            Err(_) => Vec::new(),
+        };
+        Ok(PyList::new(py, names)?.into_any().unbind())
+    }
+
+    fn glob(&self, py: Python<'_>, pattern: String) -> PyResult<Py<PyAny>> {
+        let matches = py.detach(|| -> PyResult<Vec<String>> {
+            Ok(glob_via_bash(&self.rt, &self.inner, pattern))
+        })?;
+        Ok(PyList::new(py, matches)?.into_any().unbind())
     }
 
     /// Return a live filesystem handle backed by the current interpreter.

--- a/crates/bashkit-python/tests/test_bashkit.py
+++ b/crates/bashkit-python/tests/test_bashkit.py
@@ -170,6 +170,60 @@ def test_bash_fs_handle_supports_directory_ops_and_links():
     assert fs.exists("/data") is False
 
 
+def test_bash_direct_vfs_methods_cover_core_ops():
+    bash = Bash()
+
+    bash.mkdir("/data/src", recursive=True)
+    bash.write_file("/data/src/file.txt", "alpha")
+    bash.append_file("/data/src/file.txt", "beta")
+    bash.mkdir("/data/dst", recursive=True)
+    bash.write_file("/data/dst/second.txt", "second")
+    bash.symlink("/data/src/file.txt", "/data/link.txt")
+    bash.chmod("/data/src/file.txt", 0o600)
+
+    assert bash.read_file("/data/src/file.txt") == "alphabeta"
+    assert bash.exists("/data/src/file.txt") is True
+    assert bash.read_link("/data/link.txt") == "/data/src/file.txt"
+
+    stat = bash.stat("/data/src/file.txt")
+    assert stat["mode"] == 0o600
+    assert stat["size"] == len("alphabeta")
+
+    entries = sorted(entry["name"] for entry in bash.read_dir("/data"))
+    assert entries == ["dst", "link.txt", "src"]
+    assert bash.ls("/data/src") == ["file.txt"]
+    assert sorted(bash.glob("/data/*/*.txt")) == ["/data/dst/second.txt", "/data/src/file.txt"]
+
+    bash.remove("/data/link.txt")
+    bash.remove("/data", recursive=True)
+    assert bash.exists("/data") is False
+
+
+def test_bash_direct_vfs_methods_raise_on_missing_paths_and_non_utf8():
+    bash = Bash()
+    bash.fs().mkdir("/data", recursive=True)
+    bash.fs().write_file("/data/blob.bin", b"\xff\xfe\xfd")
+
+    with pytest.raises(Exception):
+        bash.read_file("/missing.txt")
+
+    with pytest.raises(Exception, match="UTF-8"):
+        bash.read_file("/data/blob.bin")
+
+    assert bash.ls("/missing-dir") == []
+    assert bash.glob("'; echo pwned") == []
+
+
+def test_bash_direct_vfs_methods_track_shell_changes_and_reset():
+    bash = Bash()
+
+    bash.execute_sync("mkdir -p /workspace && echo shell > /workspace/from-shell.txt")
+    assert bash.read_file("/workspace/from-shell.txt") == "shell\n"
+
+    bash.reset()
+    assert bash.exists("/workspace/from-shell.txt") is False
+
+
 # -- Bash: FS / mount error cases ------------------------------------------
 
 
@@ -342,6 +396,24 @@ def test_bashtool_live_mount_preserves_state(tmp_path):
 
     tool.unmount("/workspace")
     assert tool.execute_sync("echo ${KEEP:-missing}").stdout.strip() == "1"
+
+
+def test_bashtool_direct_vfs_methods_cover_core_ops():
+    tool = BashTool()
+
+    tool.mkdir("/data", recursive=True)
+    tool.write_file("/data/file.txt", "hello")
+    tool.append_file("/data/file.txt", " world")
+    tool.symlink("/data/file.txt", "/data/link.txt")
+
+    assert tool.read_file("/data/file.txt") == "hello world"
+    assert tool.exists("/data/file.txt") is True
+    assert tool.read_link("/data/link.txt") == "/data/file.txt"
+    assert sorted(tool.ls("/data")) == ["file.txt", "link.txt"]
+    assert tool.glob("/data/*.txt") == ["/data/file.txt"]
+
+    tool.reset()
+    assert tool.exists("/data/file.txt") is False
 
 
 # -- BashTool: Async execution ----------------------------------------------

--- a/specs/013-python-package.md
+++ b/specs/013-python-package.md
@@ -125,6 +125,21 @@ result = tool.execute_sync("echo hello")
 # Reset state
 tool.reset()
 
+# Direct VFS helpers (text-oriented convenience wrappers)
+tool.read_file("/tmp/data.txt")      # -> str
+tool.write_file("/tmp/data.txt", "hello")
+tool.append_file("/tmp/data.txt", "\nworld")
+tool.mkdir("/tmp/nested", recursive=True)
+tool.exists("/tmp/data.txt")         # -> bool
+tool.remove("/tmp/nested", recursive=True)
+tool.stat("/tmp/data.txt")           # -> dict
+tool.chmod("/tmp/data.txt", 0o644)
+tool.symlink("/tmp/data.txt", "/tmp/link.txt")
+tool.read_link("/tmp/link.txt")      # -> str
+tool.read_dir("/tmp")                # -> list[dict]
+tool.ls("/tmp")                      # -> list[str]
+tool.glob("/tmp/*.txt")              # -> list[str]
+
 # LLM metadata
 tool.name              # "bashkit"
 tool.short_description # str


### PR DESCRIPTION
## Summary
Add direct text-oriented VFS convenience methods to the Python `Bash` and `BashTool` APIs so callers no longer need to go through `fs()` for common operations.

Closes #1257.

## What Changed
- add `read_file`, `write_file`, `append_file`, `mkdir`, `exists`, `remove`, `stat`, `chmod`, `symlink`, `read_link`, `read_dir`, `ls`, and `glob` to both Python bindings
- reuse shared live-FS helpers so `Bash` and `BashTool` stay behaviorally aligned
- expose the new methods in `_bashkit.pyi`
- add regression coverage for happy paths, shell-state interaction, reset behavior, UTF-8 errors, and glob safety
- document the new convenience API in the Python README and `specs/013-python-package.md`

## Verification
- `python -m pytest crates/bashkit-python/tests/test_bashkit.py -q`
- `python -m pytest crates/bashkit-python/tests/test_bashkit.py -k 'direct_vfs_methods' -q`
- `uvx ruff check crates/bashkit-python`
- `uvx ruff format --check crates/bashkit-python`
- smoke test via installed package: direct `BashTool` `mkdir`/`write_file`/`append_file`/`read_file`/`ls`/`glob`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Local Environment Notes
- `cargo test --all-features` currently fails on this machine in unrelated core tests: `fs::realfs::tests::resolve_fallback_returns_normalized_path`, `fs::realfs::tests::resolve_fallback_validates_containment`, and `logging_impl::tests::test_script_formatting`
- `just pre-pr` hit a local linker disk-space failure (`errno=28`) while building a test binary on a nearly full macOS volume
