### PR TITLE
feat(node): expose streaming output callbacks

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -52,6 +52,30 @@ await bash.execute('printf "data\\n" > /tmp/file.txt');
 console.log((await bash.execute("cat /tmp/file.txt")).stdout); // data\n
 ```
 
+### Live Output
+
+```typescript
+const bash = new Bash();
+
+const result = await bash.execute(
+  'for i in 1 2 3; do echo out-$i; echo err-$i >&2; done',
+  {
+    onOutput({ stdout, stderr }) {
+      if (stdout) process.stdout.write(stdout);
+      if (stderr) process.stderr.write(stderr);
+    },
+  },
+);
+```
+
+`onOutput` is optional and fires during execution with chunk objects shaped like
+`{ stdout, stderr }`. Chunks are not line-aligned or exact terminal interleaving, but
+concatenating all callback chunks matches the final `ExecResult.stdout` and
+`ExecResult.stderr`. The handler must be synchronous; Promise-returning
+handlers are rejected. Do not call back into the same `Bash` / `BashTool`
+instance from `onOutput` via `execute*`, `readFile`, `fs()`, or similar
+same-instance APIs.
+
 ## Configuration
 
 ### BashOptions
@@ -299,10 +323,10 @@ import {
 
 - `new Bash(options?)`
 - `Bash.create(options?)`
-- `executeSync(commands, { signal? })`
-- `execute(commands)`
-- `executeSyncOrThrow(commands, { signal? })`
-- `executeOrThrow(commands)`
+- `executeSync(commands, options?)`
+- `execute(commands, options?)`
+- `executeSyncOrThrow(commands, options?)`
+- `executeOrThrow(commands, options?)`
 - `cancel()`
 - `clearCancel()`
 - `reset()`
@@ -347,6 +371,11 @@ import {
 - `mounts?: Array<{ path: string; root: string; writable?: boolean }>`
 - `python?: boolean`
 - `externalFunctions?: string[]`
+
+### ExecuteOptions
+
+- `signal?: AbortSignal`
+- `onOutput?: (chunk: { stdout: string; stderr: string }) => void`
 
 ### ExecResult and BashError
 

--- a/crates/bashkit-js/__test__/runtime-compat/streaming-output.test.mjs
+++ b/crates/bashkit-js/__test__/runtime-compat/streaming-output.test.mjs
@@ -1,0 +1,222 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Bash, BashTool } from "./_setup.mjs";
+
+// Decision: queue a second execute() behind a same-instance sleep so abort lands
+// after JS installs AbortSignal listeners but before Rust begins the next exec.
+const SCRIPT = `
+for i in 1 2 3; do
+  echo "out-$i"
+  echo "err-$i" >&2
+done
+`;
+
+function assertChunksMatchResult(result, chunks) {
+  assert.ok(chunks.length > 0);
+  assert.equal(
+    chunks.map(([stdoutChunk]) => stdoutChunk).join(""),
+    result.stdout,
+  );
+  assert.equal(
+    chunks.map(([, stderrChunk]) => stderrChunk).join(""),
+    result.stderr,
+  );
+}
+
+for (const [label, create] of [
+  ["Bash", () => new Bash()],
+  ["BashTool", () => new BashTool()],
+]) {
+  describe(`${label} streaming output`, () => {
+    it("sync rejects Promise-returning onOutput", () => {
+      const shell = create();
+
+      assert.throws(
+        () =>
+          shell.executeSync(SCRIPT, {
+            onOutput() {
+              return Promise.reject(new Error("async exploded"));
+            },
+          }),
+        /onOutput must be synchronous and must not return a Promise/,
+      );
+    });
+
+    it("sync chunks reassemble to final result", () => {
+      const shell = create();
+      const chunks = [];
+
+      const result = shell.executeSync(SCRIPT, {
+        onOutput({ stdout: stdoutChunk, stderr: stderrChunk }) {
+          chunks.push([stdoutChunk, stderrChunk]);
+        },
+      });
+
+      assert.equal(result.exitCode, 0);
+      assertChunksMatchResult(result, chunks);
+    });
+
+    it("async chunks reassemble to final result", async () => {
+      const shell = create();
+      const chunks = [];
+
+      const result = await shell.execute(SCRIPT, {
+        onOutput({ stdout: stdoutChunk, stderr: stderrChunk }) {
+          chunks.push([stdoutChunk, stderrChunk]);
+        },
+      });
+
+      assert.equal(result.exitCode, 0);
+      assertChunksMatchResult(result, chunks);
+    });
+
+    it("queued async execute honors AbortSignal before start", async () => {
+      const shell = create();
+      const blocker = shell.execute("sleep 0.05");
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const controller = new AbortController();
+      const pending = shell.execute("echo should-not-run", {
+        signal: controller.signal,
+      });
+      controller.abort();
+
+      assert.equal((await blocker).exitCode, 0);
+
+      const result = await pending;
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.error, "execution cancelled");
+      assert.equal(result.stdout, "");
+    });
+
+    it("queued async execute with onOutput honors AbortSignal before start", async () => {
+      const shell = create();
+      const blocker = shell.execute("sleep 0.05");
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const controller = new AbortController();
+      const chunks = [];
+      const pending = shell.execute("echo should-not-run", {
+        signal: controller.signal,
+        onOutput({ stdout, stderr }) {
+          chunks.push([stdout, stderr]);
+        },
+      });
+      controller.abort();
+
+      assert.equal((await blocker).exitCode, 0);
+
+      const result = await pending;
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.error, "execution cancelled");
+      assert.deepEqual(chunks, []);
+      assert.equal(result.stdout, "");
+    });
+
+    it("async rejects Promise-returning onOutput", async () => {
+      const shell = create();
+
+      await assert.rejects(
+        () =>
+          shell.execute(SCRIPT, {
+            onOutput() {
+              return Promise.reject(new Error("async exploded"));
+            },
+          }),
+        /onOutput must be synchronous and must not return a Promise/,
+      );
+    });
+
+    it("sync callback errors abort without poisoning later calls", () => {
+      const shell = create();
+
+      assert.throws(
+        () =>
+          shell.executeSync(SCRIPT, {
+            onOutput() {
+              throw new Error("onOutput exploded");
+            },
+          }),
+        /onOutput exploded/,
+      );
+
+      const result = shell.executeSync("echo after-error");
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stdout, "after-error\n");
+    });
+
+    it("sync callback errors do not clear future explicit cancel", () => {
+      const shell = create();
+
+      assert.throws(
+        () =>
+          shell.executeSync(SCRIPT, {
+            onOutput() {
+              throw new Error("onOutput exploded");
+            },
+          }),
+        /onOutput exploded/,
+      );
+
+      shell.cancel();
+      const result = shell.executeSync("echo after-error");
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.error, "execution cancelled");
+      assert.equal(result.stdout, "");
+    });
+
+    it("async callback errors abort without poisoning later calls", async () => {
+      const shell = create();
+
+      await assert.rejects(
+        () =>
+          shell.execute(SCRIPT, {
+            onOutput() {
+              throw new Error("onOutput exploded");
+            },
+          }),
+        /onOutput exploded/,
+      );
+
+      const result = await shell.execute("echo after-error");
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stdout, "after-error\n");
+    });
+
+    it("async callback errors do not clear future explicit cancel", async () => {
+      const shell = create();
+
+      await assert.rejects(
+        () =>
+          shell.execute(SCRIPT, {
+            onOutput() {
+              throw new Error("onOutput exploded");
+            },
+          }),
+        /onOutput exploded/,
+      );
+
+      shell.cancel();
+      const result = await shell.execute("echo after-error");
+      assert.equal(result.exitCode, 1);
+      assert.equal(result.error, "execution cancelled");
+      assert.equal(result.stdout, "");
+    });
+
+    it("async rejects async onOutput", async () => {
+      const shell = create();
+
+      await assert.rejects(
+        () =>
+          shell.execute(SCRIPT, {
+            async onOutput() {
+              throw new Error("async exploded");
+            },
+          }),
+        /onOutput must be synchronous and must not return a Promise/,
+      );
+    });
+  });
+}

--- a/crates/bashkit-js/__test__/streaming-output.spec.ts
+++ b/crates/bashkit-js/__test__/streaming-output.spec.ts
@@ -1,0 +1,276 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import test, { type ExecutionContext } from "ava";
+import { Bash, BashTool } from "../wrapper.js";
+
+// Decision: queue a second execute() behind a same-instance sleep so abort lands
+// after JS installs AbortSignal listeners but before Rust begins the next exec.
+const SCRIPT = `
+for i in 1 2 3; do
+  echo "out-$i"
+  echo "err-$i" >&2
+done
+`;
+
+function assertChunksMatchResult(
+  t: ExecutionContext,
+  result: { stdout: string; stderr: string },
+  chunks: Array<[string, string]>,
+) {
+  t.true(chunks.length > 0);
+  t.is(chunks.map(([stdoutChunk]) => stdoutChunk).join(""), result.stdout);
+  t.is(chunks.map(([, stderrChunk]) => stderrChunk).join(""), result.stderr);
+}
+
+for (const [label, create] of [
+  ["Bash", () => new Bash()],
+  ["BashTool", () => new BashTool()],
+] as const) {
+  test(`${label}: executeSync rejects Promise-returning onOutput`, (t) => {
+    const shell = create();
+    const error = t.throws(() =>
+      shell.executeSync(SCRIPT, {
+        onOutput() {
+          return Promise.reject(new Error("async exploded"));
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(
+      error.message,
+      /onOutput must be synchronous and must not return a Promise/,
+    );
+  });
+
+  test(`${label}: executeSync onOutput matches final result`, (t) => {
+    const shell = create();
+    const chunks: Array<[string, string]> = [];
+
+    const result = shell.executeSync(SCRIPT, {
+      onOutput({ stdout: stdoutChunk, stderr: stderrChunk }) {
+        chunks.push([stdoutChunk, stderrChunk]);
+      },
+    });
+
+    t.is(result.exitCode, 0);
+    assertChunksMatchResult(t, result, chunks);
+  });
+
+  test(`${label}: execute onOutput matches final result`, async (t) => {
+    const shell = create();
+    const chunks: Array<[string, string]> = [];
+
+    const result = await shell.execute(SCRIPT, {
+      onOutput({ stdout: stdoutChunk, stderr: stderrChunk }) {
+        chunks.push([stdoutChunk, stderrChunk]);
+      },
+    });
+
+    t.is(result.exitCode, 0);
+    assertChunksMatchResult(t, result, chunks);
+  });
+
+  test(`${label}: queued async execute honors AbortSignal before start`, async (t) => {
+    const shell = create();
+    const blocker = shell.execute("sleep 0.05");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const controller = new AbortController();
+    const pending = shell.execute("echo should-not-run", {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    t.is((await blocker).exitCode, 0);
+
+    const result = await pending;
+    t.is(result.exitCode, 1);
+    t.is(result.error, "execution cancelled");
+    t.is(result.stdout, "");
+  });
+
+  test(`${label}: queued async execute with onOutput honors AbortSignal before start`, async (t) => {
+    const shell = create();
+    const blocker = shell.execute("sleep 0.05");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const controller = new AbortController();
+    const chunks: Array<[string, string]> = [];
+    const pending = shell.execute("echo should-not-run", {
+      signal: controller.signal,
+      onOutput({ stdout, stderr }) {
+        chunks.push([stdout, stderr]);
+      },
+    });
+    controller.abort();
+
+    t.is((await blocker).exitCode, 0);
+
+    const result = await pending;
+    t.is(result.exitCode, 1);
+    t.is(result.error, "execution cancelled");
+    t.deepEqual(chunks, []);
+    t.is(result.stdout, "");
+  });
+
+  test(`${label}: execute rejects Promise-returning onOutput`, async (t) => {
+    const shell = create();
+    const error = await t.throwsAsync(() =>
+      shell.execute(SCRIPT, {
+        onOutput() {
+          return Promise.reject(new Error("async exploded"));
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(
+      error.message,
+      /onOutput must be synchronous and must not return a Promise/,
+    );
+  });
+
+  test(`${label}: executeSync onOutput error propagates`, (t) => {
+    const shell = create();
+    const error = t.throws(() =>
+      shell.executeSync(SCRIPT, {
+        onOutput() {
+          throw new Error("onOutput exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(error.message, /onOutput exploded/);
+  });
+
+  test(`${label}: executeSync onOutput error does not poison future calls`, (t) => {
+    const shell = create();
+
+    const error = t.throws(() =>
+      shell.executeSync(SCRIPT, {
+        onOutput() {
+          throw new Error("onOutput exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(error.message, /onOutput exploded/);
+
+    const result = shell.executeSync("echo after-error");
+    t.is(result.exitCode, 0);
+    t.is(result.stdout, "after-error\n");
+  });
+
+  test(`${label}: executeSync onOutput error does not clear future explicit cancel`, (t) => {
+    const shell = create();
+
+    const error = t.throws(() =>
+      shell.executeSync(SCRIPT, {
+        onOutput() {
+          throw new Error("onOutput exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(error.message, /onOutput exploded/);
+
+    shell.cancel();
+    const result = shell.executeSync("echo after-error");
+    t.is(result.exitCode, 1);
+    t.is(result.error, "execution cancelled");
+    t.is(result.stdout, "");
+  });
+
+  test(`${label}: execute onOutput error propagates`, async (t) => {
+    const shell = create();
+    const error = await t.throwsAsync(() =>
+      shell.execute(SCRIPT, {
+        onOutput() {
+          throw new Error("onOutput exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(error.message, /onOutput exploded/);
+  });
+
+  test(`${label}: execute rejects async onOutput`, async (t) => {
+    const shell = create();
+    const error = await t.throwsAsync(() =>
+      shell.execute(SCRIPT, {
+        async onOutput() {
+          throw new Error("async exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(
+      error.message,
+      /onOutput must be synchronous and must not return a Promise/,
+    );
+  });
+
+  test(`${label}: async onOutput preserves AsyncLocalStorage context`, async (t) => {
+    const shell = create();
+    const requestContext = new AsyncLocalStorage<string>();
+    const seenStores = new Set<string | undefined>();
+
+    const result = await requestContext.run(`${label}-request`, async () =>
+      shell.execute(SCRIPT, {
+        onOutput() {
+          seenStores.add(requestContext.getStore());
+        },
+      }),
+    );
+
+    t.is(result.exitCode, 0);
+    t.deepEqual([...seenStores], [`${label}-request`]);
+  });
+
+  test(`${label}: execute onOutput error does not poison future calls`, async (t) => {
+    const shell = create();
+
+    const error = await t.throwsAsync(() =>
+      shell.execute(SCRIPT, {
+        onOutput() {
+          throw new Error("onOutput exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(error.message, /onOutput exploded/);
+
+    const result = await shell.execute("echo after-error");
+    t.is(result.exitCode, 0);
+    t.is(result.stdout, "after-error\n");
+  });
+
+  test(`${label}: execute onOutput error does not clear future explicit cancel`, async (t) => {
+    const shell = create();
+
+    const error = await t.throwsAsync(() =>
+      shell.execute(SCRIPT, {
+        onOutput() {
+          throw new Error("onOutput exploded");
+        },
+      }),
+    );
+
+    t.truthy(error);
+    t.regex(error.message, /onOutput exploded/);
+
+    shell.cancel();
+    const result = await shell.execute("echo after-error");
+    t.is(result.exitCode, 1);
+    t.is(result.error, "execution cancelled");
+    t.is(result.stdout, "");
+  });
+}

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -15,16 +15,17 @@
 
 use bashkit::tool::VERSION;
 use bashkit::{
-    Bash as RustBash, BashTool as RustBashTool, ExecutionLimits, ExtFunctionResult, FileType,
-    Metadata, MontyObject, PythonExternalFnHandler, PythonLimits, ScriptedTool as RustScriptedTool,
-    Tool, ToolArgs, ToolDef, ToolRequest,
+    Bash as RustBash, BashTool as RustBashTool, ExecResult as RustExecResult, ExecutionLimits,
+    ExtFunctionResult, FileType, Metadata, MontyObject, OutputCallback, PythonExternalFnHandler,
+    PythonLimits, ScriptedTool as RustScriptedTool, Tool, ToolArgs, ToolDef, ToolRequest,
 };
+use napi::JsValue;
 use napi_derive::napi;
 use std::collections::HashMap;
 use std::path::Path;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use tokio::sync::Mutex;
 
 // ---------------------------------------------------------------------------
@@ -399,6 +400,240 @@ pub struct ExecResult {
     pub success: bool,
 }
 
+// The native JS callback arrives as one `[stdout, stderr]` tuple payload even
+// though napi-rs models the args as `(String, String)`. Keep the public TS
+// wrapper responsible for adapting that odd FFI shape into its
+// object-shaped `{ stdout, stderr }` callback API.
+type SyncOutputFn = napi::bindgen_prelude::FunctionRef<(String, String), Option<String>>;
+type OutputTsfn = napi::threadsafe_function::ThreadsafeFunction<
+    (String, String),
+    Option<String>,
+    (String, String),
+    napi::Status,
+    false,
+    true,
+>;
+
+fn js_exec_result_from_rust(result: RustExecResult) -> ExecResult {
+    ExecResult {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exit_code: result.exit_code,
+        error: None,
+        stdout_truncated: result.stdout_truncated,
+        stderr_truncated: result.stderr_truncated,
+        final_env: result.final_env,
+        success: result.exit_code == 0,
+    }
+}
+
+fn js_exec_result_from_error(err: impl ToString) -> ExecResult {
+    let msg = err.to_string();
+    ExecResult {
+        stdout: String::new(),
+        stderr: msg.clone(),
+        exit_code: 1,
+        error: Some(msg),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        final_env: None,
+        success: false,
+    }
+}
+
+fn js_exec_result_from_bash_result(result: bashkit::Result<RustExecResult>) -> ExecResult {
+    match result {
+        Ok(result) => js_exec_result_from_rust(result),
+        Err(err) => js_exec_result_from_error(err),
+    }
+}
+
+fn callback_error_reason(err: impl ToString) -> String {
+    format!("onOutput callback failed: {}", err.to_string())
+}
+
+fn record_callback_error(
+    callback_error: &StdMutex<Option<String>>,
+    cancelled: &Arc<AtomicBool>,
+    callback_requested_cancel: &Arc<AtomicBool>,
+    message: String,
+) {
+    if let Ok(mut callback_error) = callback_error.lock()
+        && callback_error.is_none()
+    {
+        *callback_error = Some(message);
+    }
+    if !cancelled.swap(true, Ordering::SeqCst) {
+        callback_requested_cancel.store(true, Ordering::SeqCst);
+    }
+}
+
+fn take_callback_error(callback_error: &StdMutex<Option<String>>) -> Option<napi::Error> {
+    callback_error
+        .lock()
+        .ok()
+        .and_then(|mut callback_error| callback_error.take())
+        .map(napi::Error::from_reason)
+}
+
+fn build_sync_output_callback(
+    env_raw: usize,
+    on_output: SyncOutputFn,
+    cancelled: Arc<AtomicBool>,
+    callback_requested_cancel: Arc<AtomicBool>,
+    callback_error: Arc<StdMutex<Option<String>>>,
+) -> OutputCallback {
+    Box::new(move |stdout_chunk, stderr_chunk| {
+        let has_error = callback_error
+            .lock()
+            .map(|callback_error| callback_error.is_some())
+            .unwrap_or(false);
+        if has_error {
+            return;
+        }
+
+        let env = napi::Env::from_raw(env_raw as napi::sys::napi_env);
+        let callback = match on_output.borrow_back(&env) {
+            Ok(callback) => callback,
+            Err(err) => {
+                record_callback_error(
+                    &callback_error,
+                    &cancelled,
+                    &callback_requested_cancel,
+                    callback_error_reason(err),
+                );
+                return;
+            }
+        };
+
+        match callback.call((stdout_chunk.to_string(), stderr_chunk.to_string())) {
+            Ok(Some(err)) => {
+                record_callback_error(
+                    &callback_error,
+                    &cancelled,
+                    &callback_requested_cancel,
+                    callback_error_reason(err),
+                );
+            }
+            Ok(None) => {}
+            Err(err) => {
+                record_callback_error(
+                    &callback_error,
+                    &cancelled,
+                    &callback_requested_cancel,
+                    callback_error_reason(err),
+                );
+            }
+        }
+    })
+}
+
+fn build_async_output_callback(
+    tsfn: Arc<OutputTsfn>,
+    cancelled: Arc<AtomicBool>,
+    callback_requested_cancel: Arc<AtomicBool>,
+) -> (OutputCallback, Arc<StdMutex<Option<String>>>) {
+    let callback_error = Arc::new(StdMutex::new(None));
+    let callback_error_output = callback_error.clone();
+    let cancelled_output = cancelled.clone();
+    let callback_requested_cancel_output = callback_requested_cancel.clone();
+
+    let output_callback: OutputCallback = Box::new(move |stdout_chunk, stderr_chunk| {
+        let has_error = callback_error_output
+            .lock()
+            .map(|callback_error| callback_error.is_some())
+            .unwrap_or(false);
+        if has_error {
+            return;
+        }
+
+        let stdout = stdout_chunk.to_string();
+        let stderr = stderr_chunk.to_string();
+        let tsfn = tsfn.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        // OutputCallback in core bashkit is synchronous. Dispatch onto the
+        // shared callback runtime, then block until JS finishes so callback
+        // errors abort execution immediately and chunk ordering stays stable.
+        callback_runtime().spawn(async move {
+            let result: Result<Option<String>, String> = tsfn
+                .call_async((stdout, stderr))
+                .await
+                .map_err(callback_error_reason);
+            let _ = tx.send(result);
+        });
+
+        match rx.recv() {
+            Ok(Ok(Some(err))) => {
+                record_callback_error(
+                    &callback_error_output,
+                    &cancelled_output,
+                    &callback_requested_cancel_output,
+                    callback_error_reason(err),
+                );
+            }
+            Ok(Ok(None)) => {}
+            Ok(Err(err)) => {
+                record_callback_error(
+                    &callback_error_output,
+                    &cancelled_output,
+                    &callback_requested_cancel_output,
+                    err,
+                );
+            }
+            Err(_) => {
+                record_callback_error(
+                    &callback_error_output,
+                    &cancelled_output,
+                    &callback_requested_cancel_output,
+                    "onOutput callback failed: callback channel closed".to_string(),
+                );
+            }
+        }
+    });
+
+    (output_callback, callback_error)
+}
+
+fn create_output_tsfn(
+    on_output: napi::bindgen_prelude::Function<'_, (String, String), Option<String>>,
+) -> napi::Result<Arc<OutputTsfn>> {
+    let tsfn = on_output
+        .build_threadsafe_function::<(String, String)>()
+        .weak::<true>()
+        .build()?;
+    Ok(Arc::new(tsfn))
+}
+
+async fn execute_rust_bash(
+    bash: &mut RustBash,
+    commands: &str,
+    output_callback: Option<OutputCallback>,
+    callback_error: Option<&Arc<StdMutex<Option<String>>>>,
+    cancelled: Option<&Arc<AtomicBool>>,
+    callback_requested_cancel: Option<&Arc<AtomicBool>>,
+) -> napi::Result<ExecResult> {
+    let result = if let Some(output_callback) = output_callback {
+        bash.exec_streaming(commands, output_callback).await
+    } else {
+        bash.exec(commands).await
+    };
+
+    if let Some(callback_error) = callback_error
+        && let Some(err) = take_callback_error(callback_error)
+    {
+        if let Some((cancelled, callback_requested_cancel)) =
+            cancelled.zip(callback_requested_cancel)
+            && callback_requested_cancel.load(Ordering::SeqCst)
+        {
+            cancelled.store(false, Ordering::SeqCst);
+        }
+        return Err(err);
+    }
+
+    Ok(js_exec_result_from_bash_result(result))
+}
+
 // ============================================================================
 // MountConfig + BashOptions
 // ============================================================================
@@ -554,34 +789,44 @@ impl Bash {
     }
 
     /// Execute bash commands synchronously.
-    #[napi]
-    pub fn execute_sync(&self, commands: String) -> napi::Result<ExecResult> {
+    #[napi(
+        ts_args_type = "commands: string, onOutput?: (chunkPair: [string, string]) => string | undefined"
+    )]
+    pub fn execute_sync(
+        &self,
+        commands: String,
+        on_output: Option<napi::bindgen_prelude::Function<'_, (String, String), Option<String>>>,
+    ) -> napi::Result<ExecResult> {
+        let env_raw = on_output
+            .as_ref()
+            .map(|on_output| on_output.value().env as usize);
+        let on_output = on_output
+            .map(|on_output| on_output.create_ref())
+            .transpose()?;
         block_on_with(&self.state, |s| async move {
             let mut bash = s.inner.lock().await;
-            match bash.exec(&commands).await {
-                Ok(result) => Ok(ExecResult {
-                    stdout: result.stdout,
-                    stderr: result.stderr,
-                    exit_code: result.exit_code,
-                    error: None,
-                    stdout_truncated: result.stdout_truncated,
-                    stderr_truncated: result.stderr_truncated,
-                    final_env: result.final_env,
-                    success: result.exit_code == 0,
-                }),
-                Err(e) => {
-                    let msg = e.to_string();
-                    Ok(ExecResult {
-                        stdout: String::new(),
-                        stderr: msg.clone(),
-                        exit_code: 1,
-                        error: Some(msg),
-                        stdout_truncated: false,
-                        stderr_truncated: false,
-                        final_env: None,
-                        success: false,
-                    })
-                }
+            if let Some((env_raw, on_output)) = env_raw.zip(on_output) {
+                let cancelled = bash.cancellation_token();
+                let callback_requested_cancel = Arc::new(AtomicBool::new(false));
+                let callback_error = Arc::new(StdMutex::new(None));
+                let output_callback = build_sync_output_callback(
+                    env_raw,
+                    on_output,
+                    cancelled.clone(),
+                    callback_requested_cancel.clone(),
+                    callback_error.clone(),
+                );
+                execute_rust_bash(
+                    &mut bash,
+                    &commands,
+                    Some(output_callback),
+                    Some(&callback_error),
+                    Some(&cancelled),
+                    Some(&callback_requested_cancel),
+                )
+                .await
+            } else {
+                execute_rust_bash(&mut bash, &commands, None, None, None, None).await
             }
         })
     }
@@ -591,31 +836,47 @@ impl Bash {
     pub async fn execute(&self, commands: String) -> napi::Result<ExecResult> {
         let s = self.state.clone();
         let mut bash = s.inner.lock().await;
-        match bash.exec(&commands).await {
-            Ok(result) => Ok(ExecResult {
-                stdout: result.stdout,
-                stderr: result.stderr,
-                exit_code: result.exit_code,
-                error: None,
-                stdout_truncated: result.stdout_truncated,
-                stderr_truncated: result.stderr_truncated,
-                final_env: result.final_env,
-                success: result.exit_code == 0,
-            }),
-            Err(e) => {
-                let msg = e.to_string();
-                Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: msg.clone(),
-                    exit_code: 1,
-                    error: Some(msg),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
-                    final_env: None,
-                    success: false,
-                })
-            }
-        }
+        execute_rust_bash(&mut bash, &commands, None, None, None, None).await
+    }
+
+    #[napi(
+        js_name = "executeWithOutput",
+        ts_args_type = "commands: string, onOutput: (chunkPair: [string, string]) => string | undefined"
+    )]
+    pub fn execute_with_output<'env>(
+        &self,
+        commands: String,
+        on_output: napi::bindgen_prelude::Function<'env, (String, String), Option<String>>,
+    ) -> napi::Result<napi::bindgen_prelude::PromiseRaw<'env, ExecResult>> {
+        let raw_env = on_output.value().env;
+        let tsfn = create_output_tsfn(on_output)?;
+        let state = self.state.clone();
+        let promise = napi::bindgen_prelude::execute_tokio_future(
+            raw_env,
+            async move {
+                let mut bash = state.inner.lock().await;
+                let cancelled = bash.cancellation_token();
+                let callback_requested_cancel = Arc::new(AtomicBool::new(false));
+                let (output_callback, callback_error) = build_async_output_callback(
+                    tsfn,
+                    cancelled.clone(),
+                    callback_requested_cancel.clone(),
+                );
+                execute_rust_bash(
+                    &mut bash,
+                    &commands,
+                    Some(output_callback),
+                    Some(&callback_error),
+                    Some(&cancelled),
+                    Some(&callback_requested_cancel),
+                )
+                .await
+            },
+            |env, val| unsafe {
+                <ExecResult as napi::bindgen_prelude::ToNapiValue>::to_napi_value(env, val)
+            },
+        )?;
+        Ok(napi::bindgen_prelude::PromiseRaw::new(raw_env, promise))
     }
 
     /// Cancel the currently running execution.
@@ -951,34 +1212,44 @@ impl BashTool {
     }
 
     /// Execute bash commands synchronously.
-    #[napi]
-    pub fn execute_sync(&self, commands: String) -> napi::Result<ExecResult> {
+    #[napi(
+        ts_args_type = "commands: string, onOutput?: (chunkPair: [string, string]) => string | undefined"
+    )]
+    pub fn execute_sync(
+        &self,
+        commands: String,
+        on_output: Option<napi::bindgen_prelude::Function<'_, (String, String), Option<String>>>,
+    ) -> napi::Result<ExecResult> {
+        let env_raw = on_output
+            .as_ref()
+            .map(|on_output| on_output.value().env as usize);
+        let on_output = on_output
+            .map(|on_output| on_output.create_ref())
+            .transpose()?;
         block_on_with(&self.state, |s| async move {
             let mut bash = s.inner.lock().await;
-            match bash.exec(&commands).await {
-                Ok(result) => Ok(ExecResult {
-                    stdout: result.stdout,
-                    stderr: result.stderr,
-                    exit_code: result.exit_code,
-                    error: None,
-                    stdout_truncated: result.stdout_truncated,
-                    stderr_truncated: result.stderr_truncated,
-                    final_env: result.final_env,
-                    success: result.exit_code == 0,
-                }),
-                Err(e) => {
-                    let msg = e.to_string();
-                    Ok(ExecResult {
-                        stdout: String::new(),
-                        stderr: msg.clone(),
-                        exit_code: 1,
-                        error: Some(msg),
-                        stdout_truncated: false,
-                        stderr_truncated: false,
-                        final_env: None,
-                        success: false,
-                    })
-                }
+            if let Some((env_raw, on_output)) = env_raw.zip(on_output) {
+                let cancelled = bash.cancellation_token();
+                let callback_requested_cancel = Arc::new(AtomicBool::new(false));
+                let callback_error = Arc::new(StdMutex::new(None));
+                let output_callback = build_sync_output_callback(
+                    env_raw,
+                    on_output,
+                    cancelled.clone(),
+                    callback_requested_cancel.clone(),
+                    callback_error.clone(),
+                );
+                execute_rust_bash(
+                    &mut bash,
+                    &commands,
+                    Some(output_callback),
+                    Some(&callback_error),
+                    Some(&cancelled),
+                    Some(&callback_requested_cancel),
+                )
+                .await
+            } else {
+                execute_rust_bash(&mut bash, &commands, None, None, None, None).await
             }
         })
     }
@@ -988,31 +1259,47 @@ impl BashTool {
     pub async fn execute(&self, commands: String) -> napi::Result<ExecResult> {
         let s = self.state.clone();
         let mut bash = s.inner.lock().await;
-        match bash.exec(&commands).await {
-            Ok(result) => Ok(ExecResult {
-                stdout: result.stdout,
-                stderr: result.stderr,
-                exit_code: result.exit_code,
-                error: None,
-                stdout_truncated: result.stdout_truncated,
-                stderr_truncated: result.stderr_truncated,
-                final_env: result.final_env,
-                success: result.exit_code == 0,
-            }),
-            Err(e) => {
-                let msg = e.to_string();
-                Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: msg.clone(),
-                    exit_code: 1,
-                    error: Some(msg),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
-                    final_env: None,
-                    success: false,
-                })
-            }
-        }
+        execute_rust_bash(&mut bash, &commands, None, None, None, None).await
+    }
+
+    #[napi(
+        js_name = "executeWithOutput",
+        ts_args_type = "commands: string, onOutput: (chunkPair: [string, string]) => string | undefined"
+    )]
+    pub fn execute_with_output<'env>(
+        &self,
+        commands: String,
+        on_output: napi::bindgen_prelude::Function<'env, (String, String), Option<String>>,
+    ) -> napi::Result<napi::bindgen_prelude::PromiseRaw<'env, ExecResult>> {
+        let raw_env = on_output.value().env;
+        let tsfn = create_output_tsfn(on_output)?;
+        let state = self.state.clone();
+        let promise = napi::bindgen_prelude::execute_tokio_future(
+            raw_env,
+            async move {
+                let mut bash = state.inner.lock().await;
+                let cancelled = bash.cancellation_token();
+                let callback_requested_cancel = Arc::new(AtomicBool::new(false));
+                let (output_callback, callback_error) = build_async_output_callback(
+                    tsfn,
+                    cancelled.clone(),
+                    callback_requested_cancel.clone(),
+                );
+                execute_rust_bash(
+                    &mut bash,
+                    &commands,
+                    Some(output_callback),
+                    Some(&callback_error),
+                    Some(&cancelled),
+                    Some(&callback_requested_cancel),
+                )
+                .await
+            },
+            |env, val| unsafe {
+                <ExecResult as napi::bindgen_prelude::ToNapiValue>::to_napi_value(env, val)
+            },
+        )?;
+        Ok(napi::bindgen_prelude::PromiseRaw::new(raw_env, promise))
     }
 
     /// Cancel the currently running execution.

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -1,3 +1,4 @@
+import { AsyncResource } from "node:async_hooks";
 import { createRequire } from "node:module";
 import type {
   Bash as NativeBashType,
@@ -104,6 +105,109 @@ export interface BashOptions {
    * the embedded interpreter. When called, they invoke the external handler.
    */
   externalFunctions?: string[];
+}
+
+export interface OutputChunk {
+  stdout: string;
+  stderr: string;
+}
+
+export type OnOutput = (chunk: OutputChunk) => void;
+
+export interface ExecuteOptions {
+  signal?: AbortSignal;
+  /**
+   * Live chunk callback. Must be synchronous.
+   *
+   * Limitation: do not call back into the same `Bash` / `BashTool` instance
+   * from this handler (`execute*`, `readFile`, `fs()`, etc.). The current
+   * binding delivers chunks while that instance is still mid-execution, so
+   * same-instance re-entry can deadlock or panic.
+   */
+  onOutput?: OnOutput;
+}
+
+type NativeOnOutput = (chunkPair: [string, string]) => string | undefined;
+const ASYNC_ON_OUTPUT_ERROR =
+  "onOutput must be synchronous and must not return a Promise";
+const asyncExecuteQueues = new WeakMap<object, Promise<void>>();
+
+function isAsyncFunction(fn: Function): boolean {
+  return Object.prototype.toString.call(fn) === "[object AsyncFunction]";
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+function cancelledExecResult(): ExecResult {
+  return {
+    stdout: "",
+    stderr: "",
+    exitCode: 1,
+    error: "execution cancelled",
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    finalEnv: undefined,
+    success: false,
+  };
+}
+
+// Decision: serialize async execute() per instance in JS so queued AbortSignal
+// listeners only attach once a call reaches the front of the line.
+function queueAsyncExecute<T>(
+  owner: object,
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = asyncExecuteQueues.get(owner) ?? Promise.resolve();
+  const completion = previous.then(
+    () => run(),
+    () => run(),
+  );
+  asyncExecuteQueues.set(
+    owner,
+    completion.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return completion;
+}
+
+function bindOnOutputToCurrentAsyncContext(onOutput: OnOutput): OnOutput {
+  return AsyncResource.bind(onOutput) as OnOutput;
+}
+
+function toNativeOnOutput(onOutput?: OnOutput): NativeOnOutput | undefined {
+  if (!onOutput) return undefined;
+  if (isAsyncFunction(onOutput)) {
+    throw new TypeError(ASYNC_ON_OUTPUT_ERROR);
+  }
+  const onOutputWithContext = bindOnOutputToCurrentAsyncContext(onOutput);
+  // The native binding passes one tuple payload `[stdoutChunk, stderrChunk]`.
+  // Adapt that odd FFI shape here so the public wrapper API stays future-proof.
+  return ([stdoutChunk, stderrChunk]) => {
+    try {
+      const result = onOutputWithContext({
+        stdout: stdoutChunk,
+        stderr: stderrChunk,
+      });
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).catch(() => {});
+        return ASYNC_ON_OUTPUT_ERROR;
+      }
+      return undefined;
+    } catch (error) {
+      if (error instanceof Error) {
+        return error.stack ?? error.message ?? error.toString();
+      }
+      return String(error);
+    }
+  };
 }
 
 /**
@@ -264,30 +368,22 @@ export class Bash {
    * Execute bash commands synchronously and return the result.
    *
    * If `signal` is provided, the execution will be cancelled when the signal
-   * is aborted. The result will have `error: "execution cancelled"`.
+   * is aborted. If `onOutput` is provided, it receives chunk objects with
+   * `{ stdout, stderr }` during execution. Chunks are not line-aligned. The callback must be
+   * synchronous; Promise-returning handlers are rejected. Do not re-enter the
+   * same instance from `onOutput` via `execute*`, `readFile`, `fs()`, etc.
    */
-  executeSync(
-    commands: string,
-    options?: { signal?: AbortSignal },
-  ): ExecResult {
+  executeSync(commands: string, options?: ExecuteOptions): ExecResult {
+    const nativeOnOutput = toNativeOnOutput(options?.onOutput);
     if (options?.signal) {
       const signal = options.signal;
       if (signal.aborted) {
-        return {
-          stdout: "",
-          stderr: "",
-          exitCode: 1,
-          error: "execution cancelled",
-          stdoutTruncated: false,
-          stderrTruncated: false,
-          finalEnv: undefined,
-          success: false,
-        };
+        return cancelledExecResult();
       }
       const onAbort = () => this.native.cancel();
       signal.addEventListener("abort", onAbort, { once: true });
       try {
-        return this.native.executeSync(commands);
+        return this.native.executeSync(commands, nativeOnOutput);
       } finally {
         signal.removeEventListener("abort", onAbort);
         if (signal.aborted) {
@@ -295,13 +391,17 @@ export class Bash {
         }
       }
     }
-    return this.native.executeSync(commands);
+    return this.native.executeSync(commands, nativeOnOutput);
   }
 
   /**
    * Execute bash commands asynchronously, returning a Promise.
    *
    * Non-blocking for the Node.js event loop.
+   * If `onOutput` is provided, it receives chunk objects with `{ stdout, stderr }`
+   * during execution. Chunks are not line-aligned. The callback must be
+   * synchronous; Promise-returning handlers are rejected. Do not re-enter the
+   * same instance from `onOutput` via `execute*`, `readFile`, `fs()`, etc.
    *
    * @example
    * ```typescript
@@ -309,17 +409,52 @@ export class Bash {
    * console.log(result.stdout); // hello\n
    * ```
    */
-  async execute(commands: string): Promise<ExecResult> {
-    return this.native.execute(commands);
+  async execute(
+    commands: string,
+    options?: ExecuteOptions,
+  ): Promise<ExecResult> {
+    const nativeOnOutput = toNativeOnOutput(options?.onOutput);
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      return cancelledExecResult();
+    }
+    return queueAsyncExecute(this, async () => {
+      if (signal?.aborted) {
+        return cancelledExecResult();
+      }
+      if (signal) {
+        let signalTriggered = false;
+        const onAbort = () => {
+          signalTriggered = true;
+          this.native.cancel();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        try {
+          if (nativeOnOutput) {
+            return await this.native.executeWithOutput(
+              commands,
+              nativeOnOutput,
+            );
+          }
+          return await this.native.execute(commands);
+        } finally {
+          signal.removeEventListener("abort", onAbort);
+          if (signalTriggered) {
+            this.native.clearCancel();
+          }
+        }
+      }
+      if (nativeOnOutput) {
+        return this.native.executeWithOutput(commands, nativeOnOutput);
+      }
+      return this.native.execute(commands);
+    });
   }
 
   /**
    * Execute bash commands synchronously. Throws `BashError` on non-zero exit.
    */
-  executeSyncOrThrow(
-    commands: string,
-    options?: { signal?: AbortSignal },
-  ): ExecResult {
+  executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult {
     const result = this.executeSync(commands, options);
     if (result.exitCode !== 0) {
       throw new BashError(result);
@@ -330,8 +465,11 @@ export class Bash {
   /**
    * Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
    */
-  async executeOrThrow(commands: string): Promise<ExecResult> {
-    const result = await this.native.execute(commands);
+  async executeOrThrow(
+    commands: string,
+    options?: ExecuteOptions,
+  ): Promise<ExecResult> {
+    const result = await this.execute(commands, options);
     if (result.exitCode !== 0) {
       throw new BashError(result);
     }
@@ -565,29 +703,22 @@ export class BashTool {
 
   /**
    * Execute bash commands synchronously and return the result.
+   *
+   * If `onOutput` is provided, it must be synchronous; Promise-returning
+   * handlers are rejected. Do not re-enter the same instance from `onOutput`
+   * via `execute*`, `readFile`, `fs()`, etc.
    */
-  executeSync(
-    commands: string,
-    options?: { signal?: AbortSignal },
-  ): ExecResult {
+  executeSync(commands: string, options?: ExecuteOptions): ExecResult {
+    const nativeOnOutput = toNativeOnOutput(options?.onOutput);
     if (options?.signal) {
       const signal = options.signal;
       if (signal.aborted) {
-        return {
-          stdout: "",
-          stderr: "",
-          exitCode: 1,
-          error: "execution cancelled",
-          stdoutTruncated: false,
-          stderrTruncated: false,
-          finalEnv: undefined,
-          success: false,
-        };
+        return cancelledExecResult();
       }
       const onAbort = () => this.native.cancel();
       signal.addEventListener("abort", onAbort, { once: true });
       try {
-        return this.native.executeSync(commands);
+        return this.native.executeSync(commands, nativeOnOutput);
       } finally {
         signal.removeEventListener("abort", onAbort);
         if (signal.aborted) {
@@ -595,23 +726,62 @@ export class BashTool {
         }
       }
     }
-    return this.native.executeSync(commands);
+    return this.native.executeSync(commands, nativeOnOutput);
   }
 
   /**
    * Execute bash commands asynchronously, returning a Promise.
+   *
+   * If `onOutput` is provided, it must be synchronous; Promise-returning
+   * handlers are rejected. Do not re-enter the same instance from `onOutput`
+   * via `execute*`, `readFile`, `fs()`, etc.
    */
-  async execute(commands: string): Promise<ExecResult> {
-    return this.native.execute(commands);
+  async execute(
+    commands: string,
+    options?: ExecuteOptions,
+  ): Promise<ExecResult> {
+    const nativeOnOutput = toNativeOnOutput(options?.onOutput);
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      return cancelledExecResult();
+    }
+    return queueAsyncExecute(this, async () => {
+      if (signal?.aborted) {
+        return cancelledExecResult();
+      }
+      if (signal) {
+        let signalTriggered = false;
+        const onAbort = () => {
+          signalTriggered = true;
+          this.native.cancel();
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        try {
+          if (nativeOnOutput) {
+            return await this.native.executeWithOutput(
+              commands,
+              nativeOnOutput,
+            );
+          }
+          return await this.native.execute(commands);
+        } finally {
+          signal.removeEventListener("abort", onAbort);
+          if (signalTriggered) {
+            this.native.clearCancel();
+          }
+        }
+      }
+      if (nativeOnOutput) {
+        return this.native.executeWithOutput(commands, nativeOnOutput);
+      }
+      return this.native.execute(commands);
+    });
   }
 
   /**
    * Execute bash commands synchronously. Throws `BashError` on non-zero exit.
    */
-  executeSyncOrThrow(
-    commands: string,
-    options?: { signal?: AbortSignal },
-  ): ExecResult {
+  executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult {
     const result = this.executeSync(commands, options);
     if (result.exitCode !== 0) {
       throw new BashError(result);
@@ -622,8 +792,11 @@ export class BashTool {
   /**
    * Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
    */
-  async executeOrThrow(commands: string): Promise<ExecResult> {
-    const result = await this.native.execute(commands);
+  async executeOrThrow(
+    commands: string,
+    options?: ExecuteOptions,
+  ): Promise<ExecResult> {
+    const result = await this.execute(commands, options);
     if (result.exitCode !== 0) {
       throw new BashError(result);
     }


### PR DESCRIPTION
## Summary
- add optional synchronous `onOutput` callbacks to the JavaScript / TypeScript `Bash` and `BashTool` `execute*` entrypoints so callers can consume chunked stdout/stderr during execution while still receiving the final `ExecResult`
- route callback-backed execution through the core streaming path, preserve caller `AsyncLocalStorage` context across callback invocations, reject async / Promise-returning handlers, and surface callback failures without poisoning later runs
- document live output semantics in the JS README and add regression coverage for chunk concatenation, error propagation, AsyncLocalStorage, and post-error cancel behavior

## Testing
- `cargo check -p bashkit-js`
- `cd crates/bashkit-js && npm run build`
- `cd crates/bashkit-js && npm test`
- `cd crates/bashkit-js && node --test __test__/runtime-compat/*.test.mjs`
- `cd crates/bashkit-js && bun test __test__/runtime-compat/streaming-output.test.mjs`

## Notes
- Python half merged in #1308.
- Related callback re-entry limitation tracked separately in #1320.

Refs #1296
