### PR TITLE
fix(snapshot): enforce parser and function limits on restore

### DIFF
--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -109,6 +109,7 @@ through configurable limits.
 | Unbounded builtin output (TM-DOS-058) | `seq 1 1000000` produces 1M lines | Add `max_stdout_bytes` limit | **OPEN** |
 | Param expansion bomb (TM-DOS-059) | `${x//a/bigstring}` multiplicative amplification | `max_total_variable_bytes` + `max_stdout_bytes` | MITIGATED |
 | Sparse array huge-index (TM-DOS-060) | `arr[999999999]=x` | HashMap storage; `max_array_entries` | MITIGATED |
+| Snapshot restore bypasses function/parser limits (TM-DOS-061) | Crafted snapshot with oversized/deep function bodies | Re-parse restored function source under current limits; re-check function memory budget | MITIGATED |
 
 **Configuration:**
 ```rust

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -572,11 +572,13 @@ where
         .collect()
 }
 
-fn deserialize_function_from_source(
+fn deserialize_function_from_source_with_limits(
     name: &str,
     source: &str,
+    max_ast_depth: usize,
+    max_parser_operations: usize,
 ) -> std::result::Result<FunctionDef, String> {
-    let script = Parser::new(source)
+    let script = Parser::with_limits(source, max_ast_depth, max_parser_operations)
         .parse()
         .map_err(|err| format!("failed to parse function '{name}' from source: {err}"))?;
     let mut commands = script.commands.into_iter();
@@ -597,6 +599,13 @@ fn deserialize_function_from_source(
             "failed to parse function '{name}' from source: expected function definition, got {other:?}"
         )),
     }
+}
+
+fn deserialize_function_from_source(
+    name: &str,
+    source: &str,
+) -> std::result::Result<FunctionDef, String> {
+    deserialize_function_from_source_with_limits(name, source, 100, 100_000)
 }
 
 /// Interpreter state.
@@ -1326,7 +1335,42 @@ impl Interpreter {
         self.assoc_arrays = state.assoc_arrays.clone();
         self.cwd = state.cwd.clone();
         self.last_exit_code = state.last_exit_code;
-        self.functions = state.functions.clone();
+        // THREAT[TM-DOS-060]: Re-parse and budget-check restored functions so
+        // snapshots cannot bypass parser/memory limits via serialized AST.
+        let mut restored_functions = HashMap::new();
+        let mut function_memory_budget = crate::limits::MemoryBudget::default();
+        let mut function_names = state.functions.keys().cloned().collect::<Vec<_>>();
+        function_names.sort_unstable();
+        for name in function_names {
+            let Some(snapshot_func) = state.functions.get(&name) else {
+                continue;
+            };
+            let Some(source) = snapshot_func.source.as_deref() else {
+                continue;
+            };
+            let Ok(parsed_func) = deserialize_function_from_source_with_limits(
+                &name,
+                source,
+                self.limits.max_ast_depth,
+                self.limits.max_parser_operations,
+            ) else {
+                continue;
+            };
+            let body_bytes = parsed_func
+                .span
+                .end
+                .offset
+                .saturating_sub(parsed_func.span.start.offset);
+            if function_memory_budget
+                .check_function_insert(body_bytes, true, 0, &self.memory_limits)
+                .is_err()
+            {
+                continue;
+            }
+            function_memory_budget.record_function_insert(body_bytes, true, 0);
+            restored_functions.insert(name, parsed_func);
+        }
+        self.functions = restored_functions;
         self.aliases = state.aliases.clone();
         self.traps = state.traps.clone();
         // Recompute memory budget from restored state to prevent desync
@@ -1334,7 +1378,7 @@ impl Interpreter {
         let func_bytes: usize = self
             .functions
             .values()
-            .map(|f| format!("{:?}", f.body).len())
+            .map(|f| f.span.end.offset.saturating_sub(f.span.start.offset))
             .sum();
         self.memory_budget = crate::limits::MemoryBudget::recompute_from_state(
             &self.variables,

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1335,7 +1335,7 @@ impl Interpreter {
         self.assoc_arrays = state.assoc_arrays.clone();
         self.cwd = state.cwd.clone();
         self.last_exit_code = state.last_exit_code;
-        // THREAT[TM-DOS-060]: Re-parse and budget-check restored functions so
+        // THREAT[TM-DOS-061]: Re-parse and budget-check restored functions so
         // snapshots cannot bypass parser/memory limits via serialized AST.
         let mut restored_functions = HashMap::new();
         let mut function_memory_budget = crate::limits::MemoryBudget::default();

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for VFS snapshot/restore and shell state snapshot/restore
 
-use bashkit::{Bash, FileSystem, InMemoryFs, Snapshot, SnapshotOptions};
+use bashkit::{Bash, FileSystem, InMemoryFs, MemoryLimits, Snapshot, SnapshotOptions};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -373,6 +373,23 @@ async fn snapshot_without_functions_skips_function_restore() {
         .await
         .unwrap();
     assert_eq!(result.stdout, "42\n1\n");
+}
+
+#[tokio::test]
+async fn snapshot_restore_enforces_function_limits() {
+    let mut src = Bash::new();
+    src.exec("a() { echo a; }; b() { echo b; }").await.unwrap();
+    let bytes = src.snapshot().unwrap();
+
+    let limits = MemoryLimits::new().max_function_count(1);
+    let mut restored = Bash::builder().memory_limits(limits).build();
+    restored.restore_snapshot(&bytes).unwrap();
+
+    let result = restored
+        .exec("type a >/dev/null 2>&1; echo $?; type b >/dev/null 2>&1; echo $?")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "0\n1\n");
 }
 
 #[tokio::test]

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -1,6 +1,8 @@
 //! Tests for VFS snapshot/restore and shell state snapshot/restore
 
-use bashkit::{Bash, FileSystem, InMemoryFs, MemoryLimits, Snapshot, SnapshotOptions};
+use bashkit::{
+    Bash, ExecutionLimits, FileSystem, InMemoryFs, MemoryLimits, Snapshot, SnapshotOptions,
+};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -387,6 +389,34 @@ async fn snapshot_restore_enforces_function_limits() {
 
     let result = restored
         .exec("type a >/dev/null 2>&1; echo $?; type b >/dev/null 2>&1; echo $?")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "0\n1\n");
+}
+
+#[tokio::test]
+async fn snapshot_restore_enforces_parser_limits() {
+    let mut src = Bash::new();
+    let mut deep_body = String::from("deep() { ");
+    for _ in 0..20 {
+        deep_body.push_str("if true; then ");
+    }
+    deep_body.push_str("echo ok; ");
+    for _ in 0..20 {
+        deep_body.push_str("fi; ");
+    }
+    deep_body.push('}');
+    src.exec(&format!("{deep_body}; shallow() {{ echo ok; }}"))
+        .await
+        .unwrap();
+    let bytes = src.snapshot().unwrap();
+
+    let limits = ExecutionLimits::new().max_ast_depth(5);
+    let mut restored = Bash::builder().limits(limits).build();
+    restored.restore_snapshot(&bytes).unwrap();
+
+    let result = restored
+        .exec("type shallow >/dev/null 2>&1; echo $?; type deep >/dev/null 2>&1; echo $?")
         .await
         .unwrap();
     assert_eq!(result.stdout, "0\n1\n");

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -272,6 +272,7 @@ max_ast_depth: 100,           // Parser recursion (TM-DOS-022)
 | TM-DOS-058 | Single-builtin unbounded output | `seq 1 1000000` produces 1M lines despite command limit; single builtin call generates unbounded output (see also #648) | — | **OPEN** |
 | TM-DOS-059 | Parameter expansion replacement bomb | `${x//a/$(printf 'b%.0s' {1..1000})}` on large `x` amplifies output multiplicatively (10K × 1K = 10MB) | `max_total_variable_bytes` + `max_stdout_bytes` | **MITIGATED** |
 | TM-DOS-060 | Sparse array huge-index allocation | `arr[999999999]=x` could allocate ~1B empty slots if arrays are Vec-backed; negative indices could cause OOB | HashMap-based arrays; `max_array_entries` caps total entries | **MITIGATED** |
+| TM-DOS-061 | Snapshot function restore bypasses parser/function limits | Crafted snapshot restores prebuilt or deeply nested functions that exceed the current tenant's parser depth or function memory budget | Re-parse restored function source with current `ExecutionLimits`; re-apply function memory budget before insertion | **MITIGATED** |
 
 **TM-DOS-051**: `builtins/yaml.rs` — `parse_yaml_block`, `parse_yaml_map`, `parse_yaml_list` recurse
 on nested YAML structures with no depth counter. Crafted YAML with 1000+ nesting levels causes stack


### PR DESCRIPTION
### Motivation
- Prevent untrusted snapshots from bypassing parser depth and function memory limits by deserializing attacker-controlled `FunctionDef` ASTs directly into the interpreter state.
- Restore must obey the same parser and memory limits used when functions are defined normally to avoid DoS from oversized/deep function bodies.

### Description
- Rework `restore_shell_state` to re-parse restored functions from their source text using the active parser limits (`max_ast_depth` and `max_parser_operations`) instead of cloning deserialized ASTs, and restore only functions that successfully parse under those limits.
- Enforce function memory limits during restore by checking `MemoryBudget::check_function_insert` and recording inserts deterministically, so `max_function_count` and `max_function_body_bytes` cannot be bypassed by snapshots.
- Replace debug-format byte accounting with span-based byte accounting (body span length) when recomputing the memory budget to match normal function insertion accounting.
- Add `deserialize_function_from_source_with_limits` helper and a regression test `snapshot_restore_enforces_function_limits` to ensure snapshots respect configured function-count caps; update test imports accordingly.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p bashkit --test snapshot_tests snapshot_restore_enforces_function_limits` which passed.
- Ran the full `cargo test -p bashkit --test snapshot_tests` which passed (31 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85ddedac4832ba77798e9c20a68b0)