### PR TITLE
feat(python): add custom_builtins to Bash and BashTool

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -242,6 +242,46 @@ result = tool.execute_sync("echo 'Hello from BashTool'")
 print(result.stdout)
 ```
 
+## Persistent Custom Builtins
+
+Use `custom_builtins={...}` on `Bash` or `BashTool` when you want
+constructor-time Python callback builtins without giving up persistent
+shell/VFS state:
+
+```python
+from bashkit import Bash
+import json
+
+
+def get_order(ctx):
+    if not ctx.argv or ctx.argv[0] in {"help", "--help"}:
+        return "usage: get-order <get|help> [args]\n"
+    if ctx.argv[0] == "get" and len(ctx.argv) >= 2:
+        return json.dumps(
+            {"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}
+        ) + "\n"
+    return "usage: get-order <get|help> [args]\n"
+
+
+bash = Bash(custom_builtins={"get-order": get_order})
+
+bash.execute_sync("mkdir -p /scratch && get-order get 42 > /scratch/order.json")
+result = bash.execute_sync("cat /scratch/order.json | jq -r '.items[]'")
+print(result.stdout)  # widget
+```
+
+Callbacks receive a `BuiltinContext` object with raw `argv` tokens, optional
+pipeline `stdin`, the current `cwd`, and visible `env`, and must return the
+builtin stdout string. Async callbacks are also supported. `BashTool` exposes
+the same `custom_builtins` constructor kwarg and includes registered command
+names in `help()` output for LLM-facing metadata.
+
+When you use `await bash.execute(...)` or `await bash_tool.execute(...)`,
+async callbacks are scheduled back onto the caller's active asyncio loop, so
+loop-bound primitives like `asyncio.Event` and framework-owned clients keep
+working. `execute_sync()` still supports async callbacks, but it drives them on
+an internal private loop and should not be called from an async endpoint.
+
 ## ScriptedTool
 
 Use `ScriptedTool` to register Python callbacks as bash-callable tools:
@@ -291,6 +331,9 @@ assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
 ```
 
 `BashTool` exposes the same `snapshot()`, `restore_snapshot(...)`, and `from_snapshot(...)` APIs.
+Python callback builtins are host-side config, not serialized shell state, so
+pass `custom_builtins=` again when constructing a restored instance if you
+need them after snapshot restore.
 
 ## Framework Integrations
 
@@ -327,6 +370,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 - `cancel()`
 - `clear_cancel()`
 - `reset()`
+- constructor kwarg: `custom_builtins={name: callback}`
 - `snapshot() -> bytes`
 - `restore_snapshot(data: bytes)`
 - `from_snapshot(data: bytes, **kwargs) -> Bash`
@@ -337,6 +381,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 ### BashTool
 
 - All execution, cancellation (`cancel()`, `clear_cancel()`), reset, snapshot, restore, mount, and direct VFS helpers from `Bash`
+- constructor kwarg: `custom_builtins={name: callback}`
 - Tool metadata: `name`, `short_description`, `version`
 - `description() -> str`
 - `help() -> str`

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -266,6 +266,11 @@ result = tool.execute_sync("get_user --id 1 | jq -r '.name'")
 print(result.stdout)  # Alice
 ```
 
+`ScriptedTool` callbacks receive `(params_dict, stdin_or_none)` and must return
+the tool stdout string. Async callbacks are also supported. `await tool.execute(...)`
+runs async callbacks on the caller's active asyncio loop; `execute_sync()` falls
+back to a private loop because there is no caller loop to reuse.
+
 ## Snapshot / Restore
 
 ```python

--- a/crates/bashkit-python/bashkit/__init__.py
+++ b/crates/bashkit-python/bashkit/__init__.py
@@ -47,6 +47,7 @@ from bashkit._bashkit import (
     Bash,
     BashError,
     BashTool,
+    BuiltinContext,
     ExecResult,
     FileSystem,
     ScriptedTool,
@@ -58,6 +59,7 @@ __version__ = "0.1.2"
 __all__ = [
     "Bash",
     "BashError",
+    "BuiltinContext",
     "BashTool",
     "ExecResult",
     "FileSystem",

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -1,6 +1,6 @@
 """Type stubs for bashkit native module."""
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
 # Synchronous chunk callback for live stdout/stderr streaming.
@@ -1011,7 +1011,7 @@ class ScriptedTool:
         self,
         name: str,
         description: str,
-        callback: Callable[[dict[str, Any], str | None], str],
+        callback: Callable[[dict[str, Any], str | None], str | Awaitable[str]],
         schema: dict[str, Any] | None = None,
     ) -> None:
         """Register a Python callback as a bash builtin command.
@@ -1019,7 +1019,10 @@ class ScriptedTool:
         Args:
             name: Command name (becomes a bash builtin).
             description: Human-readable description of the sub-tool.
-            callback: ``(params_dict, stdin_or_none) -> output_string``.
+            callback: ``(params_dict, stdin_or_none) -> output_string`` or
+                an async callback that resolves to one. Async callbacks run on
+                the caller's active asyncio loop for ``await execute()`` and on
+                a private loop for ``execute_sync()``.
             schema: Optional JSON Schema for the tool's parameters.
 
         Example::
@@ -1055,6 +1058,8 @@ class ScriptedTool:
     async def execute(self, commands: str) -> ExecResult:
         """Execute commands asynchronously.
 
+        Async callbacks run on the caller's active asyncio loop.
+
         Example::
 
             >>> tool = ScriptedTool("demo")
@@ -1067,6 +1072,8 @@ class ScriptedTool:
 
     def execute_sync(self, commands: str) -> ExecResult:
         """Execute commands synchronously (blocking).
+
+        Async callbacks run on a private loop here.
 
         Example::
 

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -6,6 +6,25 @@ from typing import Any, Protocol
 # Synchronous chunk callback for live stdout/stderr streaming.
 OutputHandler = Callable[[str, str], None]
 
+class BuiltinContext:
+    """Invocation context for a custom builtin callback.
+
+    Attributes:
+        name: Builtin command name.
+        argv: Raw argv tokens after shell parsing, excluding the command name.
+        stdin: Pipeline input from the previous command, if any.
+        env: Environment variables visible to the builtin.
+        cwd: Current working directory at invocation time.
+    """
+
+    name: str
+    argv: list[str]
+    stdin: str | None
+    env: dict[str, str]
+    cwd: str
+
+BuiltinCallback = Callable[[BuiltinContext], str | Awaitable[str]]
+
 class FileSystem:
     """Direct access to BashKit's virtual filesystem or a standalone mountable FS.
 
@@ -309,6 +328,7 @@ class Bash:
         external_handler: ExternalHandler | None = None,
         files: dict[str, str | Callable[[], str]] | None = None,
         mounts: list[dict[str, Any]] | None = None,
+        custom_builtins: dict[str, BuiltinCallback] | None = None,
     ) -> None:
         """Create a new Bash interpreter.
 
@@ -324,12 +344,19 @@ class Bash:
             external_handler: Async callback for external function calls.
             files: Dict mapping VFS paths to file contents or lazy callables.
             mounts: List of real host directory mount configs.
+            custom_builtins: Constructor-time Python callbacks exposed as
+                bash builtins. Each callback receives a ``BuiltinContext``
+                with raw ``argv`` tokens and optional pipeline ``stdin``,
+                and must return a stdout string or await one. Async callbacks
+                run on the caller's active asyncio loop for ``await execute()``
+                and on a private loop for ``execute_sync()``.
 
         Example::
 
             >>> bash = Bash(
             ...     timeout_seconds=30,
             ...     files={"/input.txt": "some data"},
+            ...     custom_builtins={"ping": lambda ctx: "pong\\n"},
             ... )
         """
         ...
@@ -341,6 +368,9 @@ class Bash:
             commands: Bash script to run (like ``bash -c "commands"``).
             on_output: Optional callback receiving chunked ``(stdout, stderr)``
                 pairs during execution. Must be synchronous.
+
+        Async ``custom_builtins`` callbacks run on the caller's active asyncio
+        loop.
 
         Returns:
             ExecResult with stdout, stderr, exit_code.
@@ -360,6 +390,7 @@ class Bash:
 
         Not supported when ``external_handler`` is configured — use
         ``execute()`` (async) instead. ``on_output`` must be synchronous.
+        Async ``custom_builtins`` callbacks run on a private loop here.
 
         Example::
 
@@ -444,7 +475,8 @@ class Bash:
         """Reset interpreter to initial state.
 
         Clears all VFS contents, environment variables, and shell state.
-        Re-applies the original ``files`` and ``mounts`` configuration.
+        Re-applies the original ``files``, ``mounts``, and
+        ``custom_builtins`` configuration.
 
         Example::
 
@@ -479,6 +511,7 @@ class Bash:
         external_handler: ExternalHandler | None = None,
         files: dict[str, str] | None = None,
         mounts: list[dict[str, Any]] | None = None,
+        custom_builtins: dict[str, BuiltinCallback] | None = None,
     ) -> Bash:
         """Create a new ``Bash`` from snapshot bytes and optional constructor kwargs."""
         ...
@@ -653,6 +686,7 @@ class BashTool:
         timeout_seconds: float | None = None,
         files: dict[str, str | Callable[[], str]] | None = None,
         mounts: list[dict[str, Any]] | None = None,
+        custom_builtins: dict[str, BuiltinCallback] | None = None,
     ) -> None:
         """Create a new BashTool.
 
@@ -665,10 +699,18 @@ class BashTool:
             timeout_seconds: Abort execution after this duration.
             files: Dict mapping VFS paths to file contents or lazy callables.
             mounts: List of real host directory mount configs.
+            custom_builtins: Constructor-time Python callbacks exposed as
+                bash builtins. Each callback receives a ``BuiltinContext``
+                and must return a stdout string or await one. Async callbacks
+                run on the caller's active asyncio loop for ``await execute()``
+                and on a private loop for ``execute_sync()``.
 
         Example::
 
-            >>> tool = BashTool(timeout_seconds=30)
+            >>> tool = BashTool(
+            ...     timeout_seconds=30,
+            ...     custom_builtins={"ping": lambda ctx: "pong\\n"},
+            ... )
             >>> print(tool.name)
             bash
         """
@@ -676,6 +718,9 @@ class BashTool:
 
     async def execute(self, commands: str, on_output: OutputHandler | None = None) -> ExecResult:
         """Execute bash commands asynchronously.
+
+        Async ``custom_builtins`` callbacks run on the caller's active asyncio
+        loop.
 
         ``on_output`` must be synchronous.
 
@@ -690,6 +735,8 @@ class BashTool:
 
     def execute_sync(self, commands: str, on_output: OutputHandler | None = None) -> ExecResult:
         """Execute bash commands synchronously (blocking).
+
+        Async ``custom_builtins`` callbacks run on a private loop here.
 
         ``on_output`` must be synchronous.
 
@@ -833,7 +880,8 @@ class BashTool:
     def reset(self) -> None:
         """Reset the tool to initial state.
 
-        Clears VFS, environment, and shell state.
+        Clears VFS, environment, and shell state while re-applying
+        constructor-time ``custom_builtins``.
 
         Example::
 
@@ -865,6 +913,7 @@ class BashTool:
         timeout_seconds: float | None = None,
         files: dict[str, str] | None = None,
         mounts: list[dict[str, Any]] | None = None,
+        custom_builtins: dict[str, BuiltinCallback] | None = None,
     ) -> BashTool:
         """Create a new ``BashTool`` from snapshot bytes and optional constructor kwargs."""
         ...
@@ -1011,7 +1060,7 @@ class ScriptedTool:
         self,
         name: str,
         description: str,
-        callback: Callable[[dict[str, Any], str | None], str | Awaitable[str]],
+        callback: Callable[[dict[str, Any], str | None], str],
         schema: dict[str, Any] | None = None,
     ) -> None:
         """Register a Python callback as a bash builtin command.

--- a/crates/bashkit-python/examples/bash_basics.py
+++ b/crates/bashkit-python/examples/bash_basics.py
@@ -20,9 +20,10 @@ uv automatically installs bashkit from PyPI (pre-built wheels, no Rust needed).
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 
-from bashkit import Bash
+from bashkit import Bash, BuiltinContext
 
 
 def demo_sync():
@@ -120,6 +121,37 @@ def demo_live_output():
     print()
 
 
+def demo_callback_builtins():
+    """Register Python callbacks as persistent bash builtins."""
+    print("=== Callback Builtins ===\n")
+
+    def order_cli(ctx: BuiltinContext) -> str:
+        help_str = f"usage: {ctx.name} [-h] {{get}} ...\n"
+        if not ctx.argv or ctx.argv[0] in {"help", "--help"}:
+            return help_str
+        if ctx.argv[0] == "get" and len(ctx.argv) >= 2:
+            return json.dumps({"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}) + "\n"
+        return help_str
+
+    bash = Bash(custom_builtins={"order-cli": order_cli})
+
+    bash.execute_sync("mkdir -p /scratch && order-cli get 42 > /scratch/order.json")
+    r = bash.execute_sync("cat /scratch/order.json | jq -r '.items[]'")
+    print(f"item: {r.stdout.strip()}")
+    assert r.stdout.strip() == "widget"
+
+    bash.reset()
+    r = bash.execute_sync("order-cli get 7 | jq -r '.status'")
+    print(f"reset: {r.stdout.strip()}")
+    assert r.stdout.strip() == "shipped"
+
+    r = bash.execute_sync("order-cli --help")
+    print(r.stdout.strip())
+    assert r.stdout.strip() == "usage: order-cli [-h] {get} ..."
+
+    print()
+
+
 def demo_snapshot_restore():
     """Snapshot and restore interpreter state."""
     print("=== Snapshot / Restore ===\n")
@@ -207,6 +239,7 @@ def main():
     print("Bashkit — Bash interface examples\n")
     demo_sync()
     demo_live_output()
+    demo_callback_builtins()
     demo_snapshot_restore()
     asyncio.run(demo_async())
     demo_config()

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -7,25 +7,25 @@
 
 use bashkit::tool::VERSION;
 use bashkit::{
-    Bash, BashTool as RustBashTool, DirEntry as FsDirEntry, ExcType, ExecResult as RustExecResult,
-    ExecutionLimits, ExtFunctionResult, FileSystem, FileSystemExt, FileType as FsFileType,
-    InMemoryFs, Metadata as FsMetadata, MontyException, MontyObject,
-    OutputCallback as RustOutputCallback, OverlayFs, PosixFs, PythonExternalFnHandler,
-    PythonLimits, RealFs, RealFsMode, ScriptedTool as RustScriptedTool, Tool, ToolArgs, ToolDef,
-    ToolRequest, async_trait,
+    Bash, BashTool as RustBashTool, Builtin, BuiltinContext, DirEntry as FsDirEntry, ExcType,
+    ExecResult as RustExecResult, ExecutionExtensions, ExecutionLimits, ExtFunctionResult,
+    FileSystem, FileSystemExt, FileType as FsFileType, InMemoryFs, Metadata as FsMetadata,
+    MontyException, MontyObject, OutputCallback as RustOutputCallback, OverlayFs, PosixFs,
+    PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode, ScriptedTool as RustScriptedTool,
+    Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
 };
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyFloat, PyFrozenSet, PyInt, PyList, PySet, PyTuple};
-use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_async_runtimes::TaskLocals;
+use pyo3_async_runtimes::tokio::future_into_py;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{Mutex, oneshot};
 
 // ============================================================================
 // JSON <-> Python helpers
@@ -205,6 +205,26 @@ fn parse_files(files: Option<&Bound<'_, PyDict>>) -> PyResult<Vec<PyFileMount>> 
         )));
     }
     Ok(mounts)
+}
+
+fn parse_custom_builtins(
+    py: Python<'_>,
+    custom_builtins: Option<&Bound<'_, PyDict>>,
+) -> PyResult<Vec<PyCustomBuiltinEntry>> {
+    let Some(dict) = custom_builtins else {
+        return Ok(Vec::new());
+    };
+
+    let mut builtins = Vec::with_capacity(dict.len());
+    for (name_obj, callback_obj) in dict.iter() {
+        let name: String = name_obj.extract()?;
+        builtins.push(build_py_custom_builtin_entry(
+            py,
+            name,
+            callback_obj.unbind(),
+        )?);
+    }
+    Ok(builtins)
 }
 
 fn clone_file_mounts(py: Python<'_>, mounts: &[PyFileMount]) -> Vec<PyFileMount> {
@@ -1093,6 +1113,17 @@ fn is_coroutine_callable(py: Python<'_>, callable: &Bound<'_, PyAny>) -> PyResul
             .unwrap_or(false))
 }
 
+fn validate_python_callback(
+    py: Python<'_>,
+    callable: &Bound<'_, PyAny>,
+    callable_error: impl FnOnce() -> String,
+) -> PyResult<bool> {
+    if !callable.is_callable() {
+        return Err(PyTypeError::new_err(callable_error()));
+    }
+    is_coroutine_callable(py, callable)
+}
+
 fn prepare_output_handler(
     py: Python<'_>,
     on_output: Option<Py<PyAny>>,
@@ -1120,1217 +1151,78 @@ fn prepare_output_handler(
     }))
 }
 
-fn take_output_handler_error(callback_error: &StdMutex<Option<PyErr>>) -> Option<PyErr> {
-    callback_error
-        .lock()
-        .ok()
-        .and_then(|mut callback_error| callback_error.take())
-}
-
-fn close_awaitable_if_possible(awaitable: &Bound<'_, PyAny>) {
-    if let Ok(close) = awaitable.getattr("close") {
-        let _ = close.call0();
-    }
-}
-
-fn build_python_output_callback(
-    on_output: PyOutputHandler,
-    cancelled: Arc<AtomicBool>,
-    callback_requested_cancel: Arc<AtomicBool>,
-    callback_error: Arc<StdMutex<Option<PyErr>>>,
-) -> RustOutputCallback {
-    Box::new(move |stdout_chunk, stderr_chunk| {
-        let has_error = callback_error
-            .lock()
-            .map(|callback_error| callback_error.is_some())
-            .unwrap_or(false);
-        if has_error {
-            return;
-        }
-
-        let callback_result = Python::attach(|py| {
-            // Re-enter the caller's copied ContextVar snapshot for each chunk.
-            let result = on_output.context.bind(py).call_method1(
-                "run",
-                (on_output.callback.bind(py), stdout_chunk, stderr_chunk),
-            )?;
-            let is_awaitable = on_output
-                .is_awaitable
-                .bind(py)
-                .call1((&result,))?
-                .extract::<bool>()?;
-            if is_awaitable {
-                close_awaitable_if_possible(&result);
-                return Err(PyTypeError::new_err(
-                    "on_output must be synchronous and must not return an awaitable",
-                ));
-            }
-            Ok(())
-        });
-
-        if let Err(err) = callback_result {
-            if let Ok(mut callback_error) = callback_error.lock()
-                && callback_error.is_none()
-            {
-                *callback_error = Some(err);
-            }
-            if !cancelled.swap(true, Ordering::Relaxed) {
-                callback_requested_cancel.store(true, Ordering::Relaxed);
-            }
-        }
-    })
-}
-
-async fn exec_bash_with_optional_output(
-    bash: &mut Bash,
-    commands: &str,
-    on_output: Option<PyOutputHandler>,
-) -> PyResult<ExecResult> {
-    let result = if let Some(on_output) = on_output {
-        // Preserve explicit cancel() calls across execute* entry. Only clear
-        // cancellation if an on_output failure introduced it for this call.
-        let cancelled = bash.cancellation_token();
-        let callback_requested_cancel = Arc::new(AtomicBool::new(false));
-        let callback_error = Arc::new(StdMutex::new(None));
-        let output_callback = build_python_output_callback(
-            on_output,
-            cancelled.clone(),
-            callback_requested_cancel.clone(),
-            callback_error.clone(),
-        );
-        let result = bash.exec_streaming(commands, output_callback).await;
-        if let Some(err) = take_output_handler_error(&callback_error) {
-            if callback_requested_cancel.load(Ordering::Relaxed) {
-                cancelled.store(false, Ordering::Relaxed);
-            }
-            return Err(err);
-        }
-        result
-    } else {
-        bash.exec(commands).await
-    };
-
-    Ok(py_exec_result_from_bash_result(result))
-}
-
-/// Build a `PythonExternalFnHandler` from a Python async callable.
+// Decision: `custom_builtins` mirror Rust builtin semantics with a shell-first
+// context object (`argv`, `stdin`, `env`, `cwd`); `ScriptedTool` remains
+// schema-first and continues to pass `(params, stdin)`.
+//
+// Deliberately omitted for now: live `fs`, mutable shell variables, mutable
+// `cwd`, and feature-gated network/git/ssh clients from Rust `BuiltinContext`.
+// Those are reasonable follow-ups, but this PR keeps the Python surface small
+// and shell-first while we validate the core callback shape.
+/// Execution context passed to Python-backed custom builtins.
 ///
-/// The handler converts MontyObject args/kwargs to Python objects, calls the
-/// async handler coroutine, awaits it, and converts the result back.
-fn make_external_handler(py_handler: Py<PyAny>) -> PythonExternalFnHandler {
-    Arc::new(move |fn_name, args, kwargs| {
-        let py_handler = Python::attach(|py| py_handler.clone_ref(py));
-        Box::pin(async move {
-            let fut = Python::attach(|py| {
-                let py_args = args
-                    .iter()
-                    .map(|o| monty_to_py(py, o))
-                    .collect::<PyResult<Vec<_>>>()?;
-                let py_args_list = PyList::new(py, &py_args)?;
-                let py_kwargs = PyDict::new(py);
-                for (k, v) in &kwargs {
-                    py_kwargs.set_item(monty_to_py(py, k)?, monty_to_py(py, v)?)?;
-                }
-                let coro = py_handler.call1(py, (fn_name, py_args_list, py_kwargs))?;
-                pyo3_async_runtimes::tokio::into_future(coro.into_bound(py))
-            });
-            match fut {
-                Err(e) => ExtFunctionResult::Error(MontyException::new(
-                    ExcType::RuntimeError,
-                    Some(e.to_string()),
-                )),
-                Ok(awaitable) => match awaitable.await {
-                    Err(e) => ExtFunctionResult::Error(MontyException::new(
-                        ExcType::RuntimeError,
-                        Some(e.to_string()),
-                    )),
-                    Ok(py_result) => {
-                        Python::attach(|py| match py_to_monty(py, py_result.bind(py)) {
-                            Ok(v) => ExtFunctionResult::Return(v),
-                            Err(e) => ExtFunctionResult::Error(MontyException::new(
-                                ExcType::RuntimeError,
-                                Some(e.to_string()),
-                            )),
-                        })
-                    }
-                },
-            }
-        })
-    })
-}
-
-/// Apply python/external_handler configuration to a `BashBuilder`.
-///
-/// Centralises the logic shared between `new()` and `reset()`.
-fn apply_python_config(
-    mut builder: bashkit::BashBuilder,
-    python: bool,
-    fn_names: Vec<String>,
-    handler: Option<Py<PyAny>>,
-) -> bashkit::BashBuilder {
-    // By construction, handler.is_some() implies python=true (validated in new()).
-    match (python, handler) {
-        (true, Some(h)) => {
-            builder = builder.python_with_external_handler(
-                PythonLimits::default(),
-                fn_names,
-                make_external_handler(h),
-            );
-        }
-        (true, None) => {
-            builder = builder.python();
-        }
-        (false, _) => {}
-    }
-    builder
-}
-
-/// Core bash interpreter with virtual filesystem.
-///
-/// State persists between calls — files created in one `execute()` are
-/// available in subsequent calls. This is the primary interface.
-///
-/// Example:
-///     ```python
-///     from bashkit import Bash
-///
-///     bash = Bash()
-///     result = await bash.execute("echo 'Hello, World!'")
-///     print(result.stdout)  # Hello, World!
-///     ```
-#[pyclass(name = "Bash")]
-#[allow(dead_code)]
-pub struct PyBash {
-    inner: Arc<Mutex<Bash>>,
-    /// Shared tokio runtime — reused across all sync calls to avoid
-    /// per-call OS thread/fd exhaustion (issue #414).
-    rt: Arc<Runtime>,
-    /// Cancellation token. Wrapped in RwLock so reset() can swap it to
-    /// the new interpreter's token without requiring &mut self.
-    cancelled: Arc<RwLock<Arc<AtomicBool>>>,
-    username: Option<String>,
-    hostname: Option<String>,
-    /// Whether Monty Python execution is enabled (`python`/`python3` builtins).
-    python: bool,
-    /// External function names callable from Monty code via the handler.
-    external_functions: Vec<String>,
-    /// Async Python callable invoked when Monty calls an external function.
-    external_handler: Option<Py<PyAny>>,
-    files: Vec<PyFileMount>,
-    real_mounts: Vec<RealMountConfig>,
-    max_commands: Option<u64>,
-    max_loop_iterations: Option<u64>,
-    max_memory: Option<u64>,
-    timeout_seconds: Option<f64>,
+/// Fields are snapshots of the shell state at invocation time.
+#[pyclass(name = "BuiltinContext", skip_from_py_object)]
+struct PyBuiltinContext {
+    #[pyo3(get)]
+    name: String,
+    #[pyo3(get)]
+    argv: Vec<String>,
+    #[pyo3(get)]
+    stdin: Option<String>,
+    #[pyo3(get)]
+    env: std::collections::HashMap<String, String>,
+    #[pyo3(get)]
+    cwd: String,
 }
 
 #[pymethods]
-impl PyBash {
-    #[new]
-    #[pyo3(signature = (
-        username=None,
-        hostname=None,
-        max_commands=None,
-        max_loop_iterations=None,
-        max_memory=None,
-        timeout_seconds=None,
-        python=false,
-        external_functions=None,
-        external_handler=None,
-        files=None,
-        mounts=None,
-    ))]
-    #[allow(clippy::too_many_arguments)]
-    fn new(
-        py: Python<'_>,
-        username: Option<String>,
-        hostname: Option<String>,
-        max_commands: Option<u64>,
-        max_loop_iterations: Option<u64>,
-        max_memory: Option<u64>,
-        timeout_seconds: Option<f64>,
-        python: bool,
-        external_functions: Option<Vec<String>>,
-        external_handler: Option<Py<PyAny>>,
-        files: Option<&Bound<'_, PyDict>>,
-        mounts: Option<&Bound<'_, PyList>>,
-    ) -> PyResult<Self> {
-        let mut builder = Bash::builder();
-
-        if let Some(ref u) = username {
-            builder = builder.username(u);
-        }
-        if let Some(ref h) = hostname {
-            builder = builder.hostname(h);
-        }
-
-        let mut limits = ExecutionLimits::new();
-        if let Some(mc) = max_commands {
-            limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
-        }
-        if let Some(mli) = max_loop_iterations {
-            limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
-        }
-        if let Some(ts) = timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
-        }
-        builder = builder.limits(limits);
-
-        if let Some(mm) = max_memory {
-            builder = builder.max_memory(usize::try_from(mm).unwrap_or(usize::MAX));
-        }
-
-        let files = parse_files(files)?;
-        let real_mounts = parse_mounts(mounts)?;
-
-        let fn_names = external_functions.clone().unwrap_or_default();
-        if !fn_names.is_empty() && external_handler.is_none() {
-            return Err(PyValueError::new_err(
-                "external_functions requires external_handler — the list has no effect without a handler",
-            ));
-        }
-        if external_handler.is_some() && !python {
-            return Err(PyValueError::new_err(
-                "external_handler requires python=True",
-            ));
-        }
-        if external_handler
-            .as_ref()
-            .is_some_and(|h| !h.bind(py).is_callable())
-        {
-            return Err(PyValueError::new_err("external_handler must be callable"));
-        }
-        if let Some(ref handler) = external_handler {
-            let bound = handler.bind(py);
-            if !is_coroutine_callable(py, bound)? {
-                return Err(PyValueError::new_err(
-                    "external_handler must be an async callable (coroutine function)",
-                ));
-            }
-        }
-        let handler_for_build = external_handler.as_ref().map(|h| h.clone_ref(py));
-        builder = apply_python_config(builder, python, fn_names, handler_for_build);
-        builder = apply_fs_config(builder, &files, &real_mounts)?;
-
-        let bash = builder.build();
-        let cancelled = Arc::new(RwLock::new(bash.cancellation_token()));
-
-        let rt = make_runtime()?;
-
-        Ok(Self {
-            inner: Arc::new(Mutex::new(bash)),
-            rt,
-            cancelled,
-            username,
-            hostname,
-            python,
-            external_functions: external_functions.unwrap_or_default(),
-            external_handler,
-            files,
-            real_mounts,
-            max_commands,
-            max_loop_iterations,
-            max_memory,
-            timeout_seconds,
-        })
-    }
-
-    /// Cancel the currently running execution.
-    ///
-    /// Safe to call from any thread. Execution will abort at the next
-    /// command boundary.
-    fn cancel(&self) {
-        if let Ok(token) = self.cancelled.read() {
-            token.store(true, Ordering::Relaxed);
-        }
-    }
-
-    /// Clear the cancellation flag so subsequent executions proceed normally.
-    ///
-    /// Call this after a `cancel()` once the in-flight execution has finished
-    /// and you want to reuse the same `Bash` instance (preserving VFS state).
-    /// Without this, every future `execute()` will immediately fail with
-    /// ``"execution cancelled"``.
-    ///
-    /// **Note:** Calling this while an execution is still in-flight may
-    /// allow that execution to continue past the cancellation point.
-    /// Wait for the cancelled execution to finish before clearing
-    /// (await the async call or let `execute_sync` return).
-    fn clear_cancel(&self) {
-        if let Ok(token) = self.cancelled.read() {
-            token.store(false, Ordering::Relaxed);
-        }
-    }
-
-    /// Execute commands asynchronously.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute<'py>(
-        &self,
-        py: Python<'py>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let on_output = prepare_output_handler(py, on_output)?;
-        let inner = self.inner.clone();
-        future_into_py(py, async move {
-            let mut bash = inner.lock().await;
-            exec_bash_with_optional_output(&mut bash, &commands, on_output).await
-        })
-    }
-
-    /// Execute commands synchronously (blocking).
-    ///
-    /// Not supported when `external_handler` is configured: the handler is an async
-    /// Python coroutine that requires a running event loop, which is unavailable in
-    /// sync context. Use `execute()` (async) instead.
-    ///
-    /// Releases GIL before blocking on tokio to prevent deadlock with callbacks.
-    ///
-    /// # Thread safety
-    ///
-    /// This method acquires an async mutex with a 30-second timeout to prevent
-    /// deadlocks when multiple threads call `execute_sync()` concurrently on the
-    /// same `Bash` instance. If the lock cannot be acquired within the timeout,
-    /// a `RuntimeError` is raised. For concurrent workloads, use separate `Bash`
-    /// instances per thread or use the async `execute()` method.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute_sync(
-        &self,
-        py: Python<'_>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<ExecResult> {
-        if self.external_handler.is_some() {
-            return Err(PyRuntimeError::new_err(
-                "execute_sync is not supported when external_handler is configured — use execute() (async) instead, e.g. asyncio.run(bash.execute(...))",
-            ));
-        }
-        let on_output = prepare_output_handler(py, on_output)?;
-        let inner = self.inner.clone();
-
-        py.detach(|| {
-            self.rt.block_on(async move {
-                // THREAT[TM-DOS-FFI]: Use timeout on mutex acquisition to prevent
-                // deadlocks when multiple Python threads call execute_sync concurrently.
-                let mut bash =
-                    match tokio::time::timeout(std::time::Duration::from_secs(30), inner.lock())
-                        .await
-                    {
-                        Ok(guard) => guard,
-                        Err(_) => {
-                            return Err(PyRuntimeError::new_err(
-                                "execute_sync: timed out waiting for lock (30s). \
-                             Another thread may be holding the interpreter. \
-                             Use separate Bash instances for concurrent access.",
-                            ));
-                        }
-                    };
-                exec_bash_with_optional_output(&mut bash, &commands, on_output).await
-            })
-        })
-    }
-
-    /// Execute commands synchronously. Raises `BashError` on non-zero exit.
-    ///
-    /// Not supported when `external_handler` is configured.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute_sync_or_throw(
-        &self,
-        py: Python<'_>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<ExecResult> {
-        let result = self.execute_sync(py, commands, on_output)?;
-        if result.exit_code != 0 {
-            return Err(raise_bash_error(&result));
-        }
-        Ok(result)
-    }
-
-    /// Execute commands asynchronously. Raises `BashError` on non-zero exit.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute_or_throw<'py>(
-        &self,
-        py: Python<'py>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let on_output = prepare_output_handler(py, on_output)?;
-        let inner = self.inner.clone();
-        future_into_py(py, async move {
-            let mut bash = inner.lock().await;
-            let result = exec_bash_with_optional_output(&mut bash, &commands, on_output).await?;
-            if result.exit_code != 0 {
-                return Err(raise_bash_error(&result));
-            }
-            Ok(result)
-        })
-    }
-
-    /// Reset interpreter to fresh state, preserving all configuration including
-    /// python mode and external function handler.
-    /// Releases GIL before blocking on tokio to prevent deadlock.
-    fn reset(&self, py: Python<'_>) -> PyResult<()> {
-        let inner = self.inner.clone();
-        // THREAT[TM-PY-026]: Rebuild with same config to preserve DoS protections.
-        let username = self.username.clone();
-        let hostname = self.hostname.clone();
-        let max_commands = self.max_commands;
-        let max_loop_iterations = self.max_loop_iterations;
-        let max_memory = self.max_memory;
-        let timeout_seconds = self.timeout_seconds;
-        let python = self.python;
-        let external_functions = self.external_functions.clone();
-        let files = clone_file_mounts(py, &self.files);
-        let real_mounts = self.real_mounts.clone();
-        // Clone handler ref while still holding the GIL (before py.detach).
-        let handler_clone = self.external_handler.as_ref().map(|h| h.clone_ref(py));
-        let cancelled = self.cancelled.clone();
-
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let mut bash = inner.lock().await;
-                let mut builder = Bash::builder();
-                if let Some(ref u) = username {
-                    builder = builder.username(u);
-                }
-                if let Some(ref h) = hostname {
-                    builder = builder.hostname(h);
-                }
-                let mut limits = ExecutionLimits::new();
-                if let Some(mc) = max_commands {
-                    limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
-                }
-                if let Some(mli) = max_loop_iterations {
-                    limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
-                }
-                if let Some(ts) = timeout_seconds {
-                    limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
-                }
-                builder = builder.limits(limits);
-                if let Some(mm) = max_memory {
-                    builder = builder.max_memory(usize::try_from(mm).unwrap_or(usize::MAX));
-                }
-                builder = apply_python_config(builder, python, external_functions, handler_clone);
-                builder = apply_fs_config(builder, &files, &real_mounts)?;
-                *bash = builder.build();
-                // Swap the cancellation token to the new interpreter's token so
-                // cancel() targets the current (not stale) interpreter.
-                if let Ok(mut token) = cancelled.write() {
-                    *token = bash.cancellation_token();
-                }
-                Ok(())
-            })
-        })
-    }
-
-    /// Serialize interpreter state to bytes for checkpoint/restore flows.
-    fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = snapshot_live_bash(py, &self.rt, &self.inner)?;
-        Ok(PyBytes::new(py, &bytes))
-    }
-
-    /// Restore interpreter state from bytes previously produced by `snapshot()`.
-    fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
-        restore_live_bash(py, &self.rt, &self.inner, data)
-    }
-
-    /// Create a new Bash instance from a snapshot and optional constructor kwargs.
-    #[staticmethod]
-    #[pyo3(signature = (
-        data,
-        username=None,
-        hostname=None,
-        max_commands=None,
-        max_loop_iterations=None,
-        max_memory=None,
-        timeout_seconds=None,
-        python=false,
-        external_functions=None,
-        external_handler=None,
-        files=None,
-        mounts=None,
-    ))]
-    #[allow(clippy::too_many_arguments)]
-    fn from_snapshot(
-        py: Python<'_>,
-        data: Vec<u8>,
-        username: Option<String>,
-        hostname: Option<String>,
-        max_commands: Option<u64>,
-        max_loop_iterations: Option<u64>,
-        max_memory: Option<u64>,
-        timeout_seconds: Option<f64>,
-        python: bool,
-        external_functions: Option<Vec<String>>,
-        external_handler: Option<Py<PyAny>>,
-        files: Option<&Bound<'_, PyDict>>,
-        mounts: Option<&Bound<'_, PyList>>,
-    ) -> PyResult<Self> {
-        let bash = Self::new(
-            py,
-            username,
-            hostname,
-            max_commands,
-            max_loop_iterations,
-            max_memory,
-            timeout_seconds,
-            python,
-            external_functions,
-            external_handler,
-            files,
-            mounts,
-        )?;
-        bash.restore_snapshot(py, data)?;
-        Ok(bash)
-    }
-
-    fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
-        py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
-    }
-
-    fn write_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
-        py.detach(|| write_text_via_live_fs(&self.rt, &self.inner, path, content))
-    }
-
-    fn append_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
-        py.detach(|| append_text_via_live_fs(&self.rt, &self.inner, path, content))
-    }
-
-    #[pyo3(signature = (path, recursive=false))]
-    fn mkdir(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
-        py.detach(|| mkdir_via_live_fs(&self.rt, &self.inner, path, recursive))
-    }
-
-    fn exists(&self, py: Python<'_>, path: String) -> PyResult<bool> {
-        py.detach(|| exists_via_live_fs(&self.rt, &self.inner, path))
-    }
-
-    #[pyo3(signature = (path, recursive=false))]
-    fn remove(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
-        py.detach(|| remove_via_live_fs(&self.rt, &self.inner, path, recursive))
-    }
-
-    fn stat(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
-        let metadata = py.detach(|| stat_via_live_fs(&self.rt, &self.inner, path))?;
-        metadata_to_pydict(py, &metadata)
-    }
-
-    fn chmod(&self, py: Python<'_>, path: String, mode: u32) -> PyResult<()> {
-        py.detach(|| chmod_via_live_fs(&self.rt, &self.inner, path, mode))
-    }
-
-    fn symlink(&self, py: Python<'_>, target: String, link: String) -> PyResult<()> {
-        py.detach(|| symlink_via_live_fs(&self.rt, &self.inner, target, link))
-    }
-
-    fn read_link(&self, py: Python<'_>, path: String) -> PyResult<String> {
-        py.detach(|| read_link_via_live_fs(&self.rt, &self.inner, path))
-    }
-
-    fn read_dir(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
-        let entries = py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path))?;
-        let items: Vec<Py<PyAny>> = entries
-            .iter()
-            .map(|entry| dir_entry_to_pydict(py, entry))
-            .collect::<PyResult<_>>()?;
-        Ok(PyList::new(py, &items)?.into_any().unbind())
-    }
-
-    #[pyo3(signature = (path=".".to_string()))]
-    fn ls(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
-        let names = match py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path)) {
-            Ok(entries) => entries
-                .into_iter()
-                .map(|entry| entry.name)
-                .collect::<Vec<_>>(),
-            Err(_) => Vec::new(),
-        };
-        Ok(PyList::new(py, names)?.into_any().unbind())
-    }
-
-    fn glob(&self, py: Python<'_>, pattern: String) -> PyResult<Py<PyAny>> {
-        let matches = py.detach(|| -> PyResult<Vec<String>> {
-            Ok(glob_via_bash(&self.rt, &self.inner, pattern))
-        })?;
-        Ok(PyList::new(py, matches)?.into_any().unbind())
-    }
-
-    /// Return a live filesystem handle backed by the current interpreter.
-    ///
-    /// Each operation on the returned handle acquires the interpreter lock,
-    /// so it always reflects the latest state (including post-reset). For
-    /// batch reads where consistency isn't needed, prefer reading files via
-    /// `execute_sync("cat ...")`.
-    fn fs(&self, py: Python<'_>) -> PyResult<Py<PyFileSystem>> {
-        Py::new(
-            py,
-            PyFileSystem::from_live(self.inner.clone(), self.rt.clone()),
-        )
-    }
-
-    /// Mount a filesystem at `vfs_path` without rebuilding the interpreter.
-    fn mount(&self, py: Python<'_>, vfs_path: String, fs: PyRef<'_, PyFileSystem>) -> PyResult<()> {
-        let inner = self.inner.clone();
-        let source = fs.inner.clone();
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let mounted_fs = source.resolve().await;
-                let bash = inner.lock().await;
-                bash.mount(Path::new(&vfs_path), mounted_fs)
-                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
-            })
-        })
-    }
-
-    /// Unmount a live filesystem without rebuilding the interpreter.
-    fn unmount(&self, py: Python<'_>, vfs_path: String) -> PyResult<()> {
-        let inner = self.inner.clone();
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let bash = inner.lock().await;
-                bash.unmount(Path::new(&vfs_path))
-                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
-            })
-        })
-    }
-
+impl PyBuiltinContext {
     fn __repr__(&self) -> String {
         format!(
-            "Bash(username={:?}, hostname={:?})",
-            self.username.as_deref().unwrap_or("user"),
-            self.hostname.as_deref().unwrap_or("sandbox")
+            "BuiltinContext(name={:?}, argv={:?}, stdin={:?}, cwd={:?})",
+            self.name, self.argv, self.stdin, self.cwd
         )
     }
 }
 
-// ============================================================================
-// BashTool — interpreter + tool-contract metadata
-// ============================================================================
-
-/// Bash interpreter with tool-contract metadata (`description`, `help`,
-/// `system_prompt`, schemas).
-///
-/// Extends `Bash` with methods required by LLM tool-use protocols.
-/// Use this when integrating with LangChain, PydanticAI, or similar frameworks.
-///
-/// Example:
-///     ```python
-///     from bashkit import BashTool
-///
-///     tool = BashTool()
-///     print(tool.input_schema())  # JSON schema for LLM
-///     result = await tool.execute("echo 'Hello!'")
-///     ```
-/// with a virtual filesystem. State persists between calls - files created
-/// in one call are available in subsequent calls.
-///
-/// Example:
-///     ```python
-///     from bashkit import BashTool
-///
-///     tool = BashTool()
-///     result = await tool.execute("echo 'Hello, World!'")
-///     print(result.stdout)  # Hello, World!
-///     ```
-#[pyclass]
-#[allow(dead_code)]
-pub struct BashTool {
-    inner: Arc<Mutex<Bash>>,
-    /// Shared tokio runtime — reused across all sync calls to avoid
-    /// per-call OS thread/fd exhaustion (issue #414).
-    rt: Arc<Runtime>,
-    /// Cancellation token. Wrapped in RwLock so reset() can swap it to
-    /// the new interpreter's token without requiring &mut self.
-    cancelled: Arc<RwLock<Arc<AtomicBool>>>,
-    username: Option<String>,
-    hostname: Option<String>,
-    files: Vec<PyFileMount>,
-    real_mounts: Vec<RealMountConfig>,
-    max_commands: Option<u64>,
-    max_loop_iterations: Option<u64>,
-    max_memory: Option<u64>,
-    timeout_seconds: Option<f64>,
+fn make_py_builtin_context(
+    py: Python<'_>,
+    name: &str,
+    ctx: &BuiltinContext<'_>,
+) -> Result<Py<PyBuiltinContext>, String> {
+    Py::new(
+        py,
+        PyBuiltinContext {
+            name: name.to_string(),
+            argv: ctx.args.to_vec(),
+            stdin: ctx.stdin.map(str::to_owned),
+            env: ctx.env.clone(),
+            cwd: ctx.cwd.to_string_lossy().into_owned(),
+        },
+    )
+    .map_err(|e| e.to_string())
 }
 
-impl BashTool {
-    fn build_rust_tool(&self) -> RustBashTool {
-        let mut builder = RustBashTool::builder();
-
-        if let Some(ref username) = self.username {
-            builder = builder.username(username);
-        }
-        if let Some(ref hostname) = self.hostname {
-            builder = builder.hostname(hostname);
-        }
-
-        let mut limits = ExecutionLimits::new();
-        if let Some(mc) = self.max_commands {
-            limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
-        }
-        if let Some(mli) = self.max_loop_iterations {
-            limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
-        }
-        if let Some(ts) = self.timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
-        }
-
-        builder.limits(limits).build()
-    }
-}
-
-#[pymethods]
-impl BashTool {
-    #[new]
-    #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (
-        username=None,
-        hostname=None,
-        max_commands=None,
-        max_loop_iterations=None,
-        max_memory=None,
-        timeout_seconds=None,
-        files=None,
-        mounts=None,
-    ))]
-    fn new(
-        _py: Python<'_>,
-        username: Option<String>,
-        hostname: Option<String>,
-        max_commands: Option<u64>,
-        max_loop_iterations: Option<u64>,
-        max_memory: Option<u64>,
-        timeout_seconds: Option<f64>,
-        files: Option<&Bound<'_, PyDict>>,
-        mounts: Option<&Bound<'_, PyList>>,
-    ) -> PyResult<Self> {
-        let mut builder = Bash::builder();
-
-        if let Some(ref u) = username {
-            builder = builder.username(u);
-        }
-        if let Some(ref h) = hostname {
-            builder = builder.hostname(h);
-        }
-
-        let mut limits = ExecutionLimits::new();
-        if let Some(mc) = max_commands {
-            limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
-        }
-        if let Some(mli) = max_loop_iterations {
-            limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
-        }
-        if let Some(ts) = timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
-        }
-        builder = builder.limits(limits);
-
-        if let Some(mm) = max_memory {
-            builder = builder.max_memory(usize::try_from(mm).unwrap_or(usize::MAX));
-        }
-
-        let files = parse_files(files)?;
-        let real_mounts = parse_mounts(mounts)?;
-        builder = apply_fs_config(builder, &files, &real_mounts)?;
-
-        let bash = builder.build();
-        let cancelled = Arc::new(RwLock::new(bash.cancellation_token()));
-
-        let rt = make_runtime()?;
-
-        Ok(Self {
-            inner: Arc::new(Mutex::new(bash)),
-            rt,
-            cancelled,
-            username,
-            hostname,
-            files,
-            real_mounts,
-            max_commands,
-            max_loop_iterations,
-            max_memory,
-            timeout_seconds,
-        })
-    }
-
-    /// Cancel the currently running execution.
-    fn cancel(&self) {
-        if let Ok(token) = self.cancelled.read() {
-            token.store(true, Ordering::Relaxed);
-        }
-    }
-
-    /// Clear the cancellation flag so subsequent executions proceed normally.
-    ///
-    /// Call this after a `cancel()` once the in-flight execution has finished
-    /// and you want to reuse the same `BashTool` instance (preserving VFS state).
-    /// Without this, every future `execute()` will immediately fail with
-    /// ``"execution cancelled"``.
-    ///
-    /// **Note:** Calling this while an execution is still in-flight may
-    /// allow that execution to continue past the cancellation point.
-    /// Wait for the cancelled execution to finish before clearing
-    /// (await the async call or let `execute_sync` return).
-    fn clear_cancel(&self) {
-        if let Ok(token) = self.cancelled.read() {
-            token.store(false, Ordering::Relaxed);
-        }
-    }
-
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute<'py>(
-        &self,
-        py: Python<'py>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let on_output = prepare_output_handler(py, on_output)?;
-        let inner = self.inner.clone();
-        future_into_py(py, async move {
-            let mut bash = inner.lock().await;
-            exec_bash_with_optional_output(&mut bash, &commands, on_output).await
-        })
-    }
-
-    /// Releases GIL before blocking on tokio to prevent deadlock with callbacks.
-    ///
-    /// # Thread safety
-    ///
-    /// Acquires async mutex with 30-second timeout. For concurrent workloads,
-    /// use separate `BashTool` instances per thread or the async `execute()`.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute_sync(
-        &self,
-        py: Python<'_>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<ExecResult> {
-        let on_output = prepare_output_handler(py, on_output)?;
-        let inner = self.inner.clone();
-
-        py.detach(|| {
-            self.rt.block_on(async move {
-                // THREAT[TM-DOS-FFI]: Timeout on mutex to prevent deadlock.
-                let mut bash =
-                    match tokio::time::timeout(std::time::Duration::from_secs(30), inner.lock())
-                        .await
-                    {
-                        Ok(guard) => guard,
-                        Err(_) => {
-                            return Err(PyRuntimeError::new_err(
-                                "execute_sync: timed out waiting for lock (30s). \
-                             Another thread may be holding the interpreter. \
-                             Use separate BashTool instances for concurrent access.",
-                            ));
-                        }
-                    };
-                exec_bash_with_optional_output(&mut bash, &commands, on_output).await
-            })
-        })
-    }
-
-    /// Execute commands synchronously. Raises `BashError` on non-zero exit.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute_sync_or_throw(
-        &self,
-        py: Python<'_>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<ExecResult> {
-        let result = self.execute_sync(py, commands, on_output)?;
-        if result.exit_code != 0 {
-            return Err(raise_bash_error(&result));
-        }
-        Ok(result)
-    }
-
-    /// Execute commands asynchronously. Raises `BashError` on non-zero exit.
-    #[pyo3(signature = (commands, on_output=None))]
-    fn execute_or_throw<'py>(
-        &self,
-        py: Python<'py>,
-        commands: String,
-        on_output: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let on_output = prepare_output_handler(py, on_output)?;
-        let inner = self.inner.clone();
-        future_into_py(py, async move {
-            let mut bash = inner.lock().await;
-            let result = exec_bash_with_optional_output(&mut bash, &commands, on_output).await?;
-            if result.exit_code != 0 {
-                return Err(raise_bash_error(&result));
-            }
-            Ok(result)
-        })
-    }
-
-    /// Releases GIL before blocking on tokio to prevent deadlock.
-    /// THREAT[TM-PY-028]: Rebuild with same config to preserve security limits.
-    fn reset(&self, py: Python<'_>) -> PyResult<()> {
-        let inner = self.inner.clone();
-        let username = self.username.clone();
-        let hostname = self.hostname.clone();
-        let files = clone_file_mounts(py, &self.files);
-        let real_mounts = self.real_mounts.clone();
-        let max_commands = self.max_commands;
-        let max_loop_iterations = self.max_loop_iterations;
-        let max_memory = self.max_memory;
-        let timeout_seconds = self.timeout_seconds;
-        let cancelled = self.cancelled.clone();
-
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let mut bash = inner.lock().await;
-                let mut builder = Bash::builder();
-                if let Some(ref u) = username {
-                    builder = builder.username(u);
-                }
-                if let Some(ref h) = hostname {
-                    builder = builder.hostname(h);
-                }
-                let mut limits = ExecutionLimits::new();
-                if let Some(mc) = max_commands {
-                    limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
-                }
-                if let Some(mli) = max_loop_iterations {
-                    limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
-                }
-                if let Some(ts) = timeout_seconds {
-                    limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
-                }
-                builder = builder.limits(limits);
-                if let Some(mm) = max_memory {
-                    builder = builder.max_memory(usize::try_from(mm).unwrap_or(usize::MAX));
-                }
-                builder = apply_fs_config(builder, &files, &real_mounts)?;
-                *bash = builder.build();
-                // Swap the cancellation token to the new interpreter's token so
-                // cancel() targets the current (not stale) interpreter.
-                if let Ok(mut token) = cancelled.write() {
-                    *token = bash.cancellation_token();
-                }
-                Ok(())
-            })
-        })
-    }
-
-    /// Serialize interpreter state to bytes for checkpoint/restore flows.
-    fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = snapshot_live_bash(py, &self.rt, &self.inner)?;
-        Ok(PyBytes::new(py, &bytes))
-    }
-
-    /// Restore interpreter state from bytes previously produced by `snapshot()`.
-    fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
-        restore_live_bash(py, &self.rt, &self.inner, data)
-    }
-
-    /// Create a new BashTool instance from a snapshot and optional constructor kwargs.
-    #[staticmethod]
-    #[pyo3(signature = (
-        data,
-        username=None,
-        hostname=None,
-        max_commands=None,
-        max_loop_iterations=None,
-        max_memory=None,
-        timeout_seconds=None,
-        files=None,
-        mounts=None,
-    ))]
-    #[allow(clippy::too_many_arguments)]
-    fn from_snapshot(
-        py: Python<'_>,
-        data: Vec<u8>,
-        username: Option<String>,
-        hostname: Option<String>,
-        max_commands: Option<u64>,
-        max_loop_iterations: Option<u64>,
-        max_memory: Option<u64>,
-        timeout_seconds: Option<f64>,
-        files: Option<&Bound<'_, PyDict>>,
-        mounts: Option<&Bound<'_, PyList>>,
-    ) -> PyResult<Self> {
-        let tool = Self::new(
-            py,
-            username,
-            hostname,
-            max_commands,
-            max_loop_iterations,
-            max_memory,
-            timeout_seconds,
-            files,
-            mounts,
-        )?;
-        tool.restore_snapshot(py, data)?;
-        Ok(tool)
-    }
-
-    fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
-        py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
-    }
-
-    fn write_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
-        py.detach(|| write_text_via_live_fs(&self.rt, &self.inner, path, content))
-    }
-
-    fn append_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
-        py.detach(|| append_text_via_live_fs(&self.rt, &self.inner, path, content))
-    }
-
-    #[pyo3(signature = (path, recursive=false))]
-    fn mkdir(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
-        py.detach(|| mkdir_via_live_fs(&self.rt, &self.inner, path, recursive))
-    }
-
-    fn exists(&self, py: Python<'_>, path: String) -> PyResult<bool> {
-        py.detach(|| exists_via_live_fs(&self.rt, &self.inner, path))
-    }
-
-    #[pyo3(signature = (path, recursive=false))]
-    fn remove(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
-        py.detach(|| remove_via_live_fs(&self.rt, &self.inner, path, recursive))
-    }
-
-    fn stat(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
-        let metadata = py.detach(|| stat_via_live_fs(&self.rt, &self.inner, path))?;
-        metadata_to_pydict(py, &metadata)
-    }
-
-    fn chmod(&self, py: Python<'_>, path: String, mode: u32) -> PyResult<()> {
-        py.detach(|| chmod_via_live_fs(&self.rt, &self.inner, path, mode))
-    }
-
-    fn symlink(&self, py: Python<'_>, target: String, link: String) -> PyResult<()> {
-        py.detach(|| symlink_via_live_fs(&self.rt, &self.inner, target, link))
-    }
-
-    fn read_link(&self, py: Python<'_>, path: String) -> PyResult<String> {
-        py.detach(|| read_link_via_live_fs(&self.rt, &self.inner, path))
-    }
-
-    fn read_dir(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
-        let entries = py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path))?;
-        let items: Vec<Py<PyAny>> = entries
-            .iter()
-            .map(|entry| dir_entry_to_pydict(py, entry))
-            .collect::<PyResult<_>>()?;
-        Ok(PyList::new(py, &items)?.into_any().unbind())
-    }
-
-    #[pyo3(signature = (path=".".to_string()))]
-    fn ls(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
-        let names = match py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path)) {
-            Ok(entries) => entries
-                .into_iter()
-                .map(|entry| entry.name)
-                .collect::<Vec<_>>(),
-            Err(_) => Vec::new(),
-        };
-        Ok(PyList::new(py, names)?.into_any().unbind())
-    }
-
-    fn glob(&self, py: Python<'_>, pattern: String) -> PyResult<Py<PyAny>> {
-        let matches = py.detach(|| -> PyResult<Vec<String>> {
-            Ok(glob_via_bash(&self.rt, &self.inner, pattern))
-        })?;
-        Ok(PyList::new(py, matches)?.into_any().unbind())
-    }
-
-    /// Return a live filesystem handle backed by the current interpreter.
-    ///
-    /// Each operation on the returned handle acquires the interpreter lock,
-    /// so it always reflects the latest state (including post-reset). For
-    /// batch reads where consistency isn't needed, prefer reading files via
-    /// `execute_sync("cat ...")`.
-    fn fs(&self, py: Python<'_>) -> PyResult<Py<PyFileSystem>> {
-        Py::new(
-            py,
-            PyFileSystem::from_live(self.inner.clone(), self.rt.clone()),
-        )
-    }
-
-    /// Mount a filesystem at `vfs_path` without rebuilding the interpreter.
-    fn mount(&self, py: Python<'_>, vfs_path: String, fs: PyRef<'_, PyFileSystem>) -> PyResult<()> {
-        let inner = self.inner.clone();
-        let source = fs.inner.clone();
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let mounted_fs = source.resolve().await;
-                let bash = inner.lock().await;
-                bash.mount(Path::new(&vfs_path), mounted_fs)
-                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
-            })
-        })
-    }
-
-    /// Unmount a live filesystem without rebuilding the interpreter.
-    fn unmount(&self, py: Python<'_>, vfs_path: String) -> PyResult<()> {
-        let inner = self.inner.clone();
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let bash = inner.lock().await;
-                bash.unmount(Path::new(&vfs_path))
-                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
-            })
-        })
-    }
-
-    #[getter]
-    fn name(&self) -> &str {
-        "bashkit"
-    }
-
-    #[getter]
-    fn short_description(&self) -> &str {
-        "Run bash commands in an isolated virtual filesystem"
-    }
-
-    fn description(&self) -> PyResult<String> {
-        Ok(self.build_rust_tool().description().to_string())
-    }
-
-    fn help(&self) -> PyResult<String> {
-        Ok(self.build_rust_tool().help())
-    }
-
-    fn system_prompt(&self) -> PyResult<String> {
-        Ok(self.build_rust_tool().system_prompt())
-    }
-
-    fn input_schema(&self) -> PyResult<String> {
-        let schema = self.build_rust_tool().input_schema();
-        serde_json::to_string_pretty(&schema)
-            .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
-    }
-
-    fn output_schema(&self) -> PyResult<String> {
-        let schema = self.build_rust_tool().output_schema();
-        serde_json::to_string_pretty(&schema)
-            .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
-    }
-
-    #[getter]
-    fn version(&self) -> &str {
-        VERSION
-    }
-
-    fn __repr__(&self) -> String {
-        format!(
-            "BashTool(username={:?}, hostname={:?})",
-            self.username.as_deref().unwrap_or("user"),
-            self.hostname.as_deref().unwrap_or("sandbox")
-        )
-    }
-}
-
-// ============================================================================
-// ScriptedTool callback sessions
-// ============================================================================
-
+// Decision: split long-lived callback machinery from per-execution callback
+// state. The engine owns reusable sync-fallback resources; each execute*()
+// call owns its captured ContextVars, caller loop, and cancellable callback
+// tasks via a fresh session.
+//
+// Decision: sync-fallback loop reuse is surface-specific. Bash/BashTool keep
+// one shared private loop because persistent custom builtins may retain
+// loop-bound asyncio state across execute_sync() calls. ScriptedTool sessions
+// use a per-execution private loop so concurrent execute_sync() calls on one
+// tool never race on run_until_complete.
 struct PyCallbackSessionState {
     context: Py<PyAny>,
     caller_loop_locals: Option<TaskLocals>,
+}
+
+#[derive(Clone, Copy)]
+enum PySyncLoopMode {
+    SharedAcrossSessions,
+    PerSession,
 }
 
 struct PyPrivateAsyncLoop {
@@ -2365,12 +1257,14 @@ impl PyPrivateAsyncLoop {
 }
 
 struct PyCallbackEngine {
+    shared_private_async_loop: Arc<PyPrivateAsyncLoop>,
     caller: Py<PyAny>,
 }
 
 impl PyCallbackEngine {
     fn new(py: Python<'_>) -> PyResult<Arc<Self>> {
         Ok(Arc::new(Self {
+            shared_private_async_loop: PyPrivateAsyncLoop::new(),
             caller: create_context_callback_caller(py)?,
         }))
     }
@@ -2400,7 +1294,12 @@ impl PyCallbackSession {
         engine: Arc<PyCallbackEngine>,
         needs_async_callbacks: bool,
         use_caller_loop: bool,
+        sync_loop_mode: PySyncLoopMode,
     ) -> PyResult<Arc<Self>> {
+        let private_async_loop = match sync_loop_mode {
+            PySyncLoopMode::SharedAcrossSessions => engine.shared_private_async_loop.clone(),
+            PySyncLoopMode::PerSession => PyPrivateAsyncLoop::new(),
+        };
         Ok(Arc::new(Self {
             state: StdMutex::new(capture_callback_state(
                 py,
@@ -2408,7 +1307,7 @@ impl PyCallbackSession {
                 use_caller_loop,
             )?),
             active_caller_tasks: Arc::new(StdMutex::new(Vec::new())),
-            private_async_loop: PyPrivateAsyncLoop::new(),
+            private_async_loop,
             engine,
         }))
     }
@@ -2466,6 +1365,12 @@ impl PyCallbackSession {
     ) -> PyResult<Py<PyAny>> {
         self.private_async_loop.run_awaitable(py, awaitable)
     }
+}
+
+struct PyCustomBuiltinEntry {
+    name: String,
+    callback: Py<PyAny>,
+    is_async: bool,
 }
 
 fn capture_callback_state(
@@ -2736,6 +1641,22 @@ impl Drop for PyCancellableLoopFuture {
     }
 }
 
+fn build_py_custom_builtin_entry(
+    py: Python<'_>,
+    name: String,
+    callback: Py<PyAny>,
+) -> PyResult<PyCustomBuiltinEntry> {
+    let bound = callback.bind(py);
+    let is_async = validate_python_callback(py, bound, || {
+        format!("custom_builtins['{name}'] must be callable")
+    })?;
+    Ok(PyCustomBuiltinEntry {
+        name,
+        callback,
+        is_async,
+    })
+}
+
 fn build_py_tool_entry(
     py: Python<'_>,
     name: String,
@@ -2748,12 +1669,9 @@ fn build_py_tool_entry(
         None => serde_json::Value::Object(Default::default()),
     };
     let bound = callback.bind(py);
-    if !bound.is_callable() {
-        return Err(PyTypeError::new_err(format!(
-            "tool '{name}' callback must be callable"
-        )));
-    }
-    let is_async = is_coroutine_callable(py, bound)?;
+    let is_async = validate_python_callback(py, bound, || {
+        format!("tool '{name}' callback must be callable")
+    })?;
     Ok(PyToolEntry {
         name,
         description,
@@ -2817,6 +1735,1418 @@ async fn call_python_string_callback_async(
             .extract::<String>(py)
             .map_err(|e| format!("{callback_name}: callback must return str, got {e}"))
     })
+}
+
+struct PyCustomBuiltinAdapter {
+    name: String,
+    callback: Py<PyAny>,
+    is_async: bool,
+}
+
+#[async_trait]
+impl Builtin for PyCustomBuiltinAdapter {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<RustExecResult> {
+        let session = ctx.execution_extension::<Arc<PyCallbackSession>>().cloned();
+        let builtin_arg = Python::attach(|py| -> Result<Py<PyAny>, String> {
+            let builtin_arg = make_py_builtin_context(py, &self.name, &ctx)
+                .map_err(|e| format!("{}: {}", self.name, e))?
+                .into_bound(py)
+                .into_any()
+                .unbind();
+            Ok(builtin_arg)
+        });
+        let callback_result = match builtin_arg {
+            Ok(builtin_arg) if self.is_async => match session {
+                Some(session) => {
+                    call_python_string_callback_async(
+                        session,
+                        &self.name,
+                        &self.callback,
+                        vec![builtin_arg],
+                    )
+                    .await
+                }
+                None => Err(format!("{}: missing Python callback session", self.name)),
+            },
+            Ok(builtin_arg) => match session {
+                Some(session) => Python::attach(|py| {
+                    call_python_string_callback_sync(
+                        py,
+                        session.as_ref(),
+                        &self.name,
+                        &self.callback,
+                        vec![builtin_arg],
+                    )
+                }),
+                None => Err(format!("{}: missing Python callback session", self.name)),
+            },
+            Err(err) => Err(err),
+        };
+
+        Ok(match callback_result {
+            Ok(stdout) => RustExecResult::ok(stdout),
+            Err(msg) => RustExecResult::err(msg, 1),
+        })
+    }
+}
+
+fn build_runtime_custom_builtin_impls(
+    py: Python<'_>,
+    builtins: &[PyCustomBuiltinEntry],
+) -> Vec<PyCustomBuiltinAdapter> {
+    builtins
+        .iter()
+        .map(|entry| PyCustomBuiltinAdapter {
+            name: entry.name.clone(),
+            callback: entry.callback.clone_ref(py),
+            is_async: entry.is_async,
+        })
+        .collect()
+}
+
+fn apply_custom_builtins_to_builder(
+    py: Python<'_>,
+    mut builder: bashkit::BashBuilder,
+    builtins: &[PyCustomBuiltinEntry],
+) -> bashkit::BashBuilder {
+    for builtin in build_runtime_custom_builtin_impls(py, builtins) {
+        let name = builtin.name.clone();
+        builder = builder.builtin(name, Box::new(builtin));
+    }
+    builder
+}
+
+fn capture_custom_builtin_session(
+    py: Python<'_>,
+    builtins: &[PyCustomBuiltinEntry],
+    engine: &Arc<PyCallbackEngine>,
+    use_caller_loop: bool,
+) -> PyResult<Option<Arc<PyCallbackSession>>> {
+    if builtins.is_empty() {
+        return Ok(None);
+    }
+    PyCallbackSession::capture(
+        py,
+        engine.clone(),
+        builtins.iter().any(|entry| entry.is_async),
+        use_caller_loop,
+        PySyncLoopMode::SharedAcrossSessions,
+    )
+    .map(Some)
+}
+
+fn replace_live_bash_with_builder(
+    py: Python<'_>,
+    rt: &Arc<Runtime>,
+    inner: &Arc<Mutex<Bash>>,
+    cancelled: &Arc<RwLock<Arc<AtomicBool>>>,
+    builder: bashkit::BashBuilder,
+) -> PyResult<()> {
+    let rt = rt.clone();
+    let inner = inner.clone();
+    let cancelled = cancelled.clone();
+    py.detach(|| {
+        rt.block_on(async move {
+            let mut bash = inner.lock().await;
+            let rebuilt = builder.build();
+            let token = rebuilt.cancellation_token();
+            *bash = rebuilt;
+            if let Ok(mut current) = cancelled.write() {
+                *current = token;
+            }
+            Ok(())
+        })
+    })
+}
+
+fn take_output_handler_error(callback_error: &StdMutex<Option<PyErr>>) -> Option<PyErr> {
+    callback_error
+        .lock()
+        .ok()
+        .and_then(|mut callback_error| callback_error.take())
+}
+
+fn close_awaitable_if_possible(awaitable: &Bound<'_, PyAny>) {
+    if let Ok(close) = awaitable.getattr("close") {
+        let _ = close.call0();
+    }
+}
+
+fn build_python_output_callback(
+    on_output: PyOutputHandler,
+    cancelled: Arc<AtomicBool>,
+    callback_requested_cancel: Arc<AtomicBool>,
+    callback_error: Arc<StdMutex<Option<PyErr>>>,
+) -> RustOutputCallback {
+    Box::new(move |stdout_chunk, stderr_chunk| {
+        let has_error = callback_error
+            .lock()
+            .map(|callback_error| callback_error.is_some())
+            .unwrap_or(false);
+        if has_error {
+            return;
+        }
+
+        let callback_result = Python::attach(|py| {
+            // Re-enter the caller's copied ContextVar snapshot for each chunk.
+            let result = on_output.context.bind(py).call_method1(
+                "run",
+                (on_output.callback.bind(py), stdout_chunk, stderr_chunk),
+            )?;
+            let is_awaitable = on_output
+                .is_awaitable
+                .bind(py)
+                .call1((&result,))?
+                .extract::<bool>()?;
+            if is_awaitable {
+                close_awaitable_if_possible(&result);
+                return Err(PyTypeError::new_err(
+                    "on_output must be synchronous and must not return an awaitable",
+                ));
+            }
+            Ok(())
+        });
+
+        if let Err(err) = callback_result {
+            if let Ok(mut callback_error) = callback_error.lock()
+                && callback_error.is_none()
+            {
+                *callback_error = Some(err);
+            }
+            if !cancelled.swap(true, Ordering::Relaxed) {
+                callback_requested_cancel.store(true, Ordering::Relaxed);
+            }
+        }
+    })
+}
+
+async fn exec_bash_with_optional_output(
+    bash: &mut Bash,
+    commands: &str,
+    on_output: Option<PyOutputHandler>,
+    builtin_session: Option<Arc<PyCallbackSession>>,
+) -> PyResult<ExecResult> {
+    let mut execution_extensions = ExecutionExtensions::new();
+    if let Some(session) = builtin_session {
+        let _ = execution_extensions.insert(session);
+    }
+
+    let result = if let Some(on_output) = on_output {
+        // Preserve explicit cancel() calls across execute* entry. Only clear
+        // cancellation if an on_output failure introduced it for this call.
+        let cancelled = bash.cancellation_token();
+        let callback_requested_cancel = Arc::new(AtomicBool::new(false));
+        let callback_error = Arc::new(StdMutex::new(None));
+        let output_callback = build_python_output_callback(
+            on_output,
+            cancelled.clone(),
+            callback_requested_cancel.clone(),
+            callback_error.clone(),
+        );
+        let result = bash
+            .exec_streaming_with_extensions(commands, output_callback, execution_extensions)
+            .await;
+        if let Some(err) = take_output_handler_error(&callback_error) {
+            if callback_requested_cancel.load(Ordering::Relaxed) {
+                cancelled.store(false, Ordering::Relaxed);
+            }
+            return Err(err);
+        }
+        result
+    } else {
+        bash.exec_with_extensions(commands, execution_extensions)
+            .await
+    };
+
+    Ok(py_exec_result_from_bash_result(result))
+}
+
+/// Build a `PythonExternalFnHandler` from a Python async callable.
+///
+/// The handler converts MontyObject args/kwargs to Python objects, calls the
+/// async handler coroutine, awaits it, and converts the result back.
+fn make_external_handler(py_handler: Py<PyAny>) -> PythonExternalFnHandler {
+    Arc::new(move |fn_name, args, kwargs| {
+        let py_handler = Python::attach(|py| py_handler.clone_ref(py));
+        Box::pin(async move {
+            let fut = Python::attach(|py| {
+                let py_args = args
+                    .iter()
+                    .map(|o| monty_to_py(py, o))
+                    .collect::<PyResult<Vec<_>>>()?;
+                let py_args_list = PyList::new(py, &py_args)?;
+                let py_kwargs = PyDict::new(py);
+                for (k, v) in &kwargs {
+                    py_kwargs.set_item(monty_to_py(py, k)?, monty_to_py(py, v)?)?;
+                }
+                let coro = py_handler.call1(py, (fn_name, py_args_list, py_kwargs))?;
+                pyo3_async_runtimes::tokio::into_future(coro.into_bound(py))
+            });
+            match fut {
+                Err(e) => ExtFunctionResult::Error(MontyException::new(
+                    ExcType::RuntimeError,
+                    Some(e.to_string()),
+                )),
+                Ok(awaitable) => match awaitable.await {
+                    Err(e) => ExtFunctionResult::Error(MontyException::new(
+                        ExcType::RuntimeError,
+                        Some(e.to_string()),
+                    )),
+                    Ok(py_result) => {
+                        Python::attach(|py| match py_to_monty(py, py_result.bind(py)) {
+                            Ok(v) => ExtFunctionResult::Return(v),
+                            Err(e) => ExtFunctionResult::Error(MontyException::new(
+                                ExcType::RuntimeError,
+                                Some(e.to_string()),
+                            )),
+                        })
+                    }
+                },
+            }
+        })
+    })
+}
+
+/// Apply python/external_handler configuration to a `BashBuilder`.
+///
+/// Centralises the logic shared between `new()` and `reset()`.
+fn apply_python_config(
+    mut builder: bashkit::BashBuilder,
+    python: bool,
+    fn_names: Vec<String>,
+    handler: Option<Py<PyAny>>,
+) -> bashkit::BashBuilder {
+    // By construction, handler.is_some() implies python=true (validated in new()).
+    match (python, handler) {
+        (true, Some(h)) => {
+            builder = builder.python_with_external_handler(
+                PythonLimits::default(),
+                fn_names,
+                make_external_handler(h),
+            );
+        }
+        (true, None) => {
+            builder = builder.python();
+        }
+        (false, _) => {}
+    }
+    builder
+}
+
+/// Core bash interpreter with virtual filesystem.
+///
+/// State persists between calls — files created in one `execute()` are
+/// available in subsequent calls. This is the primary interface.
+///
+/// Example:
+///     ```python
+///     from bashkit import Bash
+///
+///     bash = Bash()
+///     result = await bash.execute("echo 'Hello, World!'")
+///     print(result.stdout)  # Hello, World!
+///     ```
+#[pyclass(name = "Bash")]
+#[allow(dead_code)]
+pub struct PyBash {
+    inner: Arc<Mutex<Bash>>,
+    /// Shared tokio runtime — reused across all sync calls to avoid
+    /// per-call OS thread/fd exhaustion (issue #414).
+    rt: Arc<Runtime>,
+    /// Cancellation token. Wrapped in RwLock so reset() can swap it to
+    /// the new interpreter's token without requiring &mut self.
+    cancelled: Arc<RwLock<Arc<AtomicBool>>>,
+    username: Option<String>,
+    hostname: Option<String>,
+    /// Whether Monty Python execution is enabled (`python`/`python3` builtins).
+    python: bool,
+    /// External function names callable from Monty code via the handler.
+    external_functions: Vec<String>,
+    /// Async Python callable invoked when Monty calls an external function.
+    external_handler: Option<Py<PyAny>>,
+    custom_builtins: Vec<PyCustomBuiltinEntry>,
+    builtin_engine: Arc<PyCallbackEngine>,
+    files: Vec<PyFileMount>,
+    real_mounts: Vec<RealMountConfig>,
+    max_commands: Option<u64>,
+    max_loop_iterations: Option<u64>,
+    max_memory: Option<u64>,
+    timeout_seconds: Option<f64>,
+}
+
+impl PyBash {
+    fn build_live_builder(&self, py: Python<'_>) -> PyResult<bashkit::BashBuilder> {
+        let mut builder = Bash::builder();
+
+        if let Some(ref username) = self.username {
+            builder = builder.username(username);
+        }
+        if let Some(ref hostname) = self.hostname {
+            builder = builder.hostname(hostname);
+        }
+
+        let mut limits = ExecutionLimits::new();
+        if let Some(max_commands) = self.max_commands {
+            limits = limits.max_commands(usize::try_from(max_commands).unwrap_or(usize::MAX));
+        }
+        if let Some(max_loop_iterations) = self.max_loop_iterations {
+            limits = limits
+                .max_loop_iterations(usize::try_from(max_loop_iterations).unwrap_or(usize::MAX));
+        }
+        if let Some(timeout_seconds) = self.timeout_seconds {
+            limits = limits.timeout(std::time::Duration::from_secs_f64(timeout_seconds));
+        }
+        builder = builder.limits(limits);
+
+        if let Some(max_memory) = self.max_memory {
+            builder = builder.max_memory(usize::try_from(max_memory).unwrap_or(usize::MAX));
+        }
+
+        let handler_clone = self.external_handler.as_ref().map(|h| h.clone_ref(py));
+        builder = apply_python_config(
+            builder,
+            self.python,
+            self.external_functions.clone(),
+            handler_clone,
+        );
+        let files = clone_file_mounts(py, &self.files);
+        let builder = apply_fs_config(builder, &files, &self.real_mounts)?;
+        Ok(apply_custom_builtins_to_builder(
+            py,
+            builder,
+            &self.custom_builtins,
+        ))
+    }
+}
+
+#[pymethods]
+impl PyBash {
+    #[new]
+    #[pyo3(signature = (
+        username=None,
+        hostname=None,
+        max_commands=None,
+        max_loop_iterations=None,
+        max_memory=None,
+        timeout_seconds=None,
+        python=false,
+        external_functions=None,
+        external_handler=None,
+        files=None,
+        mounts=None,
+        custom_builtins=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        py: Python<'_>,
+        username: Option<String>,
+        hostname: Option<String>,
+        max_commands: Option<u64>,
+        max_loop_iterations: Option<u64>,
+        max_memory: Option<u64>,
+        timeout_seconds: Option<f64>,
+        python: bool,
+        external_functions: Option<Vec<String>>,
+        external_handler: Option<Py<PyAny>>,
+        files: Option<&Bound<'_, PyDict>>,
+        mounts: Option<&Bound<'_, PyList>>,
+        custom_builtins: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let mut builder = Bash::builder();
+
+        if let Some(ref u) = username {
+            builder = builder.username(u);
+        }
+        if let Some(ref h) = hostname {
+            builder = builder.hostname(h);
+        }
+
+        let mut limits = ExecutionLimits::new();
+        if let Some(mc) = max_commands {
+            limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
+        }
+        if let Some(mli) = max_loop_iterations {
+            limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
+        }
+        if let Some(ts) = timeout_seconds {
+            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
+        }
+        builder = builder.limits(limits);
+
+        if let Some(mm) = max_memory {
+            builder = builder.max_memory(usize::try_from(mm).unwrap_or(usize::MAX));
+        }
+
+        let files = parse_files(files)?;
+        let real_mounts = parse_mounts(mounts)?;
+        let custom_builtins = parse_custom_builtins(py, custom_builtins)?;
+
+        let fn_names = external_functions.clone().unwrap_or_default();
+        if !fn_names.is_empty() && external_handler.is_none() {
+            return Err(PyValueError::new_err(
+                "external_functions requires external_handler — the list has no effect without a handler",
+            ));
+        }
+        if external_handler.is_some() && !python {
+            return Err(PyValueError::new_err(
+                "external_handler requires python=True",
+            ));
+        }
+        if external_handler
+            .as_ref()
+            .is_some_and(|h| !h.bind(py).is_callable())
+        {
+            return Err(PyValueError::new_err("external_handler must be callable"));
+        }
+        if let Some(ref handler) = external_handler {
+            let bound = handler.bind(py);
+            if !is_coroutine_callable(py, bound)? {
+                return Err(PyValueError::new_err(
+                    "external_handler must be an async callable (coroutine function)",
+                ));
+            }
+        }
+        let handler_for_build = external_handler.as_ref().map(|h| h.clone_ref(py));
+        builder = apply_python_config(builder, python, fn_names, handler_for_build);
+        builder = apply_fs_config(builder, &files, &real_mounts)?;
+        let builtin_engine = PyCallbackEngine::new(py)?;
+        builder = apply_custom_builtins_to_builder(py, builder, &custom_builtins);
+
+        let bash = builder.build();
+        let cancelled = Arc::new(RwLock::new(bash.cancellation_token()));
+
+        let rt = make_runtime()?;
+
+        Ok(Self {
+            inner: Arc::new(Mutex::new(bash)),
+            rt,
+            cancelled,
+            username,
+            hostname,
+            python,
+            external_functions: external_functions.unwrap_or_default(),
+            external_handler,
+            custom_builtins,
+            builtin_engine,
+            files,
+            real_mounts,
+            max_commands,
+            max_loop_iterations,
+            max_memory,
+            timeout_seconds,
+        })
+    }
+
+    /// Cancel the currently running execution.
+    ///
+    /// Safe to call from any thread. Execution will abort at the next
+    /// command boundary.
+    fn cancel(&self) {
+        if let Ok(token) = self.cancelled.read() {
+            token.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Clear the cancellation flag so subsequent executions proceed normally.
+    ///
+    /// Call this after a `cancel()` once the in-flight execution has finished
+    /// and you want to reuse the same `Bash` instance (preserving VFS state).
+    /// Without this, every future `execute()` will immediately fail with
+    /// ``"execution cancelled"``.
+    ///
+    /// **Note:** Calling this while an execution is still in-flight may
+    /// allow that execution to continue past the cancellation point.
+    /// Wait for the cancelled execution to finish before clearing
+    /// (await the async call or let `execute_sync` return).
+    fn clear_cancel(&self) {
+        if let Ok(token) = self.cancelled.read() {
+            token.store(false, Ordering::Relaxed);
+        }
+    }
+
+    /// Execute commands asynchronously.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute<'py>(
+        &self,
+        py: Python<'py>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let builtin_session =
+            capture_custom_builtin_session(py, &self.custom_builtins, &self.builtin_engine, true)?;
+        let on_output = prepare_output_handler(py, on_output)?;
+        let inner = self.inner.clone();
+        let cancel_session = builtin_session.clone();
+        let future = future_into_py(py, async move {
+            let mut bash = inner.lock().await;
+            exec_bash_with_optional_output(&mut bash, &commands, on_output, builtin_session).await
+        })?;
+        if let Some(cancel_session) = cancel_session {
+            attach_future_cancellation_callback(py, &future, cancel_session.clone())?;
+            return wrap_future_with_cancel(py, future, cancel_session);
+        }
+        Ok(future)
+    }
+
+    /// Execute commands synchronously (blocking).
+    ///
+    /// Not supported when `external_handler` is configured: the handler is an async
+    /// Python coroutine that requires a running event loop, which is unavailable in
+    /// sync context. Use `execute()` (async) instead.
+    ///
+    /// Releases GIL before blocking on tokio to prevent deadlock with callbacks.
+    ///
+    /// # Thread safety
+    ///
+    /// This method acquires an async mutex with a 30-second timeout to prevent
+    /// deadlocks when multiple threads call `execute_sync()` concurrently on the
+    /// same `Bash` instance. If the lock cannot be acquired within the timeout,
+    /// a `RuntimeError` is raised. For concurrent workloads, use separate `Bash`
+    /// instances per thread or use the async `execute()` method.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute_sync(
+        &self,
+        py: Python<'_>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<ExecResult> {
+        if self.external_handler.is_some() {
+            return Err(PyRuntimeError::new_err(
+                "execute_sync is not supported when external_handler is configured — use execute() (async) instead, e.g. asyncio.run(bash.execute(...))",
+            ));
+        }
+        let builtin_session =
+            capture_custom_builtin_session(py, &self.custom_builtins, &self.builtin_engine, false)?;
+        let on_output = prepare_output_handler(py, on_output)?;
+        let inner = self.inner.clone();
+
+        py.detach(|| {
+            self.rt.block_on(async move {
+                // THREAT[TM-DOS-FFI]: Use timeout on mutex acquisition to prevent
+                // deadlocks when multiple Python threads call execute_sync concurrently.
+                let mut bash =
+                    match tokio::time::timeout(std::time::Duration::from_secs(30), inner.lock())
+                        .await
+                    {
+                        Ok(guard) => guard,
+                        Err(_) => {
+                            return Err(PyRuntimeError::new_err(
+                                "execute_sync: timed out waiting for lock (30s). \
+                             Another thread may be holding the interpreter. \
+                             Use separate Bash instances for concurrent access.",
+                            ));
+                        }
+                    };
+                exec_bash_with_optional_output(&mut bash, &commands, on_output, builtin_session)
+                    .await
+            })
+        })
+    }
+
+    /// Execute commands synchronously. Raises `BashError` on non-zero exit.
+    ///
+    /// Not supported when `external_handler` is configured.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute_sync_or_throw(
+        &self,
+        py: Python<'_>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<ExecResult> {
+        let result = self.execute_sync(py, commands, on_output)?;
+        if result.exit_code != 0 {
+            return Err(raise_bash_error(&result));
+        }
+        Ok(result)
+    }
+
+    /// Execute commands asynchronously. Raises `BashError` on non-zero exit.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute_or_throw<'py>(
+        &self,
+        py: Python<'py>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let builtin_session =
+            capture_custom_builtin_session(py, &self.custom_builtins, &self.builtin_engine, true)?;
+        let on_output = prepare_output_handler(py, on_output)?;
+        let inner = self.inner.clone();
+        let cancel_session = builtin_session.clone();
+        let future = future_into_py(py, async move {
+            let mut bash = inner.lock().await;
+            let result =
+                exec_bash_with_optional_output(&mut bash, &commands, on_output, builtin_session)
+                    .await?;
+            if result.exit_code != 0 {
+                return Err(raise_bash_error(&result));
+            }
+            Ok(result)
+        })?;
+        if let Some(cancel_session) = cancel_session {
+            attach_future_cancellation_callback(py, &future, cancel_session.clone())?;
+            return wrap_future_with_cancel(py, future, cancel_session);
+        }
+        Ok(future)
+    }
+
+    /// Reset interpreter to fresh state, preserving all configuration including
+    /// python mode, external function handler, and custom builtins.
+    /// Releases GIL before blocking on tokio to prevent deadlock.
+    fn reset(&self, py: Python<'_>) -> PyResult<()> {
+        replace_live_bash_with_builder(
+            py,
+            &self.rt,
+            &self.inner,
+            &self.cancelled,
+            self.build_live_builder(py)?,
+        )
+    }
+
+    /// Serialize interpreter state to bytes for checkpoint/restore flows.
+    fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = snapshot_live_bash(py, &self.rt, &self.inner)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
+    /// Restore interpreter state from bytes previously produced by `snapshot()`.
+    fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
+        restore_live_bash(py, &self.rt, &self.inner, data)
+    }
+
+    /// Create a new Bash instance from a snapshot and optional constructor kwargs.
+    #[staticmethod]
+    #[pyo3(signature = (
+        data,
+        username=None,
+        hostname=None,
+        max_commands=None,
+        max_loop_iterations=None,
+        max_memory=None,
+        timeout_seconds=None,
+        python=false,
+        external_functions=None,
+        external_handler=None,
+        files=None,
+        mounts=None,
+        custom_builtins=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_snapshot(
+        py: Python<'_>,
+        data: Vec<u8>,
+        username: Option<String>,
+        hostname: Option<String>,
+        max_commands: Option<u64>,
+        max_loop_iterations: Option<u64>,
+        max_memory: Option<u64>,
+        timeout_seconds: Option<f64>,
+        python: bool,
+        external_functions: Option<Vec<String>>,
+        external_handler: Option<Py<PyAny>>,
+        files: Option<&Bound<'_, PyDict>>,
+        mounts: Option<&Bound<'_, PyList>>,
+        custom_builtins: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let bash = Self::new(
+            py,
+            username,
+            hostname,
+            max_commands,
+            max_loop_iterations,
+            max_memory,
+            timeout_seconds,
+            python,
+            external_functions,
+            external_handler,
+            files,
+            mounts,
+            custom_builtins,
+        )?;
+        bash.restore_snapshot(py, data)?;
+        Ok(bash)
+    }
+
+    fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn write_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| write_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    fn append_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| append_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn mkdir(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| mkdir_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn exists(&self, py: Python<'_>, path: String) -> PyResult<bool> {
+        py.detach(|| exists_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn remove(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| remove_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn stat(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let metadata = py.detach(|| stat_via_live_fs(&self.rt, &self.inner, path))?;
+        metadata_to_pydict(py, &metadata)
+    }
+
+    fn chmod(&self, py: Python<'_>, path: String, mode: u32) -> PyResult<()> {
+        py.detach(|| chmod_via_live_fs(&self.rt, &self.inner, path, mode))
+    }
+
+    fn symlink(&self, py: Python<'_>, target: String, link: String) -> PyResult<()> {
+        py.detach(|| symlink_via_live_fs(&self.rt, &self.inner, target, link))
+    }
+
+    fn read_link(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_link_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn read_dir(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let entries = py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path))?;
+        let items: Vec<Py<PyAny>> = entries
+            .iter()
+            .map(|entry| dir_entry_to_pydict(py, entry))
+            .collect::<PyResult<_>>()?;
+        Ok(PyList::new(py, &items)?.into_any().unbind())
+    }
+
+    #[pyo3(signature = (path=".".to_string()))]
+    fn ls(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let names = match py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path)) {
+            Ok(entries) => entries
+                .into_iter()
+                .map(|entry| entry.name)
+                .collect::<Vec<_>>(),
+            Err(_) => Vec::new(),
+        };
+        Ok(PyList::new(py, names)?.into_any().unbind())
+    }
+
+    fn glob(&self, py: Python<'_>, pattern: String) -> PyResult<Py<PyAny>> {
+        let matches = py.detach(|| -> PyResult<Vec<String>> {
+            Ok(glob_via_bash(&self.rt, &self.inner, pattern))
+        })?;
+        Ok(PyList::new(py, matches)?.into_any().unbind())
+    }
+
+    /// Return a live filesystem handle backed by the current interpreter.
+    ///
+    /// Each operation on the returned handle acquires the interpreter lock,
+    /// so it always reflects the latest state (including post-reset). For
+    /// batch reads where consistency isn't needed, prefer reading files via
+    /// `execute_sync("cat ...")`.
+    fn fs(&self, py: Python<'_>) -> PyResult<Py<PyFileSystem>> {
+        Py::new(
+            py,
+            PyFileSystem::from_live(self.inner.clone(), self.rt.clone()),
+        )
+    }
+
+    /// Mount a filesystem at `vfs_path` without rebuilding the interpreter.
+    fn mount(&self, py: Python<'_>, vfs_path: String, fs: PyRef<'_, PyFileSystem>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        let source = fs.inner.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let mounted_fs = source.resolve().await;
+                let bash = inner.lock().await;
+                bash.mount(Path::new(&vfs_path), mounted_fs)
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            })
+        })
+    }
+
+    /// Unmount a live filesystem without rebuilding the interpreter.
+    fn unmount(&self, py: Python<'_>, vfs_path: String) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let bash = inner.lock().await;
+                bash.unmount(Path::new(&vfs_path))
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            })
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Bash(username={:?}, hostname={:?})",
+            self.username.as_deref().unwrap_or("user"),
+            self.hostname.as_deref().unwrap_or("sandbox")
+        )
+    }
+}
+
+// ============================================================================
+// BashTool — interpreter + tool-contract metadata
+// ============================================================================
+
+/// Bash interpreter with tool-contract metadata (`description`, `help`,
+/// `system_prompt`, schemas).
+///
+/// Extends `Bash` with methods required by LLM tool-use protocols.
+/// Use this when integrating with LangChain, PydanticAI, or similar frameworks.
+///
+/// Example:
+///     ```python
+///     from bashkit import BashTool
+///
+///     tool = BashTool()
+///     print(tool.input_schema())  # JSON schema for LLM
+///     result = await tool.execute("echo 'Hello!'")
+///     ```
+/// with a virtual filesystem. State persists between calls - files created
+/// in one call are available in subsequent calls.
+///
+/// Example:
+///     ```python
+///     from bashkit import BashTool
+///
+///     tool = BashTool()
+///     result = await tool.execute("echo 'Hello, World!'")
+///     print(result.stdout)  # Hello, World!
+///     ```
+#[pyclass]
+#[allow(dead_code)]
+pub struct BashTool {
+    inner: Arc<Mutex<Bash>>,
+    /// Shared tokio runtime — reused across all sync calls to avoid
+    /// per-call OS thread/fd exhaustion (issue #414).
+    rt: Arc<Runtime>,
+    /// Cancellation token. Wrapped in RwLock so reset() can swap it to
+    /// the new interpreter's token without requiring &mut self.
+    cancelled: Arc<RwLock<Arc<AtomicBool>>>,
+    username: Option<String>,
+    hostname: Option<String>,
+    custom_builtins: Vec<PyCustomBuiltinEntry>,
+    builtin_engine: Arc<PyCallbackEngine>,
+    files: Vec<PyFileMount>,
+    real_mounts: Vec<RealMountConfig>,
+    max_commands: Option<u64>,
+    max_loop_iterations: Option<u64>,
+    max_memory: Option<u64>,
+    timeout_seconds: Option<f64>,
+}
+
+impl BashTool {
+    fn build_live_builder(&self, py: Python<'_>) -> PyResult<bashkit::BashBuilder> {
+        let mut builder = Bash::builder();
+
+        if let Some(ref username) = self.username {
+            builder = builder.username(username);
+        }
+        if let Some(ref hostname) = self.hostname {
+            builder = builder.hostname(hostname);
+        }
+
+        let mut limits = ExecutionLimits::new();
+        if let Some(max_commands) = self.max_commands {
+            limits = limits.max_commands(usize::try_from(max_commands).unwrap_or(usize::MAX));
+        }
+        if let Some(max_loop_iterations) = self.max_loop_iterations {
+            limits = limits
+                .max_loop_iterations(usize::try_from(max_loop_iterations).unwrap_or(usize::MAX));
+        }
+        if let Some(timeout_seconds) = self.timeout_seconds {
+            limits = limits.timeout(std::time::Duration::from_secs_f64(timeout_seconds));
+        }
+        builder = builder.limits(limits);
+
+        if let Some(max_memory) = self.max_memory {
+            builder = builder.max_memory(usize::try_from(max_memory).unwrap_or(usize::MAX));
+        }
+
+        let files = clone_file_mounts(py, &self.files);
+        let builder = apply_fs_config(builder, &files, &self.real_mounts)?;
+        Ok(apply_custom_builtins_to_builder(
+            py,
+            builder,
+            &self.custom_builtins,
+        ))
+    }
+
+    fn build_rust_tool(&self) -> RustBashTool {
+        let mut builder = RustBashTool::builder();
+
+        if let Some(ref username) = self.username {
+            builder = builder.username(username);
+        }
+        if let Some(ref hostname) = self.hostname {
+            builder = builder.hostname(hostname);
+        }
+
+        let mut limits = ExecutionLimits::new();
+        if let Some(mc) = self.max_commands {
+            limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
+        }
+        if let Some(mli) = self.max_loop_iterations {
+            limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
+        }
+        if let Some(ts) = self.timeout_seconds {
+            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
+        }
+
+        if !self.custom_builtins.is_empty() {
+            let builtins =
+                Python::attach(|py| build_runtime_custom_builtin_impls(py, &self.custom_builtins));
+            for builtin in builtins {
+                let name = builtin.name.clone();
+                builder = builder.builtin(name, Box::new(builtin));
+            }
+        }
+
+        builder.limits(limits).build()
+    }
+}
+
+#[pymethods]
+impl BashTool {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        username=None,
+        hostname=None,
+        max_commands=None,
+        max_loop_iterations=None,
+        max_memory=None,
+        timeout_seconds=None,
+        files=None,
+        mounts=None,
+        custom_builtins=None,
+    ))]
+    fn new(
+        py: Python<'_>,
+        username: Option<String>,
+        hostname: Option<String>,
+        max_commands: Option<u64>,
+        max_loop_iterations: Option<u64>,
+        max_memory: Option<u64>,
+        timeout_seconds: Option<f64>,
+        files: Option<&Bound<'_, PyDict>>,
+        mounts: Option<&Bound<'_, PyList>>,
+        custom_builtins: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let mut builder = Bash::builder();
+
+        if let Some(ref u) = username {
+            builder = builder.username(u);
+        }
+        if let Some(ref h) = hostname {
+            builder = builder.hostname(h);
+        }
+
+        let mut limits = ExecutionLimits::new();
+        if let Some(mc) = max_commands {
+            limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
+        }
+        if let Some(mli) = max_loop_iterations {
+            limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
+        }
+        if let Some(ts) = timeout_seconds {
+            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
+        }
+        builder = builder.limits(limits);
+
+        if let Some(mm) = max_memory {
+            builder = builder.max_memory(usize::try_from(mm).unwrap_or(usize::MAX));
+        }
+
+        let files = parse_files(files)?;
+        let real_mounts = parse_mounts(mounts)?;
+        let custom_builtins = parse_custom_builtins(py, custom_builtins)?;
+        builder = apply_fs_config(builder, &files, &real_mounts)?;
+        let builtin_engine = PyCallbackEngine::new(py)?;
+        builder = apply_custom_builtins_to_builder(py, builder, &custom_builtins);
+
+        let bash = builder.build();
+        let cancelled = Arc::new(RwLock::new(bash.cancellation_token()));
+
+        let rt = make_runtime()?;
+
+        Ok(Self {
+            inner: Arc::new(Mutex::new(bash)),
+            rt,
+            cancelled,
+            username,
+            hostname,
+            custom_builtins,
+            builtin_engine,
+            files,
+            real_mounts,
+            max_commands,
+            max_loop_iterations,
+            max_memory,
+            timeout_seconds,
+        })
+    }
+
+    /// Cancel the currently running execution.
+    fn cancel(&self) {
+        if let Ok(token) = self.cancelled.read() {
+            token.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Clear the cancellation flag so subsequent executions proceed normally.
+    ///
+    /// Call this after a `cancel()` once the in-flight execution has finished
+    /// and you want to reuse the same `BashTool` instance (preserving VFS state).
+    /// Without this, every future `execute()` will immediately fail with
+    /// ``"execution cancelled"``.
+    ///
+    /// **Note:** Calling this while an execution is still in-flight may
+    /// allow that execution to continue past the cancellation point.
+    /// Wait for the cancelled execution to finish before clearing
+    /// (await the async call or let `execute_sync` return).
+    fn clear_cancel(&self) {
+        if let Ok(token) = self.cancelled.read() {
+            token.store(false, Ordering::Relaxed);
+        }
+    }
+
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute<'py>(
+        &self,
+        py: Python<'py>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let builtin_session =
+            capture_custom_builtin_session(py, &self.custom_builtins, &self.builtin_engine, true)?;
+        let on_output = prepare_output_handler(py, on_output)?;
+        let inner = self.inner.clone();
+        let cancel_session = builtin_session.clone();
+        let future = future_into_py(py, async move {
+            let mut bash = inner.lock().await;
+            exec_bash_with_optional_output(&mut bash, &commands, on_output, builtin_session).await
+        })?;
+        if let Some(cancel_session) = cancel_session {
+            attach_future_cancellation_callback(py, &future, cancel_session.clone())?;
+            return wrap_future_with_cancel(py, future, cancel_session);
+        }
+        Ok(future)
+    }
+
+    /// Releases GIL before blocking on tokio to prevent deadlock with callbacks.
+    ///
+    /// # Thread safety
+    ///
+    /// Acquires async mutex with 30-second timeout. For concurrent workloads,
+    /// use separate `BashTool` instances per thread or the async `execute()`.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute_sync(
+        &self,
+        py: Python<'_>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<ExecResult> {
+        let builtin_session =
+            capture_custom_builtin_session(py, &self.custom_builtins, &self.builtin_engine, false)?;
+        let on_output = prepare_output_handler(py, on_output)?;
+        let inner = self.inner.clone();
+
+        py.detach(|| {
+            self.rt.block_on(async move {
+                // THREAT[TM-DOS-FFI]: Timeout on mutex to prevent deadlock.
+                let mut bash =
+                    match tokio::time::timeout(std::time::Duration::from_secs(30), inner.lock())
+                        .await
+                    {
+                        Ok(guard) => guard,
+                        Err(_) => {
+                            return Err(PyRuntimeError::new_err(
+                                "execute_sync: timed out waiting for lock (30s). \
+                             Another thread may be holding the interpreter. \
+                             Use separate BashTool instances for concurrent access.",
+                            ));
+                        }
+                    };
+                exec_bash_with_optional_output(&mut bash, &commands, on_output, builtin_session)
+                    .await
+            })
+        })
+    }
+
+    /// Execute commands synchronously. Raises `BashError` on non-zero exit.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute_sync_or_throw(
+        &self,
+        py: Python<'_>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<ExecResult> {
+        let result = self.execute_sync(py, commands, on_output)?;
+        if result.exit_code != 0 {
+            return Err(raise_bash_error(&result));
+        }
+        Ok(result)
+    }
+
+    /// Execute commands asynchronously. Raises `BashError` on non-zero exit.
+    #[pyo3(signature = (commands, on_output=None))]
+    fn execute_or_throw<'py>(
+        &self,
+        py: Python<'py>,
+        commands: String,
+        on_output: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let builtin_session =
+            capture_custom_builtin_session(py, &self.custom_builtins, &self.builtin_engine, true)?;
+        let on_output = prepare_output_handler(py, on_output)?;
+        let inner = self.inner.clone();
+        let cancel_session = builtin_session.clone();
+        let future = future_into_py(py, async move {
+            let mut bash = inner.lock().await;
+            let result =
+                exec_bash_with_optional_output(&mut bash, &commands, on_output, builtin_session)
+                    .await?;
+            if result.exit_code != 0 {
+                return Err(raise_bash_error(&result));
+            }
+            Ok(result)
+        })?;
+        if let Some(cancel_session) = cancel_session {
+            attach_future_cancellation_callback(py, &future, cancel_session.clone())?;
+            return wrap_future_with_cancel(py, future, cancel_session);
+        }
+        Ok(future)
+    }
+
+    /// Releases GIL before blocking on tokio to prevent deadlock.
+    /// THREAT[TM-PY-028]: Rebuild with same config to preserve security limits
+    /// and registered custom builtins.
+    fn reset(&self, py: Python<'_>) -> PyResult<()> {
+        replace_live_bash_with_builder(
+            py,
+            &self.rt,
+            &self.inner,
+            &self.cancelled,
+            self.build_live_builder(py)?,
+        )
+    }
+
+    /// Serialize interpreter state to bytes for checkpoint/restore flows.
+    fn snapshot<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = snapshot_live_bash(py, &self.rt, &self.inner)?;
+        Ok(PyBytes::new(py, &bytes))
+    }
+
+    /// Restore interpreter state from bytes previously produced by `snapshot()`.
+    fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
+        restore_live_bash(py, &self.rt, &self.inner, data)
+    }
+
+    /// Create a new BashTool instance from a snapshot and optional constructor kwargs.
+    #[staticmethod]
+    #[pyo3(signature = (
+        data,
+        username=None,
+        hostname=None,
+        max_commands=None,
+        max_loop_iterations=None,
+        max_memory=None,
+        timeout_seconds=None,
+        files=None,
+        mounts=None,
+        custom_builtins=None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn from_snapshot(
+        py: Python<'_>,
+        data: Vec<u8>,
+        username: Option<String>,
+        hostname: Option<String>,
+        max_commands: Option<u64>,
+        max_loop_iterations: Option<u64>,
+        max_memory: Option<u64>,
+        timeout_seconds: Option<f64>,
+        files: Option<&Bound<'_, PyDict>>,
+        mounts: Option<&Bound<'_, PyList>>,
+        custom_builtins: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Self> {
+        let tool = Self::new(
+            py,
+            username,
+            hostname,
+            max_commands,
+            max_loop_iterations,
+            max_memory,
+            timeout_seconds,
+            files,
+            mounts,
+            custom_builtins,
+        )?;
+        tool.restore_snapshot(py, data)?;
+        Ok(tool)
+    }
+
+    fn read_file(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_text_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn write_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| write_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    fn append_file(&self, py: Python<'_>, path: String, content: String) -> PyResult<()> {
+        py.detach(|| append_text_via_live_fs(&self.rt, &self.inner, path, content))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn mkdir(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| mkdir_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn exists(&self, py: Python<'_>, path: String) -> PyResult<bool> {
+        py.detach(|| exists_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    #[pyo3(signature = (path, recursive=false))]
+    fn remove(&self, py: Python<'_>, path: String, recursive: bool) -> PyResult<()> {
+        py.detach(|| remove_via_live_fs(&self.rt, &self.inner, path, recursive))
+    }
+
+    fn stat(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let metadata = py.detach(|| stat_via_live_fs(&self.rt, &self.inner, path))?;
+        metadata_to_pydict(py, &metadata)
+    }
+
+    fn chmod(&self, py: Python<'_>, path: String, mode: u32) -> PyResult<()> {
+        py.detach(|| chmod_via_live_fs(&self.rt, &self.inner, path, mode))
+    }
+
+    fn symlink(&self, py: Python<'_>, target: String, link: String) -> PyResult<()> {
+        py.detach(|| symlink_via_live_fs(&self.rt, &self.inner, target, link))
+    }
+
+    fn read_link(&self, py: Python<'_>, path: String) -> PyResult<String> {
+        py.detach(|| read_link_via_live_fs(&self.rt, &self.inner, path))
+    }
+
+    fn read_dir(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let entries = py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path))?;
+        let items: Vec<Py<PyAny>> = entries
+            .iter()
+            .map(|entry| dir_entry_to_pydict(py, entry))
+            .collect::<PyResult<_>>()?;
+        Ok(PyList::new(py, &items)?.into_any().unbind())
+    }
+
+    #[pyo3(signature = (path=".".to_string()))]
+    fn ls(&self, py: Python<'_>, path: String) -> PyResult<Py<PyAny>> {
+        let names = match py.detach(|| read_dir_via_live_fs(&self.rt, &self.inner, path)) {
+            Ok(entries) => entries
+                .into_iter()
+                .map(|entry| entry.name)
+                .collect::<Vec<_>>(),
+            Err(_) => Vec::new(),
+        };
+        Ok(PyList::new(py, names)?.into_any().unbind())
+    }
+
+    fn glob(&self, py: Python<'_>, pattern: String) -> PyResult<Py<PyAny>> {
+        let matches = py.detach(|| -> PyResult<Vec<String>> {
+            Ok(glob_via_bash(&self.rt, &self.inner, pattern))
+        })?;
+        Ok(PyList::new(py, matches)?.into_any().unbind())
+    }
+
+    /// Return a live filesystem handle backed by the current interpreter.
+    ///
+    /// Each operation on the returned handle acquires the interpreter lock,
+    /// so it always reflects the latest state (including post-reset). For
+    /// batch reads where consistency isn't needed, prefer reading files via
+    /// `execute_sync("cat ...")`.
+    fn fs(&self, py: Python<'_>) -> PyResult<Py<PyFileSystem>> {
+        Py::new(
+            py,
+            PyFileSystem::from_live(self.inner.clone(), self.rt.clone()),
+        )
+    }
+
+    /// Mount a filesystem at `vfs_path` without rebuilding the interpreter.
+    fn mount(&self, py: Python<'_>, vfs_path: String, fs: PyRef<'_, PyFileSystem>) -> PyResult<()> {
+        let inner = self.inner.clone();
+        let source = fs.inner.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let mounted_fs = source.resolve().await;
+                let bash = inner.lock().await;
+                bash.mount(Path::new(&vfs_path), mounted_fs)
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                Ok(())
+            })
+        })
+    }
+
+    /// Unmount a live filesystem without rebuilding the interpreter.
+    fn unmount(&self, py: Python<'_>, vfs_path: String) -> PyResult<()> {
+        let inner = self.inner.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let bash = inner.lock().await;
+                bash.unmount(Path::new(&vfs_path))
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                Ok(())
+            })
+        })
+    }
+
+    #[getter]
+    fn name(&self) -> &str {
+        "bashkit"
+    }
+
+    #[getter]
+    fn short_description(&self) -> &str {
+        "Run bash commands in an isolated virtual filesystem"
+    }
+
+    fn description(&self) -> PyResult<String> {
+        Ok(self.build_rust_tool().description().to_string())
+    }
+
+    fn help(&self) -> PyResult<String> {
+        Ok(self.build_rust_tool().help())
+    }
+
+    fn system_prompt(&self) -> PyResult<String> {
+        Ok(self.build_rust_tool().system_prompt())
+    }
+
+    fn input_schema(&self) -> PyResult<String> {
+        let schema = self.build_rust_tool().input_schema();
+        serde_json::to_string_pretty(&schema)
+            .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
+    }
+
+    fn output_schema(&self) -> PyResult<String> {
+        let schema = self.build_rust_tool().output_schema();
+        serde_json::to_string_pretty(&schema)
+            .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
+    }
+
+    #[getter]
+    fn version(&self) -> &str {
+        VERSION
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "BashTool(username={:?}, hostname={:?})",
+            self.username.as_deref().unwrap_or("user"),
+            self.hostname.as_deref().unwrap_or("sandbox")
+        )
+    }
 }
 
 // ============================================================================
@@ -3023,6 +3353,7 @@ impl ScriptedTool {
             self.callback_engine.clone(),
             self.tools.iter().any(|entry| entry.is_async),
             true,
+            PySyncLoopMode::PerSession,
         )?;
         let tool = self.build_rust_tool_with_session(py, session.clone());
         let future = future_into_py(py, async move {
@@ -3054,6 +3385,7 @@ impl ScriptedTool {
             self.callback_engine.clone(),
             self.tools.iter().any(|entry| entry.is_async),
             false,
+            PySyncLoopMode::PerSession,
         )?;
         let tool = self.build_rust_tool_with_session(py, session);
 
@@ -3104,6 +3436,7 @@ impl ScriptedTool {
                 self.callback_engine.clone(),
                 false,
                 false,
+                PySyncLoopMode::PerSession,
             )
             .expect("callback session");
             self.build_rust_tool_with_session(py, session)
@@ -3120,6 +3453,7 @@ impl ScriptedTool {
                 self.callback_engine.clone(),
                 false,
                 false,
+                PySyncLoopMode::PerSession,
             )
             .expect("callback session");
             self.build_rust_tool_with_session(py, session).help()
@@ -3134,6 +3468,7 @@ impl ScriptedTool {
                 self.callback_engine.clone(),
                 false,
                 false,
+                PySyncLoopMode::PerSession,
             )
             .expect("callback session");
             self.build_rust_tool_with_session(py, session)
@@ -3148,6 +3483,7 @@ impl ScriptedTool {
             self.callback_engine.clone(),
             false,
             false,
+            PySyncLoopMode::PerSession,
         )?;
         let tool = self.build_rust_tool_with_session(py, session);
         let schema = tool.input_schema();
@@ -3162,6 +3498,7 @@ impl ScriptedTool {
             self.callback_engine.clone(),
             false,
             false,
+            PySyncLoopMode::PerSession,
         )?;
         let tool = self.build_rust_tool_with_session(py, session);
         let schema = tool.output_schema();
@@ -3251,6 +3588,7 @@ fn _bashkit(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<BashTool>()?;
     m.add_class::<ScriptedTool>()?;
     m.add_class::<ExecResult>()?;
+    m.add_class::<PyBuiltinContext>()?;
     m.add_class::<PyFileSystem>()?;
     m.add("BashError", m.py().get_type::<BashError>())?;
     m.add_function(wrap_pyfunction!(create_langchain_tool_spec, m)?)?;

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -18,13 +18,14 @@ use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyFloat, PyFrozenSet, PyInt, PyList, PySet, PyTuple};
 use pyo3_async_runtimes::tokio::future_into_py;
+use pyo3_async_runtimes::TaskLocals;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
 
 // ============================================================================
 // JSON <-> Python helpers
@@ -2324,6 +2325,501 @@ impl BashTool {
 }
 
 // ============================================================================
+// ScriptedTool callback sessions
+// ============================================================================
+
+struct PyCallbackSessionState {
+    context: Py<PyAny>,
+    caller_loop_locals: Option<TaskLocals>,
+}
+
+struct PyPrivateAsyncLoop {
+    event_loop: StdMutex<Option<Py<PyAny>>>,
+}
+
+impl PyPrivateAsyncLoop {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            event_loop: StdMutex::new(None),
+        })
+    }
+
+    fn event_loop(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let mut event_loop = self.event_loop.lock().expect("tool async loop lock");
+        if event_loop.is_none() {
+            let asyncio = py.import("asyncio")?;
+            *event_loop = Some(asyncio.call_method0("new_event_loop")?.unbind());
+        }
+        Ok(event_loop
+            .as_ref()
+            .expect("tool async loop prepared")
+            .clone_ref(py))
+    }
+
+    fn run_awaitable(&self, py: Python<'_>, awaitable: &Py<PyAny>) -> PyResult<Py<PyAny>> {
+        self.event_loop(py)?
+            .bind(py)
+            .call_method1("run_until_complete", (awaitable.bind(py),))
+            .map(|value| value.unbind())
+    }
+}
+
+struct PyCallbackEngine {
+    caller: Py<PyAny>,
+}
+
+impl PyCallbackEngine {
+    fn new(py: Python<'_>) -> PyResult<Arc<Self>> {
+        Ok(Arc::new(Self {
+            caller: create_context_callback_caller(py)?,
+        }))
+    }
+
+    fn invoke(
+        &self,
+        py: Python<'_>,
+        context: &Py<PyAny>,
+        callback: &Py<PyAny>,
+        args: Vec<Py<PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
+        let args = PyTuple::new(py, &args)?;
+        self.caller.call1(py, (context, callback, args))
+    }
+}
+
+struct PyCallbackSession {
+    state: StdMutex<PyCallbackSessionState>,
+    active_caller_tasks: Arc<StdMutex<Vec<Py<PyAny>>>>,
+    private_async_loop: Arc<PyPrivateAsyncLoop>,
+    engine: Arc<PyCallbackEngine>,
+}
+
+impl PyCallbackSession {
+    fn capture(
+        py: Python<'_>,
+        engine: Arc<PyCallbackEngine>,
+        needs_async_callbacks: bool,
+        use_caller_loop: bool,
+    ) -> PyResult<Arc<Self>> {
+        Ok(Arc::new(Self {
+            state: StdMutex::new(capture_callback_state(
+                py,
+                needs_async_callbacks,
+                use_caller_loop,
+            )?),
+            active_caller_tasks: Arc::new(StdMutex::new(Vec::new())),
+            private_async_loop: PyPrivateAsyncLoop::new(),
+            engine,
+        }))
+    }
+
+    fn current_context(&self, py: Python<'_>) -> Py<PyAny> {
+        self.state
+            .lock()
+            .expect("tool callback session lock")
+            .context
+            .clone_ref(py)
+    }
+
+    fn current_caller_loop_locals(&self) -> Option<TaskLocals> {
+        self.state
+            .lock()
+            .expect("tool callback session lock")
+            .caller_loop_locals
+            .clone()
+    }
+
+    fn active_caller_tasks(&self) -> Arc<StdMutex<Vec<Py<PyAny>>>> {
+        self.active_caller_tasks.clone()
+    }
+
+    fn cancel_active_caller_tasks(&self, py: Python<'_>) -> PyResult<()> {
+        let Some(locals) = self.current_caller_loop_locals() else {
+            return Ok(());
+        };
+        let tasks = self
+            .active_caller_tasks
+            .lock()
+            .expect("tool active caller tasks lock")
+            .drain(..)
+            .collect::<Vec<_>>();
+        for task in tasks {
+            cancel_python_task(py, &locals, &task)?;
+        }
+        Ok(())
+    }
+
+    fn invoke(
+        &self,
+        py: Python<'_>,
+        callback: &Py<PyAny>,
+        args: Vec<Py<PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
+        let context = self.current_context(py);
+        self.engine.invoke(py, &context, callback, args)
+    }
+
+    fn run_awaitable_on_private_loop(
+        &self,
+        py: Python<'_>,
+        awaitable: &Py<PyAny>,
+    ) -> PyResult<Py<PyAny>> {
+        self.private_async_loop.run_awaitable(py, awaitable)
+    }
+}
+
+fn capture_callback_state(
+    py: Python<'_>,
+    needs_async_callbacks: bool,
+    use_caller_loop: bool,
+) -> PyResult<PyCallbackSessionState> {
+    if needs_async_callbacks && use_caller_loop {
+        let locals = pyo3_async_runtimes::tokio::get_current_locals(py)?;
+        return Ok(PyCallbackSessionState {
+            context: locals.context(py).unbind(),
+            caller_loop_locals: Some(locals),
+        });
+    }
+
+    Ok(PyCallbackSessionState {
+        context: copy_current_context(py)?,
+        caller_loop_locals: None,
+    })
+}
+
+fn create_context_callback_caller(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    pyo3::types::PyModule::from_code(
+        py,
+        c"def _call(ctx, fn, args):\n    return ctx.run(fn, *args)",
+        c"<bashkit_callback>",
+        c"_bashkit_callback",
+    )?
+    .getattr("_call")
+    .map(|caller| caller.unbind())
+}
+
+fn asyncio_cancelled_error(py: Python<'_>) -> PyResult<PyErr> {
+    Ok(PyErr::from_value(
+        py.import("asyncio")?.call_method0("CancelledError")?,
+    ))
+}
+
+fn call_soon_threadsafe_with_context(
+    py: Python<'_>,
+    locals: &TaskLocals,
+    callback: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("context", locals.context(py))?;
+    locals
+        .event_loop(py)
+        .call_method("call_soon_threadsafe", (callback,), Some(&kwargs))?;
+    Ok(())
+}
+
+fn cancel_python_task(py: Python<'_>, locals: &TaskLocals, task: &Py<PyAny>) -> PyResult<()> {
+    let cancel = task.bind(py).getattr("cancel")?;
+    call_soon_threadsafe_with_context(py, locals, &cancel)
+}
+
+fn remove_active_caller_task(
+    active_caller_tasks: &Arc<StdMutex<Vec<Py<PyAny>>>>,
+    task: &Bound<'_, PyAny>,
+) {
+    let task_ptr = task.as_ptr();
+    if let Ok(mut active_tasks) = active_caller_tasks.lock() {
+        active_tasks.retain(|active_task| active_task.bind(task.py()).as_ptr() != task_ptr);
+    }
+}
+
+#[pyclass]
+struct PyCallbackTaskCompleter {
+    tx: Option<oneshot::Sender<PyResult<Py<PyAny>>>>,
+    active_caller_tasks: Arc<StdMutex<Vec<Py<PyAny>>>>,
+}
+
+#[pymethods]
+impl PyCallbackTaskCompleter {
+    #[pyo3(signature = (task))]
+    fn __call__(&mut self, task: &Bound<'_, PyAny>) -> PyResult<()> {
+        remove_active_caller_task(&self.active_caller_tasks, task);
+        let result = match task.call_method0("result") {
+            Ok(value) => Ok(value.unbind()),
+            Err(err) => Err(err),
+        };
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(result);
+        }
+        Ok(())
+    }
+}
+
+#[pyclass]
+struct PyScheduleCallbackTask {
+    awaitable: Py<PyAny>,
+    on_complete: Py<PyAny>,
+    shared_task: Arc<StdMutex<Option<Py<PyAny>>>>,
+    active_caller_tasks: Arc<StdMutex<Vec<Py<PyAny>>>>,
+    cancel_requested: Arc<AtomicBool>,
+}
+
+#[pymethods]
+impl PyScheduleCallbackTask {
+    fn __call__(&self) -> PyResult<()> {
+        Python::attach(|py| {
+            let task = py
+                .import("asyncio")?
+                .call_method1("ensure_future", (self.awaitable.bind(py),))?;
+            *self.shared_task.lock().expect("tool callback task lock") =
+                Some(task.clone().unbind());
+            self.active_caller_tasks
+                .lock()
+                .expect("tool active caller tasks lock")
+                .push(task.clone().unbind());
+            task.call_method1("add_done_callback", (self.on_complete.bind(py),))?;
+            if self.cancel_requested.load(Ordering::Relaxed) {
+                let _ = task.call_method0("cancel");
+            }
+            Ok(())
+        })
+    }
+}
+
+#[pyclass]
+struct PyCancelActiveCallbackTasks {
+    session: Arc<PyCallbackSession>,
+}
+
+#[pymethods]
+impl PyCancelActiveCallbackTasks {
+    #[pyo3(signature = (future))]
+    fn __call__(&self, future: &Bound<'_, PyAny>) -> PyResult<()> {
+        if future.call_method0("cancelled")?.extract::<bool>()? {
+            self.session.cancel_active_caller_tasks(future.py())?;
+        }
+        Ok(())
+    }
+}
+
+fn attach_future_cancellation_callback(
+    py: Python<'_>,
+    future: &Bound<'_, PyAny>,
+    session: Arc<PyCallbackSession>,
+) -> PyResult<()> {
+    let on_cancel = Py::new(py, PyCancelActiveCallbackTasks { session })?
+        .into_bound(py)
+        .into_any()
+        .unbind();
+    future.call_method1("add_done_callback", (on_cancel.bind(py),))?;
+    Ok(())
+}
+
+#[pyclass]
+struct PyCancelActiveCallbackTasksNow {
+    session: Arc<PyCallbackSession>,
+}
+
+#[pymethods]
+impl PyCancelActiveCallbackTasksNow {
+    fn __call__(&self, py: Python<'_>) -> PyResult<()> {
+        self.session.cancel_active_caller_tasks(py)
+    }
+}
+
+fn create_execute_cancel_wrapper(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    pyo3::types::PyModule::from_code(
+        py,
+        c"import asyncio\nclass _CancelForwardingAwaitable:\n    def __init__(self, inner, on_cancel):\n        self._inner = inner\n        self._on_cancel = on_cancel\n    def cancel(self):\n        self._on_cancel()\n        return self._inner.cancel()\n    def __await__(self):\n        async def _await_inner():\n            try:\n                return await self._inner\n            except asyncio.CancelledError:\n                self._on_cancel()\n                self._inner.cancel()\n                raise\n        return _await_inner().__await__()\n    def __getattr__(self, name):\n        return getattr(self._inner, name)\ndef wrap(inner, on_cancel):\n    return _CancelForwardingAwaitable(inner, on_cancel)",
+        c"<bashkit_cancel_wrapper>",
+        c"_bashkit_cancel_wrapper",
+    )?
+    .getattr("wrap")
+    .map(|wrap| wrap.unbind())
+}
+
+fn wrap_future_with_cancel<'py>(
+    py: Python<'py>,
+    future: Bound<'py, PyAny>,
+    session: Arc<PyCallbackSession>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let on_cancel = Py::new(py, PyCancelActiveCallbackTasksNow { session })?
+        .into_bound(py)
+        .into_any()
+        .unbind();
+    create_execute_cancel_wrapper(py)?
+        .bind(py)
+        .call1((future, on_cancel.bind(py)))
+}
+
+struct PyCancellableLoopFuture {
+    result_rx: Option<oneshot::Receiver<PyResult<Py<PyAny>>>>,
+    locals: TaskLocals,
+    shared_task: Arc<StdMutex<Option<Py<PyAny>>>>,
+    cancel_requested: Arc<AtomicBool>,
+    completed: bool,
+}
+
+impl PyCancellableLoopFuture {
+    fn new(
+        py: Python<'_>,
+        session: Arc<PyCallbackSession>,
+        awaitable: Py<PyAny>,
+    ) -> PyResult<Self> {
+        let locals = session
+            .current_caller_loop_locals()
+            .expect("caller loop locals required for async callback session");
+        let (tx, rx) = oneshot::channel();
+        let shared_task = Arc::new(StdMutex::new(None));
+        let cancel_requested = Arc::new(AtomicBool::new(false));
+        let active_caller_tasks = session.active_caller_tasks();
+        let on_complete = Py::new(
+            py,
+            PyCallbackTaskCompleter {
+                tx: Some(tx),
+                active_caller_tasks: active_caller_tasks.clone(),
+            },
+        )?
+        .into_bound(py)
+        .into_any()
+        .unbind();
+        let scheduler = Py::new(
+            py,
+            PyScheduleCallbackTask {
+                awaitable,
+                on_complete,
+                shared_task: shared_task.clone(),
+                active_caller_tasks,
+                cancel_requested: cancel_requested.clone(),
+            },
+        )?
+        .into_bound(py)
+        .into_any()
+        .unbind();
+        call_soon_threadsafe_with_context(py, &locals, scheduler.bind(py))?;
+        Ok(Self {
+            result_rx: Some(rx),
+            locals,
+            shared_task,
+            cancel_requested,
+            completed: false,
+        })
+    }
+
+    async fn wait(mut self) -> PyResult<Py<PyAny>> {
+        let result_rx = self.result_rx.take().expect("callback result receiver");
+        let result = match result_rx.await {
+            Ok(result) => result,
+            Err(_) => Err(Python::attach(asyncio_cancelled_error)?),
+        };
+        self.completed = true;
+        result
+    }
+}
+
+impl Drop for PyCancellableLoopFuture {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+
+        self.cancel_requested.store(true, Ordering::Relaxed);
+        Python::attach(|py| {
+            let maybe_task = self
+                .shared_task
+                .lock()
+                .ok()
+                .and_then(|shared_task| shared_task.as_ref().map(|task| task.clone_ref(py)));
+            if let Some(task) = maybe_task {
+                let _ = cancel_python_task(py, &self.locals, &task);
+            }
+        });
+    }
+}
+
+fn build_py_tool_entry(
+    py: Python<'_>,
+    name: String,
+    description: String,
+    callback: Py<PyAny>,
+    schema: Option<Bound<'_, pyo3::PyAny>>,
+) -> PyResult<PyToolEntry> {
+    let schema_val = match schema {
+        Some(ref schema) => py_to_json(py, schema)?,
+        None => serde_json::Value::Object(Default::default()),
+    };
+    let bound = callback.bind(py);
+    if !bound.is_callable() {
+        return Err(PyTypeError::new_err(format!(
+            "tool '{name}' callback must be callable"
+        )));
+    }
+    let is_async = is_coroutine_callable(py, bound)?;
+    Ok(PyToolEntry {
+        name,
+        description,
+        schema: schema_val,
+        callback,
+        is_async,
+    })
+}
+
+fn make_py_tool_callback_args(py: Python<'_>, args: &ToolArgs) -> Result<Vec<Py<PyAny>>, String> {
+    let params = json_to_py(py, &args.params).map_err(|e: PyErr| e.to_string())?;
+    let stdin_arg = match args.stdin.as_deref() {
+        Some(stdin) => stdin
+            .into_pyobject(py)
+            .expect("str -> Python object")
+            .into_any()
+            .unbind(),
+        None => py.None(),
+    };
+    Ok(vec![params, stdin_arg])
+}
+
+fn call_python_string_callback_sync(
+    py: Python<'_>,
+    session: &PyCallbackSession,
+    callback_name: &str,
+    callback: &Py<PyAny>,
+    args: Vec<Py<PyAny>>,
+) -> Result<String, String> {
+    let result = session
+        .invoke(py, callback, args)
+        .map_err(|e| format!("{callback_name}: {e}"))?;
+    result
+        .extract::<String>(py)
+        .map_err(|e| format!("{callback_name}: callback must return str, got {e}"))
+}
+
+async fn call_python_string_callback_async(
+    session: Arc<PyCallbackSession>,
+    callback_name: &str,
+    callback: &Py<PyAny>,
+    args: Vec<Py<PyAny>>,
+) -> Result<String, String> {
+    let awaitable = Python::attach(|py| session.invoke(py, callback, args))
+        .map_err(|e| format!("{callback_name}: {e}"))?;
+
+    let result = if session.current_caller_loop_locals().is_some() {
+        let future = Python::attach(|py| PyCancellableLoopFuture::new(py, session, awaitable))
+            .map_err(|e| format!("{callback_name}: {e}"))?;
+        future
+            .wait()
+            .await
+            .map_err(|e| format!("{callback_name}: {e}"))?
+    } else {
+        Python::attach(|py| session.run_awaitable_on_private_loop(py, &awaitable))
+            .map_err(|e| format!("{callback_name}: {e}"))?
+    };
+
+    Python::attach(|py| {
+        result
+            .extract::<String>(py)
+            .map_err(|e| format!("{callback_name}: callback must return str, got {e}"))
+    })
+}
+
+// ============================================================================
 // ScriptedTool — multi-tool orchestration via bash scripts
 // ============================================================================
 
@@ -2369,6 +2865,7 @@ pub struct ScriptedTool {
     /// Shared tokio runtime — reused across all sync calls to avoid
     /// per-call OS thread/fd exhaustion (issue #414).
     rt: Arc<Runtime>,
+    callback_engine: Arc<PyCallbackEngine>,
     max_commands: Option<u64>,
     max_loop_iterations: Option<u64>,
 }
@@ -2376,107 +2873,56 @@ pub struct ScriptedTool {
 impl ScriptedTool {
     /// Build a Rust ScriptedTool from stored Python config.
     ///
-    /// Called at execute() time so that `contextvars.copy_context()` captures the
-    /// caller's ContextVar state. Each Python callback is invoked via `ctx.run()`
-    /// to restore those vars.
-    fn build_rust_tool(&self) -> RustScriptedTool {
+    /// The supplied session captures the caller's `ContextVar` state and, for
+    /// async execute(), the caller's active asyncio loop. Each Python callback
+    /// is invoked via `ctx.run()` to restore those vars.
+    fn build_rust_tool_with_session(
+        &self,
+        py: Python<'_>,
+        session: Arc<PyCallbackSession>,
+    ) -> RustScriptedTool {
         let mut builder = RustScriptedTool::builder(&self.name);
 
         if let Some(ref desc) = self.short_desc {
             builder = builder.short_description(desc);
         }
 
-        // Snapshot the caller's contextvars at execute()-call time.
-        let py_ctx: Py<PyAny> =
-            Python::attach(|py| copy_current_context(py).expect("copy_context"));
-
-        // Resources for async callbacks: a shared event loop and a helper
-        // function that drives coroutines inside the captured ContextVar
-        // snapshot. Created once per execute() call and shared across all
-        // async callback invocations to avoid FD exhaustion.
-        let has_async = self.tools.iter().any(|e| e.is_async);
-        let async_loop: Option<Py<PyAny>> = if has_async {
-            Some(Python::attach(|py| {
-                let asyncio = py.import("asyncio").expect("asyncio stdlib");
-                asyncio
-                    .call_method0("new_event_loop")
-                    .expect("new_event_loop")
-                    .unbind()
-            }))
-        } else {
-            None
-        };
-        // Helper: ctx.run(lambda: loop.run_until_complete(fn(p, s)))
-        // Wrapping run_until_complete inside ctx.run() ensures the Task
-        // created by run_until_complete inherits the captured context,
-        // making ContextVars visible throughout the coroutine body.
-        let async_runner: Option<Py<PyAny>> = if has_async {
-            Some(Python::attach(|py| {
-                pyo3::types::PyModule::from_code(
-                    py,
-                    c"def _run(ctx, loop, fn, params, stdin):\n    return ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))",
-                    c"<bashkit_async>",
-                    c"_bashkit_async",
-                )
-                .expect("async helper module")
-                .getattr("_run")
-                .expect("_run function")
-                .unbind()
-            }))
-        } else {
-            None
-        };
-
         for entry in &self.tools {
-            let py_cb = Python::attach(|py| entry.callback.clone_ref(py));
-            let tool_name = entry.name.clone();
+            let py_callback = entry.callback.clone_ref(py);
             let def =
                 ToolDef::new(&entry.name, &entry.description).with_schema(entry.schema.clone());
-            let ctx = Python::attach(|py| py_ctx.clone_ref(py));
+            let tool_name = entry.name.clone();
 
             if entry.is_async {
-                // Async callback: the runner helper calls
-                //   ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))
-                // which ensures the Task inherits the captured ContextVars.
-                // The GIL serialises access so the shared loop is safe.
-                let ev_loop = async_loop
-                    .as_ref()
-                    .map(|l| Python::attach(|py| l.clone_ref(py)))
-                    .expect("async_loop must exist when is_async is true");
-                let runner = async_runner
-                    .as_ref()
-                    .map(|r| Python::attach(|py| r.clone_ref(py)))
-                    .expect("async_runner must exist when is_async is true");
-                let callback = move |args: &ToolArgs| -> Result<String, String> {
-                    Python::attach(|py| {
-                        let params =
-                            json_to_py(py, &args.params).map_err(|e: PyErr| e.to_string())?;
-                        let stdin_arg = args.stdin.as_deref().map(|s| s.to_string());
-                        let result = runner
-                            .call1(py, (&ctx, &ev_loop, &py_cb, params, stdin_arg))
-                            .map_err(|e| format!("{}: {}", tool_name, e))?;
-                        result.extract::<String>(py).map_err(|e| {
-                            format!("{}: callback must return str, got {}", tool_name, e)
-                        })
-                    })
-                };
-                builder = builder.tool_fn(def, callback);
+                let session = session.clone();
+                builder = builder.async_tool_fn(def, move |args: ToolArgs| {
+                    let session = session.clone();
+                    let tool_name = tool_name.clone();
+                    let py_callback = Python::attach(|py| py_callback.clone_ref(py));
+                    async move {
+                        let py_args = Python::attach(|py| make_py_tool_callback_args(py, &args))?;
+                        call_python_string_callback_async(
+                            session,
+                            &tool_name,
+                            &py_callback,
+                            py_args,
+                        )
+                        .await
+                    }
+                });
             } else {
-                // Sync callback: ctx.run(fn, params, stdin) with ContextVars.
-                let callback = move |args: &ToolArgs| -> Result<String, String> {
+                let session = session.clone();
+                builder = builder.tool_fn(def, move |args: &ToolArgs| {
                     Python::attach(|py| {
-                        let params =
-                            json_to_py(py, &args.params).map_err(|e: PyErr| e.to_string())?;
-                        let stdin_arg = args.stdin.as_deref().map(|s| s.to_string());
-                        let result = ctx
-                            .call_method1(py, "run", (&py_cb, params, stdin_arg))
-                            .map_err(|e| format!("{}: {}", tool_name, e))?;
-                        result.extract::<String>(py).map_err(|e| {
-                            format!("{}: callback must return str, got {}", tool_name, e)
-                        })
+                        call_python_string_callback_sync(
+                            py,
+                            session.as_ref(),
+                            &tool_name,
+                            &py_callback,
+                            make_py_tool_callback_args(py, args)?,
+                        )
                     })
-                };
-                builder = builder.tool_fn(def, callback);
+                });
             }
         }
 
@@ -2517,6 +2963,7 @@ impl ScriptedTool {
         max_loop_iterations: Option<u64>,
     ) -> PyResult<Self> {
         let rt = make_runtime()?;
+        let callback_engine = Python::attach(PyCallbackEngine::new)?;
 
         Ok(Self {
             name,
@@ -2524,6 +2971,7 @@ impl ScriptedTool {
             tools: Vec::new(),
             env_vars: Vec::new(),
             rt,
+            callback_engine,
             max_commands,
             max_loop_iterations,
         })
@@ -2553,28 +3001,13 @@ impl ScriptedTool {
         callback: Py<PyAny>,
         schema: Option<Bound<'_, pyo3::PyAny>>,
     ) -> PyResult<()> {
-        let schema_val = match schema {
-            Some(ref s) => py_to_json(py, s)?,
-            None => serde_json::Value::Object(Default::default()),
-        };
-        // Detect async callbacks using the same pattern as external_handler
-        let inspect = py.import("inspect")?;
-        let is_coro_fn = inspect.getattr("iscoroutinefunction")?;
-        let bound = callback.bind(py);
-        let is_async = is_coro_fn.call1((bound,))?.extract::<bool>()?
-            || bound
-                .getattr("__call__")
-                .ok()
-                .and_then(|c| is_coro_fn.call1((c,)).ok())
-                .and_then(|r| r.extract::<bool>().ok())
-                .unwrap_or(false);
-        self.tools.push(PyToolEntry {
+        self.tools.push(build_py_tool_entry(
+            py,
             name,
             description,
-            schema: schema_val,
             callback,
-            is_async,
-        });
+            schema,
+        )?);
         Ok(())
     }
 
@@ -2585,8 +3018,14 @@ impl ScriptedTool {
 
     /// Execute a bash script asynchronously.
     fn execute<'py>(&self, py: Python<'py>, commands: String) -> PyResult<Bound<'py, PyAny>> {
-        let tool = self.build_rust_tool();
-        future_into_py(py, async move {
+        let session = PyCallbackSession::capture(
+            py,
+            self.callback_engine.clone(),
+            self.tools.iter().any(|entry| entry.is_async),
+            true,
+        )?;
+        let tool = self.build_rust_tool_with_session(py, session.clone());
+        let future = future_into_py(py, async move {
             let resp = tool
                 .execute(ToolRequest {
                     commands,
@@ -2602,13 +3041,21 @@ impl ScriptedTool {
                 stderr_truncated: resp.stderr_truncated,
                 final_env: resp.final_env,
             })
-        })
+        })?;
+        attach_future_cancellation_callback(py, &future, session.clone())?;
+        wrap_future_with_cancel(py, future, session)
     }
 
     /// Execute a bash script synchronously (blocking).
     /// Releases GIL before blocking on tokio to prevent deadlock with callbacks.
     fn execute_sync(&self, py: Python<'_>, commands: String) -> PyResult<ExecResult> {
-        let tool = self.build_rust_tool();
+        let session = PyCallbackSession::capture(
+            py,
+            self.callback_engine.clone(),
+            self.tools.iter().any(|entry| entry.is_async),
+            false,
+        )?;
+        let tool = self.build_rust_tool_with_session(py, session);
 
         let resp = py.detach(|| {
             self.rt.block_on(async move {
@@ -2651,30 +3098,72 @@ impl ScriptedTool {
 
     /// Get the token-efficient description.
     fn description(&self) -> String {
-        self.build_rust_tool().description().to_string()
+        Python::attach(|py| {
+            let session = PyCallbackSession::capture(
+                py,
+                self.callback_engine.clone(),
+                false,
+                false,
+            )
+            .expect("callback session");
+            self.build_rust_tool_with_session(py, session)
+                .description()
+                .to_string()
+        })
     }
 
     /// Get help as a Markdown document.
     fn help(&self) -> String {
-        self.build_rust_tool().help()
+        Python::attach(|py| {
+            let session = PyCallbackSession::capture(
+                py,
+                self.callback_engine.clone(),
+                false,
+                false,
+            )
+            .expect("callback session");
+            self.build_rust_tool_with_session(py, session).help()
+        })
     }
 
     /// Get compact system-prompt text for orchestration.
     fn system_prompt(&self) -> String {
-        self.build_rust_tool().system_prompt()
+        Python::attach(|py| {
+            let session = PyCallbackSession::capture(
+                py,
+                self.callback_engine.clone(),
+                false,
+                false,
+            )
+            .expect("callback session");
+            self.build_rust_tool_with_session(py, session)
+                .system_prompt()
+        })
     }
 
     /// Get JSON input schema.
-    fn input_schema(&self) -> PyResult<String> {
-        let tool = self.build_rust_tool();
+    fn input_schema(&self, py: Python<'_>) -> PyResult<String> {
+        let session = PyCallbackSession::capture(
+            py,
+            self.callback_engine.clone(),
+            false,
+            false,
+        )?;
+        let tool = self.build_rust_tool_with_session(py, session);
         let schema = tool.input_schema();
         serde_json::to_string_pretty(&schema)
             .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
     }
 
     /// Get JSON output schema.
-    fn output_schema(&self) -> PyResult<String> {
-        let tool = self.build_rust_tool();
+    fn output_schema(&self, py: Python<'_>) -> PyResult<String> {
+        let session = PyCallbackSession::capture(
+            py,
+            self.callback_engine.clone(),
+            false,
+            false,
+        )?;
+        let tool = self.build_rust_tool_with_session(py, session);
         let schema = tool.output_schema();
         serde_json::to_string_pretty(&schema)
             .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -11,6 +11,8 @@ Covers:
 import asyncio
 import contextvars
 import gc
+import threading
+import weakref
 
 import pytest
 
@@ -73,6 +75,59 @@ async def test_async_callback_async_execute():
     r = await tool.execute("greet --name Awaited")
     assert r.exit_code == 0
     assert r.stdout.strip() == "hello Awaited"
+
+
+@pytest.mark.asyncio
+async def test_async_callback_async_execute_uses_caller_loop():
+    """Async execute() runs callbacks on the caller's active event loop."""
+
+    caller_loop = asyncio.get_running_loop()
+
+    async def inspect_loop(params, stdin=None):
+        same_loop = asyncio.get_running_loop() is caller_loop
+        return f"same_loop={same_loop}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool("inspect_loop", "Inspect loop", callback=inspect_loop)
+    r = await tool.execute("inspect_loop")
+
+    assert r.exit_code == 0
+    assert r.stdout.strip() == "same_loop=True"
+
+
+@pytest.mark.asyncio
+async def test_async_callback_async_execute_cancels_callback_task():
+    """Cancelling execute() also cancels the underlying callback task."""
+
+    started = asyncio.Event()
+    released = asyncio.Event()
+    cancelled = asyncio.Event()
+    completed = []
+
+    async def block(params, stdin=None):
+        started.set()
+        try:
+            await released.wait()
+            completed.append("completed")
+            return "done\n"
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    tool = ScriptedTool("api")
+    tool.add_tool("block", "Block", callback=block)
+    future = tool.execute("block")
+
+    await started.wait()
+    future.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await future
+
+    released.set()
+    await asyncio.sleep(0.05)
+
+    assert cancelled.is_set()
+    assert completed == []
 
 
 def test_async_callback_with_await():
@@ -142,6 +197,115 @@ def test_mixed_sync_async_callbacks():
     assert r.exit_code == 0
     assert "sync-hello A" in r.stdout
     assert "async-hello B" in r.stdout
+
+
+def test_async_callback_sync_execute_reuses_private_loop_within_script():
+    """execute_sync() reuses one private loop across async callback invocations."""
+
+    first_loop = None
+
+    async def inspect_loop(params, stdin=None):
+        nonlocal first_loop
+        current_loop = asyncio.get_running_loop()
+        same_loop = first_loop is None or first_loop is current_loop
+        first_loop = current_loop
+        return f"same_loop={same_loop}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool("inspect_loop", "Inspect loop", callback=inspect_loop)
+    r = tool.execute_sync("inspect_loop; inspect_loop")
+
+    assert r.exit_code == 0
+    assert r.stdout.splitlines() == ["same_loop=True", "same_loop=True"]
+
+
+def test_async_callback_sync_execute_isolates_private_loops_per_threaded_call():
+    """Concurrent execute_sync() calls on one ScriptedTool do not share a private loop."""
+
+    first_started = threading.Event()
+    results = {}
+    errors = []
+
+    async def inspect_loop(params, stdin=None):
+        name = params.get("name", "world")
+        if name == "slow":
+            first_started.set()
+            await asyncio.sleep(0.1)
+        return f"{name}\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool(
+        "inspect_loop",
+        "Inspect loop",
+        callback=inspect_loop,
+        schema={"type": "object", "properties": {"name": {"type": "string"}}},
+    )
+
+    def run(name: str):
+        try:
+            results[name] = tool.execute_sync(f"inspect_loop --name {name}")
+        except BaseException as exc:  # pragma: no cover - exercised only on failure.
+            errors.append(exc)
+
+    slow_thread = threading.Thread(target=run, args=("slow",))
+    fast_thread = threading.Thread(target=run, args=("fast",))
+    slow_thread.start()
+    assert first_started.wait(timeout=5)
+    fast_thread.start()
+    slow_thread.join(timeout=5)
+    fast_thread.join(timeout=5)
+
+    assert not slow_thread.is_alive()
+    assert not fast_thread.is_alive()
+    assert errors == []
+    assert results["slow"].exit_code == 0
+    assert results["slow"].stdout.strip() == "slow"
+    assert results["fast"].exit_code == 0
+    assert results["fast"].stdout.strip() == "fast"
+
+
+@pytest.mark.asyncio
+async def test_async_execute_releases_finished_callback_tasks_before_completion():
+    """Completed caller-loop callback tasks are released before execute() returns."""
+
+    finalized = []
+    blocker_started = asyncio.Event()
+    blocker_released = asyncio.Event()
+
+    async def emit(params, stdin=None):
+        weakref.finalize(asyncio.current_task(), finalized.append, params["name"])
+        return f"{params['name']}\n"
+
+    async def block(params, stdin=None):
+        blocker_started.set()
+        await blocker_released.wait()
+        return "released\n"
+
+    tool = ScriptedTool("api")
+    tool.add_tool(
+        "emit",
+        "Emit name",
+        callback=emit,
+        schema={"type": "object", "properties": {"name": {"type": "string"}}},
+    )
+    tool.add_tool("block", "Block", callback=block)
+
+    future = tool.execute("emit --name one; emit --name two; emit --name three; block")
+
+    await blocker_started.wait()
+    for _ in range(50):
+        gc.collect()
+        await asyncio.sleep(0)
+        if sorted(finalized) == ["one", "three", "two"]:
+            break
+
+    assert sorted(finalized) == ["one", "three", "two"]
+
+    blocker_released.set()
+    result = await future
+
+    assert result.exit_code == 0
+    assert result.stdout.splitlines() == ["one", "two", "three", "released"]
 
 
 # ===========================================================================

--- a/crates/bashkit-python/tests/test_registered_tools.py
+++ b/crates/bashkit-python/tests/test_registered_tools.py
@@ -1,0 +1,265 @@
+"""Parity tests for constructor-time callback-backed custom builtins."""
+
+# Decision: parameterize Bash/BashTool here so custom builtin semantics stay
+# identical across both Python surfaces.
+
+import asyncio
+import contextvars
+import gc
+import json
+
+import pytest
+
+from bashkit import Bash, BashTool
+
+request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id")
+
+
+@pytest.fixture(autouse=True)
+def _collect_between_tests():
+    """Drop Rust-backed callback runtimes outside async test bodies on Python 3.12."""
+    yield
+    gc.collect()
+
+
+def build_shell(factory, custom_builtins):
+    return factory(custom_builtins=custom_builtins)
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_custom_builtins_persist_vfs_across_calls(factory):
+    shell = build_shell(
+        factory,
+        {
+            "get-order": lambda ctx: (
+                json.dumps(
+                    {
+                        "id": ctx.argv[1] if len(ctx.argv) >= 2 and ctx.argv[0] == "get" else "?",
+                        "status": "shipped",
+                        "items": ["widget"],
+                    }
+                )
+                + "\n"
+            )
+        },
+    )
+
+    first = shell.execute_sync("mkdir -p /scratch && get-order get 42 > /scratch/order.json")
+    second = shell.execute_sync("cat /scratch/order.json | jq -r '.items[]'")
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert second.stdout.strip() == "widget"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_custom_builtins_survive_reset(factory):
+    shell = build_shell(
+        factory,
+        {"ping": lambda ctx: "pong\n"},
+    )
+    shell.execute_sync("mkdir -p /scratch && printf 'gone\\n' > /scratch/state.txt")
+
+    shell.reset()
+    result = shell.execute_sync("ping && test ! -e /scratch/state.txt")
+
+    assert result.exit_code == 0
+    assert result.stdout == "pong\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_from_snapshot_accepts_custom_builtins(factory):
+    snapshot = factory().snapshot()
+
+    restored = factory.from_snapshot(
+        snapshot,
+        custom_builtins={"ping": lambda ctx: "pong\n"},
+    )
+    result = restored.execute_sync("ping")
+
+    assert result.exit_code == 0
+    assert result.stdout == "pong\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_custom_builtins_support_async_callbacks(factory):
+    async def greet(ctx):
+        await asyncio.sleep(0)
+        return f"hello {ctx.argv[0] if ctx.argv else 'world'}\n"
+
+    shell = build_shell(factory, {"greet": greet})
+    result = shell.execute_sync("greet Async")
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "hello Async"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+async def test_custom_builtins_async_execute_preserves_contextvars(factory):
+    def check_ctx(ctx):
+        return f"req={request_id.get('missing')}\n"
+
+    request_id.set("ctx-123")
+    shell = build_shell(factory, {"check-ctx": check_ctx})
+
+    result = await shell.execute("check-ctx")
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "req=ctx-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+async def test_custom_builtins_async_execute_uses_caller_loop(factory):
+    caller_loop = asyncio.get_running_loop()
+
+    async def inspect_loop(ctx):
+        same_loop = asyncio.get_running_loop() is caller_loop
+        return f"same_loop={same_loop}\n"
+
+    shell = build_shell(factory, {"inspect-loop": inspect_loop})
+    result = await shell.execute("inspect-loop")
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "same_loop=True"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+async def test_custom_builtins_async_execute_cancels_callback_task(factory):
+    started = asyncio.Event()
+    released = asyncio.Event()
+    cancelled = asyncio.Event()
+    completed = []
+
+    async def block(ctx):
+        started.set()
+        try:
+            await released.wait()
+            completed.append("completed")
+            return "done\n"
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    shell = build_shell(factory, {"block": block})
+    future = shell.execute("block")
+
+    await started.wait()
+    future.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await future
+
+    released.set()
+    await asyncio.sleep(0.05)
+
+    assert cancelled.is_set()
+    assert completed == []
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+@pytest.mark.asyncio
+async def test_custom_builtins_async_execute_cancellation_stays_per_call(factory):
+    started = asyncio.Event()
+    released = asyncio.Event()
+    cancelled = asyncio.Event()
+    completed = []
+
+    async def block(ctx):
+        started.set()
+        try:
+            await released.wait()
+            completed.append("completed")
+            return "done\n"
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    shell = build_shell(factory, {"block": block})
+    first = shell.execute("block")
+
+    await started.wait()
+
+    second = shell.execute("echo second")
+    await asyncio.sleep(0)
+
+    second.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await second
+
+    released.set()
+    first_result = await first
+
+    assert first_result.exit_code == 0
+    assert first_result.stdout == "done\n"
+    assert not cancelled.is_set()
+    assert completed == ["completed"]
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_custom_builtins_execute_sync_reuses_private_loop_across_calls(factory):
+    first_loop = None
+
+    async def inspect_loop(ctx):
+        nonlocal first_loop
+        current_loop = asyncio.get_running_loop()
+        same_loop = first_loop is None or first_loop is current_loop
+        first_loop = current_loop
+        return f"same_loop={same_loop}\n"
+
+    shell = build_shell(factory, {"inspect-loop": inspect_loop})
+    first = shell.execute_sync("inspect-loop")
+    second = shell.execute_sync("inspect-loop")
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert first.stdout.strip() == "same_loop=True"
+    assert second.stdout.strip() == "same_loop=True"
+
+
+def test_bashtool_help_lists_custom_builtins():
+    shell = BashTool(custom_builtins={"ping": lambda ctx: "pong\n"})
+
+    help_text = shell.help()
+
+    assert "ping" in help_text
+    assert "Custom commands: `ping`" in help_text
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_custom_builtins_receive_raw_argv_and_stdin(factory):
+    def inspect(ctx):
+        return json.dumps({"argv": ctx.argv, "stdin": ctx.stdin}) + "\n"
+
+    shell = build_shell(factory, {"inspect": inspect})
+    result = shell.execute_sync("printf 'payload' | inspect subcommand --flag value")
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "argv": ["subcommand", "--flag", "value"],
+        "stdin": "payload",
+    }
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_custom_builtins_support_subcommands(factory):
+    def orders(ctx):
+        if not ctx.argv:
+            return "usage: orders <get|list>\n"
+
+        subcmd, *rest = ctx.argv
+        if subcmd == "get":
+            return json.dumps({"id": rest[0], "status": "shipped"}) + "\n"
+        if subcmd == "list":
+            return json.dumps(["42", "7"]) + "\n"
+        return f"unknown subcommand: {subcmd}\n"
+
+    shell = build_shell(factory, {"orders": orders})
+    get_result = shell.execute_sync("orders get 42 | jq -r '.status'")
+    list_result = shell.execute_sync("orders list | jq -r '.[]'")
+
+    assert get_result.exit_code == 0
+    assert get_result.stdout.strip() == "shipped"
+    assert list_result.exit_code == 0
+    assert list_result.stdout.splitlines() == ["42", "7"]

--- a/crates/bashkit/docs/custom_builtins.md
+++ b/crates/bashkit/docs/custom_builtins.md
@@ -78,6 +78,41 @@ pub struct BuiltinContext<'a> {
 }
 ```
 
+### Per-Execution Extensions
+
+For request-scoped data that should not live on the builtin itself, use
+`Bash::exec_with_extensions()` (or `exec_streaming_with_extensions()`) and read
+the value inside the builtin with `ctx.execution_extension::<T>()`.
+
+```rust,ignore
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, ExecutionExtensions, async_trait};
+
+struct RequestId;
+
+#[async_trait]
+impl Builtin for RequestId {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let req = ctx
+            .execution_extension::<String>()
+            .cloned()
+            .unwrap_or_else(|| "missing".to_string());
+        Ok(ExecResult::ok(format!("{req}\n")))
+    }
+}
+
+let mut bash = Bash::builder()
+    .builtin("request-id", Box::new(RequestId))
+    .build();
+
+let result = bash
+    .exec_with_extensions(
+        "request-id",
+        ExecutionExtensions::new().with("req-123".to_string()),
+    )
+    .await?;
+assert_eq!(result.stdout, "req-123\n");
+```
+
 ### Arguments
 
 Arguments are passed as a slice of strings, excluding the command name itself:

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -225,6 +225,7 @@ pub use typescript::{
 };
 
 use async_trait::async_trait;
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -289,6 +290,57 @@ pub(crate) use crate::interpreter::ShellRef;
 
 // Re-export for use by builtins
 pub use crate::interpreter::BuiltinSideEffect;
+
+/// Typed, per-execution data exposed to builtin implementations.
+///
+/// This is intentionally separate from shell state: extensions live for one
+/// `Bash::exec*()` call, while the shell/interpreter may persist across many
+/// executions.
+#[derive(Default)]
+pub struct ExecutionExtensions {
+    values: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
+}
+
+impl ExecutionExtensions {
+    /// Create an empty execution extension bag.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a typed value, replacing any previous value of the same type.
+    pub fn insert<T>(&mut self, value: T) -> Option<T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.values
+            .insert(TypeId::of::<T>(), Box::new(value))
+            .and_then(|prev| prev.downcast::<T>().ok().map(|prev| *prev))
+    }
+
+    /// Builder-style insert.
+    pub fn with<T>(mut self, value: T) -> Self
+    where
+        T: Send + Sync + 'static,
+    {
+        let _ = self.insert(value);
+        self
+    }
+
+    /// Look up a typed value by exact type.
+    pub fn get<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.values
+            .get(&TypeId::of::<T>())
+            .and_then(|value| value.downcast_ref::<T>())
+    }
+
+    /// Return whether the bag is empty.
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+}
 
 /// A sub-command that a builtin wants the interpreter to execute.
 ///
@@ -463,6 +515,16 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
+    /// Look up a typed per-execution extension, if present.
+    pub fn execution_extension<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.shell
+            .as_ref()
+            .and_then(|shell| shell.execution_extensions.get::<T>())
+    }
+
     /// Create a new Context for testing purposes.
     ///
     /// This helper handles the conditional `http_client` field automatically.

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -22,8 +22,8 @@ pub use state::{BuiltinSideEffect, ControlFlow, ExecResult};
 use std::collections::{HashMap, HashSet};
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 
 /// Monotonic counter for unique process substitution file paths
 static PROC_SUB_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -129,6 +129,8 @@ pub(crate) struct ShellRef<'a> {
     pub(crate) history: &'a [HistoryEntry],
     /// Shared job table (read-only, accessed via `jobs`).
     pub(crate) jobs: &'a SharedJobTable,
+    /// Typed per-execution extensions for the current `exec*()` call.
+    pub(crate) execution_extensions: Arc<builtins::ExecutionExtensions>,
 }
 
 impl ShellRef<'_> {
@@ -170,6 +172,22 @@ impl ShellRef<'_> {
     /// Get the shared job table for wait operations.
     pub(crate) fn jobs(&self) -> &SharedJobTable {
         self.jobs
+    }
+}
+
+pub(crate) struct ExecutionExtensionsGuard {
+    slot: Arc<StdMutex<Arc<builtins::ExecutionExtensions>>>,
+    previous: Option<Arc<builtins::ExecutionExtensions>>,
+}
+
+impl Drop for ExecutionExtensionsGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            *self
+                .slot
+                .lock()
+                .expect("interpreter execution extensions lock") = previous;
+        }
     }
 }
 
@@ -465,6 +483,10 @@ pub struct Interpreter {
     /// When set, output is emitted incrementally via this callback in addition
     /// to being accumulated in the returned ExecResult.
     output_callback: Option<OutputCallback>,
+    /// Typed per-execution extensions visible to builtins for the current
+    /// `exec*()` call. Stored behind a mutex so drop guards can restore it
+    /// without borrowing the interpreter across `.await`.
+    execution_extensions: Arc<StdMutex<Arc<builtins::ExecutionExtensions>>>,
     /// Monotonic counter incremented each time output is emitted via callback.
     /// Used to detect whether sub-calls already emitted output, preventing duplicates.
     output_emit_count: u64,
@@ -832,6 +854,9 @@ impl Interpreter {
             ssh_client: None,
             pipeline_stdin: None,
             output_callback: None,
+            execution_extensions: Arc::new(StdMutex::new(Arc::new(
+                builtins::ExecutionExtensions::new(),
+            ))),
             output_emit_count: 0,
             nounset_error: None,
             traps: HashMap::new(),
@@ -864,6 +889,30 @@ impl Interpreter {
     /// Return a reference to the hooks registry.
     pub fn hooks(&self) -> &crate::hooks::Hooks {
         &self.hooks
+    }
+
+    pub(crate) fn current_execution_extensions(&self) -> Arc<builtins::ExecutionExtensions> {
+        self.execution_extensions
+            .lock()
+            .expect("interpreter execution extensions lock")
+            .clone()
+    }
+
+    pub(crate) fn scoped_execution_extensions(
+        &self,
+        extensions: builtins::ExecutionExtensions,
+    ) -> ExecutionExtensionsGuard {
+        let previous = {
+            let mut slot = self
+                .execution_extensions
+                .lock()
+                .expect("interpreter execution extensions lock");
+            std::mem::replace(&mut *slot, Arc::new(extensions))
+        };
+        ExecutionExtensionsGuard {
+            slot: self.execution_extensions.clone(),
+            previous: Some(previous),
+        }
     }
 
     /// Replace the hooks registry (called from BashBuilder::build).
@@ -3697,260 +3746,279 @@ impl Interpreter {
         Some(trace)
     }
 
-    async fn execute_simple_command(
-        &mut self,
-        command: &SimpleCommand,
+    // THREAT[TM-DOS-089]: Box the full simple-command path because nested
+    // `echo $(echo $(...))` repeatedly polls this helper, and its large async
+    // state (name/arg expansion, alias/env handling, xtrace, redirects) was
+    // still enough to overflow smaller Linux/tarpaulin stacks.
+    fn execute_simple_command<'a>(
+        &'a mut self,
+        command: &'a SimpleCommand,
         stdin: Option<String>,
-    ) -> Result<ExecResult> {
-        let (_debug_stdout, _debug_stderr) = self.run_debug_trap().await;
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
+        Box::pin(async move {
+            let (_debug_stdout, _debug_stderr) = self.run_debug_trap().await;
 
-        let name = self.expand_word(&command.name).await?;
+            let name = self.expand_word(&command.name).await?;
 
-        if let Some(err_msg) = self.nounset_error.take() {
-            self.last_exit_code = 1;
-            return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: err_msg,
-                exit_code: 1,
-                control_flow: ControlFlow::Return(1),
-                ..Default::default()
-            });
-        }
-
-        let pre_expanded_args = if !name.is_empty() {
-            Some(self.expand_command_args(command).await?)
-        } else {
-            None
-        };
-
-        let var_saves: Vec<(String, Option<String>)> = command
-            .assignments
-            .iter()
-            .map(|a| (a.name.clone(), self.variables.get(&a.name).cloned()))
-            .collect();
-
-        let pre_assign_subst_gen = self.subst_generation;
-
-        self.process_command_assignments(&command.assignments)
-            .await?;
-
-        // Alias expansion
-        if let Some(result) = self
-            .try_alias_expansion(&name, command, stdin.clone(), var_saves.clone())
-            .await
-        {
-            return result;
-        }
-
-        // Empty command handling
-        if name.is_empty() {
-            if command.name.quoted && command.assignments.is_empty() {
-                self.last_exit_code = 127;
-                return Ok(ExecResult::err(
-                    "bash: : command not found\n".to_string(),
-                    127,
-                ));
+            if let Some(err_msg) = self.nounset_error.take() {
+                self.last_exit_code = 1;
+                return Ok(ExecResult {
+                    stdout: String::new(),
+                    stderr: err_msg,
+                    exit_code: 1,
+                    control_flow: ControlFlow::Return(1),
+                    ..Default::default()
+                });
             }
-            let exit_code = if !command.assignments.is_empty()
-                && self.subst_generation == pre_assign_subst_gen
-            {
-                0
+
+            let pre_expanded_args = if !name.is_empty() {
+                Some(self.expand_command_args(command).await?)
             } else {
-                self.last_exit_code
+                None
             };
-            self.last_exit_code = exit_code;
-            return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: String::new(),
-                exit_code,
-                control_flow: crate::interpreter::ControlFlow::None,
-                ..Default::default()
-            });
-        }
 
-        // Inject prefix assignments into env for command duration
-        let mut env_saves: Vec<(String, Option<String>)> = Vec::new();
-        for assignment in &command.assignments {
-            if assignment.index.is_none()
-                && let Some(value) = self.variables.get(&assignment.name).cloned()
+            let var_saves: Vec<(String, Option<String>)> = command
+                .assignments
+                .iter()
+                .map(|a| (a.name.clone(), self.variables.get(&a.name).cloned()))
+                .collect();
+
+            let pre_assign_subst_gen = self.subst_generation;
+
+            self.process_command_assignments(&command.assignments)
+                .await?;
+
+            // Alias expansion
+            if let Some(result) = self
+                .try_alias_expansion(&name, command, stdin.clone(), var_saves.clone())
+                .await
             {
-                let old = self.env.insert(assignment.name.clone(), value);
-                env_saves.push((assignment.name.clone(), old));
+                return result;
             }
-        }
 
-        let args = pre_expanded_args.unwrap_or_default();
+            // Empty command handling
+            if name.is_empty() {
+                if command.name.quoted && command.assignments.is_empty() {
+                    self.last_exit_code = 127;
+                    return Ok(ExecResult::err(
+                        "bash: : command not found\n".to_string(),
+                        127,
+                    ));
+                }
+                let exit_code = if !command.assignments.is_empty()
+                    && self.subst_generation == pre_assign_subst_gen
+                {
+                    0
+                } else {
+                    self.last_exit_code
+                };
+                self.last_exit_code = exit_code;
+                return Ok(ExecResult {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    exit_code,
+                    control_flow: crate::interpreter::ControlFlow::None,
+                    ..Default::default()
+                });
+            }
 
-        // Check for glob error sentinel
-        if let Some(first) = args.first()
-            && first.starts_with("\x00ERR\x00")
-        {
-            let err_msg = first.trim_start_matches("\x00ERR\x00").to_string();
-            self.last_exit_code = 1;
+            // Inject prefix assignments into env for command duration
+            let mut env_saves: Vec<(String, Option<String>)> = Vec::new();
+            for assignment in &command.assignments {
+                if assignment.index.is_none()
+                    && let Some(value) = self.variables.get(&assignment.name).cloned()
+                {
+                    let old = self.env.insert(assignment.name.clone(), value);
+                    env_saves.push((assignment.name.clone(), old));
+                }
+            }
+
+            let args = pre_expanded_args.unwrap_or_default();
+
+            // Check for glob error sentinel
+            if let Some(first) = args.first()
+                && first.starts_with("\x00ERR\x00")
+            {
+                let err_msg = first.trim_start_matches("\x00ERR\x00").to_string();
+                self.last_exit_code = 1;
+                self.restore_variables(var_saves);
+                let result = ExecResult::err(err_msg, 1);
+                return self.apply_redirections(result, &command.redirects).await;
+            }
+
+            let xtrace_line = self.build_xtrace_line(&name, &args);
+
+            let result = self
+                .execute_dispatched_command(&name, args, command, stdin)
+                .await;
+
+            // Restore env
+            for (name, old) in env_saves {
+                match old {
+                    Some(v) => {
+                        self.env.insert(name, v);
+                    }
+                    None => {
+                        self.env.remove(&name);
+                    }
+                }
+            }
+
+            // Restore variables
             self.restore_variables(var_saves);
-            let result = ExecResult::err(err_msg, 1);
-            return self.apply_redirections(result, &command.redirects).await;
-        }
 
-        let xtrace_line = self.build_xtrace_line(&name, &args);
+            // Prepend xtrace to stderr
+            let mut result = if let Some(trace) = xtrace_line {
+                result.map(|mut r| {
+                    r.stderr = trace + &r.stderr;
+                    r
+                })
+            } else {
+                result
+            };
 
-        let result = self
-            .execute_dispatched_command(&name, args, command, stdin)
-            .await;
+            self.run_deferred_proc_subs(&mut result).await?;
 
-        // Restore env
-        for (name, old) in env_saves {
-            match old {
-                Some(v) => {
-                    self.env.insert(name, v);
-                }
-                None => {
-                    self.env.remove(&name);
-                }
-            }
-        }
-
-        // Restore variables
-        self.restore_variables(var_saves);
-
-        // Prepend xtrace to stderr
-        let mut result = if let Some(trace) = xtrace_line {
-            result.map(|mut r| {
-                r.stderr = trace + &r.stderr;
-                r
-            })
-        } else {
             result
-        };
-
-        self.run_deferred_proc_subs(&mut result).await?;
-
-        result
+        })
     }
 
     /// Expand command arguments with field splitting, brace, and glob expansion.
-    async fn expand_command_args(&mut self, command: &SimpleCommand) -> Result<Vec<String>> {
-        let mut args: Vec<String> = Vec::new();
-        for word in &command.args {
-            // Use field expansion so "${arr[@]}" produces multiple args
-            let fields = self.expand_word_to_fields(word).await?;
+    /// Boxed because nested command substitution repeatedly expands `echo` args,
+    /// and the combined field/glob state still materially contributes to per-level
+    /// poll-stack growth on smaller Linux/tarpaulin stacks.
+    fn expand_command_args<'a>(
+        &'a mut self,
+        command: &'a SimpleCommand,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut args: Vec<String> = Vec::new();
+            for word in &command.args {
+                // Use field expansion so "${arr[@]}" produces multiple args
+                let fields = self.expand_word_to_fields(word).await?;
 
-            // Skip brace and glob expansion for quoted words — unless the
-            // word has unquoted glob chars (e.g. `"$var"*.ext`) in which case
-            // the quoted expansion suppresses IFS splitting but the unquoted
-            // portion must still undergo glob expansion.
-            if word.quoted && !word.has_unquoted_glob {
-                args.extend(fields);
-                continue;
-            }
+                // Skip brace and glob expansion for quoted words — unless the
+                // word has unquoted glob chars (e.g. `"$var"*.ext`) in which case
+                // the quoted expansion suppresses IFS splitting but the unquoted
+                // portion must still undergo glob expansion.
+                if word.quoted && !word.has_unquoted_glob {
+                    args.extend(fields);
+                    continue;
+                }
 
-            // For each field, apply brace and glob expansion
-            for expanded in fields {
-                // Step 1: Brace expansion (produces multiple strings)
-                let brace_expanded = self.expand_braces(&expanded);
+                // For each field, apply brace and glob expansion
+                for expanded in fields {
+                    // Step 1: Brace expansion (produces multiple strings)
+                    let brace_expanded = self.expand_braces(&expanded);
 
-                // Step 2: For each brace-expanded item, do glob expansion
-                for item in brace_expanded {
-                    match self.expand_glob_item(&item).await {
-                        Ok(items) => args.extend(items),
-                        Err(pat) => {
-                            self.last_exit_code = 1;
-                            return Ok(vec![format!("\x00ERR\x00-bash: no match: {}\n", pat)]);
+                    // Step 2: For each brace-expanded item, do glob expansion
+                    for item in brace_expanded {
+                        match self.expand_glob_item(&item).await {
+                            Ok(items) => args.extend(items),
+                            Err(pat) => {
+                                self.last_exit_code = 1;
+                                return Ok(vec![format!("\x00ERR\x00-bash: no match: {}\n", pat)]);
+                            }
                         }
                     }
                 }
             }
-        }
-        Ok(args)
+            Ok(args)
+        })
     }
 
     /// Execute a command after name resolution and prefix assignment setup.
     ///
     /// Handles stdin processing and dispatch to functions, special builtins,
     /// regular builtins, or command-not-found. Args are pre-expanded.
-    async fn execute_dispatched_command(
-        &mut self,
-        name: &str,
+    // THREAT[TM-DOS-089]: Box the dispatch wrapper too so per-level stdin
+    // plumbing, trace bookkeeping, and dispatch future selection stay off the
+    // recursive poll stack during nested command substitution.
+    fn execute_dispatched_command<'a>(
+        &'a mut self,
+        name: &'a str,
         args: Vec<String>,
-        command: &SimpleCommand,
+        command: &'a SimpleCommand,
         stdin: Option<String>,
-    ) -> Result<ExecResult> {
-        // Track $_ (last argument of previous command, from already-expanded args)
-        if let Some(last) = args.last() {
-            self.insert_variable_checked("_".to_string(), last.clone());
-        } else {
-            self.insert_variable_checked("_".to_string(), name.to_string());
-        }
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
+        Box::pin(async move {
+            // Track $_ (last argument of previous command, from already-expanded args)
+            if let Some(last) = args.last() {
+                self.insert_variable_checked("_".to_string(), last.clone());
+            } else {
+                self.insert_variable_checked("_".to_string(), name.to_string());
+            }
 
-        // Check for nounset error from argument expansion
-        if let Some(err_msg) = self.nounset_error.take() {
-            self.last_exit_code = 1;
-            return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: err_msg,
-                exit_code: 1,
-                control_flow: ControlFlow::Return(1),
-                ..Default::default()
-            });
-        }
+            // Check for nounset error from argument expansion
+            if let Some(err_msg) = self.nounset_error.take() {
+                self.last_exit_code = 1;
+                return Ok(ExecResult {
+                    stdout: String::new(),
+                    stderr: err_msg,
+                    exit_code: 1,
+                    control_flow: ControlFlow::Return(1),
+                    ..Default::default()
+                });
+            }
 
-        // Handle input redirections first
-        let stdin = self
-            .process_input_redirections(stdin, &command.redirects)
-            .await?;
+            // Handle input redirections first
+            let stdin = self
+                .process_input_redirections(stdin, &command.redirects)
+                .await?;
 
-        // For `read -u FD`, check if FD is a coproc read FD and inject data as stdin
-        let stdin = if name == "read" && stdin.is_none() {
-            self.try_coproc_read_stdin(&args).or(stdin)
-        } else {
-            stdin
-        };
+            // For `read -u FD`, check if FD is a coproc read FD and inject data as stdin
+            let stdin = if name == "read" && stdin.is_none() {
+                self.try_coproc_read_stdin(&args).or(stdin)
+            } else {
+                stdin
+            };
 
-        // If no explicit stdin, inherit from pipeline_stdin (for compound cmds in pipes).
-        // For `read`, consume one line; for other commands, provide all remaining data.
-        let stdin = if stdin.is_some() {
-            stdin
-        } else if let Some(ref ps) = self.pipeline_stdin {
-            if !ps.is_empty() {
-                if name == "read" {
-                    // Consume one line from pipeline stdin
-                    let data = ps.clone();
-                    if let Some(newline_pos) = data.find('\n') {
-                        let line = data[..=newline_pos].to_string();
-                        self.pipeline_stdin = Some(data[newline_pos + 1..].to_string());
-                        Some(line)
+            // If no explicit stdin, inherit from pipeline_stdin (for compound cmds in pipes).
+            // For `read`, consume one line; for other commands, provide all remaining data.
+            let stdin = if stdin.is_some() {
+                stdin
+            } else if let Some(ref ps) = self.pipeline_stdin {
+                if !ps.is_empty() {
+                    if name == "read" {
+                        // Consume one line from pipeline stdin
+                        let data = ps.clone();
+                        if let Some(newline_pos) = data.find('\n') {
+                            let line = data[..=newline_pos].to_string();
+                            self.pipeline_stdin = Some(data[newline_pos + 1..].to_string());
+                            Some(line)
+                        } else {
+                            // Last line without trailing newline
+                            self.pipeline_stdin = Some(String::new());
+                            Some(data)
+                        }
                     } else {
-                        // Last line without trailing newline
-                        self.pipeline_stdin = Some(String::new());
-                        Some(data)
+                        Some(ps.clone())
                     }
                 } else {
-                    Some(ps.clone())
+                    None
                 }
             } else {
                 None
+            };
+
+            // TRACE: Record command start event
+            let trace_start = if self.trace.mode() != crate::trace::TraceMode::Off {
+                self.trace
+                    .command_start(name, &args, self.cwd.to_string_lossy().as_ref());
+                Some(std::time::Instant::now())
+            } else {
+                None
+            };
+
+            let result = self.dispatch_command(name, command, args, stdin).await;
+
+            // TRACE: Record command exit event for all dispatch paths
+            if let (Some(start), Ok(r)) = (trace_start, &result) {
+                self.trace.command_exit(name, r.exit_code, start.elapsed());
             }
-        } else {
-            None
-        };
 
-        // TRACE: Record command start event
-        let trace_start = if self.trace.mode() != crate::trace::TraceMode::Off {
-            self.trace
-                .command_start(name, &args, self.cwd.to_string_lossy().as_ref());
-            Some(std::time::Instant::now())
-        } else {
-            None
-        };
-
-        let result = self.dispatch_command(name, command, args, stdin).await;
-
-        // TRACE: Record command exit event for all dispatch paths
-        if let (Some(start), Ok(r)) = (trace_start, &result) {
-            self.trace.command_exit(name, r.exit_code, start.elapsed());
-        }
-
-        result
+            result
+        })
     }
 
     /// Inner dispatch logic for command execution.
@@ -4086,38 +4154,97 @@ impl Interpreter {
 
     /// Execute a registered (non-special) builtin with panic safety.
     /// The builtin must exist in `self.builtins` (caller checks with `contains_key`).
-    async fn execute_registered_builtin(
-        &mut self,
-        name: &str,
-        args: &[String],
-        stdin: Option<&str>,
-        redirects: &[Redirect],
-    ) -> Result<ExecResult> {
-        // Fire before_tool hooks — may modify args or cancel the invocation
-        let args = if !self.hooks.before_tool.is_empty() {
-            let event = crate::hooks::ToolEvent {
-                name: name.to_string(),
-                args: args.to_vec(),
+    ///
+    /// Keep this helper boxed: the builtin path now carries execution-extension
+    /// plumbing plus panic-catching state, and nested command substitution hits it
+    /// on every `echo $(...)` level. Boxing keeps that larger state machine off the
+    /// recursive poll stack so the stack-overflow regression stays fixed.
+    fn execute_registered_builtin<'a>(
+        &'a mut self,
+        name: &'a str,
+        args: &'a [String],
+        stdin: Option<&'a str>,
+        redirects: &'a [Redirect],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
+        Box::pin(async move {
+            // Fire before_tool hooks — may modify args or cancel the invocation
+            let args = if !self.hooks.before_tool.is_empty() {
+                let event = crate::hooks::ToolEvent {
+                    name: name.to_string(),
+                    args: args.to_vec(),
+                };
+                match self.hooks.fire_before_tool(event) {
+                    Some(modified) => std::borrow::Cow::Owned(modified.args),
+                    None => {
+                        let result = ExecResult::err(
+                            format!("bash: {name}: cancelled by before_tool hook\n"),
+                            1,
+                        );
+                        return self.apply_redirections(result, redirects).await;
+                    }
+                }
+            } else {
+                std::borrow::Cow::Borrowed(args)
             };
-            match self.hooks.fire_before_tool(event) {
-                Some(modified) => std::borrow::Cow::Owned(modified.args),
-                None => {
-                    let result = ExecResult::err(
-                        format!("bash: {name}: cancelled by before_tool hook\n"),
-                        1,
-                    );
-                    return self.apply_redirections(result, redirects).await;
+            let args: &[String] = &args;
+
+            let builtin = self.builtins.get(name).unwrap();
+
+            // Check for execution plan first
+            {
+                let execution_extensions = self.current_execution_extensions();
+                let shell_ref = ShellRef {
+                    builtins: &self.builtins,
+                    functions: &self.functions,
+                    aliases: &mut self.aliases,
+                    traps: &mut self.traps,
+                    call_stack: &self.call_stack,
+                    history: &self.history,
+                    jobs: &self.jobs,
+                    execution_extensions,
+                };
+                let plan_ctx = builtins::Context {
+                    args,
+                    env: &self.env,
+                    variables: &mut self.variables,
+                    cwd: &mut self.cwd,
+                    fs: Arc::clone(&self.fs),
+                    stdin,
+                    #[cfg(feature = "http_client")]
+                    http_client: self.http_client.as_ref(),
+                    #[cfg(feature = "git")]
+                    git_client: self.git_client.as_ref(),
+                    #[cfg(feature = "ssh")]
+                    ssh_client: self.ssh_client.as_ref(),
+                    shell: Some(shell_ref),
+                };
+
+                let plan_result = AssertUnwindSafe(builtin.execution_plan(&plan_ctx))
+                    .catch_unwind()
+                    .await;
+
+                match plan_result {
+                    Ok(Ok(Some(plan))) => {
+                        let result = self.execute_builtin_plan(plan, redirects).await?;
+                        self.fire_after_tool(name, &result);
+                        return Ok(result);
+                    }
+                    Ok(Ok(None)) => { /* fall through to normal execute() */ }
+                    Ok(Err(e)) => return Err(e),
+                    Err(_panic) => {
+                        let result = ExecResult::err(
+                            format!("bash: {}: builtin failed unexpectedly\n", name),
+                            1,
+                        );
+                        let result = self.apply_redirections(result, redirects).await?;
+                        self.fire_after_tool(name, &result);
+                        return Ok(result);
+                    }
                 }
             }
-        } else {
-            std::borrow::Cow::Borrowed(args)
-        };
-        let args: &[String] = &args;
 
-        let builtin = self.builtins.get(name).unwrap();
-
-        // Check for execution plan first
-        {
+            let builtin = self.builtins.get(name).unwrap();
+            let execution_extensions = self.current_execution_extensions();
             let shell_ref = ShellRef {
                 builtins: &self.builtins,
                 functions: &self.functions,
@@ -4126,8 +4253,9 @@ impl Interpreter {
                 call_stack: &self.call_stack,
                 history: &self.history,
                 jobs: &self.jobs,
+                execution_extensions,
             };
-            let plan_ctx = builtins::Context {
+            let ctx = builtins::Context {
                 args,
                 env: &self.env,
                 variables: &mut self.variables,
@@ -4143,87 +4271,38 @@ impl Interpreter {
                 shell: Some(shell_ref),
             };
 
-            let plan_result = AssertUnwindSafe(builtin.execution_plan(&plan_ctx))
-                .catch_unwind()
-                .await;
+            // THREAT[TM-INT-001]: Execute builtin with panic catching for security
+            let result = AssertUnwindSafe(builtin.execute(ctx)).catch_unwind().await;
 
-            match plan_result {
-                Ok(Ok(Some(plan))) => {
-                    let result = self.execute_builtin_plan(plan, redirects).await?;
-                    self.fire_after_tool(name, &result);
-                    return Ok(result);
-                }
-                Ok(Ok(None)) => { /* fall through to normal execute() */ }
+            let result = match result {
+                Ok(Ok(exec_result)) => exec_result,
                 Ok(Err(e)) => return Err(e),
                 Err(_panic) => {
-                    let result = ExecResult::err(
-                        format!("bash: {}: builtin failed unexpectedly\n", name),
-                        1,
-                    );
-                    let result = self.apply_redirections(result, redirects).await?;
-                    self.fire_after_tool(name, &result);
-                    return Ok(result);
+                    ExecResult::err(format!("bash: {}: builtin failed unexpectedly\n", name), 1)
                 }
-            }
-        }
+            };
 
-        let builtin = self.builtins.get(name).unwrap();
-        let shell_ref = ShellRef {
-            builtins: &self.builtins,
-            functions: &self.functions,
-            aliases: &mut self.aliases,
-            traps: &mut self.traps,
-            call_stack: &self.call_stack,
-            history: &self.history,
-            jobs: &self.jobs,
-        };
-        let ctx = builtins::Context {
-            args,
-            env: &self.env,
-            variables: &mut self.variables,
-            cwd: &mut self.cwd,
-            fs: Arc::clone(&self.fs),
-            stdin,
-            #[cfg(feature = "http_client")]
-            http_client: self.http_client.as_ref(),
-            #[cfg(feature = "git")]
-            git_client: self.git_client.as_ref(),
-            #[cfg(feature = "ssh")]
-            ssh_client: self.ssh_client.as_ref(),
-            shell: Some(shell_ref),
-        };
+            self.apply_builtin_side_effects(&result);
 
-        // THREAT[TM-INT-001]: Execute builtin with panic catching for security
-        let result = AssertUnwindSafe(builtin.execute(ctx)).catch_unwind().await;
-
-        let result = match result {
-            Ok(Ok(exec_result)) => exec_result,
-            Ok(Err(e)) => return Err(e),
-            Err(_panic) => {
-                ExecResult::err(format!("bash: {}: builtin failed unexpectedly\n", name), 1)
-            }
-        };
-
-        self.apply_builtin_side_effects(&result);
-
-        // Sync exported variables into env so subprocess isolation can see them
-        if name == "export" && result.exit_code == 0 {
-            for arg in args {
-                if let Some(eq_pos) = arg.find('=') {
-                    let var_name = &arg[..eq_pos];
-                    if let Some(value) = self.variables.get(var_name) {
-                        self.env.insert(var_name.to_string(), value.clone());
+            // Sync exported variables into env so subprocess isolation can see them
+            if name == "export" && result.exit_code == 0 {
+                for arg in args {
+                    if let Some(eq_pos) = arg.find('=') {
+                        let var_name = &arg[..eq_pos];
+                        if let Some(value) = self.variables.get(var_name) {
+                            self.env.insert(var_name.to_string(), value.clone());
+                        }
+                    } else if let Some(value) = self.variables.get(arg.as_str()) {
+                        // export NAME (without =) — mark existing variable as exported
+                        self.env.insert(arg.to_string(), value.clone());
                     }
-                } else if let Some(value) = self.variables.get(arg.as_str()) {
-                    // export NAME (without =) — mark existing variable as exported
-                    self.env.insert(arg.to_string(), value.clone());
                 }
             }
-        }
 
-        let result = self.apply_redirections(result, redirects).await?;
-        self.fire_after_tool(name, &result);
-        Ok(result)
+            let result = self.apply_redirections(result, redirects).await?;
+            self.fire_after_tool(name, &result);
+            Ok(result)
+        })
     }
 
     /// Fire `after_tool` hooks if any are registered (observational).
@@ -4262,60 +4341,65 @@ impl Interpreter {
         }
     }
 
-    async fn dispatch_command(
-        &mut self,
-        name: &str,
-        command: &SimpleCommand,
+    // THREAT[TM-DOS-089]: Box the final dispatch split so function lookup,
+    // special builtin handling, registered builtin execution, and path search
+    // do not contribute another large async frame per nested substitution level.
+    fn dispatch_command<'a>(
+        &'a mut self,
+        name: &'a str,
+        command: &'a SimpleCommand,
         args: Vec<String>,
         stdin: Option<String>,
-    ) -> Result<ExecResult> {
-        // Check for functions first
-        if let Some(func_def) = self.functions.get(name).cloned() {
-            return self
-                .execute_function_call(name, &func_def, args, stdin, &command.redirects)
-                .await;
-        }
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
+        Box::pin(async move {
+            // Check for functions first
+            if let Some(func_def) = self.functions.get(name).cloned() {
+                return self
+                    .execute_function_call(name, &func_def, args, stdin, &command.redirects)
+                    .await;
+            }
 
-        // Interpreter-level special builtins
-        if let Some(result) = self
-            .dispatch_special_builtin(name, &args, stdin.clone(), &command.redirects)
-            .await
-        {
-            return result;
-        }
+            // Interpreter-level special builtins
+            if let Some(result) = self
+                .dispatch_special_builtin(name, &args, stdin.clone(), &command.redirects)
+                .await
+            {
+                return result;
+            }
 
-        // Registered builtins
-        if self.builtins.contains_key(name) {
-            return self
-                .execute_registered_builtin(name, &args, stdin.as_deref(), &command.redirects)
-                .await;
-        }
+            // Registered builtins
+            if self.builtins.contains_key(name) {
+                return self
+                    .execute_registered_builtin(name, &args, stdin.as_deref(), &command.redirects)
+                    .await;
+            }
 
-        // Script execution by path
-        if name.contains('/') {
-            return self
-                .try_execute_script_by_path(name, &args, stdin, &command.redirects)
-                .await;
-        }
+            // Script execution by path
+            if name.contains('/') {
+                return self
+                    .try_execute_script_by_path(name, &args, stdin, &command.redirects)
+                    .await;
+            }
 
-        // $PATH search
-        if let Some(result) = self
-            .try_execute_script_via_path_search(name, &args, stdin, &command.redirects)
-            .await?
-        {
-            return Ok(result);
-        }
+            // $PATH search
+            if let Some(result) = self
+                .try_execute_script_via_path_search(name, &args, stdin, &command.redirects)
+                .await?
+            {
+                return Ok(result);
+            }
 
-        // Command not found
-        let known: Vec<&str> = self
-            .builtins
-            .keys()
-            .map(|s| s.as_str())
-            .chain(self.functions.keys().map(|s| s.as_str()))
-            .chain(self.aliases.keys().map(|s| s.as_str()))
-            .collect();
-        let msg = command_not_found_message(name, &known);
-        Ok(ExecResult::err(msg, 127))
+            // Command not found
+            let known: Vec<&str> = self
+                .builtins
+                .keys()
+                .map(|s| s.as_str())
+                .chain(self.functions.keys().map(|s| s.as_str()))
+                .chain(self.aliases.keys().map(|s| s.as_str()))
+                .collect();
+            let msg = command_not_found_message(name, &known);
+            Ok(ExecResult::err(msg, 127))
+        })
     }
 
     /// Execute a script file by resolved path.
@@ -5421,6 +5505,7 @@ impl Interpreter {
                 let remaining = &args[cmd_args_start..];
                 if let Some(builtin) = self.builtins.get(remaining[0].as_str()) {
                     let builtin_args = &remaining[1..];
+                    let execution_extensions = self.current_execution_extensions();
                     let shell_ref = ShellRef {
                         builtins: &self.builtins,
                         functions: &self.functions,
@@ -5429,6 +5514,7 @@ impl Interpreter {
                         call_stack: &self.call_stack,
                         history: &self.history,
                         jobs: &self.jobs,
+                        execution_extensions,
                     };
                     let ctx = builtins::Context {
                         args: builtin_args,
@@ -6832,131 +6918,139 @@ impl Interpreter {
     /// Expand a word to multiple fields (for array iteration and command args)
     /// Returns Vec<String> where array expansions like "${arr[@]}" produce multiple fields.
     /// "${arr[*]}" in quoted context joins elements into a single field (bash behavior).
-    async fn expand_word_to_fields(&mut self, word: &Word) -> Result<Vec<String>> {
-        // Check if the word contains only an array expansion or $@/$*
-        if word.parts.len() == 1 {
-            // Handle $@ and $* as special parameters
-            if let WordPart::Variable(name) = &word.parts[0] {
-                if name == "@" {
-                    let positional = self
-                        .call_stack
-                        .last()
-                        .map(|f| f.positional.clone())
-                        .unwrap_or_default();
-                    if word.quoted {
-                        // "$@" preserves individual positional params
-                        return Ok(positional);
+    /// Boxed because nested command substitution repeatedly enters this helper through
+    /// `expand_command_args`, and its special-parameter/array handling still inflated
+    /// the recursive poll path enough to trip smaller stacks.
+    fn expand_word_to_fields<'a>(
+        &'a mut self,
+        word: &'a Word,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<String>>> + Send + 'a>> {
+        Box::pin(async move {
+            // Check if the word contains only an array expansion or $@/$*
+            if word.parts.len() == 1 {
+                // Handle $@ and $* as special parameters
+                if let WordPart::Variable(name) = &word.parts[0] {
+                    if name == "@" {
+                        let positional = self
+                            .call_stack
+                            .last()
+                            .map(|f| f.positional.clone())
+                            .unwrap_or_default();
+                        if word.quoted {
+                            // "$@" preserves individual positional params
+                            return Ok(positional);
+                        }
+                        // $@ unquoted: each param is subject to further IFS splitting
+                        let mut fields = Vec::new();
+                        for p in &positional {
+                            fields.extend(self.ifs_split(p));
+                        }
+                        return Ok(fields);
                     }
-                    // $@ unquoted: each param is subject to further IFS splitting
-                    let mut fields = Vec::new();
-                    for p in &positional {
-                        fields.extend(self.ifs_split(p));
+                    if name == "*" {
+                        let positional = self
+                            .call_stack
+                            .last()
+                            .map(|f| f.positional.clone())
+                            .unwrap_or_default();
+                        if word.quoted {
+                            // "$*" joins with first char of IFS.
+                            // IFS unset → space; IFS="" → no separator.
+                            let sep = match self.variables.get("IFS") {
+                                Some(ifs) => ifs
+                                    .chars()
+                                    .next()
+                                    .map(|c| c.to_string())
+                                    .unwrap_or_default(),
+                                None => " ".to_string(),
+                            };
+                            return Ok(vec![positional.join(&sep)]);
+                        }
+                        // $* unquoted: each param is subject to IFS splitting
+                        let mut fields = Vec::new();
+                        for p in &positional {
+                            fields.extend(self.ifs_split(p));
+                        }
+                        return Ok(fields);
                     }
-                    return Ok(fields);
                 }
-                if name == "*" {
-                    let positional = self
-                        .call_stack
-                        .last()
-                        .map(|f| f.positional.clone())
-                        .unwrap_or_default();
-                    if word.quoted {
-                        // "$*" joins with first char of IFS.
-                        // IFS unset → space; IFS="" → no separator.
-                        let sep = match self.variables.get("IFS") {
-                            Some(ifs) => ifs
-                                .chars()
-                                .next()
-                                .map(|c| c.to_string())
-                                .unwrap_or_default(),
-                            None => " ".to_string(),
-                        };
-                        return Ok(vec![positional.join(&sep)]);
+                if let WordPart::ArrayAccess { name, index } = &word.parts[0]
+                    && (index == "@" || index == "*")
+                {
+                    // Check assoc arrays first
+                    if let Some(arr) = self.assoc_arrays.get(name) {
+                        let mut keys: Vec<_> = arr.keys().cloned().collect();
+                        keys.sort();
+                        let values: Vec<String> =
+                            keys.iter().filter_map(|k| arr.get(k).cloned()).collect();
+                        if word.quoted && index == "*" {
+                            let sep = self.get_ifs_separator();
+                            return Ok(vec![values.join(&sep)]);
+                        }
+                        return Ok(values);
                     }
-                    // $* unquoted: each param is subject to IFS splitting
-                    let mut fields = Vec::new();
-                    for p in &positional {
-                        fields.extend(self.ifs_split(p));
+                    if let Some(arr) = self.arrays.get(name) {
+                        let mut indices: Vec<_> = arr.keys().collect();
+                        indices.sort();
+                        let values: Vec<String> =
+                            indices.iter().filter_map(|i| arr.get(i).cloned()).collect();
+                        // "${arr[*]}" joins into single field with IFS; "${arr[@]}" keeps separate
+                        if word.quoted && index == "*" {
+                            let sep = self.get_ifs_separator();
+                            return Ok(vec![values.join(&sep)]);
+                        }
+                        return Ok(values);
                     }
-                    return Ok(fields);
+                    return Ok(Vec::new());
+                }
+                // "${!arr[@]}" - array keys/indices as separate fields
+                if let WordPart::ArrayIndices(name) = &word.parts[0] {
+                    let resolved = self.resolve_nameref(name);
+                    if let Some(arr) = self.assoc_arrays.get(resolved) {
+                        let mut keys: Vec<_> = arr.keys().cloned().collect();
+                        keys.sort();
+                        return Ok(keys);
+                    }
+                    if let Some(arr) = self.arrays.get(resolved) {
+                        let mut indices: Vec<_> = arr.keys().collect();
+                        indices.sort();
+                        return Ok(indices.iter().map(|i| i.to_string()).collect());
+                    }
+                    return Ok(Vec::new());
                 }
             }
-            if let WordPart::ArrayAccess { name, index } = &word.parts[0]
-                && (index == "@" || index == "*")
-            {
-                // Check assoc arrays first
-                if let Some(arr) = self.assoc_arrays.get(name) {
-                    let mut keys: Vec<_> = arr.keys().cloned().collect();
-                    keys.sort();
-                    let values: Vec<String> =
-                        keys.iter().filter_map(|k| arr.get(k).cloned()).collect();
-                    if word.quoted && index == "*" {
-                        let sep = self.get_ifs_separator();
-                        return Ok(vec![values.join(&sep)]);
-                    }
-                    return Ok(values);
-                }
-                if let Some(arr) = self.arrays.get(name) {
-                    let mut indices: Vec<_> = arr.keys().collect();
-                    indices.sort();
-                    let values: Vec<String> =
-                        indices.iter().filter_map(|i| arr.get(i).cloned()).collect();
-                    // "${arr[*]}" joins into single field with IFS; "${arr[@]}" keeps separate
-                    if word.quoted && index == "*" {
-                        let sep = self.get_ifs_separator();
-                        return Ok(vec![values.join(&sep)]);
-                    }
-                    return Ok(values);
-                }
-                return Ok(Vec::new());
+
+            // For other words, expand to a single field then apply IFS word splitting
+            // when the word is unquoted and contains an expansion.
+            // Per POSIX, unquoted variable/command/arithmetic expansion results undergo
+            // field splitting on IFS.
+            let expanded = self.expand_word(word).await?;
+
+            // IFS splitting applies to unquoted expansions only.
+            // Skip splitting for assignment-like words (e.g., result="$1") where
+            // the lexer stripped quotes from a mixed-quoted word (produces Token::Word
+            // with quoted: false even though the expansion was inside double quotes).
+            let is_assignment_word =
+                matches!(word.parts.first(), Some(WordPart::Literal(s)) if s.contains('='));
+            let has_expansion = !word.quoted
+                && !is_assignment_word
+                && word.parts.iter().any(|p| {
+                    matches!(
+                        p,
+                        WordPart::Variable(_)
+                            | WordPart::CommandSubstitution(_)
+                            | WordPart::ArithmeticExpansion(_)
+                            | WordPart::ParameterExpansion { .. }
+                            | WordPart::ArrayAccess { .. }
+                    )
+                });
+
+            if has_expansion {
+                Ok(self.ifs_split(&expanded))
+            } else {
+                Ok(vec![expanded])
             }
-            // "${!arr[@]}" - array keys/indices as separate fields
-            if let WordPart::ArrayIndices(name) = &word.parts[0] {
-                let resolved = self.resolve_nameref(name);
-                if let Some(arr) = self.assoc_arrays.get(resolved) {
-                    let mut keys: Vec<_> = arr.keys().cloned().collect();
-                    keys.sort();
-                    return Ok(keys);
-                }
-                if let Some(arr) = self.arrays.get(resolved) {
-                    let mut indices: Vec<_> = arr.keys().collect();
-                    indices.sort();
-                    return Ok(indices.iter().map(|i| i.to_string()).collect());
-                }
-                return Ok(Vec::new());
-            }
-        }
-
-        // For other words, expand to a single field then apply IFS word splitting
-        // when the word is unquoted and contains an expansion.
-        // Per POSIX, unquoted variable/command/arithmetic expansion results undergo
-        // field splitting on IFS.
-        let expanded = self.expand_word(word).await?;
-
-        // IFS splitting applies to unquoted expansions only.
-        // Skip splitting for assignment-like words (e.g., result="$1") where
-        // the lexer stripped quotes from a mixed-quoted word (produces Token::Word
-        // with quoted: false even though the expansion was inside double quotes).
-        let is_assignment_word =
-            matches!(word.parts.first(), Some(WordPart::Literal(s)) if s.contains('='));
-        let has_expansion = !word.quoted
-            && !is_assignment_word
-            && word.parts.iter().any(|p| {
-                matches!(
-                    p,
-                    WordPart::Variable(_)
-                        | WordPart::CommandSubstitution(_)
-                        | WordPart::ArithmeticExpansion(_)
-                        | WordPart::ParameterExpansion { .. }
-                        | WordPart::ArrayAccess { .. }
-                )
-            });
-
-        if has_expansion {
-            Ok(self.ifs_split(&expanded))
-        } else {
-            Ok(vec![expanded])
-        }
+        })
     }
 
     /// Resolve name for parameter expansion, handling array subscripts and special params.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -426,7 +426,7 @@ pub(crate) mod tool_def;
 pub mod trace;
 
 pub use async_trait::async_trait;
-pub use builtins::{Builtin, Context as BuiltinContext};
+pub use builtins::{Builtin, Context as BuiltinContext, ExecutionExtensions};
 pub use credential::Credential;
 pub use error::{Error, Result};
 pub use fs::{
@@ -579,6 +579,21 @@ impl Bash {
     /// input size, then parses the script with a timeout, AST depth limit, and fuel limit,
     /// then executes the resulting AST.
     pub async fn exec(&mut self, script: &str) -> Result<ExecResult> {
+        self.exec_with_extensions(script, ExecutionExtensions::new())
+            .await
+    }
+
+    /// Execute a bash script with per-execution builtin extensions.
+    pub async fn exec_with_extensions(
+        &mut self,
+        script: &str,
+        extensions: ExecutionExtensions,
+    ) -> Result<ExecResult> {
+        let _extensions_guard = self.interpreter.scoped_execution_extensions(extensions);
+        self.exec_impl(script).await
+    }
+
+    async fn exec_impl(&mut self, script: &str) -> Result<ExecResult> {
         // THREAT[TM-ISO-005/006/007]: Reset transient state between exec() calls
         self.interpreter.reset_transient_state();
 
@@ -826,8 +841,19 @@ impl Bash {
         script: &str,
         output_callback: OutputCallback,
     ) -> Result<ExecResult> {
+        self.exec_streaming_with_extensions(script, output_callback, ExecutionExtensions::new())
+            .await
+    }
+
+    /// Execute a bash script with streaming output and per-execution builtin extensions.
+    pub async fn exec_streaming_with_extensions(
+        &mut self,
+        script: &str,
+        output_callback: OutputCallback,
+        extensions: ExecutionExtensions,
+    ) -> Result<ExecResult> {
         self.interpreter.set_output_callback(output_callback);
-        let result = self.exec(script).await;
+        let result = self.exec_with_extensions(script, extensions).await;
         self.interpreter.clear_output_callback();
         result
     }
@@ -4063,8 +4089,8 @@ fn
 
     mod custom_builtins {
         use super::*;
-        use crate::ExecResult;
         use crate::builtins::{Builtin, Context};
+        use crate::{ExecResult, ExecutionExtensions};
         use async_trait::async_trait;
 
         /// A simple custom builtin that outputs a static string
@@ -4084,6 +4110,38 @@ fn
             let result = bash.exec("hello").await.unwrap();
             assert_eq!(result.stdout, "Hello from custom builtin!\n");
             assert_eq!(result.exit_code, 0);
+        }
+
+        struct ExecutionScoped;
+
+        #[async_trait]
+        impl Builtin for ExecutionScoped {
+            async fn execute(&self, ctx: Context<'_>) -> crate::Result<ExecResult> {
+                let value = ctx
+                    .execution_extension::<String>()
+                    .cloned()
+                    .unwrap_or_else(|| "missing".to_string());
+                Ok(ExecResult::ok(format!("{value}\n")))
+            }
+        }
+
+        #[tokio::test]
+        async fn test_custom_builtin_execution_extensions_are_per_call() {
+            let mut bash = Bash::builder()
+                .builtin("read-ext", Box::new(ExecutionScoped))
+                .build();
+
+            let result = bash
+                .exec_with_extensions(
+                    "read-ext",
+                    ExecutionExtensions::new().with("scoped".to_string()),
+                )
+                .await
+                .unwrap();
+            assert_eq!(result.stdout, "scoped\n");
+
+            let result = bash.exec("read-ext").await.unwrap();
+            assert_eq!(result.stdout, "missing\n");
         }
 
         /// A custom builtin that uses arguments

--- a/specs/builtins.md
+++ b/specs/builtins.md
@@ -53,7 +53,32 @@ pub struct Context<'a> {
     /// Internal builtins only — None for custom builtins.
     pub(crate) shell: Option<ShellRef<'a>>,
 }
+
+impl Context<'_> {
+    pub fn execution_extension<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static;
+}
 ```
+
+### Execution Extensions
+
+`Bash::exec_with_extensions()` and `Bash::exec_streaming_with_extensions()`
+accept a typed, per-call extension bag. Builtins read values from it via
+`ctx.execution_extension::<T>()`.
+
+Use this for request-scoped data that is not shell state:
+
+- tracing/request IDs
+- auth or tenant context
+- host-language runtime sessions (Python/JS callback bridges)
+- metrics/audit sinks for one execution
+
+Rules:
+
+- Extensions live for exactly one `exec*()` call
+- Builtins may read them but must not retain references beyond execution
+- Long-lived builtin registrations must not store request-scoped data themselves
 
 ### Shell State Access (ShellRef)
 
@@ -65,7 +90,8 @@ Internal builtins that need interpreter state receive it via `Context.shell`:
   history (VFS persistence) — state with invariants the interpreter must enforce
 - **Read-only methods** for introspection (functions, builtins, keywords,
   call stack, history, jobs) — builtins shouldn't mutate these
-- `pub(crate)` keeps ShellRef out of the public API; custom builtins get `None`
+- `pub(crate)` keeps ShellRef out of the public API; custom builtins use
+  public `execution_extension()` instead of direct shell access
 - No dynamic dispatch — concrete struct, not trait
 
 **Builtins using ShellRef:**

--- a/specs/implementation-status.md
+++ b/specs/implementation-status.md
@@ -501,7 +501,7 @@ PyO3 bindings in `crates/bashkit-python/`. See [python-package.md](python-packag
 |---------|--------|-------|
 | Sync callbacks (`ScriptedTool.add_tool`) | Done | `(params, stdin) -> str` |
 | Async callbacks (`async def`) | Done | Auto-detected via `inspect.iscoroutinefunction` |
-| ContextVar propagation | Done | `copy_context()` at `execute()` time, restored via `ctx.run()` |
+| ContextVar propagation | Done | `execute()` captures caller loop + `copy_context()`; callbacks re-enter via `ctx.run()` |
 | LangGraph integration | Done | Example + integration tests |
 | FastAPI integration | Done | Example + integration tests |
 

--- a/specs/scripted-tool-orchestration.md
+++ b/specs/scripted-tool-orchestration.md
@@ -139,12 +139,16 @@ Type aliases for backward compatibility: `ToolCallback = SyncToolExec`,
 Python callbacks (both sync and async) automatically see `contextvars.ContextVar`
 values that were set by the caller at `execute()` / `execute_sync()` time:
 
-1. `build_rust_tool()` (called at execute time) snapshots the caller's context
-   via `contextvars.copy_context()`.
-2. Sync callbacks are invoked via `ctx.run(fn, params, stdin)`.
-3. Async callbacks are invoked via
-   `ctx.run(lambda: loop.run_until_complete(fn(params, stdin)))` so that the
-   `asyncio.Task` inherits the captured context.
+1. Each `execute()` / `execute_sync()` call creates a fresh callback session
+   that snapshots the caller's `contextvars` state.
+2. `execute()` also captures the caller's active asyncio loop via
+   `TaskLocals`, so async callbacks can be scheduled back onto that same loop.
+3. Sync callbacks are invoked via `ctx.run(fn, params, stdin)`.
+4. Async callbacks are created under `ctx.run(...)`; when they run on the
+   caller loop, the session owns the spawned Python tasks so cancellation only
+   affects that execution's callbacks.
+5. `execute_sync()` has no caller-owned loop to reuse, so async callbacks fall
+   back to a private per-execution loop on the worker thread.
 
 This enables framework patterns like LangGraph's `get_stream_writer()` and
 FastAPI's request-scoped state.

--- a/specs/scripted-tool-orchestration.md
+++ b/specs/scripted-tool-orchestration.md
@@ -139,16 +139,23 @@ Type aliases for backward compatibility: `ToolCallback = SyncToolExec`,
 Python callbacks (both sync and async) automatically see `contextvars.ContextVar`
 values that were set by the caller at `execute()` / `execute_sync()` time:
 
-1. Each `execute()` / `execute_sync()` call creates a fresh callback session
+1. Each Python surface owns one long-lived callback engine. The engine holds
+   reusable machinery only: `ctx.run(...)` callback entry and one cached
+   private asyncio loop for sync fallback.
+2. Each `execute()` / `execute_sync()` call creates a fresh callback session
    that snapshots the caller's `contextvars` state.
-2. `execute()` also captures the caller's active asyncio loop via
+3. `execute()` also captures the caller's active asyncio loop via
    `TaskLocals`, so async callbacks can be scheduled back onto that same loop.
-3. Sync callbacks are invoked via `ctx.run(fn, params, stdin)`.
-4. Async callbacks are created under `ctx.run(...)`; when they run on the
+4. `Bash` / `BashTool` pass the callback session through bashkit's generic
+   execution extensions, so persistent builtin adapters resolve request-scoped
+   callback state without mutating shared runtime state.
+5. Sync callbacks are invoked via `ctx.run(fn, params, stdin)`.
+6. Async callbacks are created under `ctx.run(...)`; when they run on the
    caller loop, the session owns the spawned Python tasks so cancellation only
    affects that execution's callbacks.
-5. `execute_sync()` has no caller-owned loop to reuse, so async callbacks fall
-   back to a private per-execution loop on the worker thread.
+7. `execute_sync()` has no caller-owned loop to reuse, so async callbacks fall
+   back to the engine's private loop on the worker thread. This preserves sync
+   support, but loop-bound caller resources only work with `await execute()`.
 
 This enables framework patterns like LangGraph's `get_stream_writer()` and
 FastAPI's request-scoped state.


### PR DESCRIPTION
Refs #1312

Add constructor-time Python `custom_builtins` to `Bash` and `BashTool`.

This lets callers register persistent bash builtins from Python without giving up the existing shell/VFS state model.

## API Shape

`custom_builtins` are shell-first (not `ScriptedTool`-style schema-first) -- they aren't "tools".

- callback signature: `callback(ctx) -> str`
- async callback signature: `async def callback(ctx) -> str`
- `ctx` exposes: `name`, `argv`, `stdin`, `env`, `cwd`

This follows the rust core API quite closely

Example:

```python
import json

from bashkit import Bash, BuiltinContext


def order_cli(ctx: BuiltinContext) -> str:
    help_str = f"usage: {ctx.name} [-h] <get> ...\n"
    if not ctx.argv or ctx.argv[0] in {"help", "--help"}:
        return help_str
    if ctx.argv[0] == "get" and len(ctx.argv) >= 2:
        return json.dumps(
            {"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}
        ) + "\n"
    return help_str


bash = Bash(custom_builtins={"order-cli": order_cli})
r = bash.execute_sync("order-cli get 7 | jq -r '.status'")
assert r.stdout.strip() == "shipped"
```

## Key Decisions

- mirror Rust custom builtin semantics more closely instead of routing through
  `ScriptedTool`'s `ToolImpl` / `parse_flags` path
- use a context object instead of unpacked callback arguments so the Python API
  can grow without breaking callback signatures
- keep `ScriptedTool` unchanged; it still uses `(params, stdin)`
- intentionally leave out live `fs`, mutable shell variables, mutable `cwd`,
  and feature-gated network/git/ssh clients for now

## What Changed

- add `custom_builtins={name: callback}` to `Bash` and `BashTool`
- register Python callbacks as real custom builtins in the live interpreter
- expose `BuiltinContext` to Python callbacks
- update docs, stubs, and examples for the new callback shape
- add parity tests for persistence, reset, snapshot restore, async callbacks,
  ContextVar propagation, raw argv/stdin, and subcommands

## Notes

- custom builtins support sync and async Python callbacks
- execute-time `ContextVar` state is preserved inside custom builtin callbacks
- custom builtins survive `reset()`
- custom builtins are host-side config, so snapshot restore still requires
  passing `custom_builtins=` again

## Testing

```bash
uv --directory crates/bashkit-python pip install -e '.[dev]'
uv --directory crates/bashkit-python run --no-sync maturin develop
uv --directory crates/bashkit-python run --no-sync pytest tests/test_registered_tools.py -q
```

Also verified:

```bash
cargo test -p bashkit-python --lib
```