### PR TITLE
fix(examples): fail harness smoke test correctly

### DIFF
--- a/crates/bashkit/tests/harness_example_tests.rs
+++ b/crates/bashkit/tests/harness_example_tests.rs
@@ -1,0 +1,99 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+fn write_executable(path: &Path, content: &str) {
+    fs::write(path, content).unwrap();
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+fn example_script() -> String {
+    format!(
+        "{}/../../examples/harness-openai-joke.sh",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+#[test]
+fn harness_example_installs_non_streaming_openai_override() {
+    let temp = tempfile::tempdir().unwrap();
+    let harness_dir = temp.path().join("harness");
+    let work_dir = temp.path().join("work");
+    let fake_bashkit = temp.path().join("fake-bashkit");
+    let stdout_file = temp.path().join("stdout.txt");
+
+    fs::create_dir_all(harness_dir.join("bin")).unwrap();
+    fs::create_dir_all(&work_dir).unwrap();
+
+    write_executable(
+        &fake_bashkit,
+        &format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"${{FAKE_BASHKIT_STDOUT:-ok}}\"\nprintf '%s' \"${{FAKE_BASHKIT_STDOUT:-ok}}\" > \"{}\"\nexit \"${{FAKE_BASHKIT_EXIT:-0}}\"\n",
+            stdout_file.display()
+        ),
+    );
+
+    let output = Command::new("bash")
+        .arg(example_script())
+        .env("BASHKIT", &fake_bashkit)
+        .env("HARNESS_DIR", &harness_dir)
+        .env("WORK_DIR", &work_dir)
+        .env("OPENAI_API_KEY", "dummy")
+        .env("FAKE_BASHKIT_STDOUT", "ok")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let override_path = work_dir.join(".harness/providers/openai");
+    assert!(override_path.exists());
+    let override_body = fs::read_to_string(override_path).unwrap();
+    assert!(override_body.contains("exec /harness/plugins/openai/providers/openai \"$@\""));
+    assert!(
+        !override_body.contains("--stream"),
+        "override should suppress harness streaming autodetection"
+    );
+}
+
+#[test]
+fn harness_example_fails_when_bashkit_prints_error_output() {
+    let temp = tempfile::tempdir().unwrap();
+    let harness_dir = temp.path().join("harness");
+    let work_dir = temp.path().join("work");
+    let fake_bashkit = temp.path().join("fake-bashkit");
+
+    fs::create_dir_all(harness_dir.join("bin")).unwrap();
+    fs::create_dir_all(&work_dir).unwrap();
+
+    write_executable(
+        &fake_bashkit,
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' 'error: hook pipeline failed'\nexit 0\n",
+    );
+
+    let output = Command::new("bash")
+        .arg(example_script())
+        .env("BASHKIT", &fake_bashkit)
+        .env("HARNESS_DIR", &harness_dir)
+        .env("WORK_DIR", &work_dir)
+        .env("OPENAI_API_KEY", "dummy")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "script should fail on error-prefixed stdout"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("error: hook pipeline failed"),
+        "stdout:\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/examples/harness-openai-joke.sh
+++ b/examples/harness-openai-joke.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Run the wedow/harness agent framework via bashkit to generate a joke using OpenAI.
 #
+# Decision: install a local non-streaming OpenAI provider override in HARNESS_HOME.
+# Harness auto-enables streaming when the provider advertises `--stream`, but the
+# bashkit realfs mount used by this example does not support mkfifo for the FIFO
+# dispatcher path yet.
+#
+# Decision: treat `error:` output as failure. The harness loop can print an error
+# message while the surrounding bashkit invocation still exits 0, which hides
+# breakage in CI unless this script checks the output explicitly.
+#
 # Prerequisites:
 #   - cargo build -p bashkit-cli --features realfs
 #   - OPENAI_API_KEY set in environment
@@ -22,32 +31,52 @@ fi
 
 HARNESS_DIR="${HARNESS_DIR:-/tmp/harness}"
 WORK_DIR="${WORK_DIR:-/tmp/harness-work}"
+HARNESS_HOME="${HARNESS_HOME:-${WORK_DIR}/.harness}"
 
 if [[ ! -d "${HARNESS_DIR}" ]]; then
   echo "Cloning harness..."
   git clone https://github.com/wedow/harness "${HARNESS_DIR}"
 fi
 
-mkdir -p "${WORK_DIR}/.harness/sessions"
+mkdir -p "${HARNESS_HOME}/sessions" "${HARNESS_HOME}/providers"
+
+cat > "${HARNESS_HOME}/providers/openai" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec /harness/plugins/openai/providers/openai "$@"
+EOF
+chmod +x "${HARNESS_HOME}/providers/openai"
 
 : "${OPENAI_API_KEY:?OPENAI_API_KEY must be set}"
 
-exec "$BASHKIT" \
+output_file="$(mktemp)"
+trap 'rm -f "${output_file}"' EXIT
+
+"$BASHKIT" \
   --mount-ro "${HARNESS_DIR}:/harness" \
   --mount-rw "${WORK_DIR}:/work" \
   --timeout 120 \
   -c '
 export PATH="/harness/bin:${PATH}"
 export HOME=/work
+export HARNESS_HOME=/work/.harness
 export HARNESS_ROOT=/harness
 export HARNESS_PROVIDER=openai
 export HARNESS_MODEL=gpt-4o
 export HARNESS_MAX_TURNS=3
 export OPENAI_API_KEY="'"${OPENAI_API_KEY}"'"
-mkdir -p /work/.harness/sessions
 hs "tell me a short joke"
 
 # Other commands that work inside bashkit:
 #   hs help            — show providers, tools, plugin dirs
 #   hs session list    — list past sessions
-'
+' | tee "${output_file}"
+
+status=${PIPESTATUS[0]}
+if (( status != 0 )); then
+  exit "${status}"
+fi
+
+if grep -q '^error:' "${output_file}"; then
+  exit 1
+fi


### PR DESCRIPTION
## What
- make the harness OpenAI joke example install a local non-streaming OpenAI provider override under HARNESS_HOME
- capture bashkit stdout and fail the script when the example prints an error line
- add regression tests for both the provider override and error-output failure path

## Why
The harness example was failing inside bashkit because harness auto-enabled streaming and hit mkfifo-not-supported on the mounted realfs path. CI still reported the example step as green because the script could print an error while returning exit code 0.

## How
- override the openai provider in the example environment so harness uses the non-streaming provider path
- preserve bashkit's real exit status via PIPESTATUS
- explicitly treat error-prefixed output as a failed smoke run

## Tests
- cargo test -q --test harness_example_tests
- just test
- OPENAI_API_KEY=dummy bash examples/harness-openai-joke.sh
- just pre-pr
