### PR TITLE
feat(javascript): add BashTool snapshot support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,13 +41,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0-rc.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
+checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
 dependencies = [
  "cipher 0.5.1",
  "cpubits",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -71,9 +71,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
 dependencies = [
  "aead 0.6.0-rc.10",
- "aes 0.9.0-rc.4",
+ "aes 0.9.0",
  "cipher 0.5.1",
- "ctr 0.10.0-rc.4",
+ "ctr 0.10.0",
  "ghash 0.6.0",
  "subtle",
 ]
@@ -188,15 +188,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,12 +286,6 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
@@ -345,7 +330,6 @@ dependencies = [
  "regex",
  "reqwest",
  "russh",
- "russh-keys",
  "schemars",
  "serde",
  "serde_json",
@@ -373,7 +357,6 @@ dependencies = [
  "colored",
  "serde",
  "serde_json",
- "statrs",
  "tabled",
  "tokio",
 ]
@@ -463,9 +446,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -615,18 +598,18 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1412b9ae2463ede01f1e591412dfbcfeacecf40e8c4c3e0655814c19065c38"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
  "cipher 0.5.1",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -671,7 +654,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1016,18 +999,6 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array 0.14.7",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
@@ -1037,7 +1008,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
  "num-traits",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serdect",
  "subtle",
  "zeroize",
@@ -1061,7 +1032,7 @@ checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1070,9 +1041,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint",
  "libm",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1102,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee683dd898fbd052617b4514bc31f98bc32081a83b69ec46adef3b1ef4ae36f"
+checksum = "17469f8eb9bdbfad10f71f4cfddfd38b01143520c0e717d8796ccb4d44d44e42"
 dependencies = [
  "cipher 0.5.1",
 ]
@@ -1186,7 +1157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -1288,28 +1258,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "signature 2.2.0",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.17.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.2",
- "elliptic-curve 0.14.0-rc.29",
- "rfc6979 0.5.0-rc.5",
+ "elliptic-curve",
+ "rfc6979",
  "signature 3.0.0-rc.10",
  "spki 0.8.0",
  "zeroize",
@@ -1358,7 +1314,7 @@ checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
 dependencies = [
  "curve25519-dalek 5.0.0-pre.6",
  "ed25519 3.0.0-rc.4",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
@@ -1374,44 +1330,23 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-rc.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
- "digest 0.10.7",
- "ff",
- "generic-array 0.14.7",
- "group",
- "hkdf 0.12.4",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sec1 0.7.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.14.0-rc.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84043d573efd4ac9d2d125817979a379204bf7e328b25a4a30487e8d100e618"
-dependencies = [
- "base16ct 1.0.0",
- "crypto-bigint 0.7.3",
+ "base16ct",
+ "crypto-bigint",
  "crypto-common 0.2.1",
  "digest 0.11.2",
- "hkdf 0.13.0",
+ "hkdf",
  "hybrid-array",
  "once_cell",
  "pem-rfc7468 1.0.0",
  "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "rustcrypto-group",
- "sec1 0.8.1",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1501,16 +1436,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "fiat-crypto"
@@ -1675,7 +1600,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1758,7 +1682,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1780,17 +1704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
  "polyval 0.7.1",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1834,6 +1747,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,15 +1789,6 @@ name = "hifijson"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "242402749acf71e6f32f5857598b7002c4058a4e3c3b22b4c7d51cab9aea754e"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "hkdf"
@@ -1989,15 +1899,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2038,7 +1947,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2161,12 +2070,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2211,18 +2120,18 @@ checksum = "25f8a978272e3cbdf4768f7363eb1c8e1e6ba63c52a3ed05e29e222da4aec7cb"
 dependencies = [
  "argon2",
  "bcrypt-pbkdf",
- "crypto-bigint 0.7.3",
- "ecdsa 0.17.0-rc.16",
+ "crypto-bigint",
+ "ecdsa",
  "ed25519-dalek 3.0.0-pre.6",
  "hex",
  "hmac 0.13.0",
  "num-bigint-dig",
- "p256 0.14.0-rc.8",
- "p384 0.14.0-rc.8",
- "p521 0.14.0-rc.8",
- "rand_core 0.10.0",
- "rsa 0.10.0-rc.17",
- "sec1 0.8.1",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.10.1",
+ "rsa",
+ "sec1",
  "sha1 0.11.0",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
@@ -2241,7 +2150,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.10.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2467,9 +2376,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2494,7 +2403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
  "crypto-common 0.2.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2539,9 +2448,9 @@ checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2616,16 +2525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,7 +2576,7 @@ dependencies = [
  "hybrid-array",
  "kem",
  "module-lattice",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha3",
 ]
 
@@ -2718,23 +2617,6 @@ dependencies = [
  "smallvec",
  "speedate",
  "strum",
-]
-
-[[package]]
-name = "nalgebra"
-version = "0.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
-dependencies = [
- "approx",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.8.5",
- "rand_distr",
- "simba",
- "typenum",
 ]
 
 [[package]]
@@ -2853,16 +2735,6 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "smallvec",
- "zeroize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -2886,24 +2758,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2938,9 +2798,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "ordermap"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
  "indexmap",
 ]
@@ -3153,39 +3013,15 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder 0.13.6",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p256"
 version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f0a10fe314869359cb2901342b045f4e5a962ef9febc006f03d2a8c848fe4c"
 dependencies = [
- "ecdsa 0.17.0-rc.16",
- "elliptic-curve 0.14.0-rc.29",
+ "ecdsa",
+ "elliptic-curve",
  "primefield",
- "primeorder 0.14.0-rc.8",
+ "primeorder",
  "sha2 0.11.0",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder 0.13.6",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3194,26 +3030,12 @@ version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b079e66810c55ab3d6ba424e056dc4aefcdb8046c8c3f3816142edbdd7af7721"
 dependencies = [
- "ecdsa 0.17.0-rc.16",
- "elliptic-curve 0.14.0-rc.29",
+ "ecdsa",
+ "elliptic-curve",
  "fiat-crypto 0.3.0",
  "primefield",
- "primeorder 0.14.0-rc.8",
+ "primeorder",
  "sha2 0.11.0",
-]
-
-[[package]]
-name = "p521"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
-dependencies = [
- "base16ct 0.2.0",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder 0.13.6",
- "rand_core 0.6.4",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3222,11 +3044,11 @@ version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eecc34c4c6e6596d5271fecf90ac4f16593fa198e77282214d0c22736aa9266"
 dependencies = [
- "base16ct 1.0.0",
- "ecdsa 0.17.0-rc.16",
- "elliptic-curve 0.14.0-rc.29",
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
  "primefield",
- "primeorder 0.14.0-rc.8",
+ "primeorder",
  "sha2 0.11.0",
 ]
 
@@ -3238,21 +3060,6 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "pageant"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032d6201d2fb765158455ae0d5a510c016bb6da7232e5040e39e9c8db12b0afc"
-dependencies = [
- "bytes",
- "delegate",
- "futures",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "windows 0.58.0",
 ]
 
 [[package]]
@@ -3270,8 +3077,8 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "windows 0.62.2",
- "windows-strings 0.5.1",
+ "windows",
+ "windows-strings",
 ]
 
 [[package]]
@@ -3318,12 +3125,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -3458,17 +3259,6 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs1"
 version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
@@ -3479,32 +3269,17 @@ dependencies = [
 
 [[package]]
 name = "pkcs5"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
-dependencies = [
- "aes 0.8.4",
- "cbc 0.1.2",
- "der 0.7.10",
- "pbkdf2 0.12.2",
- "scrypt 0.11.0",
- "sha2 0.10.9",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs5"
 version = "0.8.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a777c6e26664bc9504b3ce3f6133f8f20d9071f130a4f9fcbd3186959d8dd6"
 dependencies = [
- "aes 0.9.0-rc.4",
+ "aes 0.9.0",
  "aes-gcm 0.11.0-rc.3",
- "cbc 0.2.0-rc.4",
+ "cbc 0.2.0",
  "der 0.8.0",
  "pbkdf2 0.13.0-rc.10",
- "rand_core 0.10.0",
- "scrypt 0.12.0-rc.10",
+ "rand_core 0.10.1",
+ "scrypt",
  "sha2 0.11.0",
  "spki 0.8.0",
 ]
@@ -3516,8 +3291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "pkcs5 0.7.1",
- "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -3528,8 +3301,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
  "der 0.8.0",
- "pkcs5 0.8.0-rc.13",
- "rand_core 0.10.0",
+ "pkcs5",
+ "rand_core 0.10.1",
  "spki 0.8.0",
 ]
 
@@ -3667,21 +3440,12 @@ version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6543f5eec854fbf74ba5ef651fbdc9408919b47c3e1526623687135c16d12e9"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint",
  "crypto-common 0.2.1",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -3690,7 +3454,7 @@ version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "569d9ad6ef822bb0322c7e7d84e5e286244050bd5246cac4c013535ae91c2c90"
 dependencies = [
- "elliptic-curve 0.14.0-rc.29",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3745,7 +3509,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3874,7 +3638,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3972,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3988,7 +3752,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4031,19 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4055,16 +3809,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4186,16 +3934,6 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac 0.12.1",
- "subtle",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
@@ -4220,38 +3958,17 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1 0.7.5",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rsa"
 version = "0.10.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.3",
+ "crypto-bigint",
  "crypto-primes",
  "digest 0.11.2",
- "pkcs1 0.8.0-rc.4",
+ "pkcs1",
  "pkcs8 0.11.0-rc.11",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "sha2 0.11.0",
  "signature 3.0.0-rc.10",
  "spki 0.8.0",
@@ -4338,16 +4055,16 @@ dependencies = [
  "bytes",
  "cbc 0.1.2",
  "cipher 0.5.1",
- "crypto-bigint 0.7.3",
+ "crypto-bigint",
  "ctr 0.9.2",
  "curve25519-dalek 5.0.0-pre.6",
  "data-encoding",
  "delegate",
  "der 0.8.0",
  "digest 0.10.7",
- "ecdsa 0.17.0-rc.16",
+ "ecdsa",
  "ed25519-dalek 3.0.0-pre.6",
- "elliptic-curve 0.14.0-rc.29",
+ "elliptic-curve",
  "enum_dispatch",
  "flate2",
  "futures",
@@ -4362,21 +4079,21 @@ dependencies = [
  "md5",
  "ml-kem",
  "module-lattice",
- "p256 0.14.0-rc.8",
- "p384 0.14.0-rc.8",
- "p521 0.14.0-rc.8",
- "pageant 0.2.0",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
  "pbkdf2 0.12.2",
- "pkcs1 0.8.0-rc.4",
- "pkcs5 0.8.0-rc.13",
+ "pkcs1",
+ "pkcs5",
  "pkcs8 0.11.0-rc.11",
  "polyval 0.7.1",
  "rand 0.10.1",
- "rand_core 0.10.0",
- "rsa 0.10.0-rc.17",
- "russh-cryptovec 0.59.0",
- "russh-util 0.52.0",
- "sec1 0.8.1",
+ "rand_core 0.10.1",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
  "sha1 0.10.6",
  "sha2 0.10.9",
  "signature 3.0.0-rc.10",
@@ -4392,17 +4109,6 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8e7e854e1a87e4be00fa287c98cad23faa064d0464434beaa9f014ec3baa98"
-dependencies = [
- "libc",
- "ssh-encoding",
- "winapi",
-]
-
-[[package]]
-name = "russh-cryptovec"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
@@ -4411,74 +4117,6 @@ dependencies = [
  "nix",
  "ssh-encoding",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "russh-keys"
-version = "0.49.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788a2439ce385856585346beb37c48e7c9eb5de5f4f00736720a19ffdb3f5bb5"
-dependencies = [
- "aes 0.8.4",
- "async-trait",
- "bcrypt-pbkdf",
- "block-padding 0.3.3",
- "byteorder",
- "bytes",
- "cbc 0.1.2",
- "ctr 0.9.2",
- "data-encoding",
- "der 0.7.10",
- "digest 0.10.7",
- "ecdsa 0.16.9",
- "ed25519-dalek 2.2.0",
- "elliptic-curve 0.13.8",
- "futures",
- "getrandom 0.2.17",
- "hmac 0.12.1",
- "home",
- "inout 0.1.4",
- "log",
- "md5",
- "num-integer",
- "p256 0.13.2",
- "p384 0.13.1",
- "p521 0.13.3",
- "pageant 0.0.1",
- "pbkdf2 0.12.2",
- "pkcs1 0.7.5",
- "pkcs5 0.7.1",
- "pkcs8 0.10.2",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rsa 0.9.10",
- "russh-cryptovec 0.48.0",
- "russh-util 0.48.0",
- "sec1 0.7.3",
- "serde",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
- "ssh-encoding",
- "ssh-key",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "russh-util"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c7dd577958c0cefbc8f8a2c05c48c88c42e2fdb760dbe9b96ae31d4de97a1f"
-dependencies = [
- "chrono",
- "tokio",
- "wasm-bindgen",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4514,7 +4152,7 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -4524,7 +4162,7 @@ version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
 dependencies = [
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "rustcrypto-ff",
  "subtle",
 ]
@@ -4544,9 +4182,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4663,24 +4301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher 0.4.4",
-]
-
-[[package]]
 name = "salsa20"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,24 +4370,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2 0.12.2",
- "salsa20 0.10.2",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "scrypt"
 version = "0.12.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e03ed5b54ed5fcc8e016cd94301416bc2c01c05c87a6742b97468337c8804598"
 dependencies = [
  "cfg-if",
  "pbkdf2 0.13.0-rc.10",
- "salsa20 0.11.0",
+ "salsa20",
  "sha2 0.11.0",
 ]
 
@@ -4779,25 +4388,11 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
- "generic-array 0.14.7",
- "pkcs8 0.10.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "ctutils",
  "der 0.8.0",
  "hybrid-array",
@@ -4906,7 +4501,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
 dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "serde",
 ]
 
@@ -5022,7 +4617,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5033,20 +4627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest 0.11.2",
- "rand_core 0.10.0",
-]
-
-[[package]]
-name = "simba"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5168,29 +4749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssh-key"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
-dependencies = [
- "bcrypt-pbkdf",
- "ed25519-dalek 2.2.0",
- "num-bigint-dig",
- "p256 0.13.2",
- "p384 0.13.1",
- "p521 0.13.3",
- "rand_core 0.6.4",
- "rsa 0.9.10",
- "sec1 0.7.3",
- "sha2 0.10.9",
- "signature 2.2.0",
- "ssh-cipher",
- "ssh-encoding",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5201,18 +4759,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "statrs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
-dependencies = [
- "approx",
- "nalgebra",
- "num-traits",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "strsim"
@@ -5434,9 +4980,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -5478,7 +5024,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -5794,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5807,9 +5352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5817,9 +5362,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5827,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5840,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -5896,9 +5441,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5921,16 +5466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]
@@ -5966,22 +5501,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -5992,20 +5517,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -6014,11 +5526,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6027,20 +5539,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -6048,17 +5549,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6088,17 +5578,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6108,16 +5589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/bashkit-bench/Cargo.toml
+++ b/crates/bashkit-bench/Cargo.toml
@@ -22,9 +22,6 @@ serde_json.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 
-# Statistics
-statrs = "0.18"
-
 # Terminal output
 colored = "3"
 tabled = "0.20"

--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -219,13 +219,15 @@ console.log(result.stdout); // Alice
 
 ## Snapshot / Restore
 
-State snapshots are currently available on `Bash` instances:
+State snapshots are available on both `Bash` and `BashTool` instances:
 
 ```typescript
-import { Bash } from "@everruns/bashkit";
+import { Bash, BashTool } from "@everruns/bashkit";
 
 const bash = new Bash({ username: "agent", maxCommands: 100 });
-await bash.execute("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt");
+await bash.execute(
+  "export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt",
+);
 
 const snapshot = bash.snapshot();
 
@@ -235,6 +237,17 @@ console.log((await restored.execute("echo $BUILD_ID")).stdout); // 42\n
 restored.reset();
 restored.restoreSnapshot(snapshot);
 console.log(restored.executeSync("pwd").stdout); // /workspace\n
+
+const tool = new BashTool({ username: "agent", maxCommands: 5 });
+tool.executeSync("export TOOL_STATE=ready");
+
+const toolSnapshot = tool.snapshot();
+const restoredTool = BashTool.fromSnapshot(toolSnapshot, {
+  username: "agent",
+  maxCommands: 5,
+});
+
+console.log(restoredTool.executeSync("echo $TOOL_STATE").stdout); // ready\n
 ```
 
 ## Framework Integrations
@@ -266,7 +279,10 @@ const bash = bashTool();
 ### LangChain
 
 ```typescript
-import { createBashTool, createScriptedTool } from "@everruns/bashkit/langchain";
+import {
+  createBashTool,
+  createScriptedTool,
+} from "@everruns/bashkit/langchain";
 ```
 
 ## API Reference
@@ -288,8 +304,11 @@ import { createBashTool, createScriptedTool } from "@everruns/bashkit/langchain"
 
 ### BashTool
 
-- All execution, cancellation, reset, and direct VFS helpers from `Bash`
+- All execution, cancellation, reset, snapshot, restore, and direct VFS helpers from `Bash`
 - Tool metadata: `name`, `version`, `shortDescription`
+- `snapshot()`
+- `restoreSnapshot(data)`
+- `BashTool.fromSnapshot(data, options?)`
 - `description()`
 - `help()`
 - `systemPrompt()`
@@ -334,12 +353,12 @@ import { createBashTool, createScriptedTool } from "@everruns/bashkit/langchain"
 
 ## Platform Support
 
-| OS | Architecture |
-|----|-------------|
-| macOS | `x86_64`, `aarch64` |
-| Linux | `x86_64`, `aarch64` |
-| Windows | `x86_64` |
-| WASM | `wasm32-wasip1-threads` |
+| OS      | Architecture            |
+| ------- | ----------------------- |
+| macOS   | `x86_64`, `aarch64`     |
+| Linux   | `x86_64`, `aarch64`     |
+| Windows | `x86_64`                |
+| WASM    | `wasm32-wasip1-threads` |
 
 ## How It Works
 

--- a/crates/bashkit-js/__test__/integration.spec.ts
+++ b/crates/bashkit-js/__test__/integration.spec.ts
@@ -261,6 +261,68 @@ test("integration: BashTool reset clears state", (t) => {
   t.is(tool.executeSync("whoami").stdout.trim(), "testuser");
 });
 
+test("integration: BashTool snapshot roundtrip preserves state and config", (t) => {
+  const tool = new BashTool({
+    username: "agent",
+    maxCommands: 5,
+    maxLoopIterations: 50,
+  });
+  tool.executeSync(
+    "export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt",
+  );
+
+  const snapshot = tool.snapshot();
+  const restored = BashTool.fromSnapshot(snapshot, {
+    username: "agent",
+    maxCommands: 5,
+    maxLoopIterations: 50,
+  });
+
+  t.is(restored.executeSync("echo $BUILD_ID").stdout.trim(), "42");
+  t.is(restored.executeSync("cat /workspace/state.txt").stdout.trim(), "ready");
+  t.is(restored.executeSync("pwd").stdout.trim(), "/workspace");
+  t.is(restored.executeSync("whoami").stdout.trim(), "agent");
+
+  const limited = restored.executeSync("true; true; true; true; true; true");
+  t.true(
+    limited.exitCode !== 0 || limited.error !== undefined,
+    "fromSnapshot() must preserve maxCommands",
+  );
+});
+
+test("integration: BashTool restoreSnapshot after reset restores original state", (t) => {
+  const tool = new BashTool({ username: "agent" });
+  tool.executeSync("export SNAP=yes; mkdir -p /tmp/restore && cd /tmp/restore");
+
+  const snapshot = tool.snapshot();
+
+  tool.reset();
+  t.is(tool.executeSync("echo ${SNAP:-missing}").stdout.trim(), "missing");
+
+  tool.restoreSnapshot(snapshot);
+  t.is(tool.executeSync("echo $SNAP").stdout.trim(), "yes");
+  t.is(tool.executeSync("pwd").stdout.trim(), "/tmp/restore");
+  t.is(tool.executeSync("whoami").stdout.trim(), "agent");
+});
+
+test("integration: BashTool empty snapshot roundtrip works", (t) => {
+  const tool = new BashTool();
+  const expectedPwd = tool.executeSync("pwd").stdout.trim();
+  const snapshot = tool.snapshot();
+  const restored = BashTool.fromSnapshot(snapshot);
+
+  t.is(restored.executeSync("pwd").stdout.trim(), expectedPwd);
+  t.is(restored.executeSync("echo ${MISSING:-unset}").stdout.trim(), "unset");
+});
+
+test("integration: BashTool invalid snapshot throws", (t) => {
+  const tool = new BashTool();
+  const invalid = new Uint8Array([0, 1, 2, 3, 4]);
+
+  t.throws(() => tool.restoreSnapshot(invalid));
+  t.throws(() => BashTool.fromSnapshot(invalid));
+});
+
 test("integration: multiple resets remain stable", (t) => {
   const bash = new Bash();
   for (let i = 0; i < 10; i++) {

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -1023,6 +1023,55 @@ impl BashTool {
         })
     }
 
+    // ========================================================================
+    // Snapshot / Resume
+    // ========================================================================
+
+    /// Serialize interpreter state (shell variables, VFS contents, counters) to bytes.
+    #[napi]
+    pub fn snapshot(&self) -> napi::Result<napi::bindgen_prelude::Buffer> {
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
+            let bytes = bash
+                .snapshot()
+                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            Ok(napi::bindgen_prelude::Buffer::from(bytes))
+        })
+    }
+
+    /// Restore interpreter state from a snapshot previously created with `snapshot()`.
+    #[napi]
+    pub fn restore_snapshot(&self, data: napi::bindgen_prelude::Buffer) -> napi::Result<()> {
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
+            bash.restore_snapshot(&data)
+                .map_err(|e| napi::Error::from_reason(e.to_string()))
+        })
+    }
+
+    /// Create a new BashTool instance from a snapshot.
+    ///
+    /// Accepts optional `BashOptions` so restored instances preserve caller-provided
+    /// execution limits and identity settings.
+    #[napi(factory)]
+    pub fn from_snapshot(
+        data: napi::bindgen_prelude::Buffer,
+        options: Option<BashOptions>,
+    ) -> napi::Result<Self> {
+        let opts = options.unwrap_or_else(default_opts);
+        let mut state = shared_state_from_opts(opts, None)?;
+
+        state
+            .inner
+            .get_mut()
+            .restore_snapshot(&data)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+        Ok(Self {
+            state: Arc::new(state),
+        })
+    }
+
     /// Get tool name.
     #[napi(getter)]
     pub fn name(&self) -> &str {

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -454,9 +454,7 @@ export class Bash {
   }
 
   /** List directory entries with metadata. */
-  readDir(
-    path: string,
-  ): Array<{
+  readDir(path: string): Array<{
     name: string;
     metadata: {
       fileType: string;
@@ -630,6 +628,38 @@ export class BashTool {
     this.native.reset();
   }
 
+  /**
+   * Serialize interpreter state (variables, VFS, counters) to a Uint8Array.
+   */
+  snapshot(): Uint8Array {
+    return this.native.snapshot();
+  }
+
+  /**
+   * Restore interpreter state from a previously captured snapshot.
+   * Preserves current configuration (limits, identity) but replaces
+   * shell state and VFS contents.
+   */
+  restoreSnapshot(data: Uint8Array): void {
+    this.native.restoreSnapshot(Buffer.from(data));
+  }
+
+  /**
+   * Create a new BashTool instance from a snapshot.
+   *
+   * Any provided options are applied before restoring the snapshot so limits
+   * and identity settings survive round-trips.
+   */
+  static fromSnapshot(data: Uint8Array, options?: BashOptions): BashTool {
+    const resolved = resolveFilesSync(options?.files);
+    const instance = Object.create(BashTool.prototype) as BashTool;
+    instance.native = NativeBashTool.fromSnapshot(
+      Buffer.from(data),
+      toNativeOptions(options, resolved),
+    );
+    return instance;
+  }
+
   // ==========================================================================
   // VFS file helpers
   // ==========================================================================
@@ -703,9 +733,7 @@ export class BashTool {
   }
 
   /** List directory entries with metadata. */
-  readDir(
-    path: string,
-  ): Array<{
+  readDir(path: string): Array<{
     name: string;
     metadata: {
       fileType: string;

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -42,7 +42,6 @@ reqwest = { workspace = true, optional = true }
 
 # SSH client (for ssh/scp/sftp) - optional, enabled with ssh feature
 russh = { workspace = true, optional = true }
-russh-keys = { workspace = true, optional = true }
 
 # Fault injection for testing (optional)
 fail = { workspace = true, optional = true }
@@ -102,7 +101,7 @@ logging = ["tracing"]
 git = []
 # Enable ssh/scp/sftp builtins for remote command execution and file transfer
 # Usage: cargo build --features ssh
-ssh = ["russh", "russh-keys"]
+ssh = ["russh"]
 # Enable ScriptedTool: compose ToolDef+callback pairs into a single Tool
 # Usage: cargo build --features scripted_tool
 scripted_tool = []

--- a/specs/009-implementation-status.md
+++ b/specs/009-implementation-status.md
@@ -482,10 +482,10 @@ NAPI-RS bindings in `crates/bashkit-js/`. TypeScript wrapper in `wrapper.ts`.
 
 | Class | Methods | Notes |
 |-------|---------|-------|
-| `Bash` | `executeSync`, `execute`, `cancel`, `reset` | Core interpreter |
+| `Bash` | `executeSync`, `execute`, `cancel`, `reset`, `snapshot`, `restoreSnapshot`, `fromSnapshot` | Core interpreter |
 | `Bash` (VFS) | `readFile`, `writeFile`, `mkdir`, `exists`, `remove` | Direct VFS access via NAPI |
 | `Bash` (helpers) | `ls`, `glob` | Shell-based convenience wrappers |
-| `BashTool` | `executeSync`, `execute`, `cancel`, `reset` | Interpreter + tool metadata |
+| `BashTool` | `executeSync`, `execute`, `cancel`, `reset`, `snapshot`, `restoreSnapshot`, `fromSnapshot` | Interpreter + tool metadata |
 | `BashTool` (metadata) | `name`, `shortDescription`, `description`, `help`, `systemPrompt`, `inputSchema`, `outputSchema`, `version` | LLM tool contract |
 | `BashTool` (helpers) | `readFile`, `writeFile`, `exists`, `ls`, `glob` | Shell-based VFS wrappers |
 

--- a/specs/015-ssh-support.md
+++ b/specs/015-ssh-support.md
@@ -17,7 +17,7 @@ Enable with:
 bashkit = { version = "0.1", features = ["ssh"] }
 ```
 
-Pulls in `russh` + `russh-keys` for the default transport implementation.
+Pulls in the `russh`-based default transport implementation.
 
 ### Configuration
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -35,7 +35,7 @@ version = "0.8.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.aes]]
-version = "0.9.0-rc.4"
+version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.aes-gcm]]
@@ -94,10 +94,6 @@ criteria = "safe-to-deploy"
 version = "1.0.102"
 criteria = "safe-to-deploy"
 
-[[exemptions.approx]]
-version = "0.5.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.argon2]]
 version = "0.5.3"
 criteria = "safe-to-deploy"
@@ -131,10 +127,6 @@ version = "1.16.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.base16ct]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.base16ct]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
 
@@ -159,7 +151,7 @@ version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitflags]]
-version = "2.11.0"
+version = "2.11.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitvec]]
@@ -231,11 +223,11 @@ version = "0.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.cbc]]
-version = "0.2.0-rc.4"
+version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.59"
+version = "1.2.60"
 criteria = "safe-to-deploy"
 
 [[exemptions.cesu8]]
@@ -407,10 +399,6 @@ version = "0.2.4"
 criteria = "safe-to-run"
 
 [[exemptions.crypto-bigint]]
-version = "0.5.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto-bigint]]
 version = "0.7.3"
 criteria = "safe-to-deploy"
 
@@ -439,7 +427,7 @@ version = "0.9.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.ctr]]
-version = "0.10.0-rc.4"
+version = "0.10.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ctutils]]
@@ -515,10 +503,6 @@ version = "1.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.ecdsa]]
-version = "0.16.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.ecdsa]]
 version = "0.17.0-rc.16"
 criteria = "safe-to-deploy"
 
@@ -543,11 +527,7 @@ version = "1.15.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.elliptic-curve]]
-version = "0.13.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.elliptic-curve]]
-version = "0.14.0-rc.29"
+version = "0.14.0-rc.30"
 criteria = "safe-to-deploy"
 
 [[exemptions.embedded-io]]
@@ -592,10 +572,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
 version = "2.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ff]]
-version = "0.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.fiat-crypto]]
@@ -706,24 +682,12 @@ criteria = "safe-to-deploy"
 version = "0.4.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.getrandom]]
-version = "0.4.2"
-criteria = "safe-to-run"
-
 [[exemptions.ghash]]
 version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ghash]]
 version = "0.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.globset]]
-version = "0.4.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.group]]
-version = "0.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.half]]
@@ -742,6 +706,10 @@ criteria = "safe-to-deploy"
 version = "0.16.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.hashbrown]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.heapless]]
 version = "0.7.17"
 criteria = "safe-to-deploy"
@@ -755,19 +723,11 @@ version = "0.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.hex-literal]]
-version = "0.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.hex-literal]]
 version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hifijson]]
 version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.hkdf]]
-version = "0.12.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.hkdf]]
@@ -811,7 +771,7 @@ version = "1.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-rustls]]
-version = "0.27.7"
+version = "0.27.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.hyper-util]]
@@ -867,7 +827,7 @@ version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.indexmap]]
-version = "2.13.1"
+version = "2.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.inout]]
@@ -881,14 +841,6 @@ criteria = "safe-to-deploy"
 [[exemptions.insta]]
 version = "1.47.2"
 criteria = "safe-to-run"
-
-[[exemptions.instant]]
-version = "0.1.13"
-criteria = "safe-to-deploy"
-
-[[exemptions.internal-russh-forked-ssh-key]]
-version = "0.6.10+upstream-0.6.7"
-criteria = "safe-to-deploy"
 
 [[exemptions.internal-russh-forked-ssh-key]]
 version = "0.6.18+upstream-0.6.7"
@@ -979,7 +931,7 @@ version = "0.1.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.94"
+version = "0.3.95"
 criteria = "safe-to-deploy"
 
 [[exemptions.keccak]]
@@ -1011,7 +963,7 @@ version = "1.0.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.184"
+version = "0.2.185"
 criteria = "safe-to-deploy"
 
 [[exemptions.libloading]]
@@ -1025,10 +977,6 @@ criteria = "safe-to-deploy"
 [[exemptions.linux-raw-sys]]
 version = "0.12.1"
 criteria = "safe-to-deploy"
-
-[[exemptions.linux-raw-sys]]
-version = "0.12.1"
-criteria = "safe-to-run"
 
 [[exemptions.litemap]]
 version = "0.8.2"
@@ -1052,10 +1000,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.manyhow-macros]]
 version = "0.11.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.matrixmultiply]]
-version = "0.3.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.md-5]]
@@ -1086,10 +1030,6 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.nalgebra]]
-version = "0.33.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.napi]]
 version = "3.8.4"
 criteria = "safe-to-deploy"
@@ -1115,10 +1055,6 @@ version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.nix]]
-version = "0.29.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.nix]]
 version = "0.31.2"
 criteria = "safe-to-deploy"
 
@@ -1138,20 +1074,12 @@ criteria = "safe-to-deploy"
 version = "0.8.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.num-complex]]
-version = "0.4.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.num-integer]]
 version = "0.1.46"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-iter]]
 version = "0.1.45"
-criteria = "safe-to-deploy"
-
-[[exemptions.num-rational]]
-version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-traits]]
@@ -1179,7 +1107,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordermap]]
-version = "1.1.0"
+version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.owo-colors]]
@@ -1247,23 +1175,11 @@ version = "0.117.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.p256]]
-version = "0.13.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.p256]]
 version = "0.14.0-rc.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.p384]]
-version = "0.13.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.p384]]
 version = "0.14.0-rc.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.p521]]
-version = "0.13.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.p521]]
@@ -1273,14 +1189,6 @@ criteria = "safe-to-deploy"
 [[exemptions.page_size]]
 version = "0.6.0"
 criteria = "safe-to-run"
-
-[[exemptions.pageant]]
-version = "0.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.pageant]]
-version = "0.0.3"
-criteria = "safe-to-deploy"
 
 [[exemptions.pageant]]
 version = "0.2.0"
@@ -1300,10 +1208,6 @@ criteria = "safe-to-run"
 
 [[exemptions.password-hash]]
 version = "0.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.paste]]
-version = "1.0.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.pbkdf2]]
@@ -1363,15 +1267,7 @@ version = "0.2.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkcs1]]
-version = "0.7.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.pkcs1]]
 version = "0.8.0-rc.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.pkcs5]]
-version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.pkcs5]]
@@ -1443,10 +1339,6 @@ version = "0.14.0-rc.8"
 criteria = "safe-to-deploy"
 
 [[exemptions.primeorder]]
-version = "0.13.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.primeorder]]
 version = "0.14.0-rc.8"
 criteria = "safe-to-deploy"
 
@@ -1498,10 +1390,6 @@ criteria = "safe-to-deploy"
 version = "0.2.15"
 criteria = "safe-to-deploy"
 
-[[exemptions.python3-dll-a]]
-version = "0.2.15"
-criteria = "safe-to-deploy"
-
 [[exemptions.quick-error]]
 version = "1.2.3"
 criteria = "safe-to-run"
@@ -1538,10 +1426,6 @@ criteria = "safe-to-deploy"
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.r-efi]]
-version = "6.0.0"
-criteria = "safe-to-run"
-
 [[exemptions.radium]]
 version = "0.7.0"
 criteria = "safe-to-deploy"
@@ -1555,7 +1439,7 @@ version = "0.8.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
-version = "0.9.2"
+version = "0.9.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand]]
@@ -1579,23 +1463,15 @@ version = "0.9.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand_core]]
-version = "0.10.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rand_distr]]
-version = "0.4.3"
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rand_xorshift]]
 version = "0.4.0"
 criteria = "safe-to-run"
 
-[[exemptions.rawpointer]]
-version = "0.2.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.rayon]]
-version = "1.11.0"
+version = "1.12.0"
 criteria = "safe-to-run"
 
 [[exemptions.rayon-core]]
@@ -1635,10 +1511,6 @@ version = "0.13.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rfc6979]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.rfc6979]]
 version = "0.5.0-rc.5"
 criteria = "safe-to-deploy"
 
@@ -1647,15 +1519,7 @@ version = "0.17.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.rsa]]
-version = "0.9.10"
-criteria = "safe-to-deploy"
-
-[[exemptions.rsa]]
 version = "0.10.0-rc.17"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh]]
-version = "0.52.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.russh]]
@@ -1663,23 +1527,7 @@ version = "0.60.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.russh-cryptovec]]
-version = "0.48.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh-cryptovec]]
-version = "0.52.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh-cryptovec]]
 version = "0.59.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh-keys]]
-version = "0.49.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.russh-util]]
-version = "0.48.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.russh-util]]
@@ -1706,12 +1554,8 @@ criteria = "safe-to-deploy"
 version = "1.1.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustix]]
-version = "1.1.4"
-criteria = "safe-to-run"
-
 [[exemptions.rustls]]
-version = "0.23.37"
+version = "0.23.38"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-native-certs]]
@@ -1750,14 +1594,6 @@ criteria = "safe-to-deploy"
 version = "1.0.23"
 criteria = "safe-to-deploy"
 
-[[exemptions.safe_arch]]
-version = "0.7.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.salsa20]]
-version = "0.10.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.salsa20]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
@@ -1787,20 +1623,12 @@ version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.scrypt]]
-version = "0.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.scrypt]]
 version = "0.12.0-rc.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.sdd]]
 version = "3.0.10"
 criteria = "safe-to-run"
-
-[[exemptions.sec1]]
-version = "0.7.3"
-criteria = "safe-to-deploy"
 
 [[exemptions.sec1]]
 version = "0.8.1"
@@ -1898,10 +1726,6 @@ criteria = "safe-to-deploy"
 version = "3.0.0-rc.10"
 criteria = "safe-to-deploy"
 
-[[exemptions.simba]]
-version = "0.9.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.simd-adler32]]
 version = "0.3.9"
 criteria = "safe-to-deploy"
@@ -1954,20 +1778,12 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ssh-key]]
-version = "0.6.7"
-criteria = "safe-to-deploy"
-
 [[exemptions.stable_deref_trait]]
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.static_assertions]]
 version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.statrs]]
-version = "0.18.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.strsim]]
@@ -2063,7 +1879,7 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
-version = "1.51.0"
+version = "1.52.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
@@ -2076,7 +1892,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio-stream]]
 version = "0.1.18"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.tokio-test]]
 version = "0.4.5"
@@ -2226,28 +2042,24 @@ criteria = "safe-to-deploy"
 version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 criteria = "safe-to-deploy"
 
-[[exemptions.wasip3]]
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-criteria = "safe-to-run"
-
 [[exemptions.wasm-bindgen]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.67"
+version = "0.4.68"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.117"
+version = "0.2.118"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-encoder]]
@@ -2267,7 +2079,7 @@ version = "0.244.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.94"
+version = "0.3.95"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-time]]
@@ -2278,17 +2090,13 @@ criteria = "safe-to-deploy"
 version = "1.0.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.wide]]
-version = "0.7.33"
-criteria = "safe-to-deploy"
-
 [[exemptions.winapi]]
 version = "0.3.9"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.winapi-util]]
 version = "0.1.11"
@@ -2296,11 +2104,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows]]
-version = "0.58.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.windows]]
 version = "0.62.2"
@@ -2308,10 +2112,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.windows-collections]]
 version = "0.3.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-core]]
-version = "0.58.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-core]]
@@ -2323,15 +2123,7 @@ version = "0.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-implement]]
-version = "0.58.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-implement]]
 version = "0.60.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-interface]]
-version = "0.58.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-interface]]
@@ -2347,15 +2139,7 @@ version = "0.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-result]]
-version = "0.2.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-result]]
 version = "0.4.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.windows-strings]]
-version = "0.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-strings]]


### PR DESCRIPTION
## Summary
- add `snapshot()`, `restoreSnapshot(...)`, and `BashTool.fromSnapshot(data, options?)` to the JS BashTool bindings
- preserve constructor-driven identity and limits by resolving options before restoring snapshot bytes
- document the new BashTool snapshot surface and cover round-trip, reset+restore, empty snapshot, and invalid snapshot cases in the JS integration suite

## Validation
- `npm ci`
- `npm run build`
- `npm run type-check`
- `./node_modules/.bin/ava --match="integration: BashTool *"`
- `just pre-pr` on macOS still fails only in the existing `bash_comparison_tests` parity bucket (114 mismatches), matching the previously analyzed GNU/BSD + host-environment drift

Closes #1301