### PR TITLE
fix(ci): avoid duplicate example builds in test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # Examples have a dedicated job below; skipping them here avoids
+      # duplicated example links that can exhaust runner disk on main.
       - name: Run tests
-        run: cargo test --features http_client,ssh
+        run: cargo test --workspace --lib --bins --tests --features http_client,ssh
+
+      - name: Run doc tests
+        run: cargo test --workspace --doc --features http_client,ssh
 
       - name: Run realfs tests
         run: cargo test --features realfs -p bashkit --test realfs_tests -p bashkit-cli


### PR DESCRIPTION
## Summary

- stop the `CI` test job from rebuilding examples during `cargo test`
- keep doctest coverage by running doc tests in a dedicated step
- leave example coverage in the existing `Examples` job

## Why

`main` went red on GitHub Actions run `24465694329` for commit `e51470a` because the `Test` job exhausted runner disk while linking `python_scripts` during `cargo test --features http_client,ssh`.

That job was compiling examples even though examples already have their own dedicated workflow job. Splitting the coverage avoids duplicate example links in the `Test` job and removes the disk-pressure path that broke `main`.

## Test Plan

- `cargo test --workspace --lib --bins --tests --features http_client,ssh --no-run`
- `cargo test --workspace --doc --features http_client,ssh`
- `just pre-pr` *(fails on a pre-existing `bash_comparison_tests` mismatch in `cargo test`; unrelated to this workflow-only change)*
