### PR TITLE
test(source): regression for sourced fn with fd3 block redirect + procsub while-read

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/source.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/source.test.sh
@@ -175,3 +175,37 @@ greet
 ### expect
 hello world
 ### end
+
+### source_function_fd3_block_redirect_with_procsub_while_read
+# Issue #1343: sourced function using compound block `{...} 3>&1 >file` plus
+# `while read; done < <(cmd)` must execute the loop body and produce output.
+# Before #1341 the glob inside process substitution expanded to nothing, so the
+# while loop received no input and the block produced an empty file.
+mkdir -p /tmp/issue1343_dir
+touch /tmp/issue1343_dir/a.txt /tmp/issue1343_dir/b.txt
+cat > /tmp/issue1343_funcs.sh << 'SCRIPT'
+myfunc() {
+    outfile=/tmp/issue1343_result.txt
+    {
+        echo "header"
+        while IFS='' read -r i; do
+            echo "." 1>&3
+            echo "<li>$i</li>"
+        done < <(ls /tmp/issue1343_dir/*.txt)
+        echo "done" 1>&3
+    } 3>&1 >"$outfile"
+}
+SCRIPT
+source /tmp/issue1343_funcs.sh
+myfunc
+echo "---"
+cat /tmp/issue1343_result.txt
+### expect
+.
+.
+done
+---
+header
+<li>/tmp/issue1343_dir/a.txt</li>
+<li>/tmp/issue1343_dir/b.txt</li>
+### end


### PR DESCRIPTION
## Summary

Issue #1343 reported that a sourced function mixing `{ ... } 3>&1 >"$file"` with a `while read; done < <(ls glob)` loop produced an empty output file — the while body never ran.

On current `main` this pattern already works: PR #1341 (glob inside `<(...)`) resolved the underlying cause. This PR adds a spec case that exercises the exact shape from the issue so any future regression is caught before shipping.

## What

- New spec case `source_function_fd3_block_redirect_with_procsub_while_read` in `crates/bashkit/tests/spec_cases/bash/source.test.sh`
- Test creates `/tmp/issue1343_dir/*.txt`, sources a file defining `myfunc`, calls it, then asserts both the fd3 progress stream on stdout and the `>file` contents populated by the `while read` loop

## Test plan

- [x] New spec case passes (`cargo test --test spec_tests bash_spec_tests`)
- [x] All 1978 bash spec tests green (0 failed, 25 skipped)
- [x] Expected output verified against real bash — identical
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean

Closes #1343