### PR TITLE
fix(parser): preserve glob in process substitution bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Free ~25 GB from the hosted runner. Across 6 cargo-test stages with
+      # different feature combos, target/ grows past the default 14 GB free.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost \
+            /usr/local/share/powershell /usr/local/.ghcup || true
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -2630,204 +2630,44 @@ impl<'a> Parser<'a> {
                 Ok(word)
             }
             Some(tokens::Token::ProcessSubIn) | Some(tokens::Token::ProcessSubOut) => {
-                // Process substitution <(cmd) or >(cmd)
+                // Process substitution <(cmd) or >(cmd).
+                //
+                // ISSUE #1333: slice the body directly from the original source
+                // instead of re-serializing tokens. Re-serialization lost
+                // per-segment quote boundaries for tokens like QuotedGlobWord
+                // (e.g. `./"$var"*.ext`), which caused the inner parser to see
+                // the glob `*` as quoted and suppress pathname expansion.
                 let is_input = matches!(self.current_token, Some(tokens::Token::ProcessSubIn));
                 self.advance();
 
-                // Parse commands until we hit a closing paren
-                let mut cmd_str = String::new();
-                let mut depth = 1;
+                let start_offset = match &self.current_token {
+                    Some(_) => self.current_span.start.offset,
+                    None => {
+                        return Err(Error::parse(
+                            "unexpected end of input in process substitution".to_string(),
+                        ));
+                    }
+                };
+                let end_offset;
+                let mut depth: u32 = 1;
                 loop {
                     match &self.current_token {
-                        Some(tokens::Token::LeftParen) => {
+                        Some(tokens::Token::LeftParen)
+                        | Some(tokens::Token::ProcessSubIn)
+                        | Some(tokens::Token::ProcessSubOut) => {
                             depth += 1;
-                            cmd_str.push('(');
                             self.advance();
                         }
                         Some(tokens::Token::RightParen) => {
                             depth -= 1;
                             if depth == 0 {
+                                end_offset = self.current_span.start.offset;
                                 self.advance();
                                 break;
                             }
-                            cmd_str.push(')');
-                            self.advance();
-                        }
-                        Some(tokens::Token::Word(w)) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push_str(w);
-                            self.advance();
-                        }
-                        Some(tokens::Token::QuotedWord(w))
-                        | Some(tokens::Token::QuotedGlobWord(w)) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push('"');
-                            cmd_str.push_str(w);
-                            cmd_str.push('"');
-                            self.advance();
-                        }
-                        Some(tokens::Token::LiteralWord(w)) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push('\'');
-                            cmd_str.push_str(w);
-                            cmd_str.push('\'');
-                            self.advance();
-                        }
-                        Some(tokens::Token::Pipe) => {
-                            cmd_str.push_str(" | ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Semicolon) => {
-                            cmd_str.push_str("; ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::And) => {
-                            cmd_str.push_str(" && ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Or) => {
-                            cmd_str.push_str(" || ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Background) => {
-                            cmd_str.push_str(" & ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectOut) => {
-                            cmd_str.push_str(" > ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectAppend) => {
-                            cmd_str.push_str(" >> ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectIn) => {
-                            cmd_str.push_str(" < ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::HereString) => {
-                            cmd_str.push_str(" <<< ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupOutput) => {
-                            cmd_str.push_str(" >&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectFd(fd)) => {
-                            cmd_str.push_str(&format!(" {}> ", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::LeftBrace) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push('{');
-                            self.advance();
-                        }
-                        Some(tokens::Token::RightBrace) => {
-                            cmd_str.push_str(" }");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Newline) => {
-                            cmd_str.push('\n');
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleLeftBracket) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push_str("[[");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleRightBracket) => {
-                            cmd_str.push_str(" ]]");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleLeftParen) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push_str("((");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleRightParen) => {
-                            cmd_str.push_str("))");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleSemicolon) => {
-                            cmd_str.push_str(";;");
-                            self.advance();
-                        }
-                        Some(tokens::Token::SemiAmp) => {
-                            cmd_str.push_str(";&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleSemiAmp) => {
-                            cmd_str.push_str(";;&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Assignment) => {
-                            cmd_str.push('=');
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectBoth) => {
-                            cmd_str.push_str(" &>");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Clobber) => {
-                            cmd_str.push_str(" >|");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupInput) => {
-                            cmd_str.push_str(" <&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::HereDoc) => {
-                            cmd_str.push_str(" <<");
-                            self.advance();
-                        }
-                        Some(tokens::Token::HereDocStrip) => {
-                            cmd_str.push_str(" <<-");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectFdAppend(fd)) => {
-                            cmd_str.push_str(&format!(" {}>>", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupFd(src, dst)) => {
-                            cmd_str.push_str(&format!(" {}>& {}", src, dst));
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupFdIn(src, dst)) => {
-                            cmd_str.push_str(&format!(" {}<& {}", src, dst));
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupFdClose(fd)) => {
-                            cmd_str.push_str(&format!(" {}<&-", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectFdIn(fd)) => {
-                            cmd_str.push_str(&format!(" {}< ", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::ProcessSubIn) => {
-                            cmd_str.push_str(" <(");
-                            depth += 1;
-                            self.advance();
-                        }
-                        Some(tokens::Token::ProcessSubOut) => {
-                            cmd_str.push_str(" >(");
-                            depth += 1;
                             self.advance();
                         }
                         Some(tokens::Token::Error(e)) => {
-                            // Propagate lexer errors
                             let msg = e.clone();
                             self.advance();
                             return Err(Error::parse(format!(
@@ -2840,13 +2680,15 @@ impl<'a> Parser<'a> {
                                 "unexpected end of input in process substitution".to_string(),
                             ));
                         }
-                        #[allow(unreachable_patterns)]
                         _ => {
-                            // Safety net for future Token variants
                             self.advance();
                         }
                     }
                 }
+
+                let cmd_str = self
+                    .source_slice(start_offset, end_offset)
+                    .unwrap_or_default();
 
                 // THREAT[TM-DOS-021]: Propagate parent parser limits to child parser
                 // to prevent depth limit bypass via nested process substitution.

--- a/crates/bashkit/tests/spec_cases/bash/procsub.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/procsub.test.sh
@@ -130,3 +130,31 @@ a
 b
 c
 ### end
+
+### process_subst_glob_adjacent_quoted_var
+### bash_diff: requires /dev/fd/ and VFS-specific filesystem
+# Issue #1333: glob `*` adjacent to quoted variable inside <(...) must expand
+mkdir -p /tmp/psubglob
+cd /tmp/psubglob
+: > tag_foo.tmp.html
+: > tag_bar.tmp.html
+p="tag_"
+while IFS= read -r i; do echo "got: $i"; done < <(ls ./"$p"*.tmp.html | sort)
+### expect
+got: ./tag_bar.tmp.html
+got: ./tag_foo.tmp.html
+### end
+
+### process_subst_glob_cat
+### bash_diff: requires /dev/fd/ and VFS-specific filesystem
+# Issue #1333: `cat < <(...)` variant
+mkdir -p /tmp/psubglob2
+cd /tmp/psubglob2
+: > tag_a.tmp.html
+: > tag_b.tmp.html
+p="tag_"
+cat < <(ls ./"$p"*.tmp.html | sort)
+### expect
+./tag_a.tmp.html
+./tag_b.tmp.html
+### end


### PR DESCRIPTION
## Summary

Fixes #1333. Glob metacharacters like `*` adjacent to a quoted variable (e.g. `./"$var"*.ext`) now expand correctly inside process substitution `<(…)` and `>(…)`.

Before this fix, patterns like `< <(ls ./"$prefix"*.tmp.html)` silently matched nothing, even though the same pattern worked at the top level, inside `$(...)`, inside `(…)`, and inside `{ …; } | …`.

## Why

The parser re-serialised tokens inside `<(cmd)` back into a string before handing the body to a child parser. For `QuotedGlobWord` tokens (a word like `./"$var"*.ext`), re-serialization wrapped the *entire* token's content in double quotes:

```
./$var*.ext   →   "./$var*.ext"
```

…which promoted the otherwise-unquoted `*` into a literal character, so the inner parser's pathname-expansion check at `expand_command_args` correctly decided not to glob.

## How

Replace the 180-line token-to-string reconstruction loop with a single call to the parser's existing `source_slice()` helper: walk tokens to find the matching closing `)`, then slice the body verbatim from the original source. The child parser now sees exactly what the user wrote, so quote boundaries and glob metacharacters are preserved byte-for-byte.

`TM-DOS-021` (depth/fuel budget propagation to the child parser) is preserved.

## Test plan

- [x] Added `process_subst_glob_adjacent_quoted_var` and `process_subst_glob_cat` to `crates/bashkit/tests/spec_cases/bash/procsub.test.sh` — both previously failed and now pass
- [x] `cargo test -p bashkit --test spec_tests bash_spec_tests` ✅
- [x] `cargo test -p bashkit --lib parser` ✅ (141 passed)
- [x] `cargo test -p bashkit --lib interpreter` ✅ (206 passed)
- [x] Manual smoke: `bashkit -c '... < <(ls ./"$p"*.tmp.html | sort)'` enumerates the expected files
- [x] `cargo fmt --check` ✅
- [x] Net `-130` lines (parser code simplification)