### PR TITLE
fix(snapshot): store function source alongside ast

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -17,8 +17,10 @@ This skill implements the complete "Shipping" definition and Pre-PR Checklist fr
 ### Phase 1: Pre-flight
 
 1. Confirm we're NOT on `main` or `master`
-2. Confirm there are no uncommitted changes (`git diff --quiet && git diff --cached --quiet`)
-3. If uncommitted changes exist, stop and tell the user
+2. If `HEAD` is detached and the current task has local changes ready to ship, create a branch first instead of stopping
+3. Confirm whether uncommitted changes belong to the task being shipped
+4. If the worktree is dirty only because of the current task, keep going: validate, commit, and ship those changes
+5. If unrelated uncommitted changes exist, stop and tell the user
 
 ### Phase 2: Test Coverage
 

--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -263,6 +263,10 @@ await bash.execute(
 
 const snapshot = bash.snapshot();
 const shellOnly = bash.snapshot({ excludeFilesystem: true });
+const promptOnly = bash.snapshot({
+  excludeFilesystem: true,
+  excludeFunctions: true,
+});
 
 const restored = Bash.fromSnapshot(snapshot);
 console.log((await restored.execute("echo $BUILD_ID")).stdout); // 42\n

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -724,6 +724,7 @@ pub struct BashOptions {
 #[napi(object)]
 pub struct SnapshotOptions {
     pub exclude_filesystem: Option<bool>,
+    pub exclude_functions: Option<bool>,
 }
 
 fn default_opts() -> BashOptions {
@@ -753,7 +754,11 @@ fn default_opts() -> BashOptions {
 fn to_snapshot_options(options: Option<SnapshotOptions>) -> RustSnapshotOptions {
     RustSnapshotOptions {
         exclude_filesystem: options
+            .as_ref()
             .and_then(|options| options.exclude_filesystem)
+            .unwrap_or(false),
+        exclude_functions: options
+            .and_then(|options| options.exclude_functions)
             .unwrap_or(false),
     }
 }

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -110,6 +110,7 @@ export interface BashOptions {
 
 export interface SnapshotOptions {
   excludeFilesystem?: boolean;
+  excludeFunctions?: boolean;
 }
 
 export interface OutputChunk {
@@ -310,6 +311,7 @@ function toNativeSnapshotOptions(
   if (!options) return undefined;
   return {
     excludeFilesystem: options.excludeFilesystem,
+    excludeFunctions: options.excludeFunctions,
   };
 }
 

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -237,7 +237,8 @@ print(state.cwd)  # still /workspace
 It is a Python-friendly inspection view rather than a full Rust-shell mirror,
 and fields like `env`, `variables`, and `arrays` are exposed as immutable
 mappings. Use `snapshot(exclude_filesystem=True)` when you need shell-only
-restore bytes.
+restore bytes, or `snapshot(exclude_filesystem=True, exclude_functions=True)`
+when prompt rendering does not need function restore.
 Transient fields like `last_exit_code` and `traps` are captured on the snapshot,
 but the next top-level `execute()` / `execute_sync()` clears them before running
 the new command.
@@ -351,6 +352,7 @@ bash.execute_sync(
 
 snapshot = bash.snapshot()
 shell_only = bash.snapshot(exclude_filesystem=True)
+prompt_only = bash.snapshot(exclude_filesystem=True, exclude_functions=True)
 
 restored = Bash.from_snapshot(snapshot, username="agent", max_commands=100)
 assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -522,7 +522,11 @@ class Bash:
         """
         ...
 
-    def snapshot(self, exclude_filesystem: bool = False) -> bytes:
+    def snapshot(
+        self,
+        exclude_filesystem: bool = False,
+        exclude_functions: bool = False,
+    ) -> bytes:
         """Serialize interpreter state to bytes."""
         ...
 
@@ -931,7 +935,11 @@ class BashTool:
         """
         ...
 
-    def snapshot(self, exclude_filesystem: bool = False) -> bytes:
+    def snapshot(
+        self,
+        exclude_filesystem: bool = False,
+        exclude_functions: bool = False,
+    ) -> bytes:
         """Serialize interpreter state to bytes."""
         ...
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -797,14 +797,18 @@ fn snapshot_live_bash(
     rt: &Arc<Runtime>,
     inner: &Arc<Mutex<Bash>>,
     exclude_filesystem: bool,
+    exclude_functions: bool,
 ) -> PyResult<Vec<u8>> {
     let rt = rt.clone();
     let inner = inner.clone();
     py.detach(|| {
         rt.block_on(async move {
             let bash = inner.lock().await;
-            bash.snapshot_with_options(RustSnapshotOptions { exclude_filesystem })
-                .map_err(raise_snapshot_error)
+            bash.snapshot_with_options(RustSnapshotOptions {
+                exclude_filesystem,
+                exclude_functions,
+            })
+            .map_err(raise_snapshot_error)
         })
     })
 }
@@ -2700,14 +2704,21 @@ impl PyBash {
     }
 
     /// Serialize interpreter state to bytes for checkpoint/restore flows.
-    #[pyo3(signature = (exclude_filesystem=false))]
+    #[pyo3(signature = (exclude_filesystem=false, exclude_functions=false))]
     fn snapshot<'py>(
         &self,
         py: Python<'py>,
         exclude_filesystem: bool,
+        exclude_functions: bool,
     ) -> PyResult<Bound<'py, PyBytes>> {
         self.reject_external_handler_reentry()?;
-        let bytes = snapshot_live_bash(py, &self.rt, &self.inner, exclude_filesystem)?;
+        let bytes = snapshot_live_bash(
+            py,
+            &self.rt,
+            &self.inner,
+            exclude_filesystem,
+            exclude_functions,
+        )?;
         Ok(PyBytes::new(py, &bytes))
     }
 
@@ -3264,13 +3275,20 @@ impl BashTool {
     }
 
     /// Serialize interpreter state to bytes for checkpoint/restore flows.
-    #[pyo3(signature = (exclude_filesystem=false))]
+    #[pyo3(signature = (exclude_filesystem=false, exclude_functions=false))]
     fn snapshot<'py>(
         &self,
         py: Python<'py>,
         exclude_filesystem: bool,
+        exclude_functions: bool,
     ) -> PyResult<Bound<'py, PyBytes>> {
-        let bytes = snapshot_live_bash(py, &self.rt, &self.inner, exclude_filesystem)?;
+        let bytes = snapshot_live_bash(
+            py,
+            &self.rt,
+            &self.inner,
+            exclude_filesystem,
+            exclude_functions,
+        )?;
         Ok(PyBytes::new(py, &bytes))
     }
 

--- a/crates/bashkit-python/tests/_bashkit_categories.py
+++ b/crates/bashkit-python/tests/_bashkit_categories.py
@@ -142,6 +142,19 @@ def test_bash_snapshot_can_exclude_filesystem():
     assert bash.execute_sync("cat /tmp/state.txt").stdout.strip() == "changed"
 
 
+def test_bash_snapshot_can_exclude_functions():
+    bash = Bash()
+    bash.execute_sync('greet() { echo "hi $1"; }; export KEEP=1')
+
+    snapshot = bash.snapshot(exclude_functions=True)
+
+    bash.execute_sync("export KEEP=2")
+    bash.restore_snapshot(snapshot)
+
+    assert bash.execute_sync("echo $KEEP").stdout.strip() == "1"
+    assert bash.execute_sync("type greet >/dev/null 2>&1; echo $?").stdout.strip() == "1"
+
+
 def test_bash_shell_state_exposes_read_only_snapshot_view():
     bash = Bash()
     result = bash.execute_sync(
@@ -740,6 +753,19 @@ def test_bashtool_snapshot_can_exclude_filesystem():
 
     assert tool.execute_sync("echo $KEEP").stdout.strip() == "1"
     assert tool.execute_sync("cat /tmp/tool.txt").stdout.strip() == "changed"
+
+
+def test_bashtool_snapshot_can_exclude_functions():
+    tool = BashTool()
+    tool.execute_sync('greet() { echo "hi $1"; }; export KEEP=1')
+
+    snapshot = tool.snapshot(exclude_functions=True)
+
+    tool.execute_sync("export KEEP=2")
+    tool.restore_snapshot(snapshot)
+
+    assert tool.execute_sync("echo $KEEP").stdout.strip() == "1"
+    assert tool.execute_sync("type greet >/dev/null 2>&1; echo $?").stdout.strip() == "1"
 
 
 def test_bashtool_shell_state_exposes_read_only_snapshot_view():

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -427,7 +427,11 @@ pub struct ShellState {
     /// Last exit code
     pub last_exit_code: i32,
     /// Defined shell functions
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "serialize_snapshotted_functions",
+        deserialize_with = "deserialize_snapshotted_functions"
+    )]
     pub functions: HashMap<String, FunctionDef>,
     /// Shell aliases
     pub aliases: HashMap<String, String>,
@@ -457,6 +461,129 @@ pub struct ShellStateView {
     pub aliases: HashMap<String, String>,
     /// Trap handlers
     pub traps: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ShellStateOptions {
+    pub(crate) include_functions: bool,
+}
+
+impl Default for ShellStateOptions {
+    fn default() -> Self {
+        Self {
+            include_functions: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct SnapshottedFunction {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ast: Option<FunctionDef>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum SnapshottedFunctionRepr {
+    Snapshot(SnapshottedFunction),
+    Legacy(FunctionDef),
+}
+
+fn serialize_snapshotted_functions<S>(
+    functions: &HashMap<String, FunctionDef>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let snapshotted: HashMap<String, SnapshottedFunction> = functions
+        .iter()
+        .map(|(name, func)| {
+            let mut ast = func.clone();
+            ast.source = None;
+            (
+                name.clone(),
+                SnapshottedFunction {
+                    source: func.source.clone(),
+                    ast: Some(ast),
+                },
+            )
+        })
+        .collect();
+    serde::Serialize::serialize(&snapshotted, serializer)
+}
+
+fn deserialize_snapshotted_functions<'de, D>(
+    deserializer: D,
+) -> std::result::Result<HashMap<String, FunctionDef>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let snapshotted =
+        <HashMap<String, SnapshottedFunctionRepr> as serde::Deserialize>::deserialize(
+            deserializer,
+        )?;
+    snapshotted
+        .into_iter()
+        .map(|(name, repr)| {
+            let func = match repr {
+                SnapshottedFunctionRepr::Legacy(func) => func,
+                SnapshottedFunctionRepr::Snapshot(snapshot) => {
+                    match (snapshot.ast, snapshot.source) {
+                        (Some(mut func), source) => {
+                            if func.source.is_none() {
+                                func.source = source;
+                            }
+                            func
+                        }
+                        (None, Some(source)) => deserialize_function_from_source(&name, &source)
+                            .map_err(serde::de::Error::custom)?,
+                        (None, None) => {
+                            return Err(serde::de::Error::custom(format!(
+                                "snapshot function '{name}' missing both ast and source"
+                            )));
+                        }
+                    }
+                }
+            };
+            if func.name != name {
+                return Err(serde::de::Error::custom(format!(
+                    "snapshot function key '{name}' does not match parsed name '{}'",
+                    func.name
+                )));
+            }
+            Ok((name, func))
+        })
+        .collect()
+}
+
+fn deserialize_function_from_source(
+    name: &str,
+    source: &str,
+) -> std::result::Result<FunctionDef, String> {
+    let script = Parser::new(source)
+        .parse()
+        .map_err(|err| format!("failed to parse function '{name}' from source: {err}"))?;
+    let mut commands = script.commands.into_iter();
+    let command = commands.next().ok_or_else(|| {
+        format!("failed to parse function '{name}' from source: missing function command")
+    })?;
+    if commands.next().is_some() {
+        return Err(format!(
+            "failed to parse function '{name}' from source: expected exactly one command"
+        ));
+    }
+    match command {
+        Command::Function(mut func) => {
+            func.source = Some(source.to_string());
+            Ok(func)
+        }
+        other => Err(format!(
+            "failed to parse function '{name}' from source: expected function definition, got {other:?}"
+        )),
+    }
 }
 
 /// Interpreter state.
@@ -1153,6 +1280,10 @@ impl Interpreter {
 
     /// Capture the current shell state (variables, env, cwd, options).
     pub fn shell_state(&self) -> ShellState {
+        self.shell_state_with_options(ShellStateOptions::default())
+    }
+
+    pub(crate) fn shell_state_with_options(&self, options: ShellStateOptions) -> ShellState {
         ShellState {
             env: self.env.clone(),
             variables: self.variables.clone(),
@@ -1160,7 +1291,11 @@ impl Interpreter {
             assoc_arrays: self.assoc_arrays.clone(),
             cwd: self.cwd.clone(),
             last_exit_code: self.last_exit_code,
-            functions: self.functions.clone(),
+            functions: if options.include_functions {
+                self.functions.clone()
+            } else {
+                HashMap::new()
+            },
             aliases: self.aliases.clone(),
             traps: self.traps.clone(),
         }

--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -243,6 +243,9 @@ pub struct CaseItem {
 pub struct FunctionDef {
     pub name: String,
     pub body: Box<Command>,
+    /// Original source text for this function when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
     /// Source span of this function definition
     pub span: Span,
 }
@@ -1223,6 +1226,7 @@ mod tests {
                 assignments: vec![],
                 span: Span::new(),
             })),
+            source: None,
             span: Span::new(),
         };
         assert_eq!(func.name, "my_func");
@@ -1271,6 +1275,7 @@ mod tests {
                 assignments: vec![],
                 span: Span::new(),
             })),
+            source: None,
             span: Span::new(),
         });
         assert!(matches!(func, Command::Function(_)));

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -45,6 +45,7 @@ const DEFAULT_MAX_PARSER_OPERATIONS: usize = 100_000;
 
 /// Parser for bash scripts.
 pub struct Parser<'a> {
+    input: &'a str,
     lexer: Lexer<'a>,
     current_token: Option<tokens::Token>,
     /// Span of the current token
@@ -90,6 +91,7 @@ impl<'a> Parser<'a> {
             None => (None, Span::new()),
         };
         Self {
+            input,
             lexer,
             current_token,
             current_span,
@@ -127,6 +129,18 @@ impl<'a> Parser<'a> {
             self.current_span.start.line,
             self.current_span.start.column,
         )
+    }
+
+    fn current_command_end_offset(&self) -> usize {
+        if self.current_token.is_some() {
+            self.current_span.start.offset
+        } else {
+            self.input.len()
+        }
+    }
+
+    fn source_slice(&self, start_offset: usize, end_offset: usize) -> Option<String> {
+        self.input.get(start_offset..end_offset).map(str::to_owned)
     }
 
     /// Consume one unit of fuel, returning an error if exhausted
@@ -1720,10 +1734,12 @@ impl<'a> Parser<'a> {
 
         // Parse body as brace group
         let body = self.parse_brace_group()?;
+        let end_offset = self.current_command_end_offset();
 
         Ok(Command::Function(FunctionDef {
             name,
             body: Box::new(Command::Compound(body, Vec::new())),
+            source: self.source_slice(start_span.start.offset, end_offset),
             span: start_span.merge(self.current_span),
         }))
     }
@@ -1757,10 +1773,12 @@ impl<'a> Parser<'a> {
 
         // Parse body as brace group
         let body = self.parse_brace_group()?;
+        let end_offset = self.current_command_end_offset();
 
         Ok(Command::Function(FunctionDef {
             name,
             body: Box::new(Command::Compound(body, Vec::new())),
+            source: self.source_slice(start_span.start.offset, end_offset),
             span: start_span.merge(self.current_span),
         }))
     }

--- a/crates/bashkit/src/snapshot.rs
+++ b/crates/bashkit/src/snapshot.rs
@@ -36,7 +36,7 @@
 //! - Environment variables
 //! - Current working directory
 //! - Last exit code (`$?`)
-//! - Shell functions
+//! - Shell functions (AST plus original source when available)
 //! - Shell aliases
 //! - Trap handlers
 //! - VFS contents (files, directories, symlinks)
@@ -53,7 +53,7 @@
 use sha2::{Digest, Sha256};
 
 use crate::fs::VfsSnapshot;
-use crate::interpreter::ShellState;
+use crate::interpreter::{ShellState, ShellStateOptions};
 
 /// Schema version for snapshot format compatibility.
 const SNAPSHOT_VERSION: u32 = 1;
@@ -100,6 +100,8 @@ pub struct Snapshot {
 pub struct SnapshotOptions {
     /// Skip virtual filesystem contents and capture shell state only.
     pub exclude_filesystem: bool,
+    /// Skip shell functions and avoid cloning AST-backed function state.
+    pub exclude_functions: bool,
 }
 
 impl Snapshot {
@@ -210,7 +212,11 @@ impl Snapshot {
 
 impl crate::Bash {
     fn build_snapshot(&self, options: SnapshotOptions) -> Snapshot {
-        let shell = self.interpreter.shell_state();
+        let shell = self
+            .interpreter
+            .shell_state_with_options(ShellStateOptions {
+                include_functions: !options.exclude_functions,
+            });
         let vfs = if options.exclude_filesystem {
             None
         } else {

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -333,6 +333,49 @@ async fn snapshot_preserves_functions() {
 }
 
 #[tokio::test]
+async fn snapshot_restores_functions_from_source_when_ast_missing() {
+    let mut bash = Bash::new();
+    bash.exec("greet() { echo \"hi $1\"; }").await.unwrap();
+
+    let bytes = bash.snapshot().unwrap();
+    let mut json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    json["shell"]["functions"]["greet"] = serde_json::json!({
+        "source": "greet() { echo \"hi $1\"; }"
+    });
+
+    let rewritten: Snapshot = serde_json::from_value(json).unwrap();
+    let bytes = rewritten.to_bytes().unwrap();
+    let mut restored = Bash::from_snapshot(&bytes).unwrap();
+
+    let result = restored.exec("greet world").await.unwrap();
+    assert_eq!(result.stdout.trim(), "hi world");
+}
+
+#[tokio::test]
+async fn snapshot_without_functions_skips_function_restore() {
+    let mut bash = Bash::new();
+    bash.exec("greet() { echo \"hi $1\"; }; answer=42")
+        .await
+        .unwrap();
+
+    let bytes = bash
+        .snapshot_with_options(SnapshotOptions {
+            exclude_filesystem: true,
+            exclude_functions: true,
+        })
+        .unwrap();
+    let snap = Snapshot::from_bytes(&bytes).unwrap();
+    assert!(snap.shell.functions.is_empty());
+
+    let mut restored = Bash::from_snapshot(&bytes).unwrap();
+    let result = restored
+        .exec("echo $answer; type greet >/dev/null 2>&1; echo $?")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "42\n1\n");
+}
+
+#[tokio::test]
 async fn snapshot_restore_into_existing_instance() {
     let mut bash = Bash::new();
     bash.exec("x=42; echo 'data' > /tmp/saved.txt")
@@ -366,6 +409,7 @@ async fn snapshot_without_filesystem_preserves_shell_only() {
     let bytes = bash
         .snapshot_with_options(SnapshotOptions {
             exclude_filesystem: true,
+            exclude_functions: false,
         })
         .unwrap();
 

--- a/docs/snapshotting.md
+++ b/docs/snapshotting.md
@@ -34,6 +34,7 @@ bash.exec("export BUILD_ID=42; mkdir -p /workspace && cd /workspace && echo read
 let snapshot = bash.snapshot()?;
 let shell_only = bash.snapshot_with_options(SnapshotOptions {
     exclude_filesystem: true,
+    exclude_functions: false,
 })?;
 
 let mut restored = Bash::from_snapshot(&snapshot)?;
@@ -66,6 +67,7 @@ bash.execute_sync(
 
 snapshot = bash.snapshot()
 shell_only = bash.snapshot(exclude_filesystem=True)
+prompt_only = bash.snapshot(exclude_filesystem=True, exclude_functions=True)
 
 restored = Bash.from_snapshot(snapshot, username="agent", max_commands=100)
 assert restored.execute_sync("echo $BUILD_ID").stdout.strip() == "42"
@@ -91,6 +93,10 @@ bash.executeSync(
 
 const snapshot = bash.snapshot();
 const shellOnly = bash.snapshot({ excludeFilesystem: true });
+const promptOnly = bash.snapshot({
+  excludeFilesystem: true,
+  excludeFunctions: true,
+});
 
 const restored = Bash.fromSnapshot(snapshot, {
   username: "agent",


### PR DESCRIPTION
## What
- store function source alongside serialized AST in shell snapshots
- restore functions from source when AST is missing
- add `exclude_functions` snapshot option so prompt-oriented snapshots can skip cloning function state
- expose the new option in Python and JS bindings and document it
- update the local `ship` skill to create a branch when shipping from detached HEAD

## Why
- AST-only function snapshots are brittle across parser/schema evolution
- prompt/state inspection flows should avoid cloning AST-heavy function maps when they do not need function restore

## How
- capture original function source during parse
- serialize snapshots as source plus AST, with source fallback on deserialize
- thread `exclude_functions` through Rust, Python, and JS snapshot APIs
- add regression tests for source-only restore and function-free snapshots

## Validation
- `cargo test -p bashkit --test snapshot_tests`
- `cargo test -p bashkit-python --no-run`
- `cargo test -p bashkit-js --no-run`
- `just test`
- `just pre-pr`