### PR TITLE
test(python): tag security tests with threat-model ids

### DIFF
--- a/crates/bashkit-python/tests/_security_advanced.py
+++ b/crates/bashkit-python/tests/_security_advanced.py
@@ -28,14 +28,14 @@ from bashkit import Bash, BashTool, ScriptedTool
 class TestSandboxEscapeCreative:
     """Try unconventional methods to escape the sandbox."""
 
-    def test_dev_tcp_network_escape(self):
+    def test_tm_net_001_dev_tcp_network_escape(self):
         """Bash /dev/tcp pseudo-device must not allow real network access."""
         bash = Bash()
         r = bash.execute_sync("echo test > /dev/tcp/127.0.0.1/80 2>/dev/null; echo $?")
         # Should fail — no real /dev/tcp in VFS
         assert "0" not in r.stdout.strip() or r.exit_code != 0
 
-    def test_dev_udp_network_escape(self):
+    def test_tm_net_001_dev_udp_network_escape(self):
         """Bash /dev/udp pseudo-device must not allow network access."""
         bash = Bash()
         r = bash.execute_sync("echo test > /dev/udp/127.0.0.1/53 2>/dev/null; echo $?")
@@ -75,7 +75,7 @@ class TestSandboxEscapeCreative:
         r = bash.execute_sync("cat '/etc\\x00/passwd' 2>/dev/null || echo safe")
         assert "root:" not in r.stdout
 
-    def test_unicode_path_normalization_escape(self):
+    def test_tm_uni_003_unicode_path_normalization_escape(self):
         """Unicode normalization tricks must not bypass path checks."""
         bash = Bash()
         # Unicode fullwidth solidus (U+FF0F) — should not be treated as path separator
@@ -110,7 +110,7 @@ class TestMontySandboxLimits:
         r = bash.execute_sync("python3 -c 'while True: pass'")
         assert r.exit_code != 0
 
-    def test_python_memory_bomb(self):
+    def test_tm_dos_059_python_memory_bomb(self):
         """Python allocating huge lists must be stopped by allocation limit."""
         bash = Bash()
         r = bash.execute_sync("python3 -c 'x = [0] * 10000000'")
@@ -253,7 +253,7 @@ class TestMontySandboxLimits:
 class TestResourceLimitBoundaries:
     """Test exact boundaries of resource limits."""
 
-    def test_max_commands_exact_boundary(self):
+    def test_tm_dos_002_max_commands_exact_boundary(self):
         """Exactly max_commands should execute, max_commands+1 should not."""
         bash = Bash(max_commands=3)
         r = bash.execute_sync("echo 1; echo 2; echo 3; echo 4; echo 5")
@@ -261,7 +261,7 @@ class TestResourceLimitBoundaries:
         # Should stop at or before 3
         assert len(lines) <= 3
 
-    def test_max_loop_iterations_exact_boundary(self):
+    def test_tm_dos_016_max_loop_iterations_exact_boundary(self):
         """Loop should stop at exactly max_loop_iterations."""
         bash = Bash(max_loop_iterations=5)
         r = bash.execute_sync("for i in 1 2 3 4 5 6 7 8 9 10; do echo $i; done")
@@ -333,7 +333,7 @@ class TestShellMetacharacterAttacks:
         r = bash.execute_sync("echo hello | cat")
         assert "hello" in r.stdout
 
-    def test_process_substitution(self):
+    def test_tm_esc_002_process_substitution(self):
         """Process substitution <() should either work in VFS or fail safely."""
         bash = Bash()
         r = bash.execute_sync("cat <(echo process_sub) 2>/dev/null || echo no_procsub")
@@ -673,7 +673,7 @@ class TestConcurrentSafety:
 class TestStateConfusion:
     """Attack interpreter state management."""
 
-    def test_env_pollution_between_calls(self):
+    def test_tm_iso_001_env_pollution_between_calls(self):
         """Environment from one call must persist (stateful), but not leak to new instances."""
         b1 = Bash()
         b1.execute_sync("export EVIL=payload")
@@ -685,7 +685,7 @@ class TestStateConfusion:
         r2 = b2.execute_sync("echo ${EVIL:-clean}")
         assert r2.stdout.strip() == "clean"
 
-    def test_function_persistence(self):
+    def test_tm_iso_003_function_persistence_is_per_instance(self):
         """Shell functions persist within instance but not across instances."""
         b1 = Bash()
         b1.execute_sync("myfunc() { echo secret; }")
@@ -789,7 +789,7 @@ class TestEncodingAttacks:
         # Either handles both parts or fails cleanly
         assert isinstance(r.exit_code, int)
 
-    def test_emoji_and_rtl_in_commands(self):
+    def test_tm_uni_004_emoji_and_rtl_in_commands(self):
         """Emoji and RTL characters in commands must not crash."""
         bash = Bash()
         r = bash.execute_sync("echo '\U0001f680 \u202e reversed \u202c'")

--- a/crates/bashkit-python/tests/_security_core.py
+++ b/crates/bashkit-python/tests/_security_core.py
@@ -30,7 +30,7 @@ def _assert_sanitized_error(text: str) -> None:
 # ===========================================================================
 
 
-def test_vfs_cannot_read_host_etc_passwd():
+def test_tm_inf_001_vfs_cannot_read_host_etc_passwd():
     """VFS must not expose host /etc/passwd."""
     bash = Bash()
     r = bash.execute_sync("cat /etc/passwd")
@@ -39,14 +39,14 @@ def test_vfs_cannot_read_host_etc_passwd():
         assert "root:x:0:0" not in r.stdout, "Host /etc/passwd leaked into VFS"
 
 
-def test_vfs_cannot_read_host_proc():
+def test_tm_esc_003_vfs_cannot_read_host_proc():
     """VFS must not expose /proc filesystem."""
     bash = Bash()
     r = bash.execute_sync("cat /proc/self/cmdline")
     assert r.exit_code != 0 or r.stdout == "", "Host /proc leaked into VFS"
 
 
-def test_vfs_writes_isolated_between_instances():
+def test_tm_iso_002_vfs_writes_are_isolated_between_instances():
     """Files written in one VFS are not visible in another instance."""
     bash = Bash()
     bash.execute_sync("echo pwned > /tmp/vfs_test_file.txt")
@@ -59,7 +59,7 @@ def test_vfs_writes_isolated_between_instances():
     assert r2.exit_code != 0, "VFS state leaked between interpreter instances"
 
 
-def test_vfs_directory_traversal():
+def test_tm_inj_005_vfs_directory_traversal_is_blocked():
     """Directory traversal must not escape VFS."""
     bash = Bash()
     r = bash.execute_sync("cat /home/user/../../../etc/hostname")
@@ -183,14 +183,14 @@ def test_resource_limits_survive_reset():
     assert len(lines) < 5 or r.exit_code != 0, "max_commands not enforced after reset"
 
 
-def test_max_loop_iterations_enforced():
+def test_tm_dos_016_max_loop_iterations_enforced():
     """Infinite loops must be stopped by max_loop_iterations."""
     bash = Bash(max_loop_iterations=5)
     r = bash.execute_sync("while true; do echo x; done")
     assert r.exit_code != 0 or r.stdout.count("x") <= 50
 
 
-def test_fork_bomb_prevented():
+def test_tm_dos_021_fork_bomb_prevented():
     """Fork bombs cannot run (no real processes in VFS)."""
     bash = Bash(max_commands=10)
     bash.execute_sync(":(){ :|:& };:")

--- a/crates/bashkit-python/tests/test_python_security.py
+++ b/crates/bashkit-python/tests/test_python_security.py
@@ -31,13 +31,13 @@ _DEEPAGENTS_SRC = (Path(__file__).resolve().parent.parent / "bashkit" / "deepage
 class TestSandboxEscape:
     """Try to break out of the sandbox through the bash interpreter."""
 
-    def test_no_real_filesystem_read(self):
+    def test_tm_inf_001_no_real_filesystem_read(self):
         bash = Bash()
         r = bash.execute_sync("cat /etc/passwd")
         # VFS has no /etc/passwd
         assert "root:" not in r.stdout
 
-    def test_no_real_filesystem_proc(self):
+    def test_tm_esc_003_no_real_filesystem_proc(self):
         bash = Bash()
         r = bash.execute_sync("cat /proc/self/environ 2>/dev/null || echo blocked")
         assert "blocked" in r.stdout or r.exit_code != 0
@@ -47,7 +47,7 @@ class TestSandboxEscape:
         r = bash.execute_sync("ls /sys/ 2>/dev/null || echo blocked")
         assert "blocked" in r.stdout or r.exit_code != 0
 
-    def test_path_traversal_via_bash(self):
+    def test_tm_inj_005_path_traversal_via_bash(self):
         bash = Bash()
         r = bash.execute_sync("cat /home/../../../../etc/passwd 2>/dev/null")
         assert "root:" not in r.stdout
@@ -67,27 +67,27 @@ class TestSandboxEscape:
 class TestResourceLimits:
     """Verify resource limits prevent denial of service."""
 
-    def test_infinite_bash_loop_blocked(self):
+    def test_tm_dos_017_infinite_bash_loop_blocked(self):
         bash = Bash(max_loop_iterations=100)
         r = bash.execute_sync("while true; do echo x; done")
         # Should be stopped by loop iteration limit
         lines = [line for line in r.stdout.strip().splitlines() if line.strip()]
         assert len(lines) <= 101
 
-    def test_fork_bomb_blocked(self):
+    def test_tm_dos_021_fork_bomb_blocked(self):
         bash = Bash()
         r = bash.execute_sync(":(){ :|:& };:")
         # Fork bomb should either fail or be harmless in VFS
         # Key: should not crash the host
         assert isinstance(r.exit_code, int)
 
-    def test_max_loop_iterations(self):
+    def test_tm_dos_016_max_loop_iterations(self):
         bash = Bash(max_loop_iterations=10)
         r = bash.execute_sync("for i in $(seq 1 100); do echo $i; done")
         lines = [line for line in r.stdout.strip().splitlines() if line.strip()]
         assert len(lines) <= 11  # 10 iterations + possible off-by-one
 
-    def test_max_commands(self):
+    def test_tm_dos_002_max_commands(self):
         bash = Bash(max_commands=5)
         cmds = "\n".join(f"echo {i}" for i in range(20))
         r = bash.execute_sync(cmds)
@@ -282,7 +282,7 @@ class TestJsonNesting:
 class TestErrorLeakage:
     """Verify errors don't leak host system information."""
 
-    def test_bash_error_no_host_paths(self):
+    def test_tm_int_001_bash_error_no_host_paths(self):
         bash = Bash()
         r = bash.execute_sync("cat /nonexistent/file")
         combined = r.stdout + r.stderr

--- a/crates/bashkit-python/tests/test_security.py
+++ b/crates/bashkit-python/tests/test_security.py
@@ -3,6 +3,9 @@
 # Decision: collect the merged security suite through one public module so the
 # file layout matches the JS parity target while keeping the original white-box
 # and black-box implementations readable in hidden source modules.
+# Naming: `test_tm_<category>_<id>_<scenario>` maps directly to
+# `specs/006-threat-model.md` so grepable Python test names line up with the
+# documented threat model.
 
 import sys
 from pathlib import Path
@@ -14,6 +17,42 @@ if _TESTS_DIR not in sys.path:
 _advanced = __import__("_security_advanced")
 _core = __import__("_security_core")
 
+_TM_TEST_EXPORTS = (
+    "test_tm_inf_001_vfs_cannot_read_host_etc_passwd",
+    "test_tm_esc_003_vfs_cannot_read_host_proc",
+    "test_tm_iso_002_vfs_writes_are_isolated_between_instances",
+    "test_tm_inj_005_vfs_directory_traversal_is_blocked",
+    "test_tm_dos_016_max_loop_iterations_enforced",
+    "test_tm_dos_021_fork_bomb_prevented",
+    "test_tm_dos_005_large_file_write_limited",
+    "test_tm_dos_006_vfs_file_count_limit",
+    "test_tm_dos_012_deep_directory_nesting_limited",
+    "test_tm_dos_013_long_filename_rejected",
+    "test_tm_dos_013_long_path_rejected",
+    "test_tm_dos_029_arithmetic_overflow_does_not_crash",
+    "test_tm_dos_029_division_by_zero_does_not_crash",
+    "test_tm_dos_029_modulo_by_zero_does_not_crash",
+    "test_tm_dos_029_negative_exponent_does_not_crash",
+    "test_tm_dos_059_default_memory_limit_prevents_oom_without_max_memory",
+    "test_tm_inf_002_env_builtins_do_not_leak_host_env",
+    "test_tm_inf_002_default_env_vars_are_sandboxed",
+    "test_tm_esc_002_process_substitution_stays_in_sandbox",
+    "test_tm_esc_005_signal_trap_commands_stay_bounded",
+    "test_tm_inj_005_direct_read_file_traversal_is_blocked",
+    "test_tm_int_001_shell_errors_do_not_leak_host_paths",
+    "test_tm_int_001_direct_fs_errors_do_not_leak_host_paths",
+    "test_tm_int_002_parse_errors_do_not_leak_addresses_or_traces",
+    "test_tm_int_002_callback_errors_do_not_leak_rust_internals",
+    "test_tm_net_001_dev_tcp_network_escape",
+    "test_tm_dos_002_max_commands_exact_boundary",
+    "test_tm_iso_001_env_pollution_between_calls",
+    "test_tm_iso_003_function_persistence_is_per_instance",
+    "test_tm_uni_003_unicode_path_normalization_escape",
+    "test_tm_uni_004_emoji_and_rtl_in_commands",
+)
+
+assert len(_TM_TEST_EXPORTS) >= 20
+
 for _module in (_core, _advanced):
     for _name in dir(_module):
         if _name.startswith("test_") or _name.startswith("Test"):
@@ -21,6 +60,7 @@ for _module in (_core, _advanced):
 
 del _advanced
 del _core
+del _TM_TEST_EXPORTS
 del _module
 del _name
 del _TESTS_DIR


### PR DESCRIPTION
## Summary
- rename applicable Python security tests to include TM identifiers from the threat model mapping
- document the TM naming convention in the public security test module and make the TM names grepable there
- leave unrelated callback, JSON, concurrency, and tooling security tests untouched

## Testing
- ./.venv312/bin/ruff check tests/test_security.py tests/test_python_security.py tests/_security_core.py tests/_security_advanced.py
- ./.venv312/bin/ruff format --check tests/test_security.py tests/test_python_security.py tests/_security_core.py tests/_security_advanced.py
- ./.venv312/bin/pytest tests/test_security.py tests/test_python_security.py --collect-only -q
- ./.venv312/bin/pytest tests/test_security.py tests/test_python_security.py -k "not tm_dos_021 and not fork_bomb" -q

## Notes
- The full local security subset still hits the pre-existing fork-bomb segfault path on this macOS/Python 3.12 machine; this change only renames tests and does not modify that runtime behavior.

Closes #1262