### PR TITLE
fix(parser): preserve glob expansion inside process substitution

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -11225,6 +11225,48 @@ echo "count=$COUNT"
         );
     }
 
+    /// Issue #1333: glob `*` adjacent to quoted variable must also expand
+    /// inside process substitution `<(...)`. The fix from #1287 applied at
+    /// the top-level but not inside the subshell body of `<(cmd)`.
+    #[tokio::test]
+    async fn test_glob_adjacent_to_quoted_var_in_process_substitution() {
+        let mut bash = crate::Bash::new();
+        bash.fs()
+            .mkdir(std::path::Path::new("/tmp/ps_glob"), true)
+            .await
+            .unwrap();
+        bash.fs()
+            .write_file(
+                std::path::Path::new("/tmp/ps_glob/tag_foo.tmp.html"),
+                b"foo",
+            )
+            .await
+            .unwrap();
+        bash.fs()
+            .write_file(
+                std::path::Path::new("/tmp/ps_glob/tag_bar.tmp.html"),
+                b"bar",
+            )
+            .await
+            .unwrap();
+
+        // while-read over <(ls ./"$p"*.tmp.html) — real blocker case from bashblog.
+        let result = bash
+            .exec(
+                r#"cd /tmp/ps_glob; p="tag_"; while read -r i; do echo "got:$i"; done < <(ls ./"$p"*.tmp.html)"#,
+            )
+            .await
+            .unwrap();
+        let mut lines: Vec<&str> = result.stdout.trim().lines().collect();
+        lines.sort();
+        assert_eq!(
+            lines,
+            vec!["got:./tag_bar.tmp.html", "got:./tag_foo.tmp.html"],
+            "glob * inside <(...) should expand; stderr: {}",
+            result.stderr
+        );
+    }
+
     #[tokio::test]
     async fn test_glob_with_quoted_prefix() {
         let mut bash = crate::Bash::new();

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -2630,204 +2630,42 @@ impl<'a> Parser<'a> {
                 Ok(word)
             }
             Some(tokens::Token::ProcessSubIn) | Some(tokens::Token::ProcessSubOut) => {
-                // Process substitution <(cmd) or >(cmd)
+                // Process substitution <(cmd) or >(cmd).
+                //
+                // Issue #1333: extract the body from the original source via span
+                // offsets rather than reconstructing a string from the token stream.
+                // Token-string reconstruction wraps `QuotedGlobWord` in `"..."`,
+                // erasing the unquoted-glob boundary and breaking glob expansion
+                // for patterns like `./"$var"*.ext` inside `<(...)`.
                 let is_input = matches!(self.current_token, Some(tokens::Token::ProcessSubIn));
+                // Span end of the `<(` / `>(` token is exactly the start of the body.
+                let body_start_offset = self.current_span.end.offset;
                 self.advance();
 
-                // Parse commands until we hit a closing paren
-                let mut cmd_str = String::new();
                 let mut depth = 1;
+                let body_end_offset;
                 loop {
                     match &self.current_token {
                         Some(tokens::Token::LeftParen) => {
                             depth += 1;
-                            cmd_str.push('(');
                             self.advance();
                         }
                         Some(tokens::Token::RightParen) => {
                             depth -= 1;
                             if depth == 0 {
+                                // Body ends at the start of the matching `)`.
+                                body_end_offset = self.current_span.start.offset;
                                 self.advance();
                                 break;
                             }
-                            cmd_str.push(')');
                             self.advance();
                         }
-                        Some(tokens::Token::Word(w)) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push_str(w);
-                            self.advance();
-                        }
-                        Some(tokens::Token::QuotedWord(w))
-                        | Some(tokens::Token::QuotedGlobWord(w)) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push('"');
-                            cmd_str.push_str(w);
-                            cmd_str.push('"');
-                            self.advance();
-                        }
-                        Some(tokens::Token::LiteralWord(w)) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push('\'');
-                            cmd_str.push_str(w);
-                            cmd_str.push('\'');
-                            self.advance();
-                        }
-                        Some(tokens::Token::Pipe) => {
-                            cmd_str.push_str(" | ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Semicolon) => {
-                            cmd_str.push_str("; ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::And) => {
-                            cmd_str.push_str(" && ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Or) => {
-                            cmd_str.push_str(" || ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Background) => {
-                            cmd_str.push_str(" & ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectOut) => {
-                            cmd_str.push_str(" > ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectAppend) => {
-                            cmd_str.push_str(" >> ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectIn) => {
-                            cmd_str.push_str(" < ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::HereString) => {
-                            cmd_str.push_str(" <<< ");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupOutput) => {
-                            cmd_str.push_str(" >&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectFd(fd)) => {
-                            cmd_str.push_str(&format!(" {}> ", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::LeftBrace) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push('{');
-                            self.advance();
-                        }
-                        Some(tokens::Token::RightBrace) => {
-                            cmd_str.push_str(" }");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Newline) => {
-                            cmd_str.push('\n');
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleLeftBracket) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push_str("[[");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleRightBracket) => {
-                            cmd_str.push_str(" ]]");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleLeftParen) => {
-                            if !cmd_str.is_empty() {
-                                cmd_str.push(' ');
-                            }
-                            cmd_str.push_str("((");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleRightParen) => {
-                            cmd_str.push_str("))");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleSemicolon) => {
-                            cmd_str.push_str(";;");
-                            self.advance();
-                        }
-                        Some(tokens::Token::SemiAmp) => {
-                            cmd_str.push_str(";&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DoubleSemiAmp) => {
-                            cmd_str.push_str(";;&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Assignment) => {
-                            cmd_str.push('=');
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectBoth) => {
-                            cmd_str.push_str(" &>");
-                            self.advance();
-                        }
-                        Some(tokens::Token::Clobber) => {
-                            cmd_str.push_str(" >|");
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupInput) => {
-                            cmd_str.push_str(" <&");
-                            self.advance();
-                        }
-                        Some(tokens::Token::HereDoc) => {
-                            cmd_str.push_str(" <<");
-                            self.advance();
-                        }
-                        Some(tokens::Token::HereDocStrip) => {
-                            cmd_str.push_str(" <<-");
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectFdAppend(fd)) => {
-                            cmd_str.push_str(&format!(" {}>>", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupFd(src, dst)) => {
-                            cmd_str.push_str(&format!(" {}>& {}", src, dst));
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupFdIn(src, dst)) => {
-                            cmd_str.push_str(&format!(" {}<& {}", src, dst));
-                            self.advance();
-                        }
-                        Some(tokens::Token::DupFdClose(fd)) => {
-                            cmd_str.push_str(&format!(" {}<&-", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::RedirectFdIn(fd)) => {
-                            cmd_str.push_str(&format!(" {}< ", fd));
-                            self.advance();
-                        }
-                        Some(tokens::Token::ProcessSubIn) => {
-                            cmd_str.push_str(" <(");
-                            depth += 1;
-                            self.advance();
-                        }
-                        Some(tokens::Token::ProcessSubOut) => {
-                            cmd_str.push_str(" >(");
+                        Some(tokens::Token::ProcessSubIn) | Some(tokens::Token::ProcessSubOut) => {
+                            // Nested <( / >( opens another paren level.
                             depth += 1;
                             self.advance();
                         }
                         Some(tokens::Token::Error(e)) => {
-                            // Propagate lexer errors
                             let msg = e.clone();
                             self.advance();
                             return Err(Error::parse(format!(
@@ -2840,13 +2678,15 @@ impl<'a> Parser<'a> {
                                 "unexpected end of input in process substitution".to_string(),
                             ));
                         }
-                        #[allow(unreachable_patterns)]
                         _ => {
-                            // Safety net for future Token variants
                             self.advance();
                         }
                     }
                 }
+
+                let cmd_str = self
+                    .source_slice(body_start_offset, body_end_offset)
+                    .unwrap_or_default();
 
                 // THREAT[TM-DOS-021]: Propagate parent parser limits to child parser
                 // to prevent depth limit bypass via nested process substitution.


### PR DESCRIPTION
## Summary

The `./"$var"*.ext` glob pattern expanded everywhere (top-level, `$(...)`, subshells, pipes — fixed in #1287) *except* inside `<(...)` / `>(...)` process substitution, breaking real-world scripts like bashblog's `rebuild_tags()` that drives a `while read` loop from `<(ls ./"$p"*.tmp.html)`.

## Root cause

`Parser::parse_primary_word` reconstructed the process-substitution body by walking the token stream and re-emitting each token as a string. For a `QuotedGlobWord(w)` token (introduced in #1287 to carry the "has unquoted glob but IFS-split-suppressed" bit), the reconstruction wrapped the entire processed word in `"..."`. When the inner parser re-lexed that string, everything ended up inside one pair of double quotes, so the unquoted `*` was swallowed and the resulting `Word` came back with `has_unquoted_glob = false`. `expand_command_args` then took the quoted-word fast path and skipped glob expansion.

## Fix

Extract the body directly from the original source via span offsets and hand it to the inner parser. The `ProcessSubIn` / `ProcessSubOut` token's span ends exactly after the `<(` / `>(`; the matching `)` token's span starts exactly at the closing paren. Slicing `self.input` between those two offsets yields the exact original body, preserving quoting, escapes, and whitespace without any lossy reconstruction.

This deletes ~150 lines of per-token rebuild logic and fixes the glob bug as a side effect.

## Test plan

- [x] New test `test_glob_adjacent_to_quoted_var_in_process_substitution` covers the exact bashblog `while read < <(ls ./"$p"*.tmp.html)` pattern — fails before the fix, passes after.
- [x] All 2093 `bashkit` lib tests pass.
- [x] Existing process-sub tests (`test_process_sub_*`, `test_proc_sub_*`) and glob tests (`test_glob_*`) still green.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo test --features http_client` green across all crates.

Closes #1333