### PR TITLE
docs: add public snapshotting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Awesomely fast virtual sandbox with bash and file system. Written in Rust.
 - **Multi-tenant isolation** - Each interpreter instance is fully independent
 - **Custom builtins** - Extend with domain-specific commands
 - **LLM tool contract** - `BashTool` with discovery metadata, streaming output, and system prompts
+- **Snapshotting** - Serialize shell state and VFS contents for checkpoint/resume workflows
 - **Scripted tool orchestration** - Compose ToolDef+callback pairs into multi-tool bash scripts (`scripted_tool` feature)
 - **MCP server** - Model Context Protocol endpoint via `bashkit mcp`
 - **Async-first** - Built on tokio
@@ -190,6 +191,28 @@ let mut bash = Bash::builder()
 // id → "uid=1000(deploy) gid=1000(deploy)..."
 // echo $USER → "deploy"
 ```
+
+## Snapshotting
+
+Checkpoint an interpreter to bytes, then restore it later:
+
+```rust
+use bashkit::Bash;
+
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+let mut bash = Bash::new();
+bash.exec("export BUILD_ID=42; echo ready > /tmp/state.txt").await?;
+
+let snapshot = bash.snapshot()?;
+let mut restored = Bash::from_snapshot(&snapshot)?;
+assert_eq!(restored.exec("echo $BUILD_ID").await?.stdout.trim(), "42");
+# Ok(())
+# }
+```
+
+See [docs/snapshotting.md](docs/snapshotting.md) for Rust, Python, and Node examples,
+plus snapshot security notes.
 
 ## Experimental: Git Support
 

--- a/docs/snapshotting.md
+++ b/docs/snapshotting.md
@@ -1,0 +1,112 @@
+# Snapshotting in Bashkit
+
+Bashkit can serialize an interpreter into opaque bytes and restore it later.
+Use snapshots for checkpoint/resume flows, warm sandbox caching, or rolling back
+to a known-good virtual workspace.
+
+## What a snapshot captures
+
+- Shell state: variables, exported env, arrays, aliases, and current working directory
+- Virtual filesystem contents
+- Session counters used by interpreter limits
+
+`restore_snapshot()` preserves the current instance configuration such as limits,
+builtins, and filesystem backend, then replaces shell state and VFS contents
+with the snapshot. `from_snapshot()` creates a fresh instance from bytes.
+
+In the Rust core, `Bash::from_snapshot()` returns a default-configured
+interpreter. If you need custom limits, builtins, or filesystem wiring, build
+that instance first and call `restore_snapshot()` on it.
+
+## Rust
+
+```rust
+use bashkit::{Bash, ExecutionLimits};
+
+# #[tokio::main]
+# async fn main() -> bashkit::Result<()> {
+let mut bash = Bash::new();
+bash.exec("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt")
+    .await?;
+
+let snapshot = bash.snapshot()?;
+
+let mut restored = Bash::from_snapshot(&snapshot)?;
+assert_eq!(restored.exec("echo $BUILD_ID").await?.stdout.trim(), "42");
+assert_eq!(
+    restored.exec("cat /workspace/state.txt").await?.stdout.trim(),
+    "ready"
+);
+
+// Reuse an explicitly configured instance and preserve its limits.
+let limits = ExecutionLimits::new().max_commands(100);
+let mut configured = Bash::builder().limits(limits).build();
+configured.restore_snapshot(&snapshot)?;
+# Ok(())
+# }
+```
+
+## Python
+
+Python exposes snapshotting on both `Bash` and `BashTool`:
+
+```python
+from bashkit import Bash
+
+bash = Bash(username="agent", max_commands=100)
+bash.execute_sync(
+    "export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt"
+)
+
+snapshot = bash.snapshot()
+
+restored = Bash.from_snapshot(snapshot, username="agent", max_commands=100)
+assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"
+assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "ready"
+
+restored.reset()
+restored.restore_snapshot(snapshot)
+assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
+```
+
+## Node.js / TypeScript
+
+Node exposes snapshotting on `Bash`:
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash({ username: "agent", maxCommands: 100 });
+bash.executeSync(
+  "export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt",
+);
+
+const snapshot = bash.snapshot();
+
+const restored = Bash.fromSnapshot(snapshot, {
+  username: "agent",
+  maxCommands: 100,
+});
+if (restored.executeSync("echo $BUILD_ID").stdout.trim() !== "42") {
+  throw new Error("snapshot restore failed");
+}
+
+restored.reset();
+restored.restoreSnapshot(snapshot);
+```
+
+`BashTool` snapshot parity for Node is tracked in [issue #1301](https://github.com/everruns/bashkit/issues/1301).
+
+## Security note
+
+The default snapshot format includes integrity checks for accidental corruption,
+but it does not authenticate untrusted bytes. If snapshots cross trust
+boundaries such as shared storage or network transfer, use Rust's keyed APIs
+(`snapshot_to_bytes_keyed`, `from_snapshot_keyed`, `restore_snapshot_keyed`) or
+treat the snapshot bytes as trusted-only input.
+
+## See also
+
+- [Security](./security.md)
+- [Embedded Python guide](../crates/bashkit/docs/python.md)
+- [Embedded TypeScript guide](../crates/bashkit/docs/typescript.md)


### PR DESCRIPTION
## Summary
- add a new public `docs/snapshotting.md` guide covering Rust, Python, and Node snapshot/restore flows
- surface snapshotting in the top-level README with a short example and link to the guide
- call out the current Node `BashTool` parity gap and link the tracking issue

## Testing
- `just test`
- `just pre-pr`

## Notes
- Both local commands fail on latest `main` due pre-existing `fs::realfs` test failures on this machine:
  - `fs::realfs::tests::resolve_fallback_validates_containment`
  - `fs::realfs::tests::resolve_fallback_returns_normalized_path`
- Latest GitHub CI on `main` for `7c6e1e21cccbb3afd8d41b7e44d48b31c0e66ecd` is green
- Tracking issue for Node `BashTool` snapshot parity: #1301
