### PR TITLE
fix(site): drop ASSETS binding for static-only worker

### DIFF
--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -2,8 +2,7 @@
   "name": "bashkit-site",
   "compatibility_date": "2025-10-01",
   "assets": {
-    "directory": "./dist",
-    "binding": "ASSETS"
+    "directory": "./dist"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## What
Drop the `binding: "ASSETS"` field from `site/wrangler.jsonc`.

## Why
Cloudflare deploy fails for the static-only Worker:

```
[ERROR] Cannot use assets with a binding in an assets-only Worker.
Please remove the asset binding from your configuration file,
or provide a Worker script in your configuration file ('main').
```

The `ASSETS` binding is only meaningful when a Worker script reads `env.ASSETS`. The bashkit.sh site is static — no Worker code — so the binding must go.

## How
Removed the single `"binding": "ASSETS"` line. `directory: "./dist"` stays so the static assets are still served.

## Test plan
- [x] `npx wrangler deploy` no longer errors on the assets-binding check (verified via Cloudflare build log)
- [x] No code paths touched — config-only change