### PR TITLE
feat(site): refine homepage and add builtins index

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
+        "@types/node": "^25.6.0",
         "typescript": "^5.9.0",
         "wrangler": "^4.0.0"
       },
@@ -434,7 +435,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -874,7 +874,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -897,7 +896,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -920,7 +918,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -937,7 +934,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -954,7 +950,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -971,7 +966,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -988,7 +982,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1005,7 +998,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1022,7 +1014,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1039,7 +1030,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1056,7 +1046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1073,7 +1062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1090,7 +1078,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1113,7 +1100,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1136,7 +1122,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1159,7 +1144,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1182,7 +1166,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1205,7 +1188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1228,7 +1210,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1251,7 +1232,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1274,7 +1254,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1294,7 +1273,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1314,7 +1292,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1334,7 +1311,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1922,6 +1898,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/unist": {
@@ -5071,7 +5057,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -5133,6 +5118,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/site/package.json
+++ b/site/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
+    "@types/node": "^25.6.0",
     "typescript": "^5.9.0",
     "wrangler": "^4.0.0"
   }

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -42,9 +42,9 @@
       </svg>
     </button>
     <nav class="nav">
-      <a href="#features">Features</a>
-      <a href="#install">Install</a>
-      <a href="#security">Security</a>
+      <a href="/#features">Features</a>
+      <a href="/#install">Install</a>
+      <a href="/#security">Security</a>
       <a
         href="https://docs.rs/bashkit"
         target="_blank"

--- a/site/src/pages/builtins.astro
+++ b/site/src/pages/builtins.astro
@@ -1,0 +1,327 @@
+---
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import BaseLayout from "../layouts/BaseLayout.astro";
+
+// Decision: build the public builtins index from specs/implementation-status.md
+// so the homepage and this page stay anchored to the canonical 160-command list.
+
+const implementationStatus = readFileSync(
+  resolve(process.cwd(), "../specs/implementation-status.md"),
+  "utf8",
+);
+
+const implementedSection = implementationStatus.match(
+  /### Implemented\s+[\s\S]*?\n\n([\s\S]*?)\n\n### Not Yet Implemented/,
+);
+
+const builtins = [
+  ...new Set(
+    Array.from(
+      implementedSection?.[1].matchAll(/`([^`]+)`/g) ?? [],
+      (match: RegExpMatchArray) => match[1],
+    ),
+  ),
+].sort((left, right) => left.localeCompare(right));
+
+const optInBuiltinGroups = [
+  {
+    label: "opt-in: jq",
+    tone: "gold",
+    names: new Set(["jq"]),
+  },
+  {
+    label: "opt-in: git",
+    tone: "mint",
+    names: new Set(["git"]),
+  },
+  {
+    label: "opt-in: ssh",
+    tone: "sky",
+    names: new Set(["ssh", "scp", "sftp"]),
+  },
+  {
+    label: "opt-in: python",
+    tone: "rose",
+    names: new Set(["python", "python3"]),
+  },
+  {
+    label: "opt-in: typescript",
+    tone: "violet",
+    names: new Set(["ts", "typescript", "node", "deno", "bun"]),
+  },
+];
+
+const optInBuiltinLookup = new Map(
+  optInBuiltinGroups.flatMap((group) =>
+    Array.from(
+      group.names,
+      (name) => [name, { tone: group.tone }] as const,
+    ),
+  ),
+);
+
+const groupedBuiltins = Object.entries(
+  builtins.reduce<Record<string, string[]>>((groups, builtin) => {
+    const first = builtin[0]?.toUpperCase() ?? "#";
+    const key = /[A-Z]/.test(first) ? first : "#";
+    groups[key] ??= [];
+    groups[key].push(builtin);
+    return groups;
+  }, {}),
+).sort(([left], [right]) => left.localeCompare(right));
+
+const builtinsSpecHref =
+  "https://github.com/everruns/bashkit/blob/main/specs/builtins.md";
+const implementationStatusHref =
+  "https://github.com/everruns/bashkit/blob/main/specs/implementation-status.md";
+---
+
+<BaseLayout
+  title="Bashkit builtins — 160 commands in the virtual runtime"
+  description="Browse the 160 builtins Bashkit exposes inside its in-process virtual shell runtime."
+>
+  <section class="builtins-hero section">
+    <div class="container builtins-hero__grid">
+      <div class="builtins-hero__copy">
+        <span class="builtins-eyebrow">Builtins index</span>
+        <h1>160+ builtin commands.</h1>
+        <p>
+          Bashkit reimplements the shell surface inside the runtime: text
+          processing, files, archives, network, shell control, plus optional
+          Python and TypeScript runtimes. This page mirrors the canonical
+          implemented list from the project specs.
+        </p>
+      </div>
+
+      <aside class="builtins-hero__panel">
+        <div>
+          <span class="builtins-eyebrow">Source of truth</span>
+          <h2>Tracked in specs, not guessed from source folders.</h2>
+        </div>
+        <p>
+          The count and command names here come from
+          <a href={implementationStatusHref} target="_blank" rel="noopener noreferrer"><code>specs/implementation-status.md</code></a>.
+        </p>
+        <div class="builtins-legend">
+          <span class="builtins-eyebrow">Legend</span>
+          {
+            optInBuiltinGroups.map((group) => (
+              <span class={`builtins-legend__item builtins-tone-${group.tone}`}>
+                {group.label}
+              </span>
+            ))
+          }
+        </div>
+        <div class="builtins-actions">
+          <a href={implementationStatusHref} target="_blank" rel="noopener noreferrer">
+            Implementation status
+          </a>
+          <a href={builtinsSpecHref} target="_blank" rel="noopener noreferrer">
+            Builtins spec
+          </a>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="builtins-index section section-alt">
+    <div class="container">
+      <div class="builtins-index__jump">
+        {
+          groupedBuiltins.map(([letter]) => (
+            <a href={`#group-${letter}`}>{letter}</a>
+          ))
+        }
+      </div>
+
+      <div class="builtins-groups">
+        {
+          groupedBuiltins.map(([letter, names]) => (
+            <section id={`group-${letter}`} class="builtins-group">
+              <div class="builtins-group__heading">
+                <span class="builtins-eyebrow">Group</span>
+                <h2>{letter}</h2>
+                <p>{names.length} commands</p>
+              </div>
+              <div class="builtins-group__grid">
+                {
+                  names.map((name) => (
+                    <code
+                      class={`builtins-chip ${optInBuiltinLookup.has(name) ? `builtins-tone-${optInBuiltinLookup.get(name)?.tone}` : ""}`}
+                    >
+                      {name}
+                    </code>
+                  ))
+                }
+              </div>
+            </section>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .builtins-hero {
+    background: linear-gradient(180deg, #f8f6ef 0%, var(--color-white) 100%);
+  }
+  .builtins-hero__grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+    gap: 1.25rem;
+    align-items: start;
+  }
+  .builtins-hero__copy,
+  .builtins-hero__panel,
+  .builtins-group,
+  .builtins-index__jump {
+    border: 1px solid rgb(10 22 54 / 0.12);
+    background: rgb(255 255 255 / 0.84);
+    box-shadow: 0 16px 40px rgb(10 22 54 / 0.04);
+  }
+  .builtins-hero__copy,
+  .builtins-hero__panel {
+    display: grid;
+    gap: 0.85rem;
+    padding: 1.35rem;
+  }
+  .builtins-eyebrow {
+    display: inline-flex;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-navy);
+  }
+  .builtins-hero h1,
+  .builtins-group__heading h2 {
+    font-size: clamp(2.2rem, 5vw, 4.4rem);
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+  }
+  .builtins-hero h2 {
+    font-size: clamp(1.5rem, 2.6vw, 2rem);
+    line-height: 1.08;
+    letter-spacing: -0.02em;
+  }
+  .builtins-hero p,
+  .builtins-group__heading p {
+    color: rgb(64 64 64 / 0.92);
+    font-size: 1.02rem;
+  }
+  .builtins-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+  .builtins-legend > .builtins-eyebrow {
+    color: var(--color-slate);
+  }
+  .builtins-legend {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
+  }
+  .builtins-legend__item {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.3rem 0.65rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+  .builtins-actions a,
+  .builtins-index__jump a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.7rem;
+    padding: 0.65rem 0.95rem;
+    border: 1px solid rgb(10 22 54 / 0.16);
+    background: rgb(255 255 255 / 0.72);
+    color: var(--color-obsidian);
+    font-weight: 500;
+    text-decoration: none;
+  }
+  .builtins-actions a:hover,
+  .builtins-index__jump a:hover {
+    text-decoration: none;
+    border-color: rgb(10 22 54 / 0.3);
+  }
+  .builtins-index__jump {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 1rem;
+    margin-bottom: 1rem;
+  }
+  .builtins-groups {
+    display: grid;
+    gap: 1rem;
+  }
+  .builtins-group {
+    display: grid;
+    grid-template-columns: minmax(0, 12rem) minmax(0, 1fr);
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .builtins-group__heading {
+    display: grid;
+    gap: 0.45rem;
+    align-content: start;
+  }
+  .builtins-group__heading h2 {
+    font-size: clamp(2rem, 3vw, 2.75rem);
+  }
+  .builtins-group__grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: start;
+    gap: 0.65rem;
+  }
+  .builtins-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.2rem;
+    padding: 0.4rem 0.75rem;
+    background: #10151f;
+    color: #edf2fb;
+    font-family: var(--font-mono);
+    font-size: 0.84rem;
+  }
+  .builtins-tone-gold {
+    border: 1px solid rgb(212 164 58 / 0.28);
+    background: rgb(212 164 58 / 0.12);
+    color: #7a5200;
+  }
+  .builtins-tone-mint {
+    border: 1px solid rgb(24 125 89 / 0.24);
+    background: rgb(24 125 89 / 0.12);
+    color: #0d5b40;
+  }
+  .builtins-tone-sky {
+    border: 1px solid rgb(31 102 179 / 0.24);
+    background: rgb(31 102 179 / 0.12);
+    color: #0b4f97;
+  }
+  .builtins-tone-rose {
+    border: 1px solid rgb(176 62 108 / 0.24);
+    background: rgb(176 62 108 / 0.12);
+    color: #8c2350;
+  }
+  .builtins-tone-violet {
+    border: 1px solid rgb(106 76 201 / 0.24);
+    background: rgb(106 76 201 / 0.12);
+    color: #5b3db1;
+  }
+  @media (max-width: 900px) {
+    .builtins-hero__grid,
+    .builtins-group {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -7,11 +7,63 @@ import { Code } from "astro:components";
 // scrolling to stay readable.
 // Decision: bias the homepage toward product proof, source-backed claims, and
 // concrete next steps instead of generic positioning copy.
+// Decision: use a custom proof code card in the hero instead of syntax-token
+// highlighting because the default highlighted output reads as visual noise at
+// landing-page scale.
+
+const evalSnapshot = {
+  date: "2026-02-28",
+  href: "https://github.com/everruns/bashkit/blob/main/crates/bashkit-eval/README.md",
+};
 
 const heroStats = [
-  { label: "Built-in commands", value: "160" },
-  { label: "Threats mitigated", value: "250+" },
-  { label: "Haiku 4.5 eval", value: "97%" },
+  { label: "Built-in commands", value: "160", href: "/builtins" },
+  {
+    label: "Threats mitigated",
+    value: "250+",
+    href: "https://github.com/everruns/bashkit/blob/main/specs/threat-model.md",
+    external: true,
+  },
+  {
+    label: "Haiku 4.5 eval",
+    value: "97%",
+    href: evalSnapshot.href,
+    external: true,
+  },
+];
+
+const quickStarts = [
+  { label: "Rust", href: "#quickstart-rust" },
+  { label: "Python", href: "#quickstart-python" },
+  { label: "TypeScript", href: "#quickstart-typescript" },
+];
+
+const heroQuickLinks = [
+  {
+    title: "Rust docs",
+    detail: "docs.rs reference",
+    href: "https://docs.rs/bashkit",
+  },
+  {
+    title: "Examples",
+    detail: "Rust, Python, TS",
+    href: "https://github.com/everruns/bashkit/tree/main/examples",
+  },
+];
+
+const builtinPreview = [
+  "grep",
+  "sed",
+  "awk",
+  "jq",
+  "curl",
+  "find",
+  "xargs",
+  "tar",
+  "git",
+  "ssh",
+  "python",
+  "typescript",
 ];
 
 const signals = [
@@ -77,6 +129,7 @@ async fn main() -> anyhow::Result<()> {
 
 const languages = [
   {
+    slug: "rust",
     eyebrow: "Rust",
     title: "The core crate",
     install: "cargo add bashkit",
@@ -92,6 +145,7 @@ async fn main() -> anyhow::Result<()> {
 }`,
   },
   {
+    slug: "python",
     eyebrow: "Python",
     title: "PyO3 wheel with direct Bash API",
     install: "pip install bashkit",
@@ -106,6 +160,7 @@ bash.execute_sync("export APP_ENV=dev")
 print(bash.execute_sync("echo $APP_ENV").stdout)`,
   },
   {
+    slug: "typescript",
     eyebrow: "TypeScript",
     title: "NAPI-RS runtime for Node, Bun, Deno",
     install: "npm i @everruns/bashkit",
@@ -160,11 +215,6 @@ const evals = [
   { model: "GPT-5.3-Codex", score: "91%", passed: "51/58" },
   { model: "GPT-5.2", score: "77%", passed: "41/58" },
 ];
-
-const evalSnapshot = {
-  date: "2026-02-28",
-  href: "https://github.com/everruns/bashkit/blob/main/crates/bashkit-eval/README.md",
-};
 
 const resources = [
   {
@@ -232,59 +282,95 @@ async fn main() -> anyhow::Result<()> {
           interfaces for agent frameworks — all in-memory, all sandboxed.
         </p>
 
-        <div class="atlas-actions">
-          <a href="#install" class="btn btn-primary">Quick start</a>
-          <a
-            href="https://docs.rs/bashkit"
-            class="btn btn-secondary"
-            target="_blank"
-            rel="noopener noreferrer">Read the docs</a
-          >
-          <a
-            href="https://github.com/everruns/bashkit/blob/main/specs/threat-model.md"
-            class="btn btn-secondary"
-            target="_blank"
-            rel="noopener noreferrer">Threat model</a
-          >
+        <div class="atlas-quickstarts">
+          <span class="atlas-actions__label">Quick starts</span>
+          {
+            quickStarts.map((item) => (
+              <a href={item.href} class="btn btn-secondary atlas-quickstart-link">
+                {item.label}
+              </a>
+            ))
+          }
         </div>
 
-        <div class="atlas-proof-strip">
-          <div class="atlas-proof-strip__item">
-            <span class="atlas-proof-strip__label">Install</span>
-            <code>cargo add bashkit</code>
-          </div>
-          <div class="atlas-proof-strip__item">
-            <span class="atlas-proof-strip__label">Run</span>
-            <code>let out = bash.exec("echo hi").await?;</code>
-          </div>
-          <div class="atlas-proof-strip__item">
-            <span class="atlas-proof-strip__label">Docs</span>
-            <a href="#install">Rust, Python, TypeScript</a>
-          </div>
+        <div class="atlas-hero-guide">
+          <article class="atlas-hero-guide__card">
+            <span class="atlas-proof-strip__label">Start in Rust</span>
+            <p>Install the crate.</p>
+            <pre class="atlas-hero-command"><code>cargo add bashkit</code></pre>
+          </article>
+          <article class="atlas-hero-guide__card atlas-hero-guide__card--links">
+            <span class="atlas-proof-strip__label">Go deeper</span>
+            <div class="atlas-hero-links">
+              {
+                heroQuickLinks.map((link) => (
+                  <a
+                    href={link.href}
+                    class="atlas-hero-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <span>{link.title}</span>
+                    <small>{link.detail}</small>
+                  </a>
+                ))
+              }
+            </div>
+          </article>
         </div>
 
         <div class="atlas-stats">
           {
             heroStats.map((stat) => (
-              <article class="atlas-stat">
+              <a
+                href={stat.href}
+                class="atlas-stat atlas-stat--link"
+                target={stat.external ? "_blank" : undefined}
+                rel={stat.external ? "noopener noreferrer" : undefined}
+              >
                 <span class="atlas-stat__label">{stat.label}</span>
                 <strong>{stat.value}</strong>
-              </article>
+              </a>
             ))
           }
         </div>
+
+        <article class="atlas-panel atlas-builtins-panel">
+          <div class="atlas-builtins-panel__copy">
+            <span class="atlas-eyebrow">Runtime surface</span>
+            <h3>Browse the builtins that make the sandbox usable.</h3>
+            <p>
+              Text processing, files, archives, network, Python, TypeScript,
+              and shell control all live in-process.
+            </p>
+          </div>
+          <div class="atlas-chip-list">
+            {
+              builtinPreview.map((name) => (
+                <span class="atlas-chip">{name}</span>
+              ))
+            }
+          </div>
+          <a href="/builtins" class="atlas-inline-link">See all 160 builtins</a>
+        </article>
       </div>
 
       <aside class="atlas-panel atlas-signal-panel">
         <div class="atlas-signal-panel__intro">
           <span class="atlas-eyebrow">Proof</span>
-          <h2>A runnable sample before the fold.</h2>
+          <h2>The core runtime, in context.</h2>
           <p>
             The core API is just `Bash`, plus virtual FS and limits. No sidecar
             process, no container bootstrap.
           </p>
         </div>
-        <Code code={heroSnippet} lang="rust" theme="github-dark" wrap={true} />
+        <div class="atlas-proof-code">
+          <div class="atlas-proof-code__header">
+            <span>Rust</span>
+            <span>In-process execution</span>
+          </div>
+          <pre><code>{heroSnippet}</code></pre>
+        </div>
         <div class="atlas-signal-list">
           {
             signals.map((item) => (
@@ -342,7 +428,7 @@ async fn main() -> anyhow::Result<()> {
       <div class="atlas-language-list">
         {
           languages.map((lang) => (
-            <article class="atlas-panel atlas-lang-row">
+            <article id={`quickstart-${lang.slug}`} class="atlas-panel atlas-lang-row">
               <div class="atlas-lang-row__meta">
                 <span class="atlas-eyebrow">{lang.eyebrow}</span>
                 <h3>{lang.title}</h3>
@@ -413,10 +499,10 @@ async fn main() -> anyhow::Result<()> {
       <div class="atlas-section-heading">
         <div>
           <span class="atlas-eyebrow">LLM evals</span>
-          <h2>How well do models use bashkit?</h2>
+          <h2>How well do LLMs use bashkit?</h2>
         </div>
         <p>
-          Bashkit ships with a 58-task eval harness across 15 agentic
+          Bashkit ships with a 58-task LLM eval harness across 15 agentic
           categories. Results below are from the
           <a href={evalSnapshot.href} target="_blank" rel="noopener noreferrer">
             {evalSnapshot.date}
@@ -483,8 +569,8 @@ async fn main() -> anyhow::Result<()> {
   .atlas-hero {
     position: relative;
     overflow: hidden;
-    padding-top: 5rem;
-    padding-bottom: 4rem;
+    padding-top: 4rem;
+    padding-bottom: 2rem;
     background: linear-gradient(
       180deg,
       #f8f6ef 0%,
@@ -511,7 +597,7 @@ async fn main() -> anyhow::Result<()> {
     display: grid;
     grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.85fr);
     gap: 1.5rem;
-    align-items: end;
+    align-items: start;
   }
   .atlas-hero__copy {
     display: grid;
@@ -554,23 +640,49 @@ async fn main() -> anyhow::Result<()> {
     font-size: 1.08rem;
     color: rgb(64 64 64 / 0.92);
   }
-  .atlas-actions {
+  .atlas-quickstarts {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 0.85rem;
     padding-top: 0.2rem;
   }
-  .atlas-proof-strip {
+  .atlas-actions__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-slate);
+  }
+  .atlas-quickstart-link {
+    min-height: 2.9rem;
+    background: rgb(255 255 255 / 0.76);
+    transition:
+      transform 0.12s ease,
+      border-color 0.12s ease,
+      background 0.12s ease;
+  }
+  .atlas-quickstart-link:hover {
+    text-decoration: none;
+    transform: translateY(-1px);
+    border-color: rgb(10 22 54 / 0.32);
+    background: rgb(255 255 255 / 0.92);
+  }
+  .atlas-hero-guide {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
     gap: 0.8rem;
   }
-  .atlas-proof-strip__item {
+  .atlas-hero-guide__card {
     display: grid;
-    gap: 0.35rem;
-    padding: 0.85rem 1rem;
+    gap: 0.55rem;
+    padding: 1rem;
     border: 1px solid rgb(10 22 54 / 0.12);
     background: rgb(255 255 255 / 0.72);
+  }
+  .atlas-hero-guide__card p {
+    font-size: 0.95rem;
+    color: rgb(64 64 64 / 0.92);
   }
   .atlas-proof-strip__label {
     font-size: 0.72rem;
@@ -579,12 +691,51 @@ async fn main() -> anyhow::Result<()> {
     text-transform: uppercase;
     color: var(--color-slate);
   }
-  .atlas-proof-strip code,
-  .atlas-proof-strip a {
-    font-size: 0.92rem;
-    background: transparent;
+  .atlas-hero-command {
+    margin: 0;
+    padding: 0.8rem 0.9rem;
+    border: 1px solid rgb(255 255 255 / 0.08);
+    background: #10151f;
+    color: #edf2fb;
+    overflow-x: auto;
+  }
+  .atlas-hero-command code,
+  .atlas-proof-code code {
+    display: block;
     padding: 0;
+    background: transparent;
+    color: inherit;
+    font-family: var(--font-mono);
+  }
+  .atlas-hero-command code {
+    font-size: 0.95rem;
+    white-space: pre-wrap;
     overflow-wrap: anywhere;
+  }
+  .atlas-hero-links {
+    display: grid;
+    gap: 0.55rem;
+  }
+  .atlas-hero-link {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding-bottom: 0.45rem;
+    border-bottom: 1px solid rgb(10 22 54 / 0.12);
+    color: var(--color-obsidian);
+  }
+  .atlas-hero-link:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+  .atlas-hero-link:hover {
+    text-decoration: none;
+  }
+  .atlas-hero-link small {
+    color: var(--color-slate);
+    font-size: 0.82rem;
+    text-align: right;
   }
   .atlas-stats {
     display: grid;
@@ -603,11 +754,69 @@ async fn main() -> anyhow::Result<()> {
     gap: 0.45rem;
     padding: 1rem;
   }
+  .atlas-stat--link {
+    color: inherit;
+    text-decoration: none;
+    transition:
+      transform 0.12s ease,
+      border-color 0.12s ease,
+      box-shadow 0.12s ease;
+  }
+  .atlas-stat--link:hover {
+    text-decoration: none;
+    transform: translateY(-1px);
+    border-color: rgb(10 22 54 / 0.24);
+    box-shadow: 0 20px 44px rgb(10 22 54 / 0.08);
+  }
   .atlas-stat strong {
     font-size: 1.4rem;
     line-height: 1.2;
     font-family: var(--font-mono);
     color: var(--color-obsidian);
+  }
+  .atlas-builtins-panel {
+    display: grid;
+    gap: 1rem;
+    padding: 1.15rem;
+  }
+  .atlas-builtins-panel__copy {
+    display: grid;
+    gap: 0.55rem;
+  }
+  .atlas-builtins-panel__copy h3 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    line-height: 1.15;
+  }
+  .atlas-builtins-panel__copy p {
+    color: rgb(64 64 64 / 0.92);
+  }
+  .atlas-chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+  }
+  .atlas-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.35rem 0.7rem;
+    background: #10151f;
+    color: #edf2fb;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    letter-spacing: 0.01em;
+  }
+  .atlas-inline-link {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    color: var(--color-navy);
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .atlas-inline-link:hover {
+    text-decoration: underline;
   }
   .atlas-signal-panel {
     display: grid;
@@ -615,6 +824,38 @@ async fn main() -> anyhow::Result<()> {
     padding: 1.35rem;
   }
   .atlas-signal-panel__intro { display: grid; gap: 0.7rem; }
+  .atlas-proof-code {
+    display: grid;
+    gap: 0;
+    border: 1px solid rgb(10 22 54 / 0.12);
+    background: linear-gradient(180deg, #111726 0%, #0b1020 100%);
+    color: #edf2fb;
+    overflow: hidden;
+  }
+  .atlas-proof-code__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.8rem 1rem;
+    border-bottom: 1px solid rgb(255 255 255 / 0.08);
+    background: rgb(255 255 255 / 0.03);
+    font-size: 0.76rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgb(237 242 251 / 0.72);
+  }
+  .atlas-proof-code pre {
+    margin: 0;
+    padding: 1rem;
+    overflow-x: auto;
+  }
+  .atlas-proof-code code {
+    font-size: 0.9rem;
+    line-height: 1.8;
+    white-space: pre;
+  }
   .atlas-signal-list { display: grid; gap: 0.9rem; }
   .atlas-signal-list__item {
     display: grid;
@@ -767,12 +1008,30 @@ async fn main() -> anyhow::Result<()> {
     .atlas-card-grid--resources {
       grid-template-columns: 1fr;
     }
-    .atlas-proof-strip { grid-template-columns: 1fr; }
+    .atlas-hero-guide { grid-template-columns: 1fr; }
     .atlas-stats { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .atlas-lang-row { grid-template-columns: 1fr; }
   }
   @media (max-width: 560px) {
     .atlas-stats { grid-template-columns: 1fr; }
-    .atlas-actions .btn { justify-content: center; flex: 1 1 auto; }
+    .atlas-quickstarts {
+      align-items: stretch;
+    }
+    .atlas-actions__label {
+      width: 100%;
+    }
+    .atlas-quickstart-link {
+      justify-content: center;
+      flex: 1 1 auto;
+    }
+    .atlas-hero-link {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .atlas-hero-link small { text-align: left; }
+    .atlas-proof-code__header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
   }
 </style>

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "types": ["node"]
+  },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }


### PR DESCRIPTION
## What
Refine the site homepage hero, proof panel, and navigation flow, and add a dedicated builtins index page sourced from the implementation-status spec.

## Why
The landing page had duplicated links, weak hierarchy, and unbalanced whitespace. The builtins count also needed a canonical destination with clearer opt-in runtime labeling.

## How
- reworked the homepage hero actions, support cards, stat links, and proof panel
- added a `/builtins` page that parses the spec-backed builtin list and groups commands alphabetically
- color-coded opt-in builtin commands and added a legend
- updated header links to work correctly from subpages and added Node typings for the Astro page parser

## Risk
- Low
- Could affect site layout, internal docs navigation, or Astro build behavior for the new builtins page

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered