### PR TITLE
feat(python): add clear_cancel() to Bash and BashTool

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -205,11 +205,17 @@ from bashkit import Bash
 
 bash = Bash()
 
-bash.cancel()  # no-op if nothing is running
-bash.reset()   # reset state before reusing the instance
+bash.cancel()        # abort in-flight execution (no-op if idle)
+bash.clear_cancel()  # clear the sticky flag so subsequent executions work
 ```
 
-`BashTool` exposes the same `cancel()` and `reset()` methods.
+`cancel()` sets a sticky flag that causes every future `execute()` to fail
+immediately with `"execution cancelled"`. Call `clear_cancel()` after the
+cancelled execution finishes to restore the instance for reuse — this
+preserves all VFS state. Use `reset()` only when you want to discard VFS
+and shell state entirely.
+
+`BashTool` exposes the same `cancel()`, `clear_cancel()`, and `reset()` methods.
 
 ## BashTool
 
@@ -314,6 +320,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 - `execute_or_throw(commands: str) -> ExecResult`
 - `execute_sync_or_throw(commands: str) -> ExecResult`
 - `cancel()`
+- `clear_cancel()`
 - `reset()`
 - `snapshot() -> bytes`
 - `restore_snapshot(data: bytes)`
@@ -324,7 +331,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 
 ### BashTool
 
-- All execution, cancellation, reset, snapshot, restore, mount, and direct VFS helpers from `Bash`
+- All execution, cancellation (`cancel()`, `clear_cancel()`), reset, snapshot, restore, mount, and direct VFS helpers from `Bash`
 - Tool metadata: `name`, `short_description`, `version`
 - `description() -> str`
 - `help() -> str`

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -416,6 +416,30 @@ class Bash:
         """
         ...
 
+    def clear_cancel(self) -> None:
+        """Clear the cancellation flag so subsequent executions proceed normally.
+
+        Call this after a ``cancel()`` once the in-flight execution has
+        finished and you want to reuse the same ``Bash`` instance
+        (preserving VFS state). Without this, every future ``execute()``
+        will immediately fail with ``"execution cancelled"``.
+
+        **Note:** Calling this while an execution is still in-flight may
+        allow that execution to continue past the cancellation point.
+        Wait for the cancelled execution to finish before clearing
+        (await the async call or let ``execute_sync`` return).
+
+        Example::
+
+            >>> bash = Bash()
+            >>> bash.cancel()
+            >>> bash.clear_cancel()
+            >>> result = bash.execute_sync("echo ok")
+            >>> result.exit_code
+            0
+        """
+        ...
+
     def reset(self) -> None:
         """Reset interpreter to initial state.
 
@@ -715,6 +739,30 @@ class BashTool:
 
             >>> tool = BashTool()
             >>> tool.cancel()  # no-op if nothing is running
+        """
+        ...
+
+    def clear_cancel(self) -> None:
+        """Clear the cancellation flag so subsequent executions proceed normally.
+
+        Call this after a ``cancel()`` once the in-flight execution has
+        finished and you want to reuse the same ``BashTool`` instance
+        (preserving VFS state). Without this, every future ``execute()``
+        will immediately fail with ``"execution cancelled"``.
+
+        **Note:** Calling this while an execution is still in-flight may
+        allow that execution to continue past the cancellation point.
+        Wait for the cancelled execution to finish before clearing
+        (await the async call or let ``execute_sync`` return).
+
+        Example::
+
+            >>> tool = BashTool()
+            >>> tool.cancel()
+            >>> tool.clear_cancel()
+            >>> result = tool.execute_sync("echo ok")
+            >>> result.exit_code
+            0
         """
         ...
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1444,6 +1444,23 @@ impl PyBash {
         }
     }
 
+    /// Clear the cancellation flag so subsequent executions proceed normally.
+    ///
+    /// Call this after a `cancel()` once the in-flight execution has finished
+    /// and you want to reuse the same `Bash` instance (preserving VFS state).
+    /// Without this, every future `execute()` will immediately fail with
+    /// ``"execution cancelled"``.
+    ///
+    /// **Note:** Calling this while an execution is still in-flight may
+    /// allow that execution to continue past the cancellation point.
+    /// Wait for the cancelled execution to finish before clearing
+    /// (await the async call or let `execute_sync` return).
+    fn clear_cancel(&self) {
+        if let Ok(token) = self.cancelled.read() {
+            token.store(false, Ordering::Relaxed);
+        }
+    }
+
     /// Execute commands asynchronously.
     #[pyo3(signature = (commands, on_output=None))]
     fn execute<'py>(
@@ -1939,6 +1956,23 @@ impl BashTool {
     fn cancel(&self) {
         if let Ok(token) = self.cancelled.read() {
             token.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Clear the cancellation flag so subsequent executions proceed normally.
+    ///
+    /// Call this after a `cancel()` once the in-flight execution has finished
+    /// and you want to reuse the same `BashTool` instance (preserving VFS state).
+    /// Without this, every future `execute()` will immediately fail with
+    /// ``"execution cancelled"``.
+    ///
+    /// **Note:** Calling this while an execution is still in-flight may
+    /// allow that execution to continue past the cancellation point.
+    /// Wait for the cancelled execution to finish before clearing
+    /// (await the async call or let `execute_sync` return).
+    fn clear_cancel(&self) {
+        if let Ok(token) = self.cancelled.read() {
+            token.store(false, Ordering::Relaxed);
         }
     }
 

--- a/crates/bashkit-python/tests/_bashkit_categories.py
+++ b/crates/bashkit-python/tests/_bashkit_categories.py
@@ -1723,3 +1723,97 @@ def test_bashtool_cancel_after_reset_still_works():
     tool.cancel()
     r = tool.execute_sync("echo hi")
     assert r.exit_code != 0 or "cancel" in r.stderr.lower() or "cancel" in (r.error or "").lower()
+
+
+def test_bash_clear_cancel_allows_subsequent_execution():
+    """clear_cancel() after cancel() must allow the next execute to succeed."""
+    bash = Bash()
+    bash.cancel()
+    r = bash.execute_sync("echo should_fail")
+    assert r.exit_code != 0
+
+    bash.clear_cancel()
+    r = bash.execute_sync("echo works_again")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "works_again"
+
+
+def test_bashtool_clear_cancel_allows_subsequent_execution():
+    """BashTool: clear_cancel() after cancel() must allow the next execute to succeed."""
+    tool = BashTool()
+    tool.cancel()
+    r = tool.execute_sync("echo should_fail")
+    assert r.exit_code != 0
+
+    tool.clear_cancel()
+    r = tool.execute_sync("echo works_again")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "works_again"
+
+
+@pytest.mark.asyncio
+async def test_bash_async_clear_cancel_after_cancelled_execute():
+    """Async: cancel() during execute, await it, clear_cancel(), then execute again."""
+    bash = Bash()
+    bash.cancel()
+    r = await bash.execute("echo should_fail")
+    assert r.exit_code != 0
+
+    bash.clear_cancel()
+    r = await bash.execute("echo works_again")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "works_again"
+
+
+@pytest.mark.asyncio
+async def test_bashtool_async_clear_cancel_after_cancelled_execute():
+    """BashTool async: cancel() → await execute → clear_cancel() → execute succeeds."""
+    tool = BashTool()
+    tool.cancel()
+    r = await tool.execute("echo should_fail")
+    assert r.exit_code != 0
+
+    tool.clear_cancel()
+    r = await tool.execute("echo works_again")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "works_again"
+
+
+def test_bash_clear_cancel_on_fresh_instance_is_noop():
+    """clear_cancel() on a never-cancelled instance is a harmless no-op."""
+    bash = Bash()
+    bash.clear_cancel()
+    r = bash.execute_sync("echo ok")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "ok"
+
+
+def test_bashtool_clear_cancel_on_fresh_instance_is_noop():
+    """BashTool: clear_cancel() on a never-cancelled instance is a harmless no-op."""
+    tool = BashTool()
+    tool.clear_cancel()
+    r = tool.execute_sync("echo ok")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "ok"
+
+
+def test_bash_clear_cancel_after_reset_is_noop():
+    """cancel() → reset() orphans the old token; clear_cancel() on the new token is a no-op."""
+    bash = Bash()
+    bash.cancel()
+    bash.reset()
+    bash.clear_cancel()
+    r = bash.execute_sync("echo ok")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "ok"
+
+
+def test_bashtool_clear_cancel_after_reset_is_noop():
+    """BashTool: cancel() → reset() → clear_cancel() is a safe no-op on the new token."""
+    tool = BashTool()
+    tool.cancel()
+    tool.reset()
+    tool.clear_cancel()
+    r = tool.execute_sync("echo ok")
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "ok"

--- a/crates/bashkit-python/tests/test_basic.py
+++ b/crates/bashkit-python/tests/test_basic.py
@@ -54,6 +54,14 @@ _NAMES = (
     "test_bash_cancel_after_reset_still_works",
     "test_bashtool_cancel_then_reset_clears_cancellation",
     "test_bashtool_cancel_after_reset_still_works",
+    "test_bash_clear_cancel_allows_subsequent_execution",
+    "test_bashtool_clear_cancel_allows_subsequent_execution",
+    "test_bash_async_clear_cancel_after_cancelled_execute",
+    "test_bashtool_async_clear_cancel_after_cancelled_execute",
+    "test_bash_clear_cancel_on_fresh_instance_is_noop",
+    "test_bashtool_clear_cancel_on_fresh_instance_is_noop",
+    "test_bash_clear_cancel_after_reset_is_noop",
+    "test_bashtool_clear_cancel_after_reset_is_noop",
 )
 
 globals().update({name: getattr(_categories, name) for name in _NAMES})


### PR DESCRIPTION
## Summary

- `cancel()` sets a sticky `AtomicBool` that persists across `execute()` calls. Callers that cancel in-flight execution currently have no way to reset the flag without calling `reset()`, which destroys VFS state.
- Add `clear_cancel()` to both `Bash` and `BashTool` Python classes so callers can clear the flag after awaiting the cancelled task, preserving the VFS for subsequent executions in the same session.

## Motivation

When embedding bashkit in a long-lived session where multiple code executions share a single `Bash` instance (to preserve VFS state), calling `cancel()` to abort a stuck execution permanently poisons the instance — every subsequent `execute()` immediately returns `"execution cancelled"`. The only recovery today is `reset()`, which rebuilds the interpreter and loses all VFS state. `clear_cancel()` gives callers a lightweight way to restore the instance to a usable state after a cancellation.

## Changes

- **`crates/bashkit-python/src/lib.rs`**: Add `clear_cancel()` method to both `PyBash` and `PyBashTool` — mirrors `cancel()` but stores `false` instead of `true`. Docstrings include a safety note covering both async and sync callers.
- **`crates/bashkit-python/bashkit/_bashkit.pyi`**: Add `clear_cancel()` type stubs for both `Bash` and `BashTool` with full docstrings.
- **`crates/bashkit-python/README.md`**: Updated Cancellation section to document `clear_cancel()` and clarify when to use it vs `reset()`. Added `clear_cancel()` to the API reference for both `Bash` and `BashTool`.
- **`crates/bashkit-python/tests/_bashkit_categories.py`**: Eight new tests:
  - `test_bash_clear_cancel_allows_subsequent_execution` / `test_bashtool_clear_cancel_allows_subsequent_execution` — sync: cancel → clear_cancel → execute works.
  - `test_bash_async_clear_cancel_after_cancelled_execute` / `test_bashtool_async_clear_cancel_after_cancelled_execute` — async: cancel → await execute → clear_cancel → execute works (the intended recovery flow).
  - `test_bash_clear_cancel_on_fresh_instance_is_noop` / `test_bashtool_clear_cancel_on_fresh_instance_is_noop` — clear_cancel on a never-cancelled instance is harmless.
  - `test_bash_clear_cancel_after_reset_is_noop` / `test_bashtool_clear_cancel_after_reset_is_noop` — cancel → reset → clear_cancel is a safe no-op.
- **`crates/bashkit-python/tests/test_basic.py`**: Added all 8 new test names to `_NAMES` tuple for pytest discovery.

## Test plan

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy -p bashkit-python` — no warnings (9 pre-existing dead-code warnings in core crate, unrelated)
- [x] `cargo test --test cancellation_tests -p bashkit` — 5/5 pass
- [x] `ruff check` + `ruff format --check` on `crates/bashkit-python` — pass
- [x] `pytest tests/` — 546 passed, 0 failed (includes 8 new `clear_cancel` tests — sync and async — all discovered via `test_basic.py`)