### PR TITLE
fix(ci): harden crates publish verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,19 +117,4 @@ jobs:
         run: |
           EXPECTED=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           echo "Expected version: $EXPECTED"
-          PASS=true
-
-          for CRATE in bashkit bashkit-cli; do
-            ACTUAL=$(curl -s "https://crates.io/api/v1/crates/$CRATE" | python3 -c "import sys,json; print(json.load(sys.stdin)['crate']['max_version'])")
-            if [ "$ACTUAL" = "$EXPECTED" ]; then
-              echo "✓ $CRATE@$ACTUAL on crates.io"
-            else
-              echo "✗ $CRATE: expected $EXPECTED, got $ACTUAL"
-              PASS=false
-            fi
-          done
-
-          if [ "$PASS" = "false" ]; then
-            echo "::error::Some crates.io packages were not published correctly"
-            exit 1
-          fi
+          python3 scripts/verify_crates_publish.py --expected "$EXPECTED" bashkit bashkit-cli

--- a/scripts/tests/test_verify_crates_publish.py
+++ b/scripts/tests/test_verify_crates_publish.py
@@ -1,0 +1,72 @@
+"""Lock the verifier to retry on transient crates.io error payloads."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from verify_crates_publish import (  # noqa: E402
+    HttpResponse,
+    RegistryResponseError,
+    extract_max_version,
+    fetch_max_version_with_retries,
+)
+
+
+class VerifyCratesPublishTests(unittest.TestCase):
+    def test_extract_max_version_reads_success_payload(self) -> None:
+        version = extract_max_version(
+            "bashkit",
+            HttpResponse(
+                status=200,
+                body=b'{"crate":{"id":"bashkit","max_version":"0.1.19"}}',
+            ),
+        )
+        self.assertEqual(version, "0.1.19")
+
+    def test_retry_succeeds_after_transient_error_payload(self) -> None:
+        responses = iter(
+            [
+                HttpResponse(
+                    status=200,
+                    body=b'{"errors":[{"detail":"crate metadata not ready"}]}',
+                ),
+                HttpResponse(
+                    status=200,
+                    body=b'{"crate":{"id":"bashkit","max_version":"0.1.19"}}',
+                ),
+            ]
+        )
+
+        version = fetch_max_version_with_retries(
+            crate="bashkit",
+            attempts=2,
+            delay_seconds=0,
+            timeout_seconds=1,
+            fetcher=lambda crate, timeout: next(responses),
+        )
+
+        self.assertEqual(version, "0.1.19")
+
+    def test_retry_failure_reports_last_payload_shape(self) -> None:
+        with self.assertRaises(RegistryResponseError) as error:
+            fetch_max_version_with_retries(
+                crate="bashkit",
+                attempts=2,
+                delay_seconds=0,
+                timeout_seconds=1,
+                fetcher=lambda crate, timeout: HttpResponse(
+                    status=200,
+                    body=b'{"errors":[{"detail":"still propagating"}]}',
+                ),
+            )
+
+        self.assertIn("missing 'crate' object", str(error.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_crates_publish.py
+++ b/scripts/verify_crates_publish.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Retry on crates.io API payloads that temporarily lack crate metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Callable
+
+
+USER_AGENT = "bashkit-publish-verifier/1.0"
+
+
+class RegistryResponseError(RuntimeError):
+    """crates.io answered, but not with the shape we need yet."""
+
+
+@dataclass
+class HttpResponse:
+    status: int
+    body: bytes
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify crates.io publishes are visible at the expected version."
+    )
+    parser.add_argument("--expected", required=True, help="Expected published version")
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=6,
+        help="Number of fetch attempts per crate after the initial workflow delay",
+    )
+    parser.add_argument(
+        "--delay-seconds",
+        type=float,
+        default=10.0,
+        help="Delay between retry attempts",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=30.0,
+        help="HTTP timeout per request",
+    )
+    parser.add_argument("crates", nargs="+", help="Crate names to verify")
+    return parser.parse_args()
+
+
+def fetch_response(crate: str, timeout_seconds: float) -> HttpResponse:
+    request = urllib.request.Request(
+        f"https://crates.io/api/v1/crates/{crate}",
+        headers={"User-Agent": USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            return HttpResponse(status=response.status, body=response.read())
+    except urllib.error.HTTPError as error:
+        return HttpResponse(status=error.code, body=error.read())
+
+
+def extract_max_version(crate: str, response: HttpResponse) -> str:
+    try:
+        payload = json.loads(response.body)
+    except json.JSONDecodeError as error:
+        raise RegistryResponseError(
+            f"{crate}: crates.io returned invalid JSON (status {response.status}): {error}"
+        ) from error
+
+    crate_data = payload.get("crate")
+    if response.status != 200:
+        detail = summarize_error_payload(payload)
+        raise RegistryResponseError(
+            f"{crate}: crates.io returned HTTP {response.status}: {detail}"
+        )
+    if not isinstance(crate_data, dict):
+        detail = summarize_error_payload(payload)
+        raise RegistryResponseError(
+            f"{crate}: crates.io payload missing 'crate' object: {detail}"
+        )
+    max_version = crate_data.get("max_version")
+    if not isinstance(max_version, str) or not max_version:
+        raise RegistryResponseError(
+            f"{crate}: crates.io payload missing 'crate.max_version'"
+        )
+    return max_version
+
+
+def summarize_error_payload(payload: object) -> str:
+    if isinstance(payload, dict):
+        errors = payload.get("errors")
+        if isinstance(errors, list) and errors:
+            details = [
+                error.get("detail", str(error))
+                for error in errors
+                if isinstance(error, dict)
+            ]
+            if details:
+                return "; ".join(details)
+        return json.dumps(payload, sort_keys=True)[:300]
+    return repr(payload)[:300]
+
+
+def fetch_max_version_with_retries(
+    crate: str,
+    attempts: int,
+    delay_seconds: float,
+    timeout_seconds: float,
+    fetcher: Callable[[str, float], HttpResponse] = fetch_response,
+) -> str:
+    last_error: RegistryResponseError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return extract_max_version(crate, fetcher(crate, timeout_seconds))
+        except RegistryResponseError as error:
+            last_error = error
+            if attempt == attempts:
+                break
+            print(
+                f"Retry {attempt}/{attempts - 1} for {crate}: {error}",
+                file=sys.stderr,
+            )
+            time.sleep(delay_seconds)
+
+    assert last_error is not None
+    raise last_error
+
+
+def main() -> int:
+    args = parse_args()
+    all_ok = True
+
+    for crate in args.crates:
+        actual = fetch_max_version_with_retries(
+            crate=crate,
+            attempts=args.attempts,
+            delay_seconds=args.delay_seconds,
+            timeout_seconds=args.timeout_seconds,
+        )
+        if actual == args.expected:
+            print(f"✓ {crate}@{actual} on crates.io")
+        else:
+            print(
+                f"✗ {crate}: expected {args.expected}, got {actual}",
+                file=sys.stderr,
+            )
+            all_ok = False
+
+    if not all_ok:
+        print(
+            "::error::Some crates.io packages were not published correctly",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the inline crates.io verification one-liner with a small Python helper
- retry when crates.io returns a transient error payload or non-200 response instead of assuming `crate.max_version` exists
- add a regression test covering the missing `crate` payload shape that broke the release publish workflow

## Root cause
The publish workflow assumed every crates.io API response had a `crate.max_version` field. During the `v0.1.19` release, crates.io returned a different JSON payload, so the workflow crashed with `KeyError: 'crate'` before it could distinguish propagation delay from a real publish failure.\n\n## Verification\n- python3 -m unittest discover -s scripts/tests -v\n- python3 scripts/verify_crates_publish.py --expected 0.1.19 --attempts 1 bashkit bashkit-cli\n- python3 -m py_compile scripts/verify_crates_publish.py scripts/tests/test_verify_crates_publish.py\n- git diff --check