### PR TITLE
fix(python): cover issue 1264 security gaps

### DIFF
--- a/crates/bashkit-python/tests/test_security.py
+++ b/crates/bashkit-python/tests/test_security.py
@@ -4,9 +4,25 @@ Covers: command injection, VFS isolation, resource limits,
 callback safety, env var injection, and Unicode/special char handling.
 """
 
+import re
+
 import pytest
 
 from bashkit import Bash, BashTool, ScriptedTool
+
+# Decision: Keep issue-1264 parity coverage in this file until #1259 merges the
+# Python security suites. New threat-model-traceable cases use `test_tm_*`
+# names so they can map back to `specs/006-threat-model.md`.
+
+
+def _assert_sanitized_error(text: str) -> None:
+    assert "/Users/" not in text
+    assert "/private/" not in text
+    assert "Traceback (most recent call last)" not in text
+    assert "pyo3" not in text.lower()
+    assert "rust" not in text.lower()
+    assert not re.search(r"0x[0-9a-f]{6,}", text, re.IGNORECASE)
+
 
 # ===========================================================================
 # VFS isolation: no host filesystem access
@@ -180,6 +196,269 @@ def test_fork_bomb_prevented():
     # Should either fail to parse or hit command limit
     # The key thing is it doesn't actually fork-bomb the host
     assert True  # If we get here, host wasn't harmed
+
+
+# ===========================================================================
+# Threat-model parity: VFS limits, arithmetic, env, injection
+# ===========================================================================
+
+
+def test_tm_dos_005_large_file_write_limited():
+    """TM-DOS-005: direct VFS writes must honor the default 10 MB file limit."""
+    with pytest.raises(RuntimeError, match="file too large"):
+        Bash().fs().write_file("/tmp/big.bin", b"A" * (11 * 1024 * 1024))
+
+
+def test_tm_dos_006_vfs_file_count_limit():
+    """TM-DOS-006: creating files until exhaustion must hit the VFS file cap."""
+    fs = Bash().fs()
+    created = 0
+
+    with pytest.raises(RuntimeError, match="too many files"):
+        while True:
+            fs.write_file(f"/tmp/f{created}", b"x")
+            created += 1
+
+    assert created >= 9000
+
+
+def test_tm_dos_012_deep_directory_nesting_limited():
+    """TM-DOS-012: path depth beyond 100 levels must be rejected."""
+    deep_path = "/tmp/" + "/".join(["d"] * 150)
+    with pytest.raises(RuntimeError, match="path too deep"):
+        Bash().fs().mkdir(deep_path, recursive=True)
+
+
+def test_tm_dos_013_long_filename_rejected():
+    """TM-DOS-013: filenames longer than 255 bytes must be rejected."""
+    with pytest.raises(RuntimeError, match="filename too long"):
+        Bash().fs().write_file("/tmp/" + ("A" * 300), b"x")
+
+
+def test_tm_dos_013_long_path_rejected():
+    """TM-DOS-013: paths longer than 4096 bytes must be rejected."""
+    with pytest.raises(RuntimeError, match="path too long"):
+        Bash().fs().write_file("/tmp/" + ("a/" * 2100) + "leaf", b"x")
+
+
+def test_tm_dos_029_arithmetic_overflow_does_not_crash():
+    """TM-DOS-029: integer overflow must stay inside the sandbox."""
+    r = Bash().execute_sync("echo $((9223372036854775807 + 1))")
+    assert isinstance(r.exit_code, int)
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_dos_029_division_by_zero_does_not_crash():
+    """TM-DOS-029: division by zero must return an error value, not panic."""
+    r = Bash().execute_sync("echo $((1 / 0)) 2>&1")
+    assert isinstance(r.exit_code, int)
+    assert r.stdout.strip() == "0"
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_dos_029_modulo_by_zero_does_not_crash():
+    """TM-DOS-029: modulo by zero must not unwind through the binding."""
+    r = Bash().execute_sync("echo $((1 % 0)) 2>&1")
+    assert isinstance(r.exit_code, int)
+    assert r.stdout.strip() == "0"
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_dos_029_negative_exponent_does_not_crash():
+    """TM-DOS-029: unsupported arithmetic should stay bounded."""
+    r = Bash().execute_sync("echo $((2 ** -1)) 2>&1")
+    assert isinstance(r.exit_code, int)
+    assert r.stdout.strip() == "0"
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_dos_059_default_memory_limit_prevents_oom_without_max_memory():
+    """TM-DOS-059: Bash() must enforce the default memory cap even without max_memory."""
+    bash = Bash(max_loop_iterations=10000, max_commands=10000)
+    r = bash.execute_sync('x=AAAAAAAAAA; i=0; while [ $i -lt 30 ]; do x="$x$x"; i=$((i+1)); done; echo ${#x}')
+    assert r.exit_code == 0
+    assert int(r.stdout.strip()) <= 10_000_000
+
+
+def test_tm_inf_002_env_builtins_do_not_leak_host_env():
+    """TM-INF-002: env/printenv must not expose host HOME/PATH values."""
+    bash = Bash()
+    env_output = bash.execute_sync("env").stdout
+    printenv_output = bash.execute_sync("printenv").stdout
+    combined = env_output + printenv_output
+    assert "/Users/" not in combined
+    assert "PATH=/usr" not in combined
+    assert "HOME=/home/" not in combined
+
+
+def test_tm_inf_002_default_env_vars_are_sandboxed():
+    """TM-INF-002: builtin shell vars should resolve to virtual sandbox values."""
+    r = Bash().execute_sync('echo "HOME=$HOME PATH=$PATH USER=$USER HOSTNAME=$HOSTNAME"')
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "HOME=/home/sandbox PATH= USER=sandbox HOSTNAME=bashkit-sandbox"
+
+
+def test_tm_esc_002_process_substitution_stays_in_sandbox():
+    """TM-ESC-002: process substitution must not require real subprocesses."""
+    r = Bash().execute_sync("cat <(echo test)")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "test"
+
+
+def test_tm_esc_005_signal_trap_commands_stay_bounded():
+    """TM-ESC-005: trap handlers must execute without leaving the virtual shell."""
+    r = Bash().execute_sync('trap "echo trapped" EXIT; echo done')
+    assert r.exit_code == 0
+    assert r.stdout == "done\ntrapped\n"
+
+
+def test_tm_inf_006_username_metacharacters_are_literal():
+    """TM-INF-006: usernames with shell syntax must stay literal."""
+    r = Bash(username="$(echo pwned)").execute_sync("whoami")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "$(echo pwned)"
+
+
+def test_tm_inf_005_hostname_metacharacters_are_literal():
+    """TM-INF-005: hostnames with shell syntax must stay literal."""
+    r = Bash(hostname="$(rm -rf /)").execute_sync("hostname")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "$(rm -rf /)"
+
+
+def test_tm_inf_006_username_newlines_are_stored_literally():
+    """TM-INF-006: newline-bearing usernames must not execute trailing commands."""
+    r = Bash(username="user\necho INJECTED").execute_sync("whoami")
+    assert r.exit_code == 0
+    assert r.stdout == "user\necho INJECTED\n"
+
+
+def test_tm_inf_005_hostname_newlines_are_stored_literally():
+    """TM-INF-005: newline-bearing hostnames must not execute trailing commands."""
+    r = Bash(hostname="host\necho INJECTED").execute_sync("hostname")
+    assert r.exit_code == 0
+    assert r.stdout == "host\necho INJECTED\n"
+
+
+def test_tm_inj_005_mounted_files_traversal_paths_stay_in_vfs():
+    """TM-INJ-005: crafted files dict paths may normalize, but must stay virtual."""
+    bash = Bash(files={"/tmp/../../../etc/passwd": "root:x:0"})
+    r = bash.execute_sync("cat /etc/passwd")
+    assert r.exit_code == 0
+    assert r.stdout == "root:x:0"
+
+
+def test_tm_inj_005_mounted_files_null_byte_path_is_safe():
+    """TM-INJ-005: null bytes in mount paths must not escape or crash the binding."""
+    bash = Bash(files={"/tmp/test\x00evil": "content"})
+    r = bash.execute_sync("ls /tmp")
+    assert r.exit_code == 0
+    assert "test" not in r.stdout
+
+
+def test_tm_inj_005_mounted_files_special_characters_in_content_roundtrip():
+    """TM-INJ-005: mounted file contents should preserve control characters literally."""
+    bash = Bash(files={"/tmp/special.txt": "line1\nline2\ttab\r\nwindows\n"})
+    r = bash.execute_sync("cat /tmp/special.txt")
+    assert r.exit_code == 0
+    assert r.stdout == "line1\nline2\ttab\r\nwindows\n"
+
+
+def test_tm_inj_005_mounted_files_empty_content_roundtrip():
+    """TM-INJ-005: empty mounted files should remain addressable."""
+    bash = Bash(files={"/tmp/empty.txt": ""})
+    r = bash.execute_sync("wc -c /tmp/empty.txt")
+    assert r.exit_code == 0
+    assert "/tmp/empty.txt" in r.stdout
+    assert "0" in r.stdout
+
+
+def test_tm_inj_005_crlf_line_endings_in_scripts_execute_safely():
+    """TM-INJ-005: CRLF scripts should execute without cross-line injection."""
+    r = Bash().execute_sync("echo hello\r\necho world\r\n")
+    assert r.exit_code == 0
+    assert r.stdout == "hello\r\nworld\r\n"
+
+
+def test_tm_inj_005_direct_read_file_traversal_is_blocked():
+    """TM-INJ-005: Bash.read_file() must not expose paths outside the VFS root."""
+    bash = Bash()
+    with pytest.raises(RuntimeError, match="file not found"):
+        bash.read_file("/tmp/../../etc/passwd")
+
+
+def test_tm_inj_005_direct_write_file_traversal_normalizes_inside_vfs():
+    """TM-INJ-005: Bash.write_file() must normalize traversal back into the VFS."""
+    bash = Bash()
+    bash.write_file("/tmp/../../evil.txt", "payload")
+    assert bash.exists("/evil.txt") is True
+    assert bash.exists("/tmp/evil.txt") is False
+    assert bash.read_file("/evil.txt") == "payload"
+
+
+def test_tm_inj_005_direct_ls_injection_is_safe():
+    """TM-INJ-005: Bash.ls() must treat shell metacharacters as a literal path."""
+    bash = Bash()
+    bash.write_file("/tmp/safe.txt", "ok")
+    assert bash.ls("'; echo pwned") == []
+
+
+def test_tm_inj_005_direct_glob_injection_is_safe():
+    """TM-INJ-005: Bash.glob() must reject unsafe patterns instead of composing shell."""
+    bash = Bash()
+    bash.write_file("/tmp/safe.txt", "ok")
+    assert bash.glob("'; echo pwned") == []
+
+
+def test_tm_int_001_shell_errors_do_not_leak_host_paths():
+    """TM-INT-001: shell-facing errors must stay sanitized."""
+    r = Bash().execute_sync("cat /definitely/missing/file")
+    assert r.exit_code != 0
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_int_001_direct_fs_errors_do_not_leak_host_paths():
+    """TM-INT-001: direct VFS exceptions must not disclose host paths."""
+    with pytest.raises(RuntimeError) as excinfo:
+        Bash().fs().read_file("/missing")
+    _assert_sanitized_error(str(excinfo.value))
+
+
+def test_tm_int_002_parse_errors_do_not_leak_addresses_or_traces():
+    """TM-INT-002: parse failures must not bubble interpreter internals to Python."""
+    r = Bash().execute_sync(")")
+    assert r.exit_code != 0
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_int_002_callback_errors_do_not_leak_rust_internals():
+    """TM-INT-002: callback failures must surface as compact binding errors."""
+    tool = ScriptedTool("api")
+    tool.add_tool("boom", "Explodes", callback=lambda p, s=None: (_ for _ in ()).throw(RuntimeError("kaboom")))
+    r = tool.execute_sync("boom")
+    assert r.exit_code != 0
+    _assert_sanitized_error(r.stderr)
+
+
+def test_tm_inf_014_special_variable_pid_is_sandboxed():
+    """TM-INF-014: $$ must return the virtual PID, not the host one."""
+    r = Bash().execute_sync("echo $$")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "1"
+
+
+def test_tm_inf_014_special_variable_ppid_is_sandboxed():
+    """TM-INF-014: $PPID must resolve to a virtual parent PID."""
+    r = Bash().execute_sync("echo ${PPID:-missing}")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "0"
+
+
+def test_tm_inf_014_special_variable_uid_is_sandboxed():
+    """TM-INF-014: $UID must resolve to the virtual sandbox uid."""
+    r = Bash().execute_sync("echo $UID")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "1000"
 
 
 # ===========================================================================

--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -729,7 +729,7 @@ mod tests {
         );
         let resolved = result.unwrap();
         assert!(
-            resolved.starts_with(dir.path()),
+            resolved.starts_with(fs.root()),
             "resolved path must be under root"
         );
     }
@@ -750,7 +750,7 @@ mod tests {
             "fallback path must be normalized, got: {}",
             resolved.display()
         );
-        assert!(resolved.starts_with(dir.path()));
+        assert!(resolved.starts_with(fs.root()));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -780,6 +780,7 @@ impl Interpreter {
         variables.insert("USER".to_string(), username_val.clone());
         variables.insert("UID".to_string(), "1000".to_string());
         variables.insert("EUID".to_string(), "1000".to_string());
+        variables.insert("PPID".to_string(), "0".to_string());
         variables.insert("HOSTNAME".to_string(), hostname_val.clone());
 
         // BASH_VERSINFO array: (major minor patch build status machine)

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -4014,6 +4014,13 @@ fn
     }
 
     #[tokio::test]
+    async fn test_default_ppid_is_sandboxed() {
+        let mut bash = Bash::new();
+        let result = bash.exec("echo $PPID").await.unwrap();
+        assert_eq!(result.stdout, "0\n");
+    }
+
+    #[tokio::test]
     async fn test_custom_hostname() {
         let mut bash = Bash::builder().hostname("my-server").build();
         let result = bash.exec("hostname").await.unwrap();
@@ -6250,6 +6257,7 @@ echo missing fi"#,
         assert_eq!(count.load(Ordering::Relaxed), 1);
     }
 
+    #[cfg(feature = "http_client")]
     #[tokio::test]
     async fn test_before_http_hook_cancels_request() {
         use crate::NetworkAllowlist;
@@ -6274,6 +6282,7 @@ echo missing fi"#,
         assert!(result.stderr.contains("cancelled by before_http hook"));
     }
 
+    #[cfg(feature = "http_client")]
     #[tokio::test]
     async fn test_after_http_hook_observes_response() {
         use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary
- add the missing Python security parity coverage from issue #1264, including direct `Bash.read_file()` / `write_file()` / `ls()` / `glob()` cases
- fix the default sandbox shell vars so `$PPID` resolves to a virtual parent PID and add a regression test
- keep latest-main local pre-PR checks moving by comparing `RealFs` fallback paths against the canonical root and gating `http_client`-only hook tests

## Testing
- `/private/tmp/bashkit-1264-venv/bin/pytest crates/bashkit-python/tests/test_security.py -q`
- `/private/tmp/bashkit-1264-venv/bin/ruff check crates/bashkit-python/tests/test_security.py`
- `/private/tmp/bashkit-1264-venv/bin/ruff format --check crates/bashkit-python/tests/test_security.py`
- `cargo test -p bashkit --features http_client default_ppid_is_sandboxed -- --nocapture`
- `cargo test -p bashkit resolve_fallback_validates_containment -- --nocapture`
- `cargo test -p bashkit resolve_fallback_returns_normalized_path -- --nocapture`
- `just pre-pr` (locally blocked on `bash_comparison_tests`; reproduced on clean `origin/main` in a detached worktree on this macOS machine)

Closes #1264.
