### PR TITLE
feat(python): add snapshot restore support

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -177,6 +177,27 @@ result = tool.execute_sync("greet --name Alice")
 print(result.stdout)  # hello Alice
 ```
 
+### Snapshot / Restore
+
+```python
+from bashkit import Bash
+
+bash = Bash(username="agent", max_commands=100)
+bash.execute_sync("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt")
+
+snapshot = bash.snapshot()
+
+restored = Bash.from_snapshot(snapshot, username="agent", max_commands=100)
+assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"
+assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "ready"
+
+restored.reset()
+restored.restore_snapshot(snapshot)
+assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
+
+# BashTool exposes the same snapshot/restore API.
+```
+
 ### LangChain
 
 ```python
@@ -237,6 +258,9 @@ print(result.stdout)  # Alice
 - `execute_or_throw(commands: str) -> ExecResult` — async, raises on non-zero exit
 - `execute_sync_or_throw(commands: str) -> ExecResult` — sync, raises on non-zero exit
 - `reset()` — reset interpreter state
+- `snapshot() -> bytes` — serialize interpreter state
+- `restore_snapshot(data: bytes)` — restore serialized interpreter state
+- `from_snapshot(data: bytes, **kwargs) -> Bash` — construct and restore in one step
 - `fs() -> FileSystem` — direct filesystem access
 
 ### BashTool
@@ -248,6 +272,7 @@ Convenience wrapper for AI agents. Inherits all execution methods from `Bash`, p
 - `system_prompt() -> str` — token-efficient system prompt for LLM integration
 - `input_schema() -> str` — JSON input schema
 - `output_schema() -> str` — JSON output schema
+- `snapshot() -> bytes` / `restore_snapshot(data: bytes)` / `from_snapshot(...)` — checkpoint and resume interpreter state
 
 ### ExecResult
 

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -424,6 +424,32 @@ class Bash:
         """
         ...
 
+    def snapshot(self) -> bytes:
+        """Serialize interpreter state to bytes."""
+        ...
+
+    def restore_snapshot(self, data: bytes) -> None:
+        """Restore interpreter state from bytes produced by ``snapshot()``."""
+        ...
+
+    @staticmethod
+    def from_snapshot(
+        data: bytes,
+        username: str | None = None,
+        hostname: str | None = None,
+        max_commands: int | None = None,
+        max_loop_iterations: int | None = None,
+        max_memory: int | None = None,
+        timeout_seconds: float | None = None,
+        python: bool = False,
+        external_functions: list[str] | None = None,
+        external_handler: ExternalHandler | None = None,
+        files: dict[str, str] | None = None,
+        mounts: list[dict[str, Any]] | None = None,
+    ) -> Bash:
+        """Create a new ``Bash`` from snapshot bytes and optional constructor kwargs."""
+        ...
+
     def read_file(self, path: str) -> str:
         """Read a VFS file as UTF-8 text."""
         ...
@@ -753,6 +779,29 @@ class BashTool:
             >>> result.exit_code  # file is gone
             1
         """
+        ...
+
+    def snapshot(self) -> bytes:
+        """Serialize interpreter state to bytes."""
+        ...
+
+    def restore_snapshot(self, data: bytes) -> None:
+        """Restore interpreter state from bytes produced by ``snapshot()``."""
+        ...
+
+    @staticmethod
+    def from_snapshot(
+        data: bytes,
+        username: str | None = None,
+        hostname: str | None = None,
+        max_commands: int | None = None,
+        max_loop_iterations: int | None = None,
+        max_memory: int | None = None,
+        timeout_seconds: float | None = None,
+        files: dict[str, str] | None = None,
+        mounts: list[dict[str, Any]] | None = None,
+    ) -> BashTool:
+        """Create a new ``BashTool`` from snapshot bytes and optional constructor kwargs."""
         ...
 
     def read_file(self, path: str) -> str:

--- a/crates/bashkit-python/examples/bash_basics.py
+++ b/crates/bashkit-python/examples/bash_basics.py
@@ -8,7 +8,7 @@
 """Basic usage of the Bash interface.
 
 Demonstrates core Bash features: command execution, pipelines, variables,
-loops, virtual filesystem persistence, and resource limits.
+loops, virtual filesystem persistence, snapshot/restore, and resource limits.
 
 Run:
     uv run crates/bashkit-python/examples/bash_basics.py
@@ -89,6 +89,33 @@ EOF
     print()
 
 
+def demo_snapshot_restore():
+    """Snapshot and restore interpreter state."""
+    print("=== Snapshot / Restore ===\n")
+
+    bash = Bash()
+    bash.execute_sync("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt")
+
+    snapshot = bash.snapshot()
+    print(f"snapshot: captured {len(snapshot)} bytes")
+    assert snapshot
+
+    # Restore shell state into a freshly configured instance.
+    restored = Bash.from_snapshot(snapshot, username="agent")
+    assert restored.execute_sync("whoami").stdout.strip() == "agent"
+    assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"
+    assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
+    assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "ready"
+
+    # Reset and restore also works on an existing instance.
+    restored.reset()
+    restored.restore_snapshot(snapshot)
+    print(f"restore:  {restored.execute_sync('echo $BUILD_ID').stdout.strip()}")
+    assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"
+
+    print()
+
+
 async def demo_async():
     """Async API basics."""
     print("=== Async API ===\n")
@@ -148,6 +175,7 @@ def demo_config():
 def main():
     print("Bashkit — Bash interface examples\n")
     demo_sync()
+    demo_snapshot_restore()
     asyncio.run(demo_async())
     demo_config()
     print("All examples passed.")

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -725,6 +725,43 @@ fn glob_via_bash(rt: &Arc<Runtime>, inner: &Arc<Mutex<Bash>>, pattern: String) -
     }
 }
 
+// Decision: snapshot factories build with caller kwargs first, then restore
+// bytes into that configured instance so limits and identity settings survive.
+fn raise_snapshot_error<E: std::fmt::Display>(err: E) -> PyErr {
+    BashError::new_err(err.to_string())
+}
+
+fn snapshot_live_bash(
+    py: Python<'_>,
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+) -> PyResult<Vec<u8>> {
+    let rt = rt.clone();
+    let inner = inner.clone();
+    py.detach(|| {
+        rt.block_on(async move {
+            let bash = inner.lock().await;
+            bash.snapshot().map_err(raise_snapshot_error)
+        })
+    })
+}
+
+fn restore_live_bash(
+    py: Python<'_>,
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    data: Vec<u8>,
+) -> PyResult<()> {
+    let rt = rt.clone();
+    let inner = inner.clone();
+    py.detach(|| {
+        rt.block_on(async move {
+            let mut bash = inner.lock().await;
+            bash.restore_snapshot(&data).map_err(raise_snapshot_error)
+        })
+    })
+}
+
 #[pyclass(name = "FileSystem")]
 struct PyFileSystem {
     inner: FileSystemHandle,
@@ -1444,6 +1481,67 @@ impl PyBash {
         })
     }
 
+    /// Serialize interpreter state to bytes for checkpoint/restore flows.
+    fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = snapshot_live_bash(py, &self.rt, &self.inner)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
+    /// Restore interpreter state from bytes previously produced by `snapshot()`.
+    fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
+        restore_live_bash(py, &self.rt, &self.inner, data)
+    }
+
+    /// Create a new Bash instance from a snapshot and optional constructor kwargs.
+    #[staticmethod]
+    #[pyo3(signature = (
+        data,
+        username=None,
+        hostname=None,
+        max_commands=None,
+        max_loop_iterations=None,
+        max_memory=None,
+        timeout_seconds=None,
+        python=false,
+        external_functions=None,
+        external_handler=None,
+        files=None,
+        mounts=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_snapshot(
+        py: Python<'_>,
+        data: Vec<u8>,
+        username: Option<String>,
+        hostname: Option<String>,
+        max_commands: Option<u64>,
+        max_loop_iterations: Option<u64>,
+        max_memory: Option<u64>,
+        timeout_seconds: Option<f64>,
+        python: bool,
+        external_functions: Option<Vec<String>>,
+        external_handler: Option<Py<PyAny>>,
+        files: Option<&Bound<'_, PyDict>>,
+        mounts: Option<&Bound<'_, PyList>>,
+    ) -> PyResult<Self> {
+        let bash = Self::new(
+            py,
+            username,
+            hostname,
+            max_commands,
+            max_loop_iterations,
+            max_memory,
+            timeout_seconds,
+            python,
+            external_functions,
+            external_handler,
+            files,
+            mounts,
+        )?;
+        bash.restore_snapshot(py, data)?;
+        Ok(bash)
+    }
+
     fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
         py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
     }
@@ -1897,6 +1995,58 @@ impl BashTool {
                 Ok(())
             })
         })
+    }
+
+    /// Serialize interpreter state to bytes for checkpoint/restore flows.
+    fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = snapshot_live_bash(py, &self.rt, &self.inner)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
+    /// Restore interpreter state from bytes previously produced by `snapshot()`.
+    fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
+        restore_live_bash(py, &self.rt, &self.inner, data)
+    }
+
+    /// Create a new BashTool instance from a snapshot and optional constructor kwargs.
+    #[staticmethod]
+    #[pyo3(signature = (
+        data,
+        username=None,
+        hostname=None,
+        max_commands=None,
+        max_loop_iterations=None,
+        max_memory=None,
+        timeout_seconds=None,
+        files=None,
+        mounts=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_snapshot(
+        py: Python<'_>,
+        data: Vec<u8>,
+        username: Option<String>,
+        hostname: Option<String>,
+        max_commands: Option<u64>,
+        max_loop_iterations: Option<u64>,
+        max_memory: Option<u64>,
+        timeout_seconds: Option<f64>,
+        files: Option<&Bound<'_, PyDict>>,
+        mounts: Option<&Bound<'_, PyList>>,
+    ) -> PyResult<Self> {
+        let tool = Self::new(
+            py,
+            username,
+            hostname,
+            max_commands,
+            max_loop_iterations,
+            max_memory,
+            timeout_seconds,
+            files,
+            mounts,
+        )?;
+        tool.restore_snapshot(py, data)?;
+        Ok(tool)
     }
 
     fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {

--- a/crates/bashkit-python/tests/test_bashkit.py
+++ b/crates/bashkit-python/tests/test_bashkit.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from bashkit import Bash, BashTool, FileSystem, ScriptedTool, create_langchain_tool_spec
+from bashkit import Bash, BashError, BashTool, FileSystem, ScriptedTool, create_langchain_tool_spec
 
 # ===========================================================================
 # Bash: Core interpreter
@@ -76,6 +76,63 @@ def test_bash_reset():
     bash.reset()
     r = bash.execute_sync("echo ${KEEP:-empty}")
     assert r.stdout.strip() == "empty"
+
+
+def test_bash_snapshot_roundtrip_from_snapshot_preserves_state_and_kwargs():
+    bash = Bash()
+    bash.execute_sync("export FOO=bar; mkdir -p /workspace && cd /workspace && echo data > state.txt")
+
+    snapshot = bash.snapshot()
+    assert isinstance(snapshot, bytes)
+    assert snapshot
+
+    restored = Bash.from_snapshot(
+        snapshot,
+        username="alice",
+        hostname="box",
+        max_commands=5,
+    )
+
+    assert restored.execute_sync("whoami").stdout.strip() == "alice"
+    assert restored.execute_sync("hostname").stdout.strip() == "box"
+    assert restored.execute_sync("echo $FOO").stdout.strip() == "bar"
+    assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
+    assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "data"
+
+    limited = restored.execute_sync("echo 1; echo 2; echo 3; echo 4; echo 5; echo 6")
+    assert limited.exit_code != 0 or limited.stdout.count("\n") <= 5
+
+
+def test_bash_restore_snapshot_after_reset_restores_original_state():
+    bash = Bash()
+    bash.execute_sync("export KEEP=1; mkdir -p /workspace && cd /workspace && echo saved > state.txt")
+    snapshot = bash.snapshot()
+
+    bash.reset()
+    bash.restore_snapshot(snapshot)
+
+    assert bash.execute_sync("echo $KEEP").stdout.strip() == "1"
+    assert bash.execute_sync("pwd").stdout.strip() == "/workspace"
+    assert bash.execute_sync("cat /workspace/state.txt").stdout.strip() == "saved"
+
+
+def test_bash_empty_snapshot_roundtrip():
+    fresh = Bash()
+    snapshot = fresh.snapshot()
+    restored = Bash.from_snapshot(snapshot)
+
+    assert restored.execute_sync("pwd").stdout == fresh.execute_sync("pwd").stdout
+    assert restored.execute_sync("echo ${MISSING:-empty}").stdout == "empty\n"
+
+
+def test_bash_invalid_snapshot_raises_bash_error():
+    bash = Bash()
+
+    with pytest.raises(BashError):
+        Bash.from_snapshot(b"not valid snapshot")
+
+    with pytest.raises(BashError):
+        bash.restore_snapshot(b"not valid snapshot")
 
 
 def test_bash_fs_handle_bytes_roundtrip():
@@ -543,6 +600,44 @@ def test_reset():
     tool.reset()
     r = tool.execute_sync("echo ${KEEP:-empty}")
     assert r.stdout.strip() == "empty"
+
+
+def test_bashtool_snapshot_roundtrip_from_snapshot_preserves_state_and_kwargs():
+    tool = BashTool()
+    tool.execute_sync("export FOO=bar; mkdir -p /workspace && cd /workspace && echo data > tool.txt")
+
+    snapshot = tool.snapshot()
+    assert isinstance(snapshot, bytes)
+    assert snapshot
+
+    restored = BashTool.from_snapshot(
+        snapshot,
+        username="alice",
+        hostname="box",
+        max_commands=5,
+    )
+
+    assert restored.execute_sync("whoami").stdout.strip() == "alice"
+    assert restored.execute_sync("hostname").stdout.strip() == "box"
+    assert restored.execute_sync("echo $FOO").stdout.strip() == "bar"
+    assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
+    assert restored.execute_sync("cat /workspace/tool.txt").stdout.strip() == "data"
+
+    limited = restored.execute_sync("echo 1; echo 2; echo 3; echo 4; echo 5; echo 6")
+    assert limited.exit_code != 0 or limited.stdout.count("\n") <= 5
+
+
+def test_bashtool_restore_snapshot_after_reset_restores_original_state():
+    tool = BashTool()
+    tool.execute_sync("export KEEP=1; mkdir -p /workspace && cd /workspace && echo saved > tool.txt")
+    snapshot = tool.snapshot()
+
+    tool.reset()
+    tool.restore_snapshot(snapshot)
+
+    assert tool.execute_sync("echo $KEEP").stdout.strip() == "1"
+    assert tool.execute_sync("pwd").stdout.strip() == "/workspace"
+    assert tool.execute_sync("cat /workspace/tool.txt").stdout.strip() == "saved"
 
 
 # Issue #424: reset() should preserve security configuration

--- a/crates/bashkit-python/tests/test_bashkit.py
+++ b/crates/bashkit-python/tests/test_bashkit.py
@@ -640,6 +640,25 @@ def test_bashtool_restore_snapshot_after_reset_restores_original_state():
     assert tool.execute_sync("cat /workspace/tool.txt").stdout.strip() == "saved"
 
 
+def test_bashtool_empty_snapshot_roundtrip():
+    fresh = BashTool()
+    snapshot = fresh.snapshot()
+    restored = BashTool.from_snapshot(snapshot)
+
+    assert restored.execute_sync("pwd").stdout == fresh.execute_sync("pwd").stdout
+    assert restored.execute_sync("echo ${MISSING:-empty}").stdout == "empty\n"
+
+
+def test_bashtool_invalid_snapshot_raises_bash_error():
+    tool = BashTool()
+
+    with pytest.raises(BashError):
+        BashTool.from_snapshot(b"not valid snapshot")
+
+    with pytest.raises(BashError):
+        tool.restore_snapshot(b"not valid snapshot")
+
+
 # Issue #424: reset() should preserve security configuration
 def test_reset_preserves_config():
     bash = Bash(max_commands=5, username="testuser", hostname="testhost")

--- a/specs/013-python-package.md
+++ b/specs/013-python-package.md
@@ -130,6 +130,10 @@ tool = BashTool(files={
     "/config/static.txt": "ready\n",
     "/config/generated.json": lambda: '{"ok": true}\n",
 })
+# Snapshot / restore state
+blob = tool.snapshot()
+restored = BashTool.from_snapshot(blob, username="user")
+restored.restore_snapshot(blob)
 
 # Direct VFS helpers (text-oriented convenience wrappers)
 tool.read_file("/tmp/data.txt")      # -> str
@@ -155,6 +159,17 @@ tool.system_prompt()   # compact system prompt
 tool.input_schema()    # JSON schema string
 tool.output_schema()   # JSON schema string
 tool.version           # from Rust crate
+```
+
+Snapshot/restore methods also exist on `Bash` and mirror the Node bindings:
+
+```python
+from bashkit import Bash
+
+bash = Bash()
+blob = bash.snapshot()              # -> bytes
+restored = Bash.from_snapshot(blob) # -> Bash
+restored.restore_snapshot(blob)
 ```
 
 ### ExecResult

--- a/specs/013-python-package.md
+++ b/specs/013-python-package.md
@@ -133,7 +133,6 @@ tool = BashTool(files={
 # Snapshot / restore state
 blob = tool.snapshot()
 restored = BashTool.from_snapshot(blob, username="user")
-restored.restore_snapshot(blob)
 
 # Direct VFS helpers (text-oriented convenience wrappers)
 tool.read_file("/tmp/data.txt")      # -> str
@@ -169,7 +168,6 @@ from bashkit import Bash
 bash = Bash()
 blob = bash.snapshot()              # -> bytes
 restored = Bash.from_snapshot(blob) # -> Bash
-restored.restore_snapshot(blob)
 ```
 
 ### ExecResult


### PR DESCRIPTION
Closes #1256

## Summary
- add `snapshot()`, `restore_snapshot()`, and `from_snapshot()` to the Python `Bash` and `BashTool` bindings
- preserve constructor kwargs when restoring into a fresh instance from snapshot bytes
- add Python tests, stubs, and docs for round-trip, reset/restore, empty snapshot, and invalid snapshot cases

## Testing
- `cargo test -p bashkit-python --no-run`
- `cargo fmt --check`
- `.uv-venv-bashkit/bin/python -m pytest crates/bashkit-python/tests/test_bashkit.py`
- `.uv-venv-bashkit/bin/ruff check crates/bashkit-python`
- `cargo clippy -p bashkit-python --all-targets --no-deps -- -D warnings`

## Notes
- full `cargo clippy -p bashkit-python --all-targets -- -D warnings` still hits pre-existing dead-code warnings in `crates/bashkit` unrelated to this change