### PR TITLE
fix(scripted-tool): block DiscoverTool command injection via shell separators

### DIFF
--- a/crates/bashkit/src/scripted_tool/toolset.rs
+++ b/crates/bashkit/src/scripted_tool/toolset.rs
@@ -71,8 +71,21 @@ pub struct DiscoverTool {
 const DISCOVER_ALLOWED_COMMANDS: &[&str] = &["discover", "help"];
 
 impl DiscoverTool {
+    fn has_forbidden_shell_syntax(input: &str) -> bool {
+        input.contains('\n')
+            || input.contains('\r')
+            || input.contains(';')
+            || input.contains('&')
+            || input.contains('|')
+            || input.contains('`')
+            || input.contains("$(")
+    }
+
     /// Reject commands that aren't `discover` or `help`.
     fn validate_commands(commands: &str) -> Result<(), String> {
+        if Self::has_forbidden_shell_syntax(commands) {
+            return Err("discover tool commands cannot contain shell control characters".to_string());
+        }
         let first_word = commands.split_whitespace().next().unwrap_or("");
         if DISCOVER_ALLOWED_COMMANDS.contains(&first_word) {
             Ok(())
@@ -117,6 +130,9 @@ impl DiscoverTool {
 
         // Structured: query
         if let Some(query) = obj.get("query").and_then(|v| v.as_str()) {
+            if Self::has_forbidden_shell_syntax(query) {
+                return Err("query contains unsupported shell control characters".to_string());
+            }
             return Ok(ToolRequest {
                 commands: format!("discover --search {query}"),
                 timeout_ms,
@@ -975,6 +991,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_discover_structured_query_rejects_injection() {
+        let toolset = make_tools().with_discovery().build();
+        let tools = toolset.tools();
+        let args = serde_json::json!({ "query": "user; help get_user --json" });
+        match tools[1].execution(args) {
+            Err(e) => assert!(
+                e.to_string().contains("query contains unsupported shell control characters"),
+                "unexpected error: {e}"
+            ),
+            Ok(_) => panic!("expected injection-like query to be rejected"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_discover_backward_compat() {
         let toolset = make_tools().with_discovery().build();
         let tools = toolset.tools();
@@ -983,6 +1013,21 @@ mod tests {
         let output = exec.execute().await.expect("execution succeeds");
         let stdout = output.result["stdout"].as_str().unwrap_or("");
         assert!(stdout.contains("get_user"), "stdout: {stdout}");
+    }
+
+    #[tokio::test]
+    async fn test_discover_backward_compat_rejects_shell_separators() {
+        let toolset = make_tools().with_discovery().build();
+        let tools = toolset.tools();
+        let args = serde_json::json!({ "commands": "discover --search user; help get_user" });
+        match tools[1].execution(args) {
+            Err(e) => assert!(
+                e.to_string()
+                    .contains("discover tool commands cannot contain shell control characters"),
+                "unexpected error: {e}"
+            ),
+            Ok(_) => panic!("expected injection-like commands to be rejected"),
+        }
     }
 
     #[test]

--- a/crates/bashkit/src/scripted_tool/toolset.rs
+++ b/crates/bashkit/src/scripted_tool/toolset.rs
@@ -84,7 +84,9 @@ impl DiscoverTool {
     /// Reject commands that aren't `discover` or `help`.
     fn validate_commands(commands: &str) -> Result<(), String> {
         if Self::has_forbidden_shell_syntax(commands) {
-            return Err("discover tool commands cannot contain shell control characters".to_string());
+            return Err(
+                "discover tool commands cannot contain shell control characters".to_string(),
+            );
         }
         let first_word = commands.split_whitespace().next().unwrap_or("");
         if DISCOVER_ALLOWED_COMMANDS.contains(&first_word) {
@@ -997,7 +999,8 @@ mod tests {
         let args = serde_json::json!({ "query": "user; help get_user --json" });
         match tools[1].execution(args) {
             Err(e) => assert!(
-                e.to_string().contains("query contains unsupported shell control characters"),
+                e.to_string()
+                    .contains("query contains unsupported shell control characters"),
                 "unexpected error: {e}"
             ),
             Ok(_) => panic!("expected injection-like query to be rejected"),


### PR DESCRIPTION
### Motivation
- Structured `query` input was interpolated into `discover --search {query}` without escaping, and `validate_commands` only checked the first token, allowing shell-separator injection (`;`, `|`, `&`, newlines, backticks, `$()`).
- Prevent remote callers from appending commands and bypassing the DiscoverTool safety boundary by rejecting control characters in both structured and raw inputs.

### Description
- Add `has_forbidden_shell_syntax` to detect shell control characters and sequences (`\n`, `\r`, `;`, `&`, `|`, `` ` ``, `$(`). 
- Enforce the check in `DiscoverTool::validate_commands` to reject `commands` containing control characters before checking allowed command names. 
- Reject structured `query` values containing control characters in `DiscoverTool::resolve_request` before building `discover --search {query}`. 
- Add regression tests `test_discover_structured_query_rejects_injection` and `test_discover_backward_compat_rejects_shell_separators` to assert injection attempts are rejected.
- Change localized to `crates/bashkit/src/scripted_tool/toolset.rs` with small, backward-compatible behavior: plain `commands` still accepted if safe and `all` unchanged.

### Testing
- Reproduced failing case pre-fix using `cargo test -p bashkit --features scripted_tool -- test_discover_structured_query_rejects_injection` and observed the test fail as expected. 
- Ran targeted test suite after the fix with `cargo test -p bashkit --features scripted_tool discover_` and `cargo test -p bashkit --features scripted_tool discover_structured`, and the modified tests `test_discover_structured_query_rejects_injection` and `test_discover_backward_compat_rejects_shell_separators` passed. 
- Ran a broader `cargo test -p bashkit --features scripted_tool discover_` run which showed the relevant discover tests passed (27 discover-related tests passed in the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e99c40c2c4832ba7108c66e765f17f)