### PR TITLE
fix(fs): block RealFs symlink escape via non-existent path suffix

### DIFF
--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -154,45 +154,37 @@ impl RealFs {
             return Ok(canon);
         }
 
-        // Path doesn't exist yet - check that its parent is within root
-        if let Some(parent) = joined.parent()
-            && parent.exists()
-        {
-            let canon_parent = std::fs::canonicalize(parent)?;
-            if !canon_parent.starts_with(&self.root) {
-                return Err(IoError::new(
-                    ErrorKind::PermissionDenied,
-                    "path escapes realfs root",
-                ));
-            }
-            // Re-join the filename onto the canonicalized parent
-            if let Some(file_name) = joined.file_name() {
-                return Ok(canon_parent.join(file_name));
-            }
+        // Path doesn't exist yet. Find the nearest existing ancestor, then
+        // canonicalize that ancestor to catch symlink hops in any prefix.
+        // Reattach the non-existent suffix after canonicalization.
+        let mut nearest_existing = joined.as_path();
+        while !nearest_existing.exists() {
+            nearest_existing = nearest_existing.parent().ok_or_else(|| {
+                IoError::new(ErrorKind::PermissionDenied, "path escapes realfs root")
+            })?;
         }
 
-        // SECURITY: Never return a raw path without traversal validation.
-        // The parent doesn't exist and can't be canonicalized, so we cannot
-        // verify containment with certainty. Returning the raw `joined` path
-        // here would skip all symlink/traversal checks, creating a TOCTOU
-        // window where an attacker could race to create a symlink between
-        // the exists() check above and actual file I/O. (issue #980)
-        //
-        // Defense-in-depth: normalize the host path logically and verify it
-        // stays under root. This catches any `..` that survived vpath
-        // normalization as well as any future changes to the normalization
-        // logic.
-        let normalized = normalize_host_path(&joined);
-        if !normalized.starts_with(&self.root) {
+        let canon_existing = std::fs::canonicalize(nearest_existing)?;
+        if !canon_existing.starts_with(&self.root) {
             return Err(IoError::new(
                 ErrorKind::PermissionDenied,
                 "path escapes realfs root",
             ));
         }
-        // Even with logical normalization, the path hasn't been verified on
-        // disk (no canonicalize). This is acceptable only because the parent
-        // truly doesn't exist — there's nothing on disk to symlink through.
-        Ok(normalized)
+
+        let suffix = joined
+            .strip_prefix(nearest_existing)
+            .map_err(|_| IoError::new(ErrorKind::PermissionDenied, "path escapes realfs root"))?;
+        let candidate = normalize_host_path(&canon_existing.join(suffix));
+
+        if !candidate.starts_with(&self.root) {
+            return Err(IoError::new(
+                ErrorKind::PermissionDenied,
+                "path escapes realfs root",
+            ));
+        }
+
+        Ok(candidate)
     }
 
     /// Check that the mode allows writes. Returns PermissionDenied if readonly.
@@ -797,6 +789,27 @@ mod tests {
             let expected = dir.path().join("deep/nested/dir/file.txt");
             assert!(expected.exists(), "file must be created under root");
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn security_write_rejects_symlink_escape_with_missing_parent() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        symlink(outside.path(), root.path().join("link")).unwrap();
+
+        let fs = RealFs::new(root.path(), RealFsMode::ReadWrite).unwrap();
+        let result = fs
+            .write(Path::new("/link/newdir/pwned.txt"), b"owned")
+            .await;
+
+        assert!(result.is_err(), "write through symlink escape must fail");
+        assert!(
+            !outside.path().join("newdir/pwned.txt").exists(),
+            "must not create file outside realfs root"
+        );
     }
 
     #[test]

--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -1,6 +1,7 @@
 // Decision: RealFs is a FsBackend that delegates to the real host filesystem,
 // scoped to a root directory. It supports readonly and readwrite modes.
-// Security: path traversal is prevented by canonicalizing and checking the prefix.
+// Security: path traversal is prevented by canonicalizing the resolved path or
+// the nearest existing ancestor, then checking the root prefix before I/O.
 // This module is only available with the `realfs` feature flag.
 
 //! Real filesystem backend.
@@ -12,8 +13,9 @@
 //! # Security
 //!
 //! - All paths are resolved relative to a configured root directory.
-//! - Path traversal via `..` is blocked by canonicalizing and checking the
-//!   resolved path stays under the root.
+//! - Path traversal via `..` or symlink hops in missing path suffixes is
+//!   blocked by canonicalizing the resolved path or nearest existing ancestor
+//!   and checking it stays under the root.
 //! - Readonly mode rejects all write operations at the backend level.
 //!
 //! # Modes
@@ -128,8 +130,10 @@ impl RealFs {
     /// Resolve a virtual path to a real host path, ensuring it stays under root.
     ///
     /// Virtual paths are absolute (e.g. `/foo/bar`). We strip the leading `/`
-    /// and join onto the root. Then we canonicalize (for existing paths) or
-    /// check the parent (for new paths) to prevent traversal.
+    /// and join onto the root. Then we canonicalize the full path (for
+    /// existing paths) or the nearest existing ancestor (for new paths) to
+    /// prevent traversal and symlink escapes before attaching the missing
+    /// suffix.
     fn resolve(&self, vpath: &Path) -> std::io::Result<PathBuf> {
         let normalized = normalize_vpath(vpath);
         // Strip leading "/" to make it relative
@@ -154,9 +158,9 @@ impl RealFs {
             return Ok(canon);
         }
 
-        // Path doesn't exist yet. Find the nearest existing ancestor, then
-        // canonicalize that ancestor to catch symlink hops in any prefix.
-        // Reattach the non-existent suffix after canonicalization.
+        // THREAT[TM-ESC-003]: New host paths still need containment checks.
+        // Canonicalize the nearest existing ancestor first so symlink hops in
+        // any existing prefix cannot redirect creation outside the mount root.
         let mut nearest_existing = joined.as_path();
         while !nearest_existing.exists() {
             nearest_existing = nearest_existing.parent().ok_or_else(|| {

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -321,7 +321,7 @@ max_parser_operations: 100_000,         // Parser fuel (TM-DOS-024)
 |----|--------|--------------|------------|--------|
 | TM-ESC-001 | Path traversal | `cat ../../../etc/passwd` | Path normalization | **MITIGATED** |
 | TM-ESC-002 | Symlink escape | `ln -s /etc/passwd /tmp/x` | Symlinks not followed | **MITIGATED** |
-| TM-ESC-003 | Real FS access | Direct syscalls | No real FS by default | **MITIGATED** |
+| TM-ESC-003 | Real FS access | Direct syscalls | No real FS by default; `RealFs` canonicalizes existing paths and nearest existing ancestors before attaching missing suffixes | **MITIGATED** |
 | TM-ESC-004 | Mount escape | Mount real paths | MountableFs controlled | **MITIGATED** |
 | TM-ESC-016 | Symlink escape via overlay rename | `ln -s /etc/passwd x; mv x y` | Overlay rename/copy preserve symlinks as symlinks | **FIXED** |
 

--- a/specs/vfs.md
+++ b/specs/vfs.md
@@ -69,6 +69,8 @@ let mut bash = Bash::builder()
 - Direct access to a host directory as an `FsBackend`
 - Two modes: `ReadOnly` (safe) and `ReadWrite` (dangerous)
 - Path traversal prevented via canonicalization + root prefix check
+- New-path writes canonicalize the nearest existing ancestor before attaching a
+  missing suffix, blocking symlink escapes through non-existent subpaths
 
 ##### Builder Methods
 


### PR DESCRIPTION
### Motivation
- Close a high-impact path traversal in `RealFs::resolve` where non-existent targets skipped canonicalization of ancestor components, permitting symlink-based escape from a mounted root.

### Description
- Change `RealFs::resolve` to walk up to the nearest existing ancestor, canonicalize that ancestor, enforce root-prefix containment, then reattach the non-existent suffix safely.
- Preserve logical normalization on the reconstructed candidate path and keep existing checks for existing paths and immediate parents.
- Add a Unix-only regression test `security_write_rejects_symlink_escape_with_missing_parent` that creates a symlink inside the mount pointing outside and asserts writes through that path are rejected and do not create files outside the root.

### Testing
- Ran `cargo test -p bashkit security_write_rejects_symlink_escape_with_missing_parent --features realfs` and the new regression test passed.
- Ran `cargo test -p bashkit resolve_fallback_returns_normalized_path --features realfs` and it passed.
- Ran `cargo fmt --check` and formatting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e875201dd8832ba48636b66f33bc81)