### PR TITLE
chore(ci): add codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: false
+coverage:
+  precision: 2
+  # range: [90, 100]
+  status:
+    patch: false
+    project: false
+comment:
+  layout: "header, diff, flags, files, footer"
+  hide_project_coverage: false


### PR DESCRIPTION
## Summary
- add a repo-level `.codecov.yml`
- mirror the Codecov settings used in Monty for status handling and comment layout
- keep the existing coverage workflow unchanged

## Validation
- `ruby -e 'require "yaml"; data = YAML.load_file(".codecov.yml"); abort("empty") unless data.is_a?(Hash); puts data.keys.join(",")'`
- `just test` *(fails locally on macOS in the existing `bash_comparison_tests`; `origin/main` CI is green and the failure is unrelated to this config-only change)*
- `just pre-pr` *(same local baseline failure path through `cargo test`)*