### PR TITLE
fix(ci): prevent Homebrew PAT exposure in cli-binaries workflow

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -166,9 +166,23 @@ jobs:
 
           # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
           GH_PAT=$(doppler secrets get GITHUB_TOKEN --plain)
+          echo "::add-mask::$GH_PAT"
+
+          # Use askpass to avoid embedding token in clone/push URLs or logs
+          cat > /tmp/git-askpass.sh <<'EOF'
+          #!/usr/bin/env sh
+          case "$1" in
+            *Username*) echo "x-access-token" ;;
+            *Password*) echo "$GH_PAT" ;;
+          esac
+          EOF
+          chmod 700 /tmp/git-askpass.sh
+          export GIT_ASKPASS=/tmp/git-askpass.sh
+          export GIT_TERMINAL_PROMPT=0
+          trap 'rm -f /tmp/git-askpass.sh' EXIT
 
           # Clone the tap repo
-          git clone "https://x-access-token:${GH_PAT}@github.com/everruns/homebrew-tap.git" tap
+          git clone "https://github.com/everruns/homebrew-tap.git" tap
           cp bashkit.rb tap/Formula/bashkit.rb
 
           cd tap

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -166,20 +166,22 @@ jobs:
 
           # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
           GH_PAT=$(doppler secrets get GITHUB_TOKEN --plain)
+          export GH_PAT
           echo "::add-mask::$GH_PAT"
 
           # Use askpass to avoid embedding token in clone/push URLs or logs
-          cat > /tmp/git-askpass.sh <<'EOF'
+          ASKPASS_SCRIPT=$(mktemp)
+          cat > "$ASKPASS_SCRIPT" <<'EOF'
           #!/usr/bin/env sh
           case "$1" in
             *Username*) echo "x-access-token" ;;
             *Password*) echo "$GH_PAT" ;;
           esac
           EOF
-          chmod 700 /tmp/git-askpass.sh
-          export GIT_ASKPASS=/tmp/git-askpass.sh
+          chmod 700 "$ASKPASS_SCRIPT"
+          export GIT_ASKPASS="$ASKPASS_SCRIPT"
           export GIT_TERMINAL_PROMPT=0
-          trap 'rm -f /tmp/git-askpass.sh' EXIT
+          trap 'rm -f "$ASKPASS_SCRIPT"; unset GH_PAT' EXIT
 
           # Clone the tap repo
           git clone "https://github.com/everruns/homebrew-tap.git" tap


### PR DESCRIPTION
### Motivation
- The release workflow fetched a GitHub PAT from Doppler and interpolated it directly into a `git clone` URL, which can leak the token in CI logs and enable supply-chain tampering.
- Remediate credential disclosure while preserving the workflow's ability to push the generated Homebrew formula.

### Description
- Immediately mask the Doppler-fetched `GH_PAT` with `::add-mask::` to prevent accidental log exposure.
- Replace token-in-URL usage with an `askpass` handler by writing a temporary `/tmp/git-askpass.sh` that returns the username and `GH_PAT` when Git prompts.
- Export `GIT_ASKPASS` and `GIT_TERMINAL_PROMPT=0` and use a plain HTTPS clone URL so credentials are not embedded in command arguments or logs.
- Add a `trap` to securely remove the temporary askpass script after the job completes.

### Testing
- Parsed the workflow YAML with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cli-binaries.yml")'` and it succeeded.
- Verified the workflow no longer contains the token-in-URL pattern and includes `::add-mask::` and `GIT_ASKPASS` with `rg`, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8691604ac832b8b1c24a11f941178)