### PR TITLE
feat(python): add network allowlist config

### DIFF
--- a/crates/bashkit-python/Cargo.toml
+++ b/crates/bashkit-python/Cargo.toml
@@ -18,7 +18,7 @@ doc = false  # Python extension, no Rust docs needed
 [dependencies]
 # Bashkit core
 # realfs: always-on so Python callers can use mount_real_* APIs
-bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs", "jq"] }
+bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs", "jq", "http_client"] }
 
 # PyO3 native extension
 pyo3 = { workspace = true }

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -8,7 +8,8 @@ Sandboxed bash interpreter for Python. Native bindings to the `bashkit` Rust cor
 
 - Sandboxed execution in-process, without containers or subprocess orchestration
 - Full bash syntax: variables, pipelines, redirects, loops, functions, and arrays
-- 160 built-in commands including `grep`, `sed`, `awk`, `jq`, `curl`, and `find`
+- 160 built-in commands including `grep`, `sed`, `awk`, `jq`, `curl`, `wget`, `http`, and `find`
+- Opt-in allowlisted outbound HTTP on `Bash` and `BashTool` via `network=...`
 - Persistent interpreter state across calls, including variables, cwd, and VFS contents
 - Direct virtual filesystem APIs, constructor mounts, and live host mounts
 - Snapshot and restore support on `Bash` and `BashTool`
@@ -79,6 +80,29 @@ bash = Bash(
     python=False,
 )
 ```
+
+### Network Access
+
+Outbound HTTP is disabled by default. Opt in with `network=` when you want
+`curl`, `wget`, or `http` to reach specific URLs:
+
+```python
+from bashkit import Bash
+
+bash = Bash(
+    network={
+        "allow": ["https://api.github.com", "http://127.0.0.1:8080"],
+        "block_private_ips": False,
+    }
+)
+
+result = bash.execute_sync("curl -s http://127.0.0.1:8080/health")
+print(result.stdout)
+```
+
+Omit `network` to keep HTTP disabled. Use `network={"allow": []}` when you
+want an explicit empty allowlist, or `network={"allow_all": True}` for trusted
+test environments.
 
 ### Live Output
 
@@ -366,9 +390,9 @@ restored.restore_snapshot(shell_only)
 ```
 
 `BashTool` exposes the same `snapshot()`, `restore_snapshot(...)`, and `from_snapshot(...)` APIs.
-Python callback builtins are host-side config, not serialized shell state, so
-pass `custom_builtins=` again when constructing a restored instance if you
-need them after snapshot restore.
+Python callback builtins and `network=` are host-side config, not serialized
+shell state, so pass `custom_builtins=` / `network=` again when constructing a
+restored instance if you need them after snapshot restore.
 
 ## Framework Integrations
 
@@ -405,6 +429,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 - `cancel()`
 - `clear_cancel()`
 - `reset()`
+- constructor kwarg: `network={...}`
 - constructor kwarg: `custom_builtins={name: callback}`
 - `snapshot() -> bytes`
 - `restore_snapshot(data: bytes)`
@@ -416,6 +441,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 ### BashTool
 
 - All execution, cancellation (`cancel()`, `clear_cancel()`), reset, snapshot, restore, mount, and direct VFS helpers from `Bash`
+- constructor kwarg: `network={...}`
 - constructor kwarg: `custom_builtins={name: callback}`
 - Tool metadata: `name`, `short_description`, `version`
 - `description() -> str`

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -1,7 +1,7 @@
 """Type stubs for bashkit native module."""
 
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, TypedDict
 
 # Synchronous chunk callback for live stdout/stderr streaming.
 OutputHandler = Callable[[str, str], None]
@@ -24,6 +24,20 @@ class BuiltinContext:
     cwd: str
 
 BuiltinCallback = Callable[[BuiltinContext], str | Awaitable[str]]
+
+class AllowlistNetworkConfig(TypedDict, total=False):
+    """Allowlisted outbound HTTP config for ``Bash`` / ``BashTool``."""
+
+    allow: list[str]
+    block_private_ips: bool
+
+class AllowAllNetworkConfig(TypedDict, total=False):
+    """Allow-all outbound HTTP config for trusted/test environments."""
+
+    allow_all: Literal[True]
+    block_private_ips: bool
+
+NetworkConfig = AllowlistNetworkConfig | AllowAllNetworkConfig
 
 class FileSystem:
     """Direct access to BashKit's virtual filesystem or a standalone mountable FS.
@@ -359,6 +373,8 @@ class Bash:
         files: dict[str, str | Callable[[], str]] | None = None,
         mounts: list[dict[str, Any]] | None = None,
         custom_builtins: dict[str, BuiltinCallback] | None = None,
+        *,
+        network: NetworkConfig | None = None,
     ) -> None:
         """Create a new Bash interpreter.
 
@@ -377,6 +393,10 @@ class Bash:
                 ``execute()``; those re-entrant calls are rejected.
             files: Dict mapping VFS paths to file contents or lazy callables.
             mounts: List of real host directory mount configs.
+            network: Opt-in outbound HTTP config. Omit to keep network
+                disabled. Use ``{"allow": [...]}`` for an allowlist or
+                ``{"allow_all": True}`` for trusted/test environments.
+                Private IP blocking defaults to ``True``.
             custom_builtins: Constructor-time Python callbacks exposed as
                 bash builtins. Each callback receives a ``BuiltinContext``
                 with raw ``argv`` tokens and optional pipeline ``stdin``,
@@ -512,7 +532,7 @@ class Bash:
         """Reset interpreter to initial state.
 
         Clears all VFS contents, environment variables, and shell state.
-        Re-applies the original ``files``, ``mounts``, and
+        Re-applies the original ``files``, ``mounts``, ``network``, and
         ``custom_builtins`` configuration.
 
         Example::
@@ -557,6 +577,8 @@ class Bash:
         files: dict[str, str] | None = None,
         mounts: list[dict[str, Any]] | None = None,
         custom_builtins: dict[str, BuiltinCallback] | None = None,
+        *,
+        network: NetworkConfig | None = None,
     ) -> Bash:
         """Create a new ``Bash`` from snapshot bytes and optional constructor kwargs."""
         ...
@@ -732,6 +754,8 @@ class BashTool:
         files: dict[str, str | Callable[[], str]] | None = None,
         mounts: list[dict[str, Any]] | None = None,
         custom_builtins: dict[str, BuiltinCallback] | None = None,
+        *,
+        network: NetworkConfig | None = None,
     ) -> None:
         """Create a new BashTool.
 
@@ -744,6 +768,10 @@ class BashTool:
             timeout_seconds: Abort execution after this duration.
             files: Dict mapping VFS paths to file contents or lazy callables.
             mounts: List of real host directory mount configs.
+            network: Opt-in outbound HTTP config. Omit to keep network
+                disabled. Use ``{"allow": [...]}`` or
+                ``{"allow_all": True}``. Private IP blocking defaults
+                to ``True``.
             custom_builtins: Constructor-time Python callbacks exposed as
                 bash builtins. Each callback receives a ``BuiltinContext``
                 and must return a stdout string or await one. Async callbacks
@@ -930,7 +958,7 @@ class BashTool:
         """Reset the tool to initial state.
 
         Clears VFS, environment, and shell state while re-applying
-        constructor-time ``custom_builtins``.
+        constructor-time ``custom_builtins`` and ``network`` config.
 
         Example::
 
@@ -971,6 +999,8 @@ class BashTool:
         files: dict[str, str] | None = None,
         mounts: list[dict[str, Any]] | None = None,
         custom_builtins: dict[str, BuiltinCallback] | None = None,
+        *,
+        network: NetworkConfig | None = None,
     ) -> BashTool:
         """Create a new ``BashTool`` from snapshot bytes and optional constructor kwargs."""
         ...

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -10,10 +10,10 @@ use bashkit::{
     Bash, BashTool as RustBashTool, Builtin, BuiltinContext, DirEntry as FsDirEntry, ExcType,
     ExecResult as RustExecResult, ExecutionExtensions, ExecutionLimits, ExtFunctionResult,
     FileSystem, FileSystemExt, FileType as FsFileType, InMemoryFs, Metadata as FsMetadata,
-    MontyException, MontyObject, OutputCallback as RustOutputCallback, OverlayFs, PosixFs,
-    PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode, ScriptedTool as RustScriptedTool,
-    ShellStateView as RustShellStateView, SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs,
-    ToolDef, ToolRequest, async_trait,
+    MontyException, MontyObject, NetworkAllowlist, OutputCallback as RustOutputCallback, OverlayFs,
+    PosixFs, PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode,
+    ScriptedTool as RustScriptedTool, ShellStateView as RustShellStateView,
+    SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
 };
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
@@ -137,6 +137,34 @@ struct RealMountConfig {
     writable: bool,
 }
 
+// Decision: `network=None` means "no HTTP client configured"; this preserves
+// the existing disabled-by-default behavior.
+// Decision: `network={"allow": []}` remains distinct from omitted network by
+// attaching an explicit empty allowlist to Rust.
+// Decision: `network` stays keyword-only on Python constructors so the
+// historical positional `custom_builtins` slot remains source-compatible.
+#[derive(Clone)]
+enum PyNetworkMode {
+    Allow(Vec<String>),
+    AllowAll,
+}
+
+#[derive(Clone)]
+struct PyNetworkConfig {
+    mode: PyNetworkMode,
+    block_private_ips: bool,
+}
+
+impl PyNetworkConfig {
+    fn to_allowlist(&self) -> NetworkAllowlist {
+        let allowlist = match &self.mode {
+            PyNetworkMode::Allow(patterns) => NetworkAllowlist::new().allow_many(patterns.clone()),
+            PyNetworkMode::AllowAll => NetworkAllowlist::allow_all(),
+        };
+        allowlist.block_private_ips(self.block_private_ips)
+    }
+}
+
 enum PyFileMount {
     Static { path: String, content: String },
     Lazy { path: String, provider: Py<PyAny> },
@@ -209,6 +237,61 @@ fn parse_files(files: Option<&Bound<'_, PyDict>>) -> PyResult<Vec<PyFileMount>> 
         )));
     }
     Ok(mounts)
+}
+
+fn parse_network(network: Option<&Bound<'_, PyDict>>) -> PyResult<Option<PyNetworkConfig>> {
+    let Some(dict) = network else {
+        return Ok(None);
+    };
+
+    for (key_obj, _) in dict.iter() {
+        let key: String = key_obj.extract()?;
+        if !matches!(key.as_str(), "allow" | "allow_all" | "block_private_ips") {
+            return Err(PyValueError::new_err(format!(
+                "network['{key}'] is not supported yet; supported keys: 'allow', 'allow_all', 'block_private_ips'"
+            )));
+        }
+    }
+
+    let allow = dict
+        .get_item("allow")?
+        .map(|value| value.extract::<Vec<String>>())
+        .transpose()?;
+    let allow_all = dict
+        .get_item("allow_all")?
+        .map(|value| value.extract::<bool>())
+        .transpose()?;
+    let block_private_ips = dict
+        .get_item("block_private_ips")?
+        .map(|value| value.extract::<bool>())
+        .transpose()?
+        .unwrap_or(true);
+
+    if allow.is_some() && allow_all.is_some() {
+        return Err(PyValueError::new_err(
+            "network cannot contain both 'allow' and 'allow_all'",
+        ));
+    }
+    if matches!(allow_all, Some(false)) {
+        return Err(PyValueError::new_err(
+            "network['allow_all'] must be True when provided",
+        ));
+    }
+
+    let mode = if let Some(patterns) = allow {
+        PyNetworkMode::Allow(patterns)
+    } else if allow_all == Some(true) {
+        PyNetworkMode::AllowAll
+    } else {
+        return Err(PyValueError::new_err(
+            "network must include 'allow' or 'allow_all=True'; omit network to keep HTTP disabled",
+        ));
+    };
+
+    Ok(Some(PyNetworkConfig {
+        mode,
+        block_private_ips,
+    }))
 }
 
 fn parse_custom_builtins(
@@ -2380,6 +2463,16 @@ fn apply_python_config(
     builder
 }
 
+fn apply_network_config(
+    mut builder: bashkit::BashBuilder,
+    network: Option<&PyNetworkConfig>,
+) -> bashkit::BashBuilder {
+    if let Some(network) = network {
+        builder = builder.network(network.to_allowlist());
+    }
+    builder
+}
+
 /// Core bash interpreter with virtual filesystem.
 ///
 /// State persists between calls — files created in one `execute()` are
@@ -2416,6 +2509,7 @@ pub struct PyBash {
     builtin_engine: Arc<PyCallbackEngine>,
     files: Vec<PyFileMount>,
     real_mounts: Vec<RealMountConfig>,
+    network: Option<PyNetworkConfig>,
     max_commands: Option<u64>,
     max_loop_iterations: Option<u64>,
     max_memory: Option<u64>,
@@ -2463,7 +2557,8 @@ impl PyBash {
             self.external_handler_reentry_depth.clone(),
         );
         let files = clone_file_mounts(py, &self.files);
-        let builder = apply_fs_config(builder, &files, &self.real_mounts)?;
+        let mut builder = apply_fs_config(builder, &files, &self.real_mounts)?;
+        builder = apply_network_config(builder, self.network.as_ref());
         Ok(apply_custom_builtins_to_builder(
             py,
             builder,
@@ -2488,6 +2583,8 @@ impl PyBash {
         files=None,
         mounts=None,
         custom_builtins=None,
+        *,
+        network=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -2504,6 +2601,7 @@ impl PyBash {
         files: Option<&Bound<'_, PyDict>>,
         mounts: Option<&Bound<'_, PyList>>,
         custom_builtins: Option<&Bound<'_, PyDict>>,
+        network: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
         let mut builder = Bash::builder();
 
@@ -2532,6 +2630,7 @@ impl PyBash {
 
         let files = parse_files(files)?;
         let real_mounts = parse_mounts(mounts)?;
+        let network = parse_network(network)?;
         let custom_builtins = parse_custom_builtins(py, custom_builtins)?;
 
         let fn_names = external_functions.clone().unwrap_or_default();
@@ -2569,6 +2668,7 @@ impl PyBash {
             external_handler_reentry_depth.clone(),
         );
         builder = apply_fs_config(builder, &files, &real_mounts)?;
+        builder = apply_network_config(builder, network.as_ref());
         let builtin_engine = PyCallbackEngine::new(py)?;
         builder = apply_custom_builtins_to_builder(py, builder, &custom_builtins);
 
@@ -2591,6 +2691,7 @@ impl PyBash {
             builtin_engine,
             files,
             real_mounts,
+            network,
             max_commands,
             max_loop_iterations,
             max_memory,
@@ -2814,6 +2915,8 @@ impl PyBash {
         files=None,
         mounts=None,
         custom_builtins=None,
+        *,
+        network=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn from_snapshot(
@@ -2831,6 +2934,7 @@ impl PyBash {
         files: Option<&Bound<'_, PyDict>>,
         mounts: Option<&Bound<'_, PyList>>,
         custom_builtins: Option<&Bound<'_, PyDict>>,
+        network: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
         let bash = Self::new(
             py,
@@ -2846,6 +2950,7 @@ impl PyBash {
             files,
             mounts,
             custom_builtins,
+            network,
         )?;
         bash.restore_snapshot(py, data)?;
         Ok(bash)
@@ -3035,6 +3140,7 @@ pub struct BashTool {
     builtin_engine: Arc<PyCallbackEngine>,
     files: Vec<PyFileMount>,
     real_mounts: Vec<RealMountConfig>,
+    network: Option<PyNetworkConfig>,
     max_commands: Option<u64>,
     max_loop_iterations: Option<u64>,
     max_memory: Option<u64>,
@@ -3070,7 +3176,8 @@ impl BashTool {
         }
 
         let files = clone_file_mounts(py, &self.files);
-        let builder = apply_fs_config(builder, &files, &self.real_mounts)?;
+        let mut builder = apply_fs_config(builder, &files, &self.real_mounts)?;
+        builder = apply_network_config(builder, self.network.as_ref());
         Ok(apply_custom_builtins_to_builder(
             py,
             builder,
@@ -3126,6 +3233,8 @@ impl BashTool {
         files=None,
         mounts=None,
         custom_builtins=None,
+        *,
+        network=None,
     ))]
     fn new(
         py: Python<'_>,
@@ -3138,6 +3247,7 @@ impl BashTool {
         files: Option<&Bound<'_, PyDict>>,
         mounts: Option<&Bound<'_, PyList>>,
         custom_builtins: Option<&Bound<'_, PyDict>>,
+        network: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
         let mut builder = Bash::builder();
 
@@ -3166,8 +3276,10 @@ impl BashTool {
 
         let files = parse_files(files)?;
         let real_mounts = parse_mounts(mounts)?;
+        let network = parse_network(network)?;
         let custom_builtins = parse_custom_builtins(py, custom_builtins)?;
         builder = apply_fs_config(builder, &files, &real_mounts)?;
+        builder = apply_network_config(builder, network.as_ref());
         let builtin_engine = PyCallbackEngine::new(py)?;
         builder = apply_custom_builtins_to_builder(py, builder, &custom_builtins);
 
@@ -3186,6 +3298,7 @@ impl BashTool {
             builtin_engine,
             files,
             real_mounts,
+            network,
             max_commands,
             max_loop_iterations,
             max_memory,
@@ -3379,6 +3492,8 @@ impl BashTool {
         files=None,
         mounts=None,
         custom_builtins=None,
+        *,
+        network=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn from_snapshot(
@@ -3393,6 +3508,7 @@ impl BashTool {
         files: Option<&Bound<'_, PyDict>>,
         mounts: Option<&Bound<'_, PyList>>,
         custom_builtins: Option<&Bound<'_, PyDict>>,
+        network: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Self> {
         let tool = Self::new(
             py,
@@ -3405,6 +3521,7 @@ impl BashTool {
             files,
             mounts,
             custom_builtins,
+            network,
         )?;
         tool.restore_snapshot(py, data)?;
         Ok(tool)

--- a/crates/bashkit-python/tests/test_network.py
+++ b/crates/bashkit-python/tests/test_network.py
@@ -1,0 +1,143 @@
+"""Python network-config parity tests for Bash and BashTool."""
+
+# Decision: use a loopback HTTP server so tests stay hermetic and never depend
+# on public internet reachability.
+# Decision: step-1 coverage exercises both omitted-network vs explicit-empty
+# allowlist semantics because those two cases intentionally differ.
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from bashkit import Bash, BashTool
+
+
+class _OkHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - stdlib handler name
+        body = b"ok\n"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A003 - stdlib API name
+        return
+
+
+@pytest.fixture
+def loopback_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OkHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_disabled_by_default(factory, loopback_server):
+    shell = factory()
+
+    result = shell.execute_sync(f"curl -s {loopback_server}")
+
+    assert result.exit_code != 0
+    assert "network access not configured" in result.stderr
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_explicit_empty_allowlist_blocks_all(factory, loopback_server):
+    shell = factory(network={"allow": []})
+
+    result = shell.execute_sync(f"curl -s {loopback_server}")
+
+    assert result.exit_code != 0
+    assert "empty allowlist" in result.stderr
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+@pytest.mark.parametrize(
+    ("label", "command"),
+    [
+        ("curl", "curl -s {url}"),
+        ("wget", "wget -q -O - {url}"),
+        ("http", "http {url}"),
+    ],
+)
+def test_network_allowlisted_requests_succeed(factory, loopback_server, label, command):
+    shell = factory(
+        network={"allow": [loopback_server], "block_private_ips": False},
+    )
+
+    result = shell.execute_sync(command.format(url=loopback_server))
+
+    assert result.exit_code == 0, f"{label} failed: {result.stderr}"
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_allow_all_mode(factory, loopback_server):
+    shell = factory(network={"allow_all": True, "block_private_ips": False})
+
+    result = shell.execute_sync(f"curl -s {loopback_server}")
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_non_allowlisted_url_still_fails(factory, loopback_server):
+    shell = factory(
+        network={"allow": [loopback_server], "block_private_ips": False},
+    )
+    blocked_url = loopback_server.rsplit(":", 1)[0] + ":1"
+
+    result = shell.execute_sync(f"curl -s {blocked_url}")
+
+    assert result.exit_code != 0
+    assert "allowlist" in result.stderr.lower()
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_blocks_private_ips_by_default(factory, loopback_server):
+    shell = factory(network={"allow": [loopback_server]})
+
+    result = shell.execute_sync(f"curl -s {loopback_server}")
+
+    assert result.exit_code != 0
+    assert "private/reserved IP" in result.stderr
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_reset_preserves_config(factory, loopback_server):
+    shell = factory(
+        network={"allow": [loopback_server], "block_private_ips": False},
+    )
+
+    before = shell.execute_sync(f"curl -s {loopback_server}")
+    shell.reset()
+    after = shell.execute_sync(f"curl -s {loopback_server}")
+
+    assert before.exit_code == 0
+    assert before.stdout.strip() == "ok"
+    assert after.exit_code == 0
+    assert after.stdout.strip() == "ok"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_network_from_snapshot_accepts_config(factory, loopback_server):
+    snapshot = factory().snapshot()
+
+    restored = factory.from_snapshot(
+        snapshot,
+        network={"allow": [loopback_server], "block_private_ips": False},
+    )
+    result = restored.execute_sync(f"curl -s {loopback_server}")
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "ok"

--- a/crates/bashkit-python/tests/test_registered_tools.py
+++ b/crates/bashkit-python/tests/test_registered_tools.py
@@ -26,6 +26,68 @@ def build_shell(factory, custom_builtins):
     return factory(custom_builtins=custom_builtins)
 
 
+def build_shell_positional(factory, custom_builtins):
+    # Decision: exercise the historical positional `custom_builtins` slot so
+    # constructor signature regressions fail at call time.
+    if factory is Bash:
+        return factory(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+            None,
+            None,
+            None,
+            None,
+            custom_builtins,
+        )
+    return factory(
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        custom_builtins,
+    )
+
+
+def restore_shell_positional(factory, snapshot, custom_builtins):
+    if factory is Bash:
+        return factory.from_snapshot(
+            snapshot,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+            None,
+            None,
+            None,
+            None,
+            custom_builtins,
+        )
+    return factory.from_snapshot(
+        snapshot,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        custom_builtins,
+    )
+
+
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
 def test_custom_builtins_persist_vfs_across_calls(factory):
     shell = build_shell(
@@ -68,6 +130,16 @@ def test_custom_builtins_survive_reset(factory):
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_constructor_accepts_positional_custom_builtins(factory):
+    shell = build_shell_positional(factory, {"ping": lambda ctx: "pong\n"})
+
+    result = shell.execute_sync("ping")
+
+    assert result.exit_code == 0
+    assert result.stdout == "pong\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
 def test_from_snapshot_accepts_custom_builtins(factory):
     snapshot = factory().snapshot()
 
@@ -75,6 +147,17 @@ def test_from_snapshot_accepts_custom_builtins(factory):
         snapshot,
         custom_builtins={"ping": lambda ctx: "pong\n"},
     )
+    result = restored.execute_sync("ping")
+
+    assert result.exit_code == 0
+    assert result.stdout == "pong\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_from_snapshot_accepts_positional_custom_builtins(factory):
+    snapshot = factory().snapshot()
+
+    restored = restore_shell_positional(factory, snapshot, {"ping": lambda ctx: "pong\n"})
     result = restored.execute_sync("ping")
 
     assert result.exit_code == 0


### PR DESCRIPTION
Refs #1348

Part 1/4 of the Python outbound-network parity rollout. Follow-up commits in this stack add credentials, callback hooks, and bot-auth.

## What
- enable `http_client` in the Python extension build
- add `network=` parsing on `Bash(...)` and `BashTool(...)` for `allow=[...]`, `allow_all=True`, and `block_private_ips`
- preserve the configured network surface across `reset()` and accept `network=` in `from_snapshot(...)`
- add Python docs, stubs, and regression coverage for disabled-by-default behavior, explicit empty allowlists, allowlisted requests, allow-all mode, blocked hosts, private-IP blocking, reset, and snapshot restore

## Why
#1348 tracks full outbound HTTP parity for Python `Bash` / `BashTool`. This first slice lands the allowlist plumbing and request gating without pulling in credentials, transport hooks, or bot-auth yet.

## How
- thread parsed Python network config into the Rust builder and rebuild paths
- keep omitted `network` distinct from `network={"allow": []}` so Python preserves Rust's disabled-vs-empty-allowlist semantics
- leave private-IP blocking default-on unless callers explicitly opt out
- use a loopback HTTP server in tests so coverage stays hermetic and never depends on public network access

## Tests
- `VIRTUAL_ENV=/tmp/bashkit-allowlist-venv PATH=/tmp/bashkit-allowlist-venv/bin:$PATH maturin develop --manifest-path crates/bashkit-python/Cargo.toml -q`
- `/tmp/bashkit-allowlist-venv/bin/pytest crates/bashkit-python/tests/test_network.py -q`
- `UV_TOOL_DIR=/tmp/uv-tools uvx ruff check crates/bashkit-python`
- `UV_TOOL_DIR=/tmp/uv-tools uvx ruff format --check crates/bashkit-python`
