### PR TITLE
fix(realfs): canonicalize mount paths before policy checks

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -513,7 +513,7 @@ pub use logging::LogConfig;
 use interpreter::Interpreter;
 use parser::Parser;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Main entry point for Bashkit.
@@ -2371,6 +2371,22 @@ impl BashBuilder {
 
         let mut current_fs = base_fs;
         let mut mount_points: Vec<(PathBuf, Arc<dyn FileSystem>)> = Vec::new();
+        let canonical_allowlist: Option<Vec<PathBuf>> = mount_allowlist.map(|allowlist| {
+            allowlist
+                .iter()
+                .filter_map(|allowed| match std::fs::canonicalize(allowed) {
+                    Ok(path) => Some(path),
+                    Err(e) => {
+                        eprintln!(
+                            "bashkit: warning: failed to canonicalize allowlist path {}: {}",
+                            allowed.display(),
+                            e
+                        );
+                        None
+                    }
+                })
+                .collect()
+        });
 
         for m in real_mounts {
             // Warn on writable mounts
@@ -2381,11 +2397,22 @@ impl BashBuilder {
                 );
             }
 
+            let canonical_host = match std::fs::canonicalize(&m.host_path) {
+                Ok(path) => path,
+                Err(e) => {
+                    eprintln!(
+                        "bashkit: warning: failed to canonicalize mount path {}: {}",
+                        m.host_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
             // Block sensitive paths
-            let host_str = m.host_path.to_string_lossy();
             if Self::SENSITIVE_MOUNT_PATHS
                 .iter()
-                .any(|s| host_str.starts_with(s))
+                .any(|s| canonical_host.starts_with(Path::new(s)))
             {
                 eprintln!(
                     "bashkit: warning: refusing to mount sensitive path {}",
@@ -2395,10 +2422,10 @@ impl BashBuilder {
             }
 
             // Check allowlist if configured
-            if let Some(allowlist) = mount_allowlist
+            if let Some(allowlist) = &canonical_allowlist
                 && !allowlist
                     .iter()
-                    .any(|allowed| m.host_path.starts_with(allowed))
+                    .any(|allowed| canonical_host.starts_with(allowed))
             {
                 eprintln!(
                     "bashkit: warning: mount path {} not in allowlist, skipping",
@@ -2407,7 +2434,7 @@ impl BashBuilder {
                 continue;
             }
 
-            let real_backend = match fs::RealFs::new(&m.host_path, m.mode) {
+            let real_backend = match fs::RealFs::new(&canonical_host, m.mode) {
                 Ok(b) => b,
                 Err(e) => {
                     eprintln!(

--- a/crates/bashkit/tests/realfs_tests.rs
+++ b/crates/bashkit/tests/realfs_tests.rs
@@ -405,6 +405,63 @@ async fn mount_sensitive_path_blocked() {
     );
 }
 
+#[tokio::test]
+async fn mount_allowlist_blocks_dotdot_escape() {
+    let sandbox = tempfile::tempdir().unwrap();
+    let allowed_root = sandbox.path().join("allowed");
+    let secret_root = sandbox.path().join("secret");
+    std::fs::create_dir_all(&allowed_root).unwrap();
+    std::fs::create_dir_all(&secret_root).unwrap();
+    std::fs::write(secret_root.join("data.txt"), "top-secret\n").unwrap();
+
+    let escaped_mount = allowed_root.join("../secret");
+    let mut bash = Bash::builder()
+        .allowed_mount_paths([&allowed_root])
+        .mount_real_readonly_at(&escaped_mount, "/mnt/data")
+        .build();
+
+    let r = bash
+        .exec("cat /mnt/data/data.txt 2>&1; echo $?")
+        .await
+        .unwrap();
+    assert!(
+        r.stdout.trim().ends_with('1') || r.stdout.contains("No such file"),
+        "Dot-dot allowlist escape should be blocked, got: {}",
+        r.stdout
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn mount_allowlist_blocks_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let sandbox = tempfile::tempdir().unwrap();
+    let allowed_root = sandbox.path().join("allowed");
+    let secret_root = sandbox.path().join("secret");
+    std::fs::create_dir_all(&allowed_root).unwrap();
+    std::fs::create_dir_all(&secret_root).unwrap();
+    std::fs::write(secret_root.join("data.txt"), "top-secret\n").unwrap();
+
+    let link_path = allowed_root.join("escape_link");
+    symlink(&secret_root, &link_path).unwrap();
+
+    let mut bash = Bash::builder()
+        .allowed_mount_paths([&allowed_root])
+        .mount_real_readonly_at(&link_path, "/mnt/data")
+        .build();
+
+    let r = bash
+        .exec("cat /mnt/data/data.txt 2>&1; echo $?")
+        .await
+        .unwrap();
+    assert!(
+        r.stdout.trim().ends_with('1') || r.stdout.contains("No such file"),
+        "Symlink allowlist escape should be blocked, got: {}",
+        r.stdout
+    );
+}
+
 // --- Runtime mount/unmount (exercises Bash::mount / Bash::unmount) ---
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent bypass of sensitive-path and allowlist checks where non-canonical host paths (e.g. `..` segments or symlinks) could resolve into disallowed locations after `RealFs::new` canonicalization.
- Ensure policy checks operate on the same canonical path that is used to create the `RealFs` backend.

### Description
- Canonicalize configured allowlist entries into `canonical_allowlist` and skip invalid entries with a warning at build time using `std::fs::canonicalize`.
- Canonicalize each requested mount target into `canonical_host` and skip mounts that fail canonicalization, emitting a warning.
- Perform sensitive-path blocking and allowlist prefix checks against the canonicalized host path and use the canonical path when calling `fs::RealFs::new`.
- Add regression tests `mount_allowlist_blocks_dotdot_escape` and `mount_allowlist_blocks_symlink_escape` that assert `..` traversal and symlink escapes are blocked by the allowlist.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran targeted tests with `cargo test -p bashkit --features realfs --test realfs_tests mount_allowlist_blocks_dotdot_escape` and it passed.
- Ran `cargo test -p bashkit --features realfs --test realfs_tests mount_allowlist_blocks_symlink_escape` and it passed.
- Ran `cargo test -p bashkit --features realfs --test realfs_tests mount_allowlist_blocks_unlisted_path` and `mount_sensitive_path_blocked` and both passed (tests compiled with warnings but succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a01e26e0832ba1f65287141999bc)