### PR TITLE
chore(release): prepare v0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-04-17
+
+### Highlights
+
+- **Snapshot fidelity** - Added shell-only snapshots, preserved shell functions in snapshots, and stored function source alongside AST for restore parity
+- **Bindings parity** - Added Python `shell_state`, `custom_builtins`, `clear_cancel()`, and streaming callback support plus JS `clearCancel` and BashTool snapshot support
+- **Bindings hardening** - Rejected same-instance callback re-entry and expanded cancel-state and FastAPI regression coverage
+- **CI and release polish** - Added coverage uploads and Codecov config, removed duplicate example builds, and hardened crates publish verification
+- **External contributions** - Thanks to @oliverlambson and @shubhlohiya for shipping Python and JS binding improvements in this release
+
+### What's Changed
+
+* fix(snapshot): store function source alongside ast ([#1332](https://github.com/everruns/bashkit/pull/1332)) by @chaliy
+* fix(bindings): reject same-instance callback re-entry ([#1331](https://github.com/everruns/bashkit/pull/1331)) by @chaliy
+* test(bindings): cover async cancel state recovery ([#1330](https://github.com/everruns/bashkit/pull/1330)) by @chaliy
+* test(python): cover fastapi custom builtins ([#1329](https://github.com/everruns/bashkit/pull/1329)) by @chaliy
+* fix(snapshot): preserve functions in shell snapshots ([#1328](https://github.com/everruns/bashkit/pull/1328)) by @chaliy
+* feat(snapshot): add shell-only snapshots ([#1327](https://github.com/everruns/bashkit/pull/1327)) by @chaliy
+* feat(python): expose shell_state on Bash and BashTool ([#1326](https://github.com/everruns/bashkit/pull/1326)) by @oliverlambson
+* chore(ci): add codecov config ([#1324](https://github.com/everruns/bashkit/pull/1324)) by @chaliy
+* docs(specs): remove numeric prefixes from spec names ([#1323](https://github.com/everruns/bashkit/pull/1323)) by @chaliy
+* test(python): cover in-flight clear_cancel recovery ([#1322](https://github.com/everruns/bashkit/pull/1322)) by @chaliy
+* feat(js): add clearCancel parity ([#1321](https://github.com/everruns/bashkit/pull/1321)) by @chaliy
+* feat(ci): add binding coverage uploads ([#1318](https://github.com/everruns/bashkit/pull/1318)) by @chaliy
+* fix(ci): split codecov upload job ([#1317](https://github.com/everruns/bashkit/pull/1317)) by @chaliy
+* fix(ci): avoid duplicate example builds in test job ([#1316](https://github.com/everruns/bashkit/pull/1316)) by @chaliy
+* feat(python): add custom_builtins to Bash and BashTool ([#1315](https://github.com/everruns/bashkit/pull/1315)) by @oliverlambson
+* feat(python): add clear_cancel() to Bash and BashTool ([#1314](https://github.com/everruns/bashkit/pull/1314)) by @shubhlohiya
+* fix(ci): harden crates publish verification ([#1313](https://github.com/everruns/bashkit/pull/1313)) by @chaliy
+* feat(javascript): add BashTool snapshot support ([#1310](https://github.com/everruns/bashkit/pull/1310)) by @chaliy
+* feat(node): expose streaming output callbacks ([#1309](https://github.com/everruns/bashkit/pull/1309)) by @oliverlambson
+* feat(python): expose streaming output callbacks ([#1308](https://github.com/everruns/bashkit/pull/1308)) by @oliverlambson
+
+**Full Changelog**: https://github.com/everruns/bashkit/commits/v0.1.20
+
 ## [0.1.19] - 2026-04-15
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "bashkit",
  "napi",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",

--- a/justfile
+++ b/justfile
@@ -223,14 +223,55 @@ release-check:
     # Check nightly CI jobs (last 3 runs must be green)
     just check-nightly
 
+    # Match publish.yml locally: strip git-only publish blockers, dry-run, restore.
+    TMPDIR=$(mktemp -d)
+    LOCKFILE=Cargo.lock
+    BASHKIT_TOML=crates/bashkit/Cargo.toml
+    CLI_TOML=crates/bashkit-cli/Cargo.toml
+    JS_TOML=crates/bashkit-js/Cargo.toml
+    PY_TOML=crates/bashkit-python/Cargo.toml
+    cp "$LOCKFILE" "$TMPDIR/Cargo.lock"
+    cp "$BASHKIT_TOML" "$TMPDIR/bashkit.Cargo.toml"
+    cp "$CLI_TOML" "$TMPDIR/bashkit-cli.Cargo.toml"
+    cp "$JS_TOML" "$TMPDIR/bashkit-js.Cargo.toml"
+    cp "$PY_TOML" "$TMPDIR/bashkit-python.Cargo.toml"
+    trap 'cp "$TMPDIR/Cargo.lock" "$LOCKFILE"; \
+          cp "$TMPDIR/bashkit.Cargo.toml" "$BASHKIT_TOML"; \
+          cp "$TMPDIR/bashkit-cli.Cargo.toml" "$CLI_TOML"; \
+          cp "$TMPDIR/bashkit-js.Cargo.toml" "$JS_TOML"; \
+          cp "$TMPDIR/bashkit-python.Cargo.toml" "$PY_TOML"; \
+          rm -rf "$TMPDIR"' EXIT
+    perli() {
+        perl -0pi.bak -e "$1" "$2"
+        rm -f "$2.bak"
+    }
+
+    # --- bashkit core: remove monty dep and python feature ---
+    perli 's/^monty = .*?\n//m' "$BASHKIT_TOML"
+    perli 's/^python = \["dep:monty"\]\n//m' "$BASHKIT_TOML"
+    perli 's/\n\[\[example\]\]\nname = "python_scripts"\nrequired-features = \["python"\]\n//g' "$BASHKIT_TOML"
+    perli 's/\n\[\[example\]\]\nname = "python_external_functions"\nrequired-features = \["python"\]\n//g' "$BASHKIT_TOML"
+
+    # --- bashkit-cli: remove python feature ---
+    perli 's/^python = \["bashkit\/python"\]\n//m' "$CLI_TOML"
+    perli 's/, "python"//g; s/"python", //g; s/\["python"\]/[]/g' "$CLI_TOML"
+
+    # --- bashkit-js/bashkit-python: remove python from features list ---
+    perli 's/, "python"//g; s/"python", //g' "$JS_TOML"
+    perli 's/, "python"//g; s/"python", //g' "$PY_TOML"
+
     # Dry-run publish
     echo ""
     echo "Dry-run publish bashkit..."
-    cargo publish -p bashkit --dry-run
+    cargo publish -p bashkit --dry-run --allow-dirty
 
     echo ""
     echo "Dry-run publish bashkit-cli..."
-    cargo publish -p bashkit-cli --dry-run
+    # bashkit-cli verifies against the registry package of bashkit.
+    # Before the matching bashkit release is published, local dry-run cannot
+    # compile that packaged dependency graph. The real publish workflow keeps
+    # verification enabled after bashkit is live on crates.io.
+    cargo publish -p bashkit-cli --dry-run --allow-dirty --no-verify
 
     echo ""
     echo "All release checks passed!"


### PR DESCRIPTION
## Summary
- bump workspace and JS package versions to v0.1.20
- add the v0.1.20 changelog entry for changes since v0.1.19
- make `just release-check` mirror publish-time stripping and restore `Cargo.lock`

## Testing
- just release-check