### PR TITLE
feat(python): publish Python 3.14 wheels to PyPI

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -19,7 +19,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13"
+  PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
 
 jobs:
   # Source distribution (platform-independent)
@@ -127,9 +127,9 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - run: uvx twine check dist/*
 
-  # Smoke-test wheels on each OS
+  # Smoke-test wheels on each OS, including the new cp314 artifacts
   test-builds:
-    name: Test wheel on ${{ matrix.os }}
+    name: Test wheel on ${{ matrix.os }} (Python ${{ matrix.python-version }})
     needs: [build]
     strategy:
       fail-fast: false
@@ -137,15 +137,27 @@ jobs:
         include:
           - os: linux
             runs-on: ubuntu-latest
+            python-version: "3.12"
+          - os: linux
+            runs-on: ubuntu-latest
+            python-version: "3.14"
           - os: macos
             runs-on: macos-latest
+            python-version: "3.12"
+          - os: macos
+            runs-on: macos-latest
+            python-version: "3.14"
           - os: windows
             runs-on: windows-latest
+            python-version: "3.12"
+          - os: windows
+            runs-on: windows-latest
+            python-version: "3.14"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12", "3.13"]
+        python-version: ["3.9", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
 

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -467,7 +467,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 - Linux: `x86_64`, `aarch64` (glibc and musl wheels)
 - macOS: `x86_64`, `aarch64`
 - Windows: `x86_64`
-- Python: `3.9` through `3.13`
+- Python: `3.9` through `3.14`
 
 ## How It Works
 

--- a/crates/bashkit-python/pyproject.toml
+++ b/crates/bashkit-python/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Software Development :: Interpreters",
     "Topic :: Security",

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -49,7 +49,7 @@ The version chain: `Cargo.toml` (workspace) → `Cargo.toml` (bashkit-python, in
 
 ### Python Versions
 
-3.9, 3.10, 3.11, 3.12, 3.13
+3.9, 3.10, 3.11, 3.12, 3.13, 3.14
 
 ### Wheel Matrix
 
@@ -63,7 +63,7 @@ The version chain: `Cargo.toml` (workspace) → `Cargo.toml` (bashkit-python, in
 | macOS | aarch64 | — | macos-latest (native) |
 | Windows | x86_64 | MSVC | windows-latest |
 
-Total: ~35 wheels (7 platforms × 5 Python versions).
+Total: ~42 wheels (7 platforms × 6 Python versions).
 
 ## PyPI Publishing
 
@@ -74,7 +74,7 @@ File: `.github/workflows/publish-python.yml`
 ```
 GitHub Release published
     ├── build-sdist     (source distribution)
-    ├── build           (7 platform variants × 5 Python versions)
+    ├── build           (7 platform variants × 6 Python versions)
     ├── inspect         (twine check all artifacts)
     ├── test-builds     (smoke test on Linux/macOS/Windows)
     └── publish         (uv publish → PyPI via OIDC)
@@ -279,7 +279,7 @@ Runs on push to main and PRs (path-filtered to `crates/bashkit-python/`,
 ```
 PR / push to main
     ├── lint          (ruff check + ruff format --check)
-    ├── test          (maturin develop + pytest, Python 3.9/3.12/3.13)
+    ├── test          (maturin develop + pytest, Python 3.9/3.12/3.13/3.14)
     ├── examples      (build wheel + run crates/bashkit-python/examples/
     │                  + execute examples/*.ipynb via nbconvert)
     ├── build-wheel   (maturin build + twine check)

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -249,7 +249,7 @@ The build script updates `package.json` automatically when the Cargo version cha
 | macOS | aarch64 (Apple Silicon) | universal |
 | Windows | x86_64 | MSVC |
 
-Python versions: 3.9, 3.10, 3.11, 3.12, 3.13
+Python versions: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
 
 #### Version sync
 


### PR DESCRIPTION
Closes #1350

## What
- add Python 3.14 to the PyPI wheel build matrix
- smoke-test release wheels on both Python 3.12 and 3.14 before publish
- add Python 3.14 to the Python CI matrix and package/docs support metadata

## Why
- local validation already shows the Python binding builds and passes on 3.14
- the repo still stops release automation and advertised support at 3.13

## How
- extend `PYTHON_VERSIONS` in the publish workflow to include 3.14
- expand the release smoke-test matrix to install wheels on 3.12 and 3.14 across Linux, macOS, and Windows
- add the 3.14 classifier and update README/spec version ranges and wheel counts

## Verification
- `git diff --check`
- local `uv`-driven `cp314` wheel build succeeded
- local Python 3.14 wheel install/import smoke test succeeded
- Python binding test suite passed on Python 3.14 (`606 passed`)