### PR TITLE
fix(snapshot): preserve functions in shell snapshots

### DIFF
--- a/crates/bashkit-cli/src/interactive.rs
+++ b/crates/bashkit-cli/src/interactive.rs
@@ -641,6 +641,7 @@ mod tests {
             assoc_arrays: std::collections::HashMap::new(),
             cwd: std::path::PathBuf::from("/"),
             last_exit_code: 0,
+            functions: std::collections::HashMap::new(),
             aliases: std::collections::HashMap::new(),
             traps: std::collections::HashMap::new(),
         }

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -317,13 +317,18 @@ back to a private loop because there is no caller loop to reuse.
 from bashkit import Bash
 
 bash = Bash(username="agent", max_commands=100)
-bash.execute_sync("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo ready > state.txt")
+bash.execute_sync(
+    "export BUILD_ID=42; "
+    "greet() { echo \"hi $1\"; }; "
+    "mkdir -p /workspace && cd /workspace && echo ready > state.txt"
+)
 
 snapshot = bash.snapshot()
 shell_only = bash.snapshot(exclude_filesystem=True)
 
 restored = Bash.from_snapshot(snapshot, username="agent", max_commands=100)
 assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"
+assert restored.execute_sync("greet agent").stdout.strip() == "hi agent"
 assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "ready"
 
 restored.reset()

--- a/crates/bashkit-python/tests/_bashkit_categories.py
+++ b/crates/bashkit-python/tests/_bashkit_categories.py
@@ -81,7 +81,9 @@ def test_bash_reset():
 
 def test_bash_snapshot_roundtrip_from_snapshot_preserves_state_and_kwargs():
     bash = Bash()
-    bash.execute_sync("export FOO=bar; mkdir -p /workspace && cd /workspace && echo data > state.txt")
+    bash.execute_sync(
+        'export FOO=bar; greet() { echo "hi $1"; }; mkdir -p /workspace && cd /workspace && echo data > state.txt'
+    )
 
     snapshot = bash.snapshot()
     assert isinstance(snapshot, bytes)
@@ -97,6 +99,7 @@ def test_bash_snapshot_roundtrip_from_snapshot_preserves_state_and_kwargs():
     assert restored.execute_sync("whoami").stdout.strip() == "alice"
     assert restored.execute_sync("hostname").stdout.strip() == "box"
     assert restored.execute_sync("echo $FOO").stdout.strip() == "bar"
+    assert restored.execute_sync("greet agent").stdout.strip() == "hi agent"
     assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
     assert restored.execute_sync("cat /workspace/state.txt").stdout.strip() == "data"
 
@@ -618,7 +621,9 @@ def test_reset():
 
 def test_bashtool_snapshot_roundtrip_from_snapshot_preserves_state_and_kwargs():
     tool = BashTool()
-    tool.execute_sync("export FOO=bar; mkdir -p /workspace && cd /workspace && echo data > tool.txt")
+    tool.execute_sync(
+        'export FOO=bar; greet() { echo "hi $1"; }; mkdir -p /workspace && cd /workspace && echo data > tool.txt'
+    )
 
     snapshot = tool.snapshot()
     assert isinstance(snapshot, bytes)
@@ -634,6 +639,7 @@ def test_bashtool_snapshot_roundtrip_from_snapshot_preserves_state_and_kwargs():
     assert restored.execute_sync("whoami").stdout.strip() == "alice"
     assert restored.execute_sync("hostname").stdout.strip() == "box"
     assert restored.execute_sync("echo $FOO").stdout.strip() == "bar"
+    assert restored.execute_sync("greet agent").stdout.strip() == "hi agent"
     assert restored.execute_sync("pwd").stdout.strip() == "/workspace"
     assert restored.execute_sync("cat /workspace/tool.txt").stdout.strip() == "data"
 

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -426,6 +426,9 @@ pub struct ShellState {
     pub cwd: PathBuf,
     /// Last exit code
     pub last_exit_code: i32,
+    /// Defined shell functions
+    #[serde(default)]
+    pub functions: HashMap<String, FunctionDef>,
     /// Shell aliases
     pub aliases: HashMap<String, String>,
     /// Trap handlers
@@ -1133,6 +1136,7 @@ impl Interpreter {
             assoc_arrays: self.assoc_arrays.clone(),
             cwd: self.cwd.clone(),
             last_exit_code: self.last_exit_code,
+            functions: self.functions.clone(),
             aliases: self.aliases.clone(),
             traps: self.traps.clone(),
         }
@@ -1146,6 +1150,7 @@ impl Interpreter {
         self.assoc_arrays = state.assoc_arrays.clone();
         self.cwd = state.cwd.clone();
         self.last_exit_code = state.last_exit_code;
+        self.functions = state.functions.clone();
         self.aliases = state.aliases.clone();
         self.traps = state.traps.clone();
         // Recompute memory budget from restored state to prevent desync

--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -9,7 +9,7 @@ use super::span::Span;
 use std::fmt;
 
 /// A complete bash script.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Script {
     pub commands: Vec<Command>,
     /// Source span of the entire script
@@ -17,7 +17,7 @@ pub struct Script {
 }
 
 /// A single command in the script.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Command {
     /// A simple command (e.g., `echo hello`)
     Simple(SimpleCommand),
@@ -36,7 +36,7 @@ pub enum Command {
 }
 
 /// A simple command with arguments and redirections.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SimpleCommand {
     /// Command name
     pub name: Word,
@@ -51,7 +51,7 @@ pub struct SimpleCommand {
 }
 
 /// A pipeline of commands.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Pipeline {
     /// Whether the pipeline is negated (!)
     pub negated: bool,
@@ -62,7 +62,7 @@ pub struct Pipeline {
 }
 
 /// A list of commands with operators.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CommandList {
     /// First command
     pub first: Box<Command>,
@@ -73,7 +73,7 @@ pub struct CommandList {
 }
 
 /// Operators for command lists.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ListOperator {
     /// && - execute next if previous succeeded
     And,
@@ -86,7 +86,7 @@ pub enum ListOperator {
 }
 
 /// Compound commands (control structures).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum CompoundCommand {
     /// If statement
     If(IfCommand),
@@ -121,7 +121,7 @@ pub enum CompoundCommand {
 /// In bashkit's sandboxed model, the coprocess runs synchronously and its
 /// stdout is buffered for later reading via the NAME array FDs.
 /// `NAME[0]` = virtual read FD, `NAME[1]` = virtual write FD, `NAME_PID` = virtual PID.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CoprocCommand {
     /// Coprocess name (defaults to "COPROC")
     pub name: String,
@@ -136,7 +136,7 @@ pub struct CoprocCommand {
 /// Note: Bashkit only supports wall-clock time measurement.
 /// User/system CPU time is not tracked (always reported as 0).
 /// This is a known incompatibility with bash.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TimeCommand {
     /// Use POSIX output format (-p flag)
     pub posix_format: bool,
@@ -147,7 +147,7 @@ pub struct TimeCommand {
 }
 
 /// If statement.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct IfCommand {
     pub condition: Vec<Command>,
     pub then_branch: Vec<Command>,
@@ -158,7 +158,7 @@ pub struct IfCommand {
 }
 
 /// For loop.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ForCommand {
     pub variable: String,
     pub words: Option<Vec<Word>>,
@@ -168,7 +168,7 @@ pub struct ForCommand {
 }
 
 /// Select loop.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SelectCommand {
     pub variable: String,
     pub words: Vec<Word>,
@@ -178,7 +178,7 @@ pub struct SelectCommand {
 }
 
 /// C-style arithmetic for loop: for ((init; cond; step)); do body; done
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ArithmeticForCommand {
     /// Initialization expression
     pub init: String,
@@ -193,7 +193,7 @@ pub struct ArithmeticForCommand {
 }
 
 /// While loop.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct WhileCommand {
     pub condition: Vec<Command>,
     pub body: Vec<Command>,
@@ -202,7 +202,7 @@ pub struct WhileCommand {
 }
 
 /// Until loop.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UntilCommand {
     pub condition: Vec<Command>,
     pub body: Vec<Command>,
@@ -211,7 +211,7 @@ pub struct UntilCommand {
 }
 
 /// Case statement.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CaseCommand {
     pub word: Word,
     pub cases: Vec<CaseItem>,
@@ -220,7 +220,7 @@ pub struct CaseCommand {
 }
 
 /// Terminator for a case item.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum CaseTerminator {
     /// `;;` — stop matching
     Break,
@@ -231,7 +231,7 @@ pub enum CaseTerminator {
 }
 
 /// A single case item.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CaseItem {
     pub patterns: Vec<Word>,
     pub commands: Vec<Command>,
@@ -239,7 +239,7 @@ pub struct CaseItem {
 }
 
 /// Function definition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FunctionDef {
     pub name: String,
     pub body: Box<Command>,
@@ -248,7 +248,7 @@ pub struct FunctionDef {
 }
 
 /// A word (potentially with expansions).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Word {
     pub parts: Vec<WordPart>,
     /// True if this word came from a quoted source (single or double quotes)
@@ -390,7 +390,7 @@ impl fmt::Display for Word {
 }
 
 /// Parts of a word.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum WordPart {
     /// Literal text
     Literal(String),
@@ -450,7 +450,7 @@ pub enum WordPart {
 }
 
 /// Parameter expansion operators
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ParameterOp {
     /// :- use default if unset/empty
     UseDefault,
@@ -489,7 +489,7 @@ pub enum ParameterOp {
 }
 
 /// I/O redirection.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Redirect {
     /// File descriptor (default: 1 for output, 0 for input)
     pub fd: Option<i32>,
@@ -502,7 +502,7 @@ pub struct Redirect {
 }
 
 /// Types of redirections.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum RedirectKind {
     /// > - redirect output
     Output,
@@ -527,7 +527,7 @@ pub enum RedirectKind {
 }
 
 /// Variable assignment.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Assignment {
     pub name: String,
     /// Optional array index for indexed assignments like `arr[0]=value`
@@ -538,7 +538,7 @@ pub struct Assignment {
 }
 
 /// Value in an assignment - scalar or array
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum AssignmentValue {
     /// Scalar value: VAR=value
     Scalar(Word),

--- a/crates/bashkit/src/parser/span.rs
+++ b/crates/bashkit/src/parser/span.rs
@@ -4,7 +4,7 @@
 //! lexing, parsing, and execution.
 
 /// A position in source code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Position {
     /// 1-based line number
     pub line: usize,
@@ -43,7 +43,7 @@ impl std::fmt::Display for Position {
 }
 
 /// A span of source code (start to end position).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct Span {
     /// Start position (inclusive)
     pub start: Position,

--- a/crates/bashkit/src/snapshot.rs
+++ b/crates/bashkit/src/snapshot.rs
@@ -36,6 +36,7 @@
 //! - Environment variables
 //! - Current working directory
 //! - Last exit code (`$?`)
+//! - Shell functions
 //! - Shell aliases
 //! - Trap handlers
 //! - VFS contents (files, directories, symlinks)
@@ -43,7 +44,6 @@
 //!
 //! # What is NOT captured
 //!
-//! - Function definitions (AST is not serializable; define functions after restore)
 //! - Builtins (immutable configuration, not state)
 //! - Active execution stack (snapshot only between `exec()` calls)
 //! - Tokio runtime state

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -321,6 +321,18 @@ async fn snapshot_preserves_cwd() {
 }
 
 #[tokio::test]
+async fn snapshot_preserves_functions() {
+    let mut bash = Bash::new();
+    bash.exec("greet() { echo \"hi $1\"; }").await.unwrap();
+
+    let bytes = bash.snapshot().unwrap();
+    let mut bash2 = Bash::from_snapshot(&bytes).unwrap();
+
+    let r = bash2.exec("greet world").await.unwrap();
+    assert_eq!(r.stdout.trim(), "hi world");
+}
+
+#[tokio::test]
 async fn snapshot_restore_into_existing_instance() {
     let mut bash = Bash::new();
     bash.exec("x=42; echo 'data' > /tmp/saved.txt")
@@ -347,7 +359,7 @@ async fn snapshot_restore_into_existing_instance() {
 #[tokio::test]
 async fn snapshot_without_filesystem_preserves_shell_only() {
     let mut bash = Bash::new();
-    bash.exec("x=42; echo 'saved' > /tmp/state.txt")
+    bash.exec("x=42; greet() { echo \"hi $1\"; }; echo 'saved' > /tmp/state.txt")
         .await
         .unwrap();
 
@@ -365,6 +377,9 @@ async fn snapshot_without_filesystem_preserves_shell_only() {
 
     let r = bash.exec("echo $x").await.unwrap();
     assert_eq!(r.stdout.trim(), "42");
+
+    let r = bash.exec("greet world").await.unwrap();
+    assert_eq!(r.stdout.trim(), "hi world");
 
     let r = bash.exec("cat /tmp/state.txt").await.unwrap();
     assert_eq!(r.stdout.trim(), "changed");

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -166,8 +166,10 @@ Snapshot/restore methods also exist on `Bash` and mirror the Node bindings:
 from bashkit import Bash
 
 bash = Bash()
+bash.execute_sync("greet() { echo \"hi $1\"; }")
 blob = bash.snapshot()              # -> bytes
 restored = Bash.from_snapshot(blob) # -> Bash
+assert restored.execute_sync("greet agent").stdout.strip() == "hi agent"
 ```
 
 ### ExecResult


### PR DESCRIPTION
## What
- include shell function definitions in serialized shell state
- make parser AST/span types snapshot-serializable so function defs can roundtrip
- extend Rust and Python snapshot coverage, including shell-only snapshots

## Why
- snapshot restore lost shell functions, so restored sessions could not call functions defined before snapshotting
- latest main added shell-only snapshot options, so function state needs to survive that path too

## How
- add `functions` to `ShellState` with a serde default for older snapshots
- restore functions before recomputing memory budget
- update CLI test helpers and public docs/spec examples to match the new contract

## Verification
- `PATH="$PWD/.venv-tools/bin:$PATH" just python-lint`
- `CARGO_BUILD_JOBS=1 cargo test -p bashkit --test snapshot_tests`
- `CARGO_BUILD_JOBS=1 just test`
- `VIRTUAL_ENV="$PWD/.venv-tools" PATH="$PWD/.venv-tools/bin:$PATH" maturin develop -m crates/bashkit-python/Cargo.toml`
- `VIRTUAL_ENV="$PWD/.venv-tools" PATH="$PWD/.venv-tools/bin:$PATH" pytest crates/bashkit-python/tests/test_basic.py -k snapshot_roundtrip`
- `CARGO_BUILD_JOBS=1 just pre-pr`