### PR TITLE
test(node): add missing security coverage

### DIFF
--- a/crates/bashkit-js/__test__/runtime-compat/security.test.mjs
+++ b/crates/bashkit-js/__test__/runtime-compat/security.test.mjs
@@ -2,18 +2,35 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { Bash } from "./_setup.mjs";
+import { Bash, ScriptedTool } from "./_setup.mjs";
+
+function sleepMs(ms) {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+function nestedSchemaArray(depth) {
+  let value = 1;
+  for (let i = 0; i < depth; i++) {
+    value = [value];
+  }
+  return value;
+}
 
 describe("security", () => {
   it("command limit enforced", () => {
     const bash = new Bash({ maxCommands: 5 });
-    const r = bash.executeSync("true; true; true; true; true; true; true; true; true; true");
+    const r = bash.executeSync(
+      "true; true; true; true; true; true; true; true; true; true",
+    );
     assert.ok(r.exitCode !== 0 || r.error !== undefined);
   });
 
   it("loop iteration limit enforced", () => {
     const bash = new Bash({ maxLoopIterations: 5 });
-    const r = bash.executeSync("for i in 1 2 3 4 5 6 7 8 9 10; do echo $i; done");
+    const r = bash.executeSync(
+      "for i in 1 2 3 4 5 6 7 8 9 10; do echo $i; done",
+    );
     assert.ok(r.exitCode !== 0 || r.error !== undefined);
   });
 
@@ -34,12 +51,21 @@ describe("security", () => {
     assert.notEqual(bash.executeSync("exec /bin/bash").exitCode, 0);
     assert.notEqual(bash.executeSync("cat /proc/self/maps 2>&1").exitCode, 0);
     assert.notEqual(bash.executeSync("cat /etc/passwd 2>&1").exitCode, 0);
+    assert.notEqual(
+      bash
+        .executeSync("echo test > /dev/udp/127.0.0.1/53 2>&1; echo $?")
+        .stdout.trim(),
+      "0",
+    );
   });
 
   it("VFS path traversal blocked", () => {
     const bash = new Bash();
     bash.executeSync('echo "secret" > /home/data.txt');
-    assert.notEqual(bash.executeSync("cat /home/../../../etc/shadow 2>&1").exitCode, 0);
+    assert.notEqual(
+      bash.executeSync("cat /home/../../../etc/shadow 2>&1").exitCode,
+      0,
+    );
   });
 
   it("recovery after exceeding limits", () => {
@@ -48,5 +74,55 @@ describe("security", () => {
     const r = bash.executeSync("echo recovered");
     assert.equal(r.exitCode, 0);
     assert.equal(r.stdout.trim(), "recovered");
+  });
+
+  it("direct VFS write rejects file above size limit", () => {
+    const bash = new Bash();
+    assert.throws(
+      () => bash.writeFile("/tmp/too-large.txt", "X".repeat(10_000_001)),
+      /file too large/i,
+    );
+  });
+
+  it("ScriptedTool slow callback completes", async () => {
+    const tool = new ScriptedTool({ name: "slow" });
+    tool.addTool("slow", "Slow callback", () => {
+      sleepMs(50);
+      return "done\n";
+    });
+
+    const result = await tool.execute("slow");
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout.trim(), "done");
+  });
+
+  it("ScriptedTool stdin injection stays literal", async () => {
+    const tool = new ScriptedTool({ name: "echo_stdin" });
+    tool.addTool("echo_stdin", "Echo stdin", (_params, stdin) => stdin ?? "");
+
+    const result = await tool.execute("echo '$(echo injected)' | echo_stdin");
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout.trim(), "$(echo injected)");
+  });
+
+  it("ScriptedTool schema array nesting bomb is rejected", () => {
+    const tool = new ScriptedTool({ name: "array_bomb" });
+    assert.throws(
+      () =>
+        tool.addTool("test", "Array bomb", () => "ok\n", nestedSchemaArray(70)),
+      /nesting depth exceeds maximum of 64/i,
+    );
+  });
+
+  it("environment stays isolated across instances", () => {
+    const first = new Bash();
+    first.executeSync("export EVIL=payload");
+    assert.equal(first.executeSync("echo $EVIL").stdout.trim(), "payload");
+
+    const second = new Bash();
+    assert.equal(
+      second.executeSync("echo ${EVIL:-clean}").stdout.trim(),
+      "clean",
+    );
   });
 });

--- a/crates/bashkit-js/__test__/security.spec.ts
+++ b/crates/bashkit-js/__test__/security.spec.ts
@@ -11,7 +11,28 @@
  */
 
 import test from "ava";
-import { Bash, BashTool, BashError } from "../wrapper.js";
+import { Bash, BashTool, BashError, ScriptedTool } from "../wrapper.js";
+
+function sleepMs(ms: number): void {
+  const signal = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(signal, 0, 0, ms);
+}
+
+function nestedSchemaObject(depth: number): Record<string, unknown> {
+  let value: Record<string, unknown> = { type: "string" };
+  for (let i = 0; i < depth; i++) {
+    value = { child: value };
+  }
+  return value;
+}
+
+function nestedSchemaArray(depth: number): unknown {
+  let value: unknown = 1;
+  for (let i = 0; i < depth; i++) {
+    value = [value];
+  }
+  return value;
+}
 
 // ============================================================================
 // 1. WHITE-BOX — Resource Limit Enforcement (TM-DOS)
@@ -1103,4 +1124,206 @@ test("BB: sync constructor rejects async file providers", (t) => {
     undefined,
     "sync constructor must reject async providers",
   );
+});
+
+// ============================================================================
+// 19. WHITE-BOX — Additional Callback / Schema Security
+// ============================================================================
+
+test("WB: direct VFS write accepts file at exact size limit (TM-DOS-005)", (t) => {
+  const bash = new Bash();
+  const content = "X".repeat(10_000_000);
+
+  bash.writeFile("/tmp/exact-limit.txt", content);
+
+  t.is(bash.stat("/tmp/exact-limit.txt").size, 10_000_000);
+  t.is(bash.executeSync("wc -c /tmp/exact-limit.txt").exitCode, 0);
+});
+
+test("WB: direct VFS write rejects file above size limit (TM-DOS-005)", (t) => {
+  const bash = new Bash();
+  const err = t.throws(() =>
+    bash.writeFile("/tmp/too-large.txt", "X".repeat(10_000_001)),
+  );
+
+  t.truthy(err);
+  t.regex(String(err.message), /file too large/i);
+});
+
+test("WB: BashTool.writeFile stores EOF marker content verbatim", (t) => {
+  const tool = new BashTool();
+  const content = "EOF\necho injected\nEOF\n";
+
+  tool.writeFile("/tmp/eof-marker.txt", content);
+
+  t.is(tool.readFile("/tmp/eof-marker.txt"), content);
+  t.not(tool.executeSync("test -e /tmp/injected").exitCode, 0);
+});
+
+test("WB: BashTool.writeFile stores repeated heredoc marker content verbatim", (t) => {
+  const tool = new BashTool();
+  const content = "HEREDOC\nline two\nHEREDOC\nline four\n";
+
+  tool.writeFile("/tmp/heredoc-marker.txt", content);
+
+  t.is(tool.readFile("/tmp/heredoc-marker.txt"), content);
+});
+
+test("WB: ScriptedTool slow callback completes without deadlock (TM-DOS-023)", async (t) => {
+  const tool = new ScriptedTool({ name: "slow" });
+  tool.addTool("slow", "Slow callback", () => {
+    sleepMs(50);
+    return "done\n";
+  });
+
+  const started = performance.now();
+  const result = await tool.execute("slow");
+  const elapsed = performance.now() - started;
+
+  t.is(result.exitCode, 0);
+  t.is(result.stdout.trim(), "done");
+  t.true(elapsed >= 40, `elapsed=${elapsed}`);
+  t.true(elapsed < 1_000, `elapsed=${elapsed}`);
+});
+
+test("WB: ScriptedTool stdin injection stays literal (TM-INJ-001)", async (t) => {
+  const tool = new ScriptedTool({ name: "echo_stdin" });
+  tool.addTool("echo_stdin", "Echo stdin", (_params, stdin) => stdin ?? "");
+
+  const result = await tool.execute("echo '$(echo injected)' | echo_stdin");
+
+  t.is(result.exitCode, 0);
+  t.is(result.stdout.trim(), "$(echo injected)");
+});
+
+test("WB: ScriptedTool schema nesting at exact limit is accepted (TM-DOS-027)", (t) => {
+  const tool = new ScriptedTool({ name: "depth_63" });
+
+  tool.addTool("test", "Depth 63", () => "ok\n", nestedSchemaObject(63));
+
+  t.is(tool.toolCount(), 1);
+});
+
+test("WB: ScriptedTool schema nesting beyond limit is rejected (TM-DOS-027)", (t) => {
+  const tool = new ScriptedTool({ name: "depth_64" });
+
+  const err = t.throws(() =>
+    tool.addTool("test", "Depth 64", () => "ok\n", nestedSchemaObject(64)),
+  );
+
+  t.truthy(err);
+  t.regex(String(err.message), /nesting depth exceeds maximum of 64/i);
+});
+
+test("WB: ScriptedTool schema array nesting bomb is rejected (TM-DOS-027)", (t) => {
+  const tool = new ScriptedTool({ name: "array_bomb" });
+
+  const err = t.throws(() =>
+    tool.addTool(
+      "test",
+      "Array bomb",
+      () => "ok\n",
+      nestedSchemaArray(70) as Record<string, unknown>,
+    ),
+  );
+
+  t.truthy(err);
+  t.regex(String(err.message), /nesting depth exceeds maximum of 64/i);
+});
+
+// ============================================================================
+// 20. WHITE-BOX — Additional State Confusion
+// ============================================================================
+
+test("WB: exported environment persists in-instance but not across instances (TM-ISO-010)", (t) => {
+  const first = new Bash();
+  first.executeSync("export EVIL=payload");
+
+  t.is(first.executeSync("echo $EVIL").stdout.trim(), "payload");
+
+  const second = new Bash();
+  t.is(second.executeSync("echo ${EVIL:-clean}").stdout.trim(), "clean");
+});
+
+test("WB: aliases stay isolated between instances (TM-ISO-007)", (t) => {
+  const first = new Bash();
+  first.executeSync("alias ll='echo alias-one'");
+
+  t.true(
+    first.executeSync("alias").stdout.includes("alias ll='echo alias-one'"),
+  );
+
+  const second = new Bash();
+  t.is(second.executeSync("alias").stdout.trim(), "");
+});
+
+test("WB: reset clears nested VFS trees completely (TM-ISO-001)", (t) => {
+  const bash = new Bash();
+  bash.executeSync("mkdir -p /tmp/a/b/c");
+  bash.executeSync("echo data > /tmp/a/b/c/file.txt");
+  bash.executeSync("export SECRET=abc123");
+  bash.reset();
+
+  const result = bash.executeSync(
+    "cat /tmp/a/b/c/file.txt 2>&1; echo ${SECRET:-gone}",
+  );
+  t.false(result.stdout.includes("data"));
+  t.true(result.stdout.includes("gone"));
+});
+
+// ============================================================================
+// 21. BLACK-BOX — Additional Network / Encoding / Timing
+// ============================================================================
+
+test("BB: /dev/udp network escape attempt (TM-NET-001)", (t) => {
+  const bash = new Bash();
+  const result = bash.executeSync(
+    "echo test > /dev/udp/127.0.0.1/53 2>&1; echo $?",
+  );
+
+  t.not(result.stdout.trim(), "0", "/dev/udp must not allow network access");
+  t.true(result.stderr.includes("/dev/udp") || result.stdout.trim() === "1");
+});
+
+test("BB: UTF-8 overlong encoding attempt stays inert", (t) => {
+  const bash = new Bash();
+  const result = bash.executeSync(
+    "echo 'test\\xC0\\xAFetc\\xC0\\xAFpasswd' 2>/dev/null || echo safe",
+  );
+
+  t.false(result.stdout.includes("root:"));
+  t.true(result.stdout.includes("test"));
+});
+
+test("BB: trailing backslash at end of command does not crash", (t) => {
+  const bash = new Bash();
+  const result = bash.executeSync("echo hello\\");
+
+  t.is(result.exitCode, 0);
+  t.is(result.stdout.trim(), "hello\\");
+});
+
+test("BB: CRLF payload in string literal remains data", (t) => {
+  const bash = new Bash();
+  const result = bash.executeSync("echo 'before\\r\\nHTTP/1.1 200 OK\\r\\n'");
+
+  t.is(result.exitCode, 0);
+  t.true(result.stdout.includes("HTTP/1.1 200 OK"));
+});
+
+test("BB: equivalent file probes stay within coarse timing delta (TM-DOS-023)", (t) => {
+  const bash = new Bash();
+  bash.executeSync("echo secret > /tmp/present.txt");
+
+  const presentStart = performance.now();
+  const present = bash.executeSync("cat /tmp/present.txt >/dev/null");
+  const presentElapsed = performance.now() - presentStart;
+
+  const missingStart = performance.now();
+  const missing = bash.executeSync("cat /tmp/missing.txt >/dev/null 2>&1");
+  const missingElapsed = performance.now() - missingStart;
+
+  t.is(present.exitCode, 0);
+  t.not(missing.exitCode, 0);
+  t.true(Math.abs(presentElapsed - missingElapsed) < 250);
 });

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -24,6 +24,8 @@ export type { ExecResult };
  */
 export type FileValue = string | (() => string) | (() => Promise<string>);
 
+const MAX_JSON_NESTING_DEPTH = 64;
+
 /**
  * Options for creating a Bash or BashTool instance.
  */
@@ -123,6 +125,27 @@ async function resolveFiles(
     }
   }
   return resolved;
+}
+
+function validateJsonNestingDepth(value: unknown, depth = 0): void {
+  if (depth > MAX_JSON_NESTING_DEPTH) {
+    throw new RangeError(
+      `JSON nesting depth exceeds maximum of ${MAX_JSON_NESTING_DEPTH}`,
+    );
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      validateJsonNestingDepth(item, depth + 1);
+    }
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      validateJsonNestingDepth(item, depth + 1);
+    }
+  }
 }
 
 /**
@@ -400,7 +423,13 @@ export class Bash {
   }
 
   /** Get metadata for a path (fileType, size, mode, timestamps). */
-  stat(path: string): { fileType: string; size: number; mode: number; modified: number; created: number } {
+  stat(path: string): {
+    fileType: string;
+    size: number;
+    mode: number;
+    modified: number;
+    created: number;
+  } {
     return this.native.stat(path);
   }
 
@@ -425,7 +454,18 @@ export class Bash {
   }
 
   /** List directory entries with metadata. */
-  readDir(path: string): Array<{ name: string; metadata: { fileType: string; size: number; mode: number; modified: number; created: number } }> {
+  readDir(
+    path: string,
+  ): Array<{
+    name: string;
+    metadata: {
+      fileType: string;
+      size: number;
+      mode: number;
+      modified: number;
+      created: number;
+    };
+  }> {
     return this.native.readDir(path);
   }
 
@@ -632,7 +672,13 @@ export class BashTool {
   }
 
   /** Get metadata for a path (fileType, size, mode, timestamps). */
-  stat(path: string): { fileType: string; size: number; mode: number; modified: number; created: number } {
+  stat(path: string): {
+    fileType: string;
+    size: number;
+    mode: number;
+    modified: number;
+    created: number;
+  } {
     return this.native.stat(path);
   }
 
@@ -657,7 +703,18 @@ export class BashTool {
   }
 
   /** List directory entries with metadata. */
-  readDir(path: string): Array<{ name: string; metadata: { fileType: string; size: number; mode: number; modified: number; created: number } }> {
+  readDir(
+    path: string,
+  ): Array<{
+    name: string;
+    metadata: {
+      fileType: string;
+      size: number;
+      mode: number;
+      modified: number;
+      created: number;
+    };
+  }> {
     return this.native.readDir(path);
   }
 
@@ -813,6 +870,9 @@ export class ScriptedTool {
     callback: ToolCallback,
     schema?: Record<string, unknown>,
   ): void {
+    if (schema) {
+      validateJsonNestingDepth(schema);
+    }
     // Wrap the user callback to handle JSON serialization protocol
     const wrappedCallback = (requestJson: string): string => {
       const request = JSON.parse(requestJson) as {


### PR DESCRIPTION
Closes #1263

## What
- add 15 new Node security tests in `crates/bashkit-js/__test__/security.spec.ts`
- add 5 runtime-compat security checks in `crates/bashkit-js/__test__/runtime-compat/security.test.mjs`
- enforce JSON schema nesting depth in the JS `ScriptedTool` wrapper for parity with Python

## Why
- the Node binding was missing security coverage for `/dev/udp`, callback stdin handling, schema depth bombs, additional state-isolation cases, large-file boundaries, and encoding/timing edge cases
- the new schema-depth tests exposed a parity gap: Python rejected overly deep schemas, while JS accepted them

## How
- cover `/dev/udp` network escape behavior, exact and over-limit file-size writes, heredoc-marker content safety via `writeFile`, slow callback execution, callback stdin literal handling, schema nesting bounds, alias/env/reset isolation, UTF-8 overlong payloads, trailing backslashes, CRLF payloads, and coarse timing comparisons
- mirror a representative subset in the runtime-compat suite for Bun/Deno/Node coverage
- validate schema nesting before serializing schema values in `ScriptedTool.addTool`

## Verification
- `cd crates/bashkit-js && npm run build:ts`
- `cd crates/bashkit-js && npm run type-check`
- `cd crates/bashkit-js && npx ava __test__/security.spec.ts`
- `cd crates/bashkit-js && node --test __test__/runtime-compat/security.test.mjs`
- `cd crates/bashkit-js && npm test`
- `cd crates/bashkit-js && node --test __test__/runtime-compat/*.mjs`

## Notes
- `just pre-pr` remains locally red on current `origin/main` due unrelated baseline Rust issues outside the JS surface; this PR only changes Node wrapper/tests
