### PR TITLE
docs(readme): align Python and Node package guides

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -1,6 +1,17 @@
 # @everruns/bashkit
 
-Sandboxed bash interpreter for JavaScript/TypeScript. Native NAPI-RS bindings to the [bashkit](https://github.com/everruns/bashkit) Rust core. Works with Node.js, Bun, and Deno.
+Sandboxed bash interpreter for JavaScript and TypeScript. Native NAPI-RS bindings to the `bashkit` Rust core for Node.js, Bun, and Deno.
+
+## Features
+
+- Sandboxed, in-process execution with a virtual filesystem
+- Full bash syntax: variables, pipelines, redirects, loops, functions, and arrays
+- 160 built-in commands including `grep`, `sed`, `awk`, `jq`, `curl`, and `find`
+- Sync and async execution APIs
+- Direct VFS helpers, constructor mounts, and live host mounts
+- Cancellation support via `cancel()`
+- Snapshot and restore support on `Bash`
+- AI framework adapters for OpenAI, Anthropic, Vercel AI SDK, and LangChain
 
 ## Install
 
@@ -10,231 +21,333 @@ bun add @everruns/bashkit       # Bun
 deno add npm:@everruns/bashkit  # Deno
 ```
 
-## Features
+## Quick Start
 
-- **Sandboxed execution** — all commands run in-process with a virtual filesystem, no containers needed
-- **160 built-in commands** — echo, cat, grep, sed, awk, jq, curl, find, and more
-- **Full bash syntax** — variables, pipelines, redirects, loops, functions, arrays
-- **Resource limits** — protect against infinite loops and runaway scripts
-- **Sync and async APIs** — `executeSync()` and `execute()` (Promise-based)
-- **Virtual filesystem access** — read, write, mkdir, glob directly from JS
-- **Cancellation** — `cancel()` and `AbortSignal` support
-- **Scripted tool orchestration** — compose JS callbacks as bash builtins via `ScriptedTool`
-- **LLM tool contract** — `BashTool` with discovery metadata, schemas, and system prompts
-
-## Usage
+### Sync Execution
 
 ```typescript
-import { Bash, BashTool, ScriptedTool, getVersion } from '@everruns/bashkit';
+import { Bash } from "@everruns/bashkit";
 
-// Basic usage
 const bash = new Bash();
+
 const result = bash.executeSync('echo "Hello, World!"');
 console.log(result.stdout); // Hello, World!\n
 
-// Async
-const r = await bash.execute('echo "async!"');
-console.log(r.stdout); // async!\n
-
-// State persists between calls
-bash.executeSync('X=42');
-bash.executeSync('echo $X'); // stdout: 42\n
-
-// With tool-contract metadata
-const tool = new BashTool();
-console.log(tool.name);           // "bashkit"
-console.log(tool.inputSchema());  // JSON schema for LLM tool-use
-console.log(tool.description());  // Token-efficient tool description
-console.log(tool.help());         // Markdown help document
-console.log(tool.systemPrompt()); // Compact system prompt
-
-const tr = tool.executeSync('echo hello');
-console.log(tr.stdout); // hello\n
+bash.executeSync("X=42");
+console.log(bash.executeSync("echo $X").stdout); // 42\n
 ```
 
-### Virtual Filesystem
-
-Read, write, and inspect files directly without executing bash commands:
+### Async Execution
 
 ```typescript
+import { Bash } from "@everruns/bashkit";
+
 const bash = new Bash();
-bash.writeFile('/data/config.json', '{"key": "value"}');
-const content = bash.readFile('/data/config.json');
-bash.mkdir('/data/subdir', true);   // recursive
-bash.exists('/data/config.json');   // true
-bash.remove('/data/subdir', true);  // recursive
-bash.ls('/data');                   // string[]
-bash.glob('**/*.json');             // string[]
+
+const result = await bash.execute('echo -e "banana\\napple\\ncherry" | sort');
+console.log(result.stdout); // apple\nbanana\ncherry\n
+
+await bash.execute('printf "data\\n" > /tmp/file.txt');
+console.log((await bash.execute("cat /tmp/file.txt")).stdout); // data\n
 ```
 
-### File Mounts
+## Configuration
 
-Mount files at construction time with strings, sync functions, or async functions:
+### BashOptions
 
 ```typescript
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash({
+  username: "agent",
+  hostname: "sandbox",
+  maxCommands: 1000,
+  maxLoopIterations: 10000,
+  maxMemory: 10 * 1024 * 1024,
+  timeoutMs: 30_000,
+  mounts: [{ path: "/workspace", root: "./src", writable: true }],
+  python: false,
+});
+```
+
+## Virtual Filesystem
+
+### Direct Methods on Bash and BashTool
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash();
+
+bash.mkdir("/data", true);
+bash.writeFile("/data/config.json", '{"debug":true}');
+bash.appendFile("/data/config.json", "\n");
+
+console.log(bash.readFile("/data/config.json"));
+console.log(bash.exists("/data/config.json"));
+console.log(bash.ls("/data"));
+console.log(bash.glob("/data/*.json"));
+```
+
+`BashTool` exposes the same direct filesystem helpers.
+
+### FileSystem Accessor
+
+Call `bash.fs()` or `tool.fs()` when you need the underlying filesystem handle directly. For most applications, the convenience methods on `Bash` and `BashTool` are simpler and more explicit.
+
+### Pre-Initialized Files
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
 const bash = new Bash({
   files: {
-    '/config.json': '{"key": "value"}',
-    '/lazy.txt': () => 'computed on first read',
-    '/async.txt': async () => fetchContent(),
+    "/config.json": '{"key":"value"}',
+    "/lazy.txt": () => "computed on first read",
   },
 });
 
-// For async file providers, use the static factory
-const bash2 = await Bash.create({
-  files: { '/data.txt': async () => loadData() },
+console.log(bash.readFile("/config.json"));
+
+const asyncBash = await Bash.create({
+  files: {
+    "/async.txt": async () => "loaded asynchronously",
+  },
 });
 ```
 
-### Cancellation
+### Real Filesystem Mounts
 
 ```typescript
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash({
+  mounts: [
+    { path: "/docs", root: "./docs" },
+    { path: "/workspace", root: "./src", writable: true },
+  ],
+});
+
+console.log(bash.executeSync("ls /workspace").stdout);
+```
+
+### Live Mounts
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
 const bash = new Bash();
 
-// Cancel method
-const promise = bash.execute('sleep 60');
-bash.cancel();
-
-// AbortSignal
-const controller = new AbortController();
-const promise2 = bash.execute('sleep 60', { signal: controller.signal });
-controller.abort();
+bash.mount("./src", "/workspace", true);
+console.log(bash.executeSync("ls /workspace").stdout);
+bash.unmount("/workspace");
 ```
 
-### Error Handling
+## Error Handling
 
 ```typescript
-import { BashError } from '@everruns/bashkit';
+import { Bash, BashError } from "@everruns/bashkit";
 
-// Throws BashError on non-zero exit
+const bash = new Bash();
+
 try {
-  bash.executeSyncOrThrow('exit 1');
-} catch (e) {
-  if (e instanceof BashError) {
-    console.log(e.exitCode); // 1
-    console.log(e.stderr);
+  bash.executeSyncOrThrow("exit 1");
+} catch (err) {
+  if (err instanceof BashError) {
+    console.log(err.exitCode);
+    console.log(err.stderr);
   }
 }
-
-// Async variant
-await bash.executeOrThrow('false');
 ```
 
-### ScriptedTool
-
-Compose JS callbacks as bash builtins — an LLM writes a single bash script that pipes, loops, and branches across all registered tools:
+## Cancellation
 
 ```typescript
-const tool = new ScriptedTool({ name: 'api' });
-tool.addTool('get_user', 'Fetch user by ID', (params) => {
-  return JSON.stringify({ id: params.id, name: 'Alice' });
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash();
+
+const running = bash.execute("sleep 60");
+bash.cancel();
+await running;
+
+bash.reset(); // reset before reusing the instance
+```
+
+`BashTool` exposes the same `cancel()` and `reset()` methods. For synchronous execution, `executeSync(...)` and `executeSyncOrThrow(...)` also accept `{ signal }`.
+
+## BashTool
+
+`BashTool` wraps the interpreter with tool-contract metadata for agent frameworks:
+
+- `name`
+- `version`
+- `shortDescription`
+- `description()`
+- `help()`
+- `systemPrompt()`
+- `inputSchema()`
+- `outputSchema()`
+
+```typescript
+import { BashTool } from "@everruns/bashkit";
+
+const tool = new BashTool();
+
+console.log(tool.name);
+console.log(tool.inputSchema());
+
+const result = tool.executeSync("echo hello");
+console.log(result.stdout);
+```
+
+## ScriptedTool
+
+Use `ScriptedTool` to register JavaScript callbacks as bash-callable tools:
+
+```typescript
+import { ScriptedTool } from "@everruns/bashkit";
+
+const tool = new ScriptedTool({ name: "api" });
+tool.addTool("get_user", "Fetch user by ID", (params) => {
+  return JSON.stringify({ id: params.id, name: "Alice" });
 });
 
 const result = tool.executeSync("get_user --id 1 | jq -r '.name'");
 console.log(result.stdout); // Alice
 ```
 
-## API
+## Snapshot / Restore
 
-### `Bash`
-
-Core interpreter with virtual filesystem.
-
-- `new Bash(options?)` — create instance
-- `Bash.create(options?)` — async factory for async file providers
-- `executeSync(commands)` — run bash commands, returns `ExecResult`
-- `executeSyncOrThrow(commands)` — run, throws `BashError` on non-zero exit
-- `execute(commands)` — async execution, returns `Promise<ExecResult>`
-- `executeOrThrow(commands)` — async, throws `BashError` on non-zero exit
-- `cancel()` — cancel running execution
-- `reset()` — clear state, preserve config
-- `readFile(path)` — read file as string
-- `writeFile(path, content)` — write/overwrite file
-- `mkdir(path, recursive?)` — create directory
-- `exists(path)` — check path exists
-- `remove(path, recursive?)` — delete file/directory
-- `ls(path?)` — list directory contents
-- `glob(pattern)` — find files by pattern
-
-### `BashTool`
-
-Interpreter + tool-contract metadata. All `Bash` methods, plus:
-
-- `name` — tool name (`"bashkit"`)
-- `version` — version string
-- `shortDescription` — one-liner
-- `description()` — token-efficient tool description
-- `help()` — Markdown help document
-- `systemPrompt()` — compact system prompt for LLM orchestration
-- `inputSchema()` — JSON input schema
-- `outputSchema()` — JSON output schema
-
-### `ScriptedTool`
-
-Multi-tool orchestration — register JS callbacks as bash builtins.
-
-- `new ScriptedTool(options)` — create with name, shortDescription, limits
-- `addTool(name, description, callback, schema?)` — register a tool
-- `executeSync(script)` / `execute(script)` — run script
-- `executeSyncOrThrow(script)` / `executeOrThrow(script)` — run, throw on error
-- `env(key, value)` — set environment variable
-- `toolCount()` — number of registered tools
-- Tool metadata: `name`, `shortDescription`, `version`, `description()`, `help()`, `systemPrompt()`, `inputSchema()`, `outputSchema()`
-
-### `BashOptions`
+State snapshots are currently available on `Bash` instances:
 
 ```typescript
-interface BashOptions {
-  username?: string;
-  hostname?: string;
-  maxCommands?: number;
-  maxLoopIterations?: number;
-  files?: Record<string, string | (() => string) | (() => Promise<string>)>;
-  python?: boolean;
-  externalFunctions?: string[];
-}
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash({ username: "agent", maxCommands: 100 });
+await bash.execute("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt");
+
+const snapshot = bash.snapshot();
+
+const restored = Bash.fromSnapshot(snapshot);
+console.log((await restored.execute("echo $BUILD_ID")).stdout); // 42\n
+
+restored.reset();
+restored.restoreSnapshot(snapshot);
+console.log(restored.executeSync("pwd").stdout); // /workspace\n
 ```
 
-### `ExecResult`
+## Framework Integrations
+
+### OpenAI
 
 ```typescript
-interface ExecResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  success: boolean;
-  error?: string;
-  stdoutTruncated?: boolean;
-  stderrTruncated?: boolean;
-}
+import { bashTool } from "@everruns/bashkit/openai";
+
+const bash = bashTool();
 ```
 
-### `BashError`
+### Anthropic
 
 ```typescript
-class BashError extends Error {
-  exitCode: number;
-  stderr: string;
-  display(): string;
-}
+import { bashTool } from "@everruns/bashkit/anthropic";
+
+const bash = bashTool();
 ```
 
-### `getVersion()`
+### Vercel AI SDK
 
-Returns the bashkit version string.
+```typescript
+import { bashTool } from "@everruns/bashkit/ai";
+
+const bash = bashTool();
+```
+
+### LangChain
+
+```typescript
+import { createBashTool, createScriptedTool } from "@everruns/bashkit/langchain";
+```
+
+## API Reference
+
+### Bash
+
+- `new Bash(options?)`
+- `Bash.create(options?)`
+- `executeSync(commands, { signal? })`
+- `execute(commands)`
+- `executeSyncOrThrow(commands, { signal? })`
+- `executeOrThrow(commands)`
+- `cancel()`
+- `reset()`
+- `snapshot()`
+- `restoreSnapshot(data)`
+- `Bash.fromSnapshot(data)`
+- Direct VFS helpers: `readFile`, `writeFile`, `appendFile`, `mkdir`, `remove`, `exists`, `stat`, `readDir`, `ls`, `glob`, `mount`, `unmount`, `fs`
+
+### BashTool
+
+- All execution, cancellation, reset, and direct VFS helpers from `Bash`
+- Tool metadata: `name`, `version`, `shortDescription`
+- `description()`
+- `help()`
+- `systemPrompt()`
+- `inputSchema()`
+- `outputSchema()`
+
+### ScriptedTool
+
+- `new ScriptedTool(options)`
+- `addTool(name, description, callback, schema?)`
+- `executeSync(script)`
+- `execute(script)`
+- `executeSyncOrThrow(script)`
+- `executeOrThrow(script)`
+- `env(key, value)`
+- `toolCount()`
+
+### BashOptions
+
+- `username?: string`
+- `hostname?: string`
+- `maxCommands?: number`
+- `maxLoopIterations?: number`
+- `maxMemory?: number`
+- `timeoutMs?: number`
+- `files?: Record<string, string | (() => string) | (() => Promise<string>)>`
+- `mounts?: Array<{ path: string; root: string; writable?: boolean }>`
+- `python?: boolean`
+- `externalFunctions?: string[]`
+
+### ExecResult and BashError
+
+- `ExecResult.stdout`
+- `ExecResult.stderr`
+- `ExecResult.exitCode`
+- `ExecResult.error`
+- `ExecResult.success`
+- `ExecResult.stdoutTruncated`
+- `ExecResult.stderrTruncated`
+- `BashError.exitCode`
+- `BashError.stderr`
 
 ## Platform Support
 
 | OS | Architecture |
 |----|-------------|
-| macOS | x86_64, aarch64 (Apple Silicon) |
-| Linux | x86_64, aarch64 |
-| Windows | x86_64 |
-| WASM | wasm32-wasip1-threads |
+| macOS | `x86_64`, `aarch64` |
+| Linux | `x86_64`, `aarch64` |
+| Windows | `x86_64` |
+| WASM | `wasm32-wasip1-threads` |
+
+## How It Works
+
+The JavaScript package wraps the Rust `bashkit` interpreter through NAPI-RS bindings. Commands execute in-process against a virtual filesystem, with the Rust core enforcing parsing, execution, and resource limits while the JS wrapper exposes a TypeScript-friendly API and framework adapters.
 
 ## Part of Everruns
 
-Bashkit is part of the [Everruns](https://github.com/everruns) ecosystem — tools and runtimes for building reliable AI agents. See the [bashkit monorepo](https://github.com/everruns/bashkit) for the Rust core, Python package (`bashkit`), and more.
+Bashkit is part of the [Everruns](https://github.com/everruns) ecosystem. See the [bashkit monorepo](https://github.com/everruns/bashkit) for the Rust core, the Python package (`bashkit`), and related tooling.
 
 ## License
 

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -2,83 +2,87 @@
 
 [![PyPI](https://img.shields.io/pypi/v/bashkit)](https://pypi.org/project/bashkit/)
 
-A sandboxed bash interpreter for AI agents.
-
-```python
-from bashkit import BashTool
-
-tool = BashTool()
-result = tool.execute_sync("echo 'Hello, World!'")
-print(result.stdout)  # Hello, World!
-```
+Sandboxed bash interpreter for Python. Native bindings to the `bashkit` Rust core for fast, in-process execution with a virtual filesystem.
 
 ## Features
 
-- **Sandboxed execution** — all commands run in-process with a virtual filesystem, no containers needed
-- **160 built-in commands** — echo, cat, grep, sed, awk, jq, curl, find, and more
-- **Full bash syntax** — variables, pipelines, redirects, loops, functions, arrays
-- **Resource limits** — protect against infinite loops and runaway scripts
-- **Framework integrations** — LangChain, PydanticAI, and Deep Agents
+- Sandboxed execution in-process, without containers or subprocess orchestration
+- Full bash syntax: variables, pipelines, redirects, loops, functions, and arrays
+- 160 built-in commands including `grep`, `sed`, `awk`, `jq`, `curl`, and `find`
+- Persistent interpreter state across calls, including variables, cwd, and VFS contents
+- Direct virtual filesystem APIs, constructor mounts, and live host mounts
+- Snapshot and restore support on `Bash` and `BashTool`
+- AI integrations for LangChain, PydanticAI, and Deep Agents
 
 ## Installation
 
 ```bash
 pip install bashkit
 
-# With framework support
+# Optional integrations
 pip install 'bashkit[langchain]'
 pip install 'bashkit[pydantic-ai]'
+pip install 'bashkit[deepagents]'
 ```
 
-## Usage
+## Quick Start
 
-### Async
+### Sync Execution
+
+```python
+from bashkit import Bash
+
+bash = Bash()
+
+result = bash.execute_sync("echo 'Hello, World!'")
+print(result.stdout)  # Hello, World!
+
+bash.execute_sync("export APP_ENV=dev")
+print(bash.execute_sync("echo $APP_ENV").stdout)  # dev
+```
+
+### Async Execution
 
 ```python
 import asyncio
 from bashkit import Bash
 
+
 async def main():
     bash = Bash()
 
-    # Simple command
-    result = await bash.execute("echo 'Hello, World!'")
-    print(result.stdout)  # Hello, World!
-
-    # Pipeline
     result = await bash.execute("echo -e 'banana\\napple\\ncherry' | sort")
     print(result.stdout)  # apple\nbanana\ncherry
 
-    # Virtual filesystem persists between calls
-    await bash.execute("echo 'data' > /tmp/file.txt")
-    result = await bash.execute("cat /tmp/file.txt")
-    print(result.stdout)  # data
+    await bash.execute("printf 'data\\n' > /tmp/file.txt")
+    saved = await bash.execute("cat /tmp/file.txt")
+    print(saved.stdout)  # data
+
 
 asyncio.run(main())
 ```
 
-### Sync
+## Configuration
+
+### Constructor Options
 
 ```python
-from bashkit import BashTool
+from bashkit import Bash
 
-tool = BashTool()
-result = tool.execute_sync("echo 'Hello!'")
-print(result.stdout)
-```
-
-### Configuration
-
-```python
 bash = Bash(
-    username="agent",           # Custom username (whoami)
-    hostname="sandbox",         # Custom hostname
-    max_commands=1000,          # Limit total commands
-    max_loop_iterations=10000,  # Limit loop iterations
+    username="agent",
+    hostname="sandbox",
+    max_commands=1000,
+    max_loop_iterations=10000,
+    max_memory=10 * 1024 * 1024,
+    timeout_seconds=30,
+    python=False,
 )
 ```
 
-### Direct Filesystem Access
+## Virtual Filesystem
+
+### Direct Methods on Bash and BashTool
 
 ```python
 from bashkit import Bash
@@ -86,12 +90,15 @@ from bashkit import Bash
 bash = Bash()
 bash.mkdir("/data", recursive=True)
 bash.write_file("/data/config.json", '{"debug": true}\n')
-assert bash.read_file("/data/config.json") == '{"debug": true}\n'
-assert bash.ls("/data") == ["config.json"]
-assert bash.glob("/data/*.json") == ["/data/config.json"]
+bash.append_file("/data/config.json", '{"trace": false}\n')
 
-# The same convenience methods exist on BashTool()
+print(bash.read_file("/data/config.json"))
+print(bash.exists("/data/config.json"))
+print(bash.ls("/data"))
+print(bash.glob("/data/*.json"))
 ```
+
+The same direct filesystem helpers are available on `BashTool()`.
 
 ### FileSystem Accessor
 
@@ -100,39 +107,40 @@ from bashkit import Bash
 
 bash = Bash()
 fs = bash.fs()
+
 fs.mkdir("/data", recursive=True)
 fs.write_file("/data/blob.bin", b"\x00\x01hello")
-assert fs.read_file("/data/blob.bin") == b"\x00\x01hello"
-
-# Additional filesystem operations
-fs.append_file("/data/blob.bin", b" world")
 fs.copy("/data/blob.bin", "/data/backup.bin")
-fs.rename("/data/backup.bin", "/data/copy.bin")
-info = fs.stat("/data/blob.bin")       # dict with size, type, etc.
-entries = fs.read_dir("/data")         # detailed directory listing
-fs.symlink("/data/link", "/data/blob.bin")
-fs.chmod("/data/blob.bin", 0o644)
+
+assert fs.read_file("/data/blob.bin") == b"\x00\x01hello"
+assert fs.exists("/data/backup.bin")
 ```
 
-### Files and Mounts
+### Pre-Initialized Files
 
 ```python
-from bashkit import Bash, FileSystem
+from bashkit import Bash
 
-# Text files (in-memory, writable)
-bash = Bash(files={"/config/app.conf": "debug=true\n"})
-
-# Lazy file providers (called on first read, then cached)
 bash = Bash(files={
     "/config/static.txt": "ready\n",
     "/config/report.json": lambda: '{"ok": true}\n',
 })
 
-# Real filesystem mounts (read-only by default)
+print(bash.execute_sync("cat /config/static.txt").stdout)
+print(bash.execute_sync("cat /config/report.json").stdout)
+```
+
+### Real Filesystem Mounts
+
+```python
+from bashkit import Bash
+
 bash = Bash(mounts=[
     {"host_path": "/path/to/data", "vfs_path": "/data"},
     {"host_path": "/path/to/workspace", "vfs_path": "/workspace", "writable": True},
 ])
+
+print(bash.execute_sync("ls /workspace").stdout)
 ```
 
 ### Live Mounts
@@ -142,42 +150,92 @@ from bashkit import Bash, FileSystem
 
 bash = Bash()
 workspace = FileSystem.real("/path/to/workspace", writable=True)
-bash.mount("/workspace", workspace)
 
+bash.mount("/workspace", workspace)
 bash.execute_sync("echo 'hello' > /workspace/demo.txt")
 bash.unmount("/workspace")
 ```
 
-### BashTool — Convenience Wrapper for AI Agents
+## Error Handling
 
-`BashTool` is a convenience wrapper specifically designed for AI agents. It wraps `Bash` and adds contract metadata (`description`, Markdown `help`, `system_prompt`, JSON schemas) needed by tool-use protocols. Use this when integrating with LangChain, PydanticAI, or similar agent frameworks.
+```python
+from bashkit import Bash, BashError
+
+bash = Bash()
+
+try:
+    bash.execute_sync_or_throw("exit 42")
+except BashError as err:
+    print(err.exit_code)  # 42
+    print(err.stderr)
+    print(str(err))
+```
+
+Use `execute_or_throw()` and `execute_sync_or_throw()` when you want failures surfaced as exceptions instead of inspecting `exit_code` manually.
+
+## Cancellation
+
+```python
+from bashkit import Bash
+
+bash = Bash()
+
+bash.cancel()  # no-op if nothing is running
+bash.reset()   # reset state before reusing the instance
+```
+
+`BashTool` exposes the same `cancel()` and `reset()` methods.
+
+## BashTool
+
+`BashTool` wraps `Bash` and adds tool-contract metadata for agent frameworks:
+
+- `name`
+- `short_description`
+- `version`
+- `description()`
+- `help()`
+- `system_prompt()`
+- `input_schema()`
+- `output_schema()`
 
 ```python
 from bashkit import BashTool
 
 tool = BashTool()
-print(tool.input_schema())    # JSON schema for LLM tool-use
-print(tool.description())     # Token-efficient tool description
-print(tool.system_prompt())   # Token-efficient prompt
-print(tool.help())            # Markdown help document
 
-result = await tool.execute("echo 'Hello!'")
+print(tool.description())
+print(tool.input_schema())
+
+result = tool.execute_sync("echo 'Hello from BashTool'")
+print(result.stdout)
 ```
 
-### Scripted Tool Orchestration
+## ScriptedTool
 
-Compose multiple tools into a single bash-scriptable interface:
+Use `ScriptedTool` to register Python callbacks as bash-callable tools:
 
 ```python
 from bashkit import ScriptedTool
 
+
+def get_user(params, stdin=None):
+    return '{"id": 1, "name": "Alice"}'
+
+
 tool = ScriptedTool("api")
-tool.add_tool("greet", "Greet a user", callback=lambda p, s=None: f"hello {p.get('name', 'world')}")
-result = tool.execute_sync("greet --name Alice")
-print(result.stdout)  # hello Alice
+tool.add_tool(
+    "get_user",
+    "Fetch user by ID",
+    callback=get_user,
+    schema={"type": "object", "properties": {"id": {"type": "integer"}}},
+)
+
+result = tool.execute_sync("get_user --id 1 | jq -r '.name'")
+print(result.stdout)  # Alice
 ```
 
-### Snapshot / Restore
+## Snapshot / Restore
 
 ```python
 from bashkit import Bash
@@ -194,17 +252,18 @@ assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "read
 restored.reset()
 restored.restore_snapshot(snapshot)
 assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
-
-# BashTool exposes the same snapshot/restore API.
 ```
+
+`BashTool` exposes the same `snapshot()`, `restore_snapshot(...)`, and `from_snapshot(...)` APIs.
+
+## Framework Integrations
 
 ### LangChain
 
 ```python
 from bashkit.langchain import create_bash_tool
 
-bash_tool = create_bash_tool()
-# Use with any LangChain agent
+tool = create_bash_tool()
 ```
 
 ### PydanticAI
@@ -212,110 +271,94 @@ bash_tool = create_bash_tool()
 ```python
 from bashkit.pydantic_ai import create_bash_tool
 
-bash_tool = create_bash_tool()
-# Use with any PydanticAI agent
+tool = create_bash_tool()
 ```
 
 ### Deep Agents
 
 ```python
 from bashkit.deepagents import BashkitBackend, BashkitMiddleware
-# Use with Deep Agents framework
 ```
-
-## ScriptedTool — Multi-Tool Orchestration
-
-Compose Python callbacks as bash builtins. An LLM writes a single bash script that pipes, loops, and branches across all registered tools.
-
-```python
-from bashkit import ScriptedTool
-
-def get_user(params, stdin=None):
-    return '{"id": 1, "name": "Alice"}'
-
-tool = ScriptedTool("api")
-tool.add_tool("get_user", "Fetch user by ID",
-    callback=get_user,
-    schema={"type": "object", "properties": {"id": {"type": "integer"}}})
-
-result = tool.execute_sync("get_user --id 1 | jq -r '.name'")
-print(result.stdout)  # Alice
-```
-
-## Features
-
-- **Sandboxed, in-process execution**: All commands run in isolation with a virtual filesystem
-- **160 built-in commands**: echo, cat, grep, sed, awk, jq, curl, find, and more
-- **Full bash syntax**: Variables, pipelines, redirects, loops, functions, arrays
-- **Resource limits**: Protect against infinite loops and runaway scripts
 
 ## API Reference
 
 ### Bash
 
-- `execute(commands: str) -> ExecResult` — execute commands asynchronously
-- `execute_sync(commands: str) -> ExecResult` — execute commands synchronously
-- `execute_or_throw(commands: str) -> ExecResult` — async, raises on non-zero exit
-- `execute_sync_or_throw(commands: str) -> ExecResult` — sync, raises on non-zero exit
-- `reset()` — reset interpreter state
-- `snapshot() -> bytes` — serialize interpreter state
-- `restore_snapshot(data: bytes)` — restore serialized interpreter state
-- `from_snapshot(data: bytes, **kwargs) -> Bash` — construct and restore in one step
-- `fs() -> FileSystem` — direct filesystem access
+- `execute(commands: str) -> ExecResult`
+- `execute_sync(commands: str) -> ExecResult`
+- `execute_or_throw(commands: str) -> ExecResult`
+- `execute_sync_or_throw(commands: str) -> ExecResult`
+- `cancel()`
+- `reset()`
+- `snapshot() -> bytes`
+- `restore_snapshot(data: bytes)`
+- `from_snapshot(data: bytes, **kwargs) -> Bash`
+- `mount(vfs_path: str, fs: FileSystem)`
+- `unmount(vfs_path: str)`
+- Direct VFS helpers: `read_file`, `write_file`, `append_file`, `mkdir`, `remove`, `exists`, `stat`, `read_dir`, `ls`, `glob`, `copy`, `rename`, `symlink`, `chmod`, `read_link`
 
 ### BashTool
 
-Convenience wrapper for AI agents. Inherits all execution methods from `Bash`, plus:
-
-- `description() -> str` — token-efficient tool description
-- `help() -> str` — Markdown help document
-- `system_prompt() -> str` — token-efficient system prompt for LLM integration
-- `input_schema() -> str` — JSON input schema
-- `output_schema() -> str` — JSON output schema
-- `snapshot() -> bytes` / `restore_snapshot(data: bytes)` / `from_snapshot(...)` — checkpoint and resume interpreter state
-
-### ExecResult
-
-- `stdout: str` — standard output
-- `stderr: str` — standard error
-- `exit_code: int` — exit code (0 = success)
-- `error: Optional[str]` — error message if execution failed
-- `success: bool` — True if exit_code == 0
-- `to_dict() -> dict` — convert to dictionary
-
-### FileSystem
-
-- `mkdir(path, recursive=False)` — create directory
-- `write_file(path, content)` — write bytes to file
-- `read_file(path) -> bytes` — read file contents
-- `append_file(path, content)` — append bytes to file
-- `exists(path) -> bool` — check if path exists
-- `remove(path, recursive=False)` — delete file/directory
-- `stat(path) -> dict` — file metadata (size, type, etc.)
-- `read_dir(path) -> list` — detailed directory listing
-- `rename(src, dst)` — rename file/directory
-- `copy(src, dst)` — copy file
-- `symlink(link, target)` — create symlink
-- `chmod(path, mode)` — change file permissions
-- `read_link(path) -> str` — read symlink target
+- All execution, cancellation, reset, snapshot, restore, mount, and direct VFS helpers from `Bash`
+- Tool metadata: `name`, `short_description`, `version`
+- `description() -> str`
+- `help() -> str`
+- `system_prompt() -> str`
+- `input_schema() -> str`
+- `output_schema() -> str`
 
 ### ScriptedTool
 
-- `add_tool(name, description, callback, schema=None)` — register a tool
-- `execute(script: str) -> ExecResult` — execute script asynchronously
-- `execute_sync(script: str) -> ExecResult` — execute script synchronously
-- `execute_or_throw(script: str) -> ExecResult` — async, raises on non-zero exit
-- `execute_sync_or_throw(script: str) -> ExecResult` — sync, raises on non-zero exit
-- `env(key: str, value: str)` — set environment variable
-- `tool_count() -> int` — number of registered tools
+- `add_tool(name, description, callback, schema=None)`
+- `execute(script: str) -> ExecResult`
+- `execute_sync(script: str) -> ExecResult`
+- `execute_or_throw(script: str) -> ExecResult`
+- `execute_sync_or_throw(script: str) -> ExecResult`
+- `env(key: str, value: str)`
+- `tool_count() -> int`
 
-## How it works
+### FileSystem
 
-Bashkit is built on top of [Bashkit core](https://github.com/everruns/bashkit), a bash interpreter written in Rust. The Python package provides a native extension for fast, sandboxed execution without spawning subprocesses or containers.
+- `mkdir(path, recursive=False)`
+- `write_file(path, content)`
+- `read_file(path) -> bytes`
+- `append_file(path, content)`
+- `exists(path) -> bool`
+- `remove(path, recursive=False)`
+- `stat(path) -> dict`
+- `read_dir(path) -> list`
+- `rename(src, dst)`
+- `copy(src, dst)`
+- `symlink(target, link)`
+- `chmod(path, mode)`
+- `read_link(path) -> str`
+- `FileSystem.real(host_path, writable=False) -> FileSystem`
+
+### ExecResult and BashError
+
+- `ExecResult.stdout`
+- `ExecResult.stderr`
+- `ExecResult.exit_code`
+- `ExecResult.error`
+- `ExecResult.success`
+- `ExecResult.to_dict()`
+- `BashError.exit_code`
+- `BashError.stderr`
+
+## Platform Support
+
+- Linux: `x86_64`, `aarch64` (glibc and musl wheels)
+- macOS: `x86_64`, `aarch64`
+- Windows: `x86_64`
+- Python: `3.9` through `3.13`
+
+## How It Works
+
+Bashkit is built on the `bashkit` Rust core, which implements a sandboxed bash interpreter and virtual filesystem. The Python package exposes that engine through a native extension, so commands run in-process with persistent state and resource limits, without shelling out to the host system.
 
 ## Part of Everruns
 
-Bashkit is part of the [Everruns](https://github.com/everruns) ecosystem — tools and runtimes for building reliable AI agents. See the [bashkit monorepo](https://github.com/everruns/bashkit) for the Rust core, Node.js package (`@everruns/bashkit`), and more.
+Bashkit is part of the [Everruns](https://github.com/everruns) ecosystem. See the [bashkit monorepo](https://github.com/everruns/bashkit) for the Rust core, the JavaScript package (`@everruns/bashkit`), and related tooling.
 
 ## License
 


### PR DESCRIPTION
## Summary
- align the Python and Node READMEs to the same section order
- add the missing error handling, cancellation, platform, live mount, and how-it-works coverage without claiming unsupported APIs
- refresh the API summaries and examples so snapshot, mount, and tool metadata sections match the current bindings

## Validation
- `git diff --check`
- `rg -n "^## |^### " crates/bashkit-python/README.md crates/bashkit-js/README.md`
- `just pre-pr` on macOS fails in the existing `bash_comparison_tests`; reproduced unchanged on detached `origin/main`

Closes #1265