### PR TITLE
feat(awk): implement range patterns (/start/,/end/)

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -54,6 +54,9 @@ struct AwkRule {
 enum AwkPattern {
     Regex(Regex),
     Expression(AwkExpr),
+    /// Range pattern: /start/,/end/ — matches from start to end inclusive.
+    /// Each sub-pattern can be a Regex or Expression.
+    Range(Box<AwkPattern>, Box<AwkPattern>),
 }
 
 #[derive(Debug, Clone)]
@@ -670,6 +673,29 @@ impl<'a> AwkParser<'a> {
         Ok(AwkRule { pattern, actions })
     }
 
+    /// Parse a `/regex/` literal into an `AwkPattern::Regex`.
+    /// Assumes the leading `/` is at `self.pos`.
+    fn parse_regex_pattern(&mut self) -> Result<AwkPattern> {
+        self.pos += 1; // skip opening '/'
+        let start = self.pos;
+        while self.pos < self.input.len() {
+            let c = self.current_char().unwrap();
+            if c == '/' {
+                let pattern = &self.input[start..self.pos];
+                self.pos += 1;
+                let regex = build_regex(pattern)
+                    .map_err(|e| Error::Execution(format!("awk: invalid regex: {}", e)))?;
+                return Ok(AwkPattern::Regex(regex));
+            } else if c == '\\' {
+                self.pos += 1; // skip '\\' (ASCII)
+                self.advance(); // skip next char (may be multi-byte)
+            } else {
+                self.advance(); // regex content may be multi-byte
+            }
+        }
+        Err(Error::Execution("awk: unterminated regex".to_string()))
+    }
+
     fn parse_pattern(&mut self) -> Result<Option<AwkPattern>> {
         self.skip_whitespace();
 
@@ -680,35 +706,36 @@ impl<'a> AwkParser<'a> {
         let c = self.current_char().unwrap();
 
         // Check for regex pattern
-        if c == '/' {
-            self.pos += 1;
-            let start = self.pos;
-            while self.pos < self.input.len() {
-                let c = self.current_char().unwrap();
-                if c == '/' {
-                    let pattern = &self.input[start..self.pos];
-                    self.pos += 1;
-                    let regex = build_regex(pattern)
-                        .map_err(|e| Error::Execution(format!("awk: invalid regex: {}", e)))?;
-                    return Ok(Some(AwkPattern::Regex(regex)));
-                } else if c == '\\' {
-                    self.pos += 1; // skip '\\' (ASCII)
-                    self.advance(); // skip next char (may be multi-byte)
-                } else {
-                    self.advance(); // regex content may be multi-byte
-                }
-            }
-            return Err(Error::Execution("awk: unterminated regex".to_string()));
-        }
-
-        // Check for opening brace (no pattern)
-        if c == '{' {
+        let first: Option<AwkPattern> = if c == '/' {
+            Some(self.parse_regex_pattern()?)
+        } else if c == '{' {
+            // Check for opening brace (no pattern)
             return Ok(None);
-        }
+        } else {
+            // Expression pattern
+            let expr = self.parse_expression()?;
+            Some(AwkPattern::Expression(expr))
+        };
 
-        // Expression pattern
-        let expr = self.parse_expression()?;
-        Ok(Some(AwkPattern::Expression(expr)))
+        // Check for range pattern: pattern1 , pattern2
+        if let Some(first_pat) = first {
+            self.skip_whitespace();
+            if self.pos < self.input.len() && self.current_char().unwrap() == ',' {
+                self.pos += 1; // consume ','
+                let second = self.parse_pattern()?;
+                let second_pat = second.ok_or_else(|| {
+                    Error::Execution("awk: expected second pattern in range".to_string())
+                })?;
+                Ok(Some(AwkPattern::Range(
+                    Box::new(first_pat),
+                    Box::new(second_pat),
+                )))
+            } else {
+                Ok(Some(first_pat))
+            }
+        } else {
+            Ok(None)
+        }
     }
 
     fn parse_action_block(&mut self) -> Result<Vec<AwkAction>> {
@@ -2115,6 +2142,10 @@ struct AwkInterpreter {
     fs: Option<Arc<dyn FileSystem>>,
     /// Working directory for resolving relative paths.
     cwd: PathBuf,
+    /// Tracks active state for range patterns (rule index -> is_active).
+    /// When start pattern matches, range becomes active. When end pattern
+    /// matches, that line is included but range becomes inactive.
+    range_active: HashMap<usize, bool>,
 }
 
 impl AwkInterpreter {
@@ -2132,6 +2163,7 @@ impl AwkInterpreter {
             call_depth: 0,
             fs: None,
             cwd: PathBuf::from("/"),
+            range_active: HashMap::new(),
         }
     }
 
@@ -3307,6 +3339,36 @@ impl AwkInterpreter {
                 re.is_match(&line)
             }
             AwkPattern::Expression(expr) => self.eval_expr(expr).as_bool(),
+            // Range patterns are handled specially via matches_pattern_with_index
+            // which tracks state. This arm shouldn't normally be reached for ranges
+            // in the main loop, but handle it defensively.
+            AwkPattern::Range(_, _) => false,
+        }
+    }
+
+    /// Check if a rule's pattern matches, with range state tracking by rule index.
+    fn matches_pattern_with_index(&mut self, pattern: &AwkPattern, rule_idx: usize) -> bool {
+        match pattern {
+            AwkPattern::Range(start, end) => {
+                let active = *self.range_active.get(&rule_idx).unwrap_or(&false);
+                if active {
+                    // Already in range — check if end pattern matches
+                    if self.matches_pattern(end) {
+                        // End pattern matched: include this line, deactivate range
+                        self.range_active.insert(rule_idx, false);
+                    }
+                    true
+                } else {
+                    // Not in range — check if start pattern matches
+                    if self.matches_pattern(start) {
+                        self.range_active.insert(rule_idx, true);
+                        true
+                    } else {
+                        false
+                    }
+                }
+            }
+            other => self.matches_pattern(other),
         }
     }
 }
@@ -3498,10 +3560,10 @@ impl Builtin for Awk {
                 let line = interp.input_lines[interp.line_index].clone();
                 interp.state.set_line(&line);
 
-                for rule in &program.main_rules {
-                    // Check pattern
+                for (rule_idx, rule) in program.main_rules.iter().enumerate() {
+                    // Check pattern (with range state tracking)
                     let matches = match &rule.pattern {
-                        Some(pattern) => interp.matches_pattern(pattern),
+                        Some(pattern) => interp.matches_pattern_with_index(pattern, rule_idx),
                         None => true,
                     };
 

--- a/crates/bashkit/tests/awk_range_pattern_tests.rs
+++ b/crates/bashkit/tests/awk_range_pattern_tests.rs
@@ -1,0 +1,97 @@
+//! Tests for awk range patterns (/start/,/end/)
+
+use bashkit::Bash;
+use std::path::Path;
+
+#[tokio::test]
+async fn awk_range_pattern_basic() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"printf "a\nb\nc\nd\ne\n" | awk '/b/,/d/{print}'"#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "b\nc\nd\n");
+}
+
+#[tokio::test]
+async fn awk_range_pattern_with_exclusion() {
+    let mut bash = Bash::new();
+    let fs = bash.fs();
+    fs.write_file(
+        Path::new("/tmp/range_test.txt"),
+        b"before\n<!-- text begin -->\ncontent line 1\ncontent line 2\n<!-- text end -->\nafter\n",
+    )
+    .await
+    .unwrap();
+
+    let result = bash
+        .exec(
+            r#"awk '/<!-- text begin -->/,/<!-- text end -->/{if (!/<!-- text begin -->/ && !/<!-- text end -->/) print}' /tmp/range_test.txt"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "content line 1\ncontent line 2\n");
+}
+
+#[tokio::test]
+async fn awk_range_pattern_multiple_ranges() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"printf "a\nSTART\nb\nEND\nc\nSTART\nd\nEND\ne\n" | awk '/START/,/END/{print}'"#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "START\nb\nEND\nSTART\nd\nEND\n");
+}
+
+#[tokio::test]
+async fn awk_range_pattern_with_action_block() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"printf "1\n2\n3\n4\n5\n" | awk '/2/,/4/{print "-> " $0}'"#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "-> 2\n-> 3\n-> 4\n");
+}
+
+/// bashblog get_post_title pattern
+#[tokio::test]
+async fn awk_range_pattern_html_title_extraction() {
+    let mut bash = Bash::new();
+    let fs = bash.fs();
+    fs.write_file(
+        Path::new("/tmp/post.html"),
+        b"<h3><a class=\"ablack\" href=\"test.html\">\nMy Post Title\n</a></h3>\n",
+    )
+    .await
+    .unwrap();
+
+    let result = bash
+        .exec(
+            r#"awk '/<h3><a class="ablack" href=".+">/, /<\/a><\/h3>/{if (!/<h3><a class="ablack" href=".+">/ && !/<\/a><\/h3>/) print}' /tmp/post.html"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "My Post Title");
+}
+
+/// Range that starts but never ends (should match all remaining lines)
+#[tokio::test]
+async fn awk_range_pattern_unterminated() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"printf "a\nSTART\nb\nc\n" | awk '/START/,/END/{print}'"#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "START\nb\nc\n");
+}
+
+/// Range with default print action (no action block)
+#[tokio::test]
+async fn awk_range_pattern_default_action() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"printf "x\na\nb\nc\ny\n" | awk '/a/,/c/'"#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "a\nb\nc\n");
+}


### PR DESCRIPTION
## Summary

- Add awk range pattern support (`/start/,/end/`) — matches all lines from start pattern through end pattern inclusive
- Found while running [bashblog](https://github.com/cfenollosa/bashblog) via bashkit CLI, which uses range patterns extensively for HTML content extraction

## Changes

- Add `Range(Box<AwkPattern>, Box<AwkPattern>)` variant to `AwkPattern` enum
- Extract `parse_regex_pattern()` helper for reuse
- Detect comma after first pattern in `parse_pattern()` to build range
- Add `range_active` state tracking in `AwkInterpreter`
- Add `matches_pattern_with_index()` for stateful range matching
- 7 new tests covering basic, multi-range, unterminated, and bashblog-specific patterns

## Test plan

- [x] `cargo test --test awk_range_pattern_tests` — 7 tests pass
- [x] `cargo test --test awk_pattern_tests` — existing tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean (pre-existing dead-code warnings only)
- [x] Verified bashblog `rebuild` pipeline runs end-to-end via bashkit CLI