### PR TITLE
chore(release): prepare v0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 ## [Unreleased]
 
+## [0.1.19] - 2026-04-15
+
+### Highlights
+
+- **Scripted tool ergonomics** — New `ToolImpl` composition plus `--help`, `--dry-run`, and structured discover schema for MCP-backed callbacks
+- **Python bindings** — Added direct VFS helpers, callable file providers, snapshot restore, stronger parity coverage, and security regression tests
+- **Targeted fixes** — Correct `touch` mtimes for existing paths, quoted-adjacent glob expansion, Python publish stripping for multi-feature defaults, and `rustls-webpki` audit advisories
+- **Docs and CI polish** — New snapshotting guide, richer Python/Node examples, aligned package docs, and JS type-check coverage in CI
+- **External contribution** — Python snapshot restore support landed via @oliverlambson in [#1298](https://github.com/everruns/bashkit/pull/1298)
+
+### What's Changed
+
+* docs(readme): align Python and Node package guides ([#1307](https://github.com/everruns/bashkit/pull/1307)) by @chaliy
+* test(python): tag security tests with threat-model ids ([#1306](https://github.com/everruns/bashkit/pull/1306)) by @chaliy
+* test(python): add parity suites for builtins, strings, and scripts ([#1305](https://github.com/everruns/bashkit/pull/1305)) by @chaliy
+* refactor(python): split binding tests by category ([#1304](https://github.com/everruns/bashkit/pull/1304)) by @chaliy
+* fix(python): cover issue 1264 security gaps ([#1303](https://github.com/everruns/bashkit/pull/1303)) by @chaliy
+* docs: add public snapshotting guide ([#1302](https://github.com/everruns/bashkit/pull/1302)) by @chaliy
+* test(node): add missing security coverage ([#1300](https://github.com/everruns/bashkit/pull/1300)) by @chaliy
+* test(node): add integration workflow coverage ([#1299](https://github.com/everruns/bashkit/pull/1299)) by @chaliy
+* feat(python): add snapshot restore support ([#1298](https://github.com/everruns/bashkit/pull/1298)) by @oliverlambson
+* feat(python): support callable file providers ([#1297](https://github.com/everruns/bashkit/pull/1297)) by @chaliy
+* feat(python): add direct VFS convenience methods ([#1295](https://github.com/everruns/bashkit/pull/1295)) by @chaliy
+* fix(touch): update mtimes for existing paths ([#1294](https://github.com/everruns/bashkit/pull/1294)) by @chaliy
+* feat(scripted-tool): add --dry-run flag with pluggable validation ([#1293](https://github.com/everruns/bashkit/pull/1293)) by @chaliy
+* feat(scripting-toolset): structured discover input schema for MCP ([#1292](https://github.com/everruns/bashkit/pull/1292)) by @chaliy
+* docs(python): add @example blocks to type stubs and modules ([#1291](https://github.com/everruns/bashkit/pull/1291)) by @chaliy
+* docs: add missing examples to Python and Node bindings ([#1290](https://github.com/everruns/bashkit/pull/1290)) by @chaliy
+* ci(node): add TypeScript type-check job to JS workflow ([#1289](https://github.com/everruns/bashkit/pull/1289)) by @chaliy
+* feat(scripted-tool): add --help flag to tool callbacks ([#1288](https://github.com/everruns/bashkit/pull/1288)) by @chaliy
+* fix(glob): expand glob * adjacent to quoted variable expansion ([#1287](https://github.com/everruns/bashkit/pull/1287)) by @chaliy
+* fix(security): resolve 6 CodeQL alerts in test code ([#1286](https://github.com/everruns/bashkit/pull/1286)) by @chaliy
+* fix(ci): handle multi-feature default array in python stripping ([#1285](https://github.com/everruns/bashkit/pull/1285)) by @chaliy
+* feat(scripted_tool): add ToolImpl combining ToolDef + sync/async exec ([#1284](https://github.com/everruns/bashkit/pull/1284)) by @chaliy
+* feat(credential): generic credential injection for outbound HTTP requests ([#1282](https://github.com/everruns/bashkit/pull/1282)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/commits/v0.1.19
+
 ## [0.1.18] - 2026-04-14
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "bashkit",
  "napi",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -4607,9 +4607,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5321,7 +5321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1731,7 +1731,7 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
-version = "0.103.10"
+version = "0.103.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustversion]]


### PR DESCRIPTION
## Summary

- bump Bashkit release metadata from `0.1.18` to `0.1.19`
- add the `0.1.19` changelog entry, including explicit external contribution credit for @oliverlambson in #1298
- update `Cargo.lock` to pull `rustls-webpki 0.103.12` so the current cargo-audit failure on `main` is cleared for this release

## Why

- `main` is currently blocked from shipping because the Audit job fails on `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099` in `rustls-webpki 0.103.10`
- the release PR needs that dependency remediation or it inherits the same red CI state and cannot publish

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo audit --ignore RUSTSEC-2023-0071`
- `cargo deny check`
- `cargo run -p bashkit-cli -- --version`

## Notes

- `cargo test --all-features` still hits the existing `bash_comparison_tests` parity mismatch set already present on `main` (114 mismatches), unchanged by this branch