### PR TITLE
test(python): add parity suites for builtins, strings, and scripts

### DIFF
--- a/crates/bashkit-python/tests/test_builtins.py
+++ b/crates/bashkit-python/tests/test_builtins.py
@@ -1,7 +1,14 @@
 """Builtin-command coverage pulled out of the legacy Python test module."""
 
+# Decision: keep Python parity test names close to the Node suite so cross-
+# binding coverage diffs stay mechanical.
+
 import sys
 from pathlib import Path
+
+import pytest
+
+from bashkit import Bash
 
 _TESTS_DIR = str(Path(__file__).parent)
 if _TESTS_DIR not in sys.path:
@@ -16,3 +23,303 @@ globals().update({name: getattr(_categories, name) for name in _NAMES})
 del _categories
 del _NAMES
 del _TESTS_DIR
+
+
+def test_builtin_cat_reads_file():
+    bash = Bash()
+    bash.execute_sync("printf 'hello\\n' > /tmp/cat.txt")
+    result = bash.execute_sync("cat /tmp/cat.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_builtin_cat_concatenates_files():
+    bash = Bash()
+    bash.execute_sync("printf 'a\\n' > /tmp/a.txt")
+    bash.execute_sync("printf 'b\\n' > /tmp/b.txt")
+    result = bash.execute_sync("cat /tmp/a.txt /tmp/b.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a\nb"
+
+
+def test_builtin_head_limits_lines():
+    bash = Bash()
+    bash.execute_sync("printf '1\\n2\\n3\\n4\\n5\\n' > /tmp/head.txt")
+    result = bash.execute_sync("head -n 2 /tmp/head.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "1\n2"
+
+
+def test_builtin_tail_limits_lines():
+    bash = Bash()
+    bash.execute_sync("printf '1\\n2\\n3\\n4\\n5\\n' > /tmp/tail.txt")
+    result = bash.execute_sync("tail -n 2 /tmp/tail.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "4\n5"
+
+
+def test_builtin_wc_counts_lines():
+    bash = Bash()
+    bash.execute_sync("printf 'a\\nb\\nc\\n' > /tmp/wc.txt")
+    result = bash.execute_sync("wc -l < /tmp/wc.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "3"
+
+
+def test_builtin_wc_counts_words():
+    bash = Bash()
+    result = bash.execute_sync("printf 'one two three\\n' | wc -w")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "3"
+
+
+def test_builtin_grep_basic_match():
+    bash = Bash()
+    result = bash.execute_sync("printf 'apple\\nbanana\\ncherry\\n' | grep banana")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "banana"
+
+
+def test_builtin_grep_case_insensitive():
+    bash = Bash()
+    result = bash.execute_sync("printf 'Hello\\nworld\\n' | grep -i hello")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "Hello"
+
+
+def test_builtin_grep_inverted_match():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a\\nb\\nc\\n' | grep -v b")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a\nc"
+
+
+def test_builtin_grep_counts_matches():
+    bash = Bash()
+    result = bash.execute_sync("printf 'aa\\nab\\nac\\nbb\\n' | grep -c '^a'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "3"
+
+
+def test_builtin_grep_no_match_returns_non_zero():
+    bash = Bash()
+    result = bash.execute_sync("printf 'hello\\n' | grep xyz")
+    assert result.exit_code != 0
+    assert result.stdout == ""
+
+
+def test_builtin_sed_substitutes_first_match():
+    bash = Bash()
+    result = bash.execute_sync("printf 'hello world\\n' | sed 's/world/earth/'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello earth"
+
+
+def test_builtin_sed_substitutes_globally():
+    bash = Bash()
+    result = bash.execute_sync("printf 'aaa\\n' | sed 's/a/b/g'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "bbb"
+
+
+def test_builtin_sed_deletes_matching_line():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a\\nb\\nc\\n' | sed '/b/d'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a\nc"
+
+
+def test_builtin_awk_prints_selected_field():
+    bash = Bash()
+    result = bash.execute_sync("printf 'one two three\\n' | awk '{print $2}'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "two"
+
+
+def test_builtin_awk_honors_custom_separator():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a:b:c\\n' | awk -F: '{print $3}'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "c"
+
+
+def test_builtin_awk_sums_numeric_column():
+    bash = Bash()
+    result = bash.execute_sync("printf '1\\n2\\n3\\n4\\n' | awk '{s+=$1} END {print s}'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "10"
+
+
+def test_builtin_sort_ascending():
+    bash = Bash()
+    result = bash.execute_sync("printf 'c\\na\\nb\\n' | sort")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a\nb\nc"
+
+
+def test_builtin_sort_descending():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a\\nb\\nc\\n' | sort -r")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "c\nb\na"
+
+
+def test_builtin_sort_numeric():
+    bash = Bash()
+    result = bash.execute_sync("printf '10\\n2\\n1\\n20\\n' | sort -n")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "1\n2\n10\n20"
+
+
+def test_builtin_uniq_removes_adjacent_duplicates():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a\\na\\nb\\nb\\nc\\n' | uniq")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a\nb\nc"
+
+
+def test_builtin_sort_and_uniq_count_duplicates():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a\\nb\\na\\na\\n' | sort | uniq -c")
+    assert result.exit_code == 0
+    assert "3" in result.stdout
+    assert "a" in result.stdout
+
+
+def test_builtin_tr_transliterates_characters():
+    bash = Bash()
+    result = bash.execute_sync("printf 'hello\\n' | tr 'a-z' 'A-Z'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "HELLO"
+
+
+def test_builtin_tr_deletes_characters():
+    bash = Bash()
+    result = bash.execute_sync("printf 'h-e-l-l-o\\n' | tr -d '-'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_builtin_cut_extracts_requested_field():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a,b,c\\n' | cut -d, -f2")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "b"
+
+
+def test_builtin_printf_formats_basic_string():
+    bash = Bash()
+    result = bash.execute_sync('printf "Hello %s" "World"')
+    assert result.exit_code == 0
+    assert result.stdout == "Hello World"
+
+
+def test_builtin_printf_formats_numbers():
+    bash = Bash()
+    result = bash.execute_sync('printf "%d + %d = %d" 2 3 5')
+    assert result.exit_code == 0
+    assert result.stdout == "2 + 3 = 5"
+
+
+def test_builtin_export_and_env_expose_variable():
+    bash = Bash()
+    bash.execute_sync("export MY_VAR=hello")
+    result = bash.execute_sync("env | grep '^MY_VAR='")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "MY_VAR=hello"
+
+
+def test_builtin_unset_clears_variable():
+    bash = Bash()
+    bash.execute_sync("X=123")
+    bash.execute_sync("unset X")
+    result = bash.execute_sync("echo ${X:-gone}")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "gone"
+
+
+def test_builtin_jq_extracts_field():
+    bash = Bash()
+    result = bash.execute_sync('printf \'{"name":"alice","age":30}\\n\' | jq -r \'.name\'')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alice"
+
+
+def test_builtin_jq_reports_array_length():
+    bash = Bash()
+    result = bash.execute_sync("printf '[1,2,3]\\n' | jq 'length'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "3"
+
+
+def test_builtin_jq_filters_array_rows():
+    bash = Bash()
+    result = bash.execute_sync(
+        'printf \'[{"name":"alice","age":30},{"name":"bob","age":25}]\\n\' | jq -r \'.[] | select(.age > 28) | .name\''
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alice"
+
+
+def test_builtin_md5sum_produces_expected_hash():
+    bash = Bash()
+    result = bash.execute_sync("printf 'hello' | md5sum")
+    assert result.exit_code == 0
+    assert result.stdout.startswith("5d41402abc4b2a76b9719d911017c592")
+
+
+def test_builtin_sha256sum_produces_expected_hash():
+    bash = Bash()
+    result = bash.execute_sync("printf 'hello' | sha256sum")
+    assert result.exit_code == 0
+    assert result.stdout.startswith("2cf24dba5fb0a30e26e83b2ac5b9e29e")
+
+
+def test_builtin_date_runs_without_error():
+    bash = Bash()
+    result = bash.execute_sync("date")
+    assert result.exit_code == 0
+    assert result.stdout.strip()
+
+
+def test_builtin_base64_encodes_and_decodes():
+    bash = Bash()
+    encoded = bash.execute_sync("printf 'hello' | base64")
+    assert encoded.exit_code == 0
+    assert encoded.stdout.strip() == "aGVsbG8="
+
+    decoded = bash.execute_sync("printf '%s' 'aGVsbG8=' | base64 -d")
+    assert decoded.exit_code == 0
+    assert decoded.stdout == "hello"
+
+
+def test_builtin_seq_generates_range():
+    bash = Bash()
+    result = bash.execute_sync("seq 3 5")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "3\n4\n5"
+
+
+def test_builtin_seq_generates_range_with_step():
+    bash = Bash()
+    result = bash.execute_sync("seq 1 2 5")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "1\n3\n5"
+
+
+@pytest.mark.asyncio
+async def test_builtin_async_grep_case_insensitive():
+    bash = Bash()
+    result = await bash.execute("printf 'Hello\\nworld\\n' | grep -i hello")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_builtin_async_jq_filters_array_rows():
+    bash = Bash()
+    result = await bash.execute(
+        'printf \'[{"name":"alice","age":30},{"name":"bob","age":25}]\\n\' | jq -r \'.[] | select(.age > 28) | .name\''
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alice"

--- a/crates/bashkit-python/tests/test_scripts.py
+++ b/crates/bashkit-python/tests/test_scripts.py
@@ -1,10 +1,15 @@
 """Script-shaped workflows and higher-level Python binding scenarios."""
 
-# Decision: keep the legacy implementations centralized until parity follow-up
-# issues add the larger dedicated suites for builtins, strings, and scripts.
+# Decision: keep the legacy high-level coverage while adding Node-parity script
+# scenarios here so the file becomes the canonical script-pattern suite.
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
+
+from bashkit import Bash, BashTool
 
 _TESTS_DIR = str(Path(__file__).parent)
 if _TESTS_DIR not in sys.path:
@@ -42,3 +47,254 @@ globals().update({name: getattr(_categories, name) for name in _NAMES})
 del _categories
 del _NAMES
 del _TESTS_DIR
+
+
+def test_script_count_lines_in_file():
+    bash = Bash()
+    bash.execute_sync("printf 'a\\nb\\nc\\nd\\ne\\n' > /tmp/lines.txt")
+    result = bash.execute_sync("wc -l < /tmp/lines.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "5"
+
+
+def test_script_find_and_replace_in_file():
+    bash = Bash()
+    bash.execute_sync("printf 'Hello World\\n' > /tmp/replace.txt")
+    bash.execute_sync("sed -i 's/World/Earth/' /tmp/replace.txt")
+    result = bash.execute_sync("cat /tmp/replace.txt")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "Hello Earth"
+
+
+def test_script_extract_unique_values():
+    bash = Bash()
+    result = bash.execute_sync("printf 'apple\\nbanana\\napple\\ncherry\\nbanana\\n' | sort -u")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "apple\nbanana\ncherry"
+
+
+def test_script_json_processing_pipeline():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+printf '[{"name":"alice","age":30},{"name":"bob","age":25}]\\n' | \
+  jq -r '.[] | select(.age > 28) | .name'
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alice"
+
+
+def test_script_create_directory_tree_and_verify():
+    bash = Bash()
+    bash.execute_sync("mkdir -p /tmp/project/{src,lib,test}")
+    bash.execute_sync("touch /tmp/project/src/main.sh")
+    bash.execute_sync("touch /tmp/project/test/test.sh")
+    result = bash.execute_sync("ls /tmp/project/src")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "main.sh"
+
+
+def test_script_config_file_generator():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+APP_NAME=myapp
+APP_PORT=8080
+cat <<EOF
+{
+  "name": "$APP_NAME",
+  "port": $APP_PORT
+}
+EOF
+"""
+    )
+    assert result.exit_code == 0
+    config = json.loads(result.stdout)
+    assert config == {"name": "myapp", "port": 8080}
+
+
+def test_script_loop_with_accumulator():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+SUM=0
+for n in 1 2 3 4 5; do
+  SUM=$((SUM + n))
+done
+echo $SUM
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "15"
+
+
+def test_script_data_transformation_pipeline():
+    bash = Bash()
+    bash.execute_sync("printf 'Alice,30\\nBob,25\\nCharlie,35\\n' > /tmp/data.csv")
+    result = bash.execute_sync("cat /tmp/data.csv | sort -t, -k2 -n | head -1 | cut -d, -f1")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "Bob"
+
+
+def test_script_error_handling_with_or_fallback():
+    bash = Bash()
+    result = bash.execute_sync("cat /nonexistent/file 2>/dev/null || echo fallback")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "fallback"
+
+
+def test_script_conditional_file_creation():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+FILE=/tmp/conditional.txt
+if [ ! -f "$FILE" ]; then
+  echo created > "$FILE"
+fi
+cat "$FILE"
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "created"
+
+
+def test_script_function_with_multiple_operations():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+process_list() {
+  local items="$1"
+  echo "$items" | tr ',' '\n' | sort | while read item; do
+    echo "- $item"
+  done
+}
+process_list "cherry,apple,banana"
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "- apple\n- banana\n- cherry"
+
+
+def test_script_nested_loops_multiline():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+for i in 1 2; do
+  for j in a b; do
+    echo -n "$i$j "
+  done
+done
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "1a 1b 2a 2b"
+
+
+def test_script_while_read_loop_multiline():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+printf '1:one\n2:two\n3:three\n' | while IFS=: read num word; do
+  echo "$word=$num"
+done
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "one=1\ntwo=2\nthree=3"
+
+
+def test_script_bashtool_llm_style_single_command():
+    tool = BashTool()
+    result = tool.execute_sync("echo 'Hello from the AI agent'")
+    assert result.exit_code == 0
+    assert "Hello from the AI agent" in result.stdout
+
+
+def test_script_bashtool_llm_style_multi_step_script():
+    tool = BashTool()
+    result = tool.execute_sync(
+        """
+mkdir -p /tmp/workspace
+echo '{"status": "ok"}' > /tmp/workspace/result.json
+cat /tmp/workspace/result.json | jq -r '.status'
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "ok"
+
+
+def test_script_bashtool_llm_style_data_analysis():
+    tool = BashTool()
+    tool.execute_sync("printf '2024-01-01,100\\n2024-01-02,200\\n2024-01-03,150\\n' > /tmp/sales.csv")
+    total = tool.execute_sync("awk -F, '{sum+=$2} END {print sum}' /tmp/sales.csv")
+    count = tool.execute_sync("wc -l < /tmp/sales.csv")
+    assert total.exit_code == 0
+    assert total.stdout.strip() == "450"
+    assert count.exit_code == 0
+    assert count.stdout.strip() == "3"
+
+
+def test_script_bashtool_sequential_calls_build_state():
+    tool = BashTool()
+    tool.execute_sync("mkdir -p /tmp/project && cd /tmp/project")
+    tool.execute_sync("printf '# My Project\\n' > /tmp/project/README.md")
+    tool.execute_sync("printf 'fn main() {}\\n' > /tmp/project/main.rs")
+    result = tool.execute_sync("ls /tmp/project")
+    assert result.exit_code == 0
+    assert "README.md" in result.stdout
+    assert "main.rs" in result.stdout
+
+
+def test_script_many_sequential_commands():
+    bash = Bash()
+    for i in range(50):
+        result = bash.execute_sync(f"echo {i}")
+        assert result.exit_code == 0
+    final = bash.execute_sync("echo done")
+    assert final.exit_code == 0
+    assert final.stdout.strip() == "done"
+
+
+def test_script_large_output():
+    bash = Bash()
+    result = bash.execute_sync("seq 1 1000")
+    lines = result.stdout.strip().splitlines()
+    assert result.exit_code == 0
+    assert len(lines) == 1000
+    assert lines[0] == "1"
+    assert lines[-1] == "1000"
+
+
+def test_script_empty_stdin_pipe():
+    bash = Bash()
+    result = bash.execute_sync("printf '' | grep 'x'")
+    assert result.exit_code != 0
+    assert result.stdout == ""
+
+
+@pytest.mark.asyncio
+async def test_script_async_json_processing_pipeline():
+    bash = Bash()
+    result = await bash.execute(
+        """
+printf '[{"name":"alice","age":30},{"name":"bob","age":25}]\\n' | \
+  jq -r '.[] | select(.age > 28) | .name'
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alice"
+
+
+@pytest.mark.asyncio
+async def test_script_async_bashtool_llm_style_multi_step_script():
+    tool = BashTool()
+    result = await tool.execute(
+        """
+mkdir -p /tmp/workspace
+echo '{"status": "ok"}' > /tmp/workspace/result.json
+cat /tmp/workspace/result.json | jq -r '.status'
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "ok"

--- a/crates/bashkit-python/tests/test_strings_and_quoting.py
+++ b/crates/bashkit-python/tests/test_strings_and_quoting.py
@@ -1,7 +1,14 @@
 """String-handling and quoting-adjacent Python binding tests."""
 
+# Decision: keep Python parity test names close to the Node suite so cross-
+# binding coverage diffs stay mechanical.
+
 import sys
 from pathlib import Path
+
+import pytest
+
+from bashkit import Bash
 
 _TESTS_DIR = str(Path(__file__).parent)
 if _TESTS_DIR not in sys.path:
@@ -16,3 +23,221 @@ globals().update({name: getattr(_categories, name) for name in _NAMES})
 del _categories
 del _NAMES
 del _TESTS_DIR
+
+
+def test_quoting_single_quotes_preserve_literal_value():
+    bash = Bash()
+    result = bash.execute_sync("echo '$HOME'")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "$HOME"
+
+
+def test_quoting_double_quotes_expand_variables():
+    bash = Bash()
+    bash.execute_sync("X=world")
+    result = bash.execute_sync('echo "hello $X"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello world"
+
+
+def test_quoting_double_quotes_preserve_spaces():
+    bash = Bash()
+    bash.execute_sync('X="hello   world"')
+    result = bash.execute_sync('echo "$X"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello   world"
+
+
+def test_quoting_backslash_escaping_in_double_quotes():
+    bash = Bash()
+    result = bash.execute_sync('echo "a\\$b"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a$b"
+
+
+def test_quoting_nested_command_substitution_in_quotes():
+    bash = Bash()
+    result = bash.execute_sync('echo "count: $(echo 42)"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "count: 42"
+
+
+def test_quoting_heredoc_basic():
+    bash = Bash()
+    result = bash.execute_sync(
+        """cat <<EOF
+hello world
+EOF"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello world"
+
+
+def test_quoting_heredoc_with_variable_expansion():
+    bash = Bash()
+    bash.execute_sync("NAME=alice")
+    result = bash.execute_sync(
+        """cat <<EOF
+hello $NAME
+EOF"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello alice"
+
+
+def test_quoting_heredoc_quoted_delimiter_suppresses_expansion():
+    bash = Bash()
+    bash.execute_sync("NAME=alice")
+    result = bash.execute_sync(
+        """cat <<'EOF'
+hello $NAME
+EOF"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello $NAME"
+
+
+def test_quoting_string_concatenation():
+    bash = Bash()
+    bash.execute_sync("A=hello; B=world")
+    result = bash.execute_sync('echo "${A}${B}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "helloworld"
+
+
+def test_quoting_string_replacement_first_match():
+    bash = Bash()
+    bash.execute_sync("S='hello world hello'")
+    result = bash.execute_sync('echo "${S/hello/bye}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "bye world hello"
+
+
+def test_quoting_string_replacement_global():
+    bash = Bash()
+    bash.execute_sync("S='hello world hello'")
+    result = bash.execute_sync('echo "${S//hello/bye}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "bye world bye"
+
+
+def test_quoting_uppercase_conversion():
+    bash = Bash()
+    bash.execute_sync("S=hello")
+    result = bash.execute_sync('echo "${S^^}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "HELLO"
+
+
+def test_quoting_lowercase_conversion():
+    bash = Bash()
+    bash.execute_sync("S=HELLO")
+    result = bash.execute_sync('echo "${S,,}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_quoting_array_declaration_and_access():
+    bash = Bash()
+    bash.execute_sync("ARR=(apple banana cherry)")
+    first = bash.execute_sync('echo "${ARR[0]}"')
+    last = bash.execute_sync('echo "${ARR[2]}"')
+    assert first.exit_code == 0
+    assert first.stdout.strip() == "apple"
+    assert last.exit_code == 0
+    assert last.stdout.strip() == "cherry"
+
+
+def test_quoting_array_length():
+    bash = Bash()
+    bash.execute_sync("ARR=(a b c d)")
+    result = bash.execute_sync('echo "${#ARR[@]}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "4"
+
+
+def test_quoting_array_all_elements():
+    bash = Bash()
+    bash.execute_sync("ARR=(x y z)")
+    result = bash.execute_sync('echo "${ARR[@]}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "x y z"
+
+
+def test_quoting_array_append():
+    bash = Bash()
+    bash.execute_sync("ARR=(a b)")
+    bash.execute_sync("ARR+=(c)")
+    result = bash.execute_sync('echo "${ARR[@]}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a b c"
+
+
+def test_quoting_array_iteration_in_for_loop():
+    bash = Bash()
+    result = bash.execute_sync(
+        """
+FRUITS=(apple banana cherry)
+for fruit in "${FRUITS[@]}"; do
+  echo "$fruit"
+done
+"""
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "apple\nbanana\ncherry"
+
+
+def test_quoting_empty_string_variable():
+    bash = Bash()
+    bash.execute_sync('X=""')
+    result = bash.execute_sync('echo "[$X]"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "[]"
+
+
+def test_quoting_newlines_in_variable():
+    bash = Bash()
+    bash.execute_sync('X="line1\nline2"')
+    result = bash.execute_sync('echo -e "$X"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "line1\nline2"
+
+
+def test_quoting_tab_character_preserved():
+    bash = Bash()
+    result = bash.execute_sync("printf 'a\\tb'")
+    assert result.exit_code == 0
+    assert result.stdout == "a\tb"
+
+
+def test_quoting_semicolon_separates_commands():
+    bash = Bash()
+    result = bash.execute_sync("echo a; echo b")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a\nb"
+
+
+def test_quoting_long_string_handling():
+    bash = Bash()
+    long_value = "x" * 10000
+    result = bash.execute_sync(f"X={long_value}; echo ${{#X}}")
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "10000"
+
+
+@pytest.mark.asyncio
+async def test_quoting_async_double_quotes_expand_variables():
+    bash = Bash()
+    bash.execute_sync("X=world")
+    result = await bash.execute('echo "hello $X"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_quoting_async_array_append():
+    bash = Bash()
+    bash.execute_sync("ARR=(a b)")
+    result = await bash.execute('ARR+=(c); echo "${ARR[@]}"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "a b c"


### PR DESCRIPTION
## Summary
- replace the thin builtin and string parity shims with dedicated Python binding suites
- expand the script category with Node-style real-world Bash and BashTool scenarios while keeping existing high-level coverage
- add explicit async coverage in each category and verify the new acceptance-count targets locally

## Testing
- ./.venv312/bin/ruff check tests/test_builtins.py tests/test_strings_and_quoting.py tests/test_scripts.py
- ./.venv312/bin/ruff format --check tests/test_builtins.py tests/test_strings_and_quoting.py tests/test_scripts.py
- ./.venv312/bin/pytest tests/test_builtins.py tests/test_strings_and_quoting.py tests/test_scripts.py -q

Closes #1260