### PR TITLE
feat(site): render /docs from canonical docs/ markdown

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -44,11 +44,11 @@
     <nav class="nav">
       <a href="/#features">Features</a>
       <a href="/#install">Install</a>
-      <a href="/#security">Security</a>
+      <a href="/docs">Docs</a>
       <a
         href="https://docs.rs/bashkit"
         target="_blank"
-        rel="noopener noreferrer">Docs</a
+        rel="noopener noreferrer">API</a
       >
       <a
         href="https://github.com/everruns/bashkit"

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,0 +1,10 @@
+// Decision: render user-facing guides from the canonical ../docs/ tree via
+// Astro's glob loader so the site and the repo share a single source of truth.
+import { defineCollection } from "astro:content";
+import { glob } from "astro/loaders";
+
+const docs = defineCollection({
+  loader: glob({ pattern: "*.md", base: "../docs" }),
+});
+
+export const collections = { docs };

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -1,0 +1,224 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+import { DOC_META, DOC_META_BY_SLUG } from "../pages/docs/_meta";
+
+interface Props {
+  slug: string;
+  title: string;
+  description?: string;
+}
+
+const { slug, title, description } = Astro.props;
+
+const meta = DOC_META_BY_SLUG[slug];
+const index = DOC_META.findIndex((doc) => doc.slug === slug);
+const prev = index > 0 ? DOC_META[index - 1] : null;
+const next = index >= 0 && index < DOC_META.length - 1 ? DOC_META[index + 1] : null;
+
+const editUrl = `https://github.com/everruns/bashkit/blob/main/docs/${slug}.md`;
+---
+
+<BaseLayout
+  title={`${title} — Bashkit docs`}
+  description={description ?? meta?.summary}
+>
+  <article class="doc section">
+    <div class="container doc__container">
+      <nav class="doc__breadcrumb" aria-label="Breadcrumb">
+        <a href="/docs">Docs</a>
+        <span aria-hidden="true">/</span>
+        <span>{meta?.section ?? title}</span>
+      </nav>
+
+      <div class="doc__body">
+        <slot />
+      </div>
+
+      <footer class="doc__foot">
+        <a class="doc__edit" href={editUrl} target="_blank" rel="noopener noreferrer">
+          Edit this page on GitHub
+        </a>
+        <div class="doc__nav">
+          {prev ? (
+            <a class="doc__nav-link doc__nav-link--prev" href={`/docs/${prev.slug}`}>
+              <span class="doc__nav-eyebrow">Previous</span>
+              <span class="doc__nav-title">{prev.title}</span>
+            </a>
+          ) : <span />}
+          {next ? (
+            <a class="doc__nav-link doc__nav-link--next" href={`/docs/${next.slug}`}>
+              <span class="doc__nav-eyebrow">Next</span>
+              <span class="doc__nav-title">{next.title}</span>
+            </a>
+          ) : <span />}
+        </div>
+      </footer>
+    </div>
+  </article>
+</BaseLayout>
+
+<style>
+  .doc {
+    padding: var(--space-xl) 0;
+  }
+  .doc__container {
+    max-width: 44rem;
+  }
+  .doc__breadcrumb {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.85rem;
+    color: var(--color-slate);
+    margin-bottom: var(--space-md);
+  }
+  .doc__breadcrumb a {
+    color: var(--color-slate);
+  }
+  .doc__breadcrumb a:hover {
+    color: var(--color-obsidian);
+  }
+  .doc__body {
+    font-size: 1.02rem;
+    line-height: 1.7;
+    color: var(--color-charcoal);
+  }
+  .doc__body :global(h1) {
+    font-size: clamp(2rem, 3.6vw, 2.8rem);
+    letter-spacing: -0.02em;
+    margin-bottom: var(--space-md);
+    color: var(--color-obsidian);
+  }
+  .doc__body :global(h2) {
+    font-size: 1.5rem;
+    margin-top: var(--space-xl);
+    margin-bottom: var(--space-sm);
+    letter-spacing: -0.01em;
+    color: var(--color-obsidian);
+  }
+  .doc__body :global(h3) {
+    font-size: 1.15rem;
+    margin-top: var(--space-lg);
+    margin-bottom: var(--space-sm);
+    color: var(--color-obsidian);
+  }
+  .doc__body :global(p),
+  .doc__body :global(ul),
+  .doc__body :global(ol),
+  .doc__body :global(pre),
+  .doc__body :global(blockquote),
+  .doc__body :global(table) {
+    margin-bottom: var(--space-md);
+  }
+  .doc__body :global(ul),
+  .doc__body :global(ol) {
+    padding-left: 1.5rem;
+  }
+  .doc__body :global(li) {
+    margin-bottom: 0.35rem;
+  }
+  .doc__body :global(a) {
+    color: var(--color-navy);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+  .doc__body :global(code) {
+    font-size: 0.88em;
+  }
+  .doc__body :global(pre) {
+    padding: 1rem 1.1rem;
+    overflow-x: auto;
+    border: 1px solid rgb(10 22 54 / 0.1);
+    background: #fafaf7 !important;
+    font-size: 0.88rem;
+    line-height: 1.55;
+  }
+  .doc__body :global(pre) :global(code) {
+    background: transparent;
+    padding: 0;
+    font-size: inherit;
+  }
+  .doc__body :global(blockquote) {
+    border-left: 3px solid var(--color-gold);
+    padding: 0.25rem 0 0.25rem 1rem;
+    color: var(--color-slate);
+    font-style: italic;
+  }
+  .doc__body :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.95rem;
+  }
+  .doc__body :global(th),
+  .doc__body :global(td) {
+    text-align: left;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid rgb(10 22 54 / 0.12);
+    vertical-align: top;
+  }
+  .doc__body :global(th) {
+    background: var(--color-smoke);
+    font-weight: 600;
+  }
+  .doc__body :global(hr) {
+    border: none;
+    border-top: 1px solid rgb(10 22 54 / 0.12);
+    margin: var(--space-lg) 0;
+  }
+
+  .doc__foot {
+    margin-top: var(--space-xl);
+    padding-top: var(--space-lg);
+    border-top: 1px solid rgb(10 22 54 / 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+  .doc__edit {
+    color: var(--color-slate);
+    font-size: 0.9rem;
+  }
+  .doc__edit:hover {
+    color: var(--color-obsidian);
+  }
+  .doc__nav {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-md);
+  }
+  .doc__nav-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.85rem 1rem;
+    border: 1px solid rgb(10 22 54 / 0.12);
+    color: var(--color-obsidian);
+    text-decoration: none;
+  }
+  .doc__nav-link:hover {
+    border-color: rgb(10 22 54 / 0.3);
+    text-decoration: none;
+  }
+  .doc__nav-link--next {
+    text-align: right;
+  }
+  .doc__nav-eyebrow {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-slate);
+  }
+  .doc__nav-title {
+    font-weight: 600;
+  }
+  @media (max-width: 640px) {
+    .doc__nav {
+      grid-template-columns: 1fr;
+    }
+    .doc__nav-link--next {
+      text-align: left;
+    }
+  }
+</style>

--- a/site/src/pages/docs/[slug].astro
+++ b/site/src/pages/docs/[slug].astro
@@ -1,0 +1,27 @@
+---
+import { getCollection, render } from "astro:content";
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import { DOC_META_BY_SLUG } from "./_meta";
+
+export async function getStaticPaths() {
+  const docs = await getCollection("docs");
+  return docs
+    .filter((entry) => DOC_META_BY_SLUG[entry.id])
+    .map((entry) => ({
+      params: { slug: entry.id },
+      props: { entry },
+    }));
+}
+
+const { entry } = Astro.props;
+const meta = DOC_META_BY_SLUG[entry.id];
+const { Content, headings } = await render(entry);
+
+// Title: prefer an explicit H1 from markdown, fall back to curated metadata.
+const h1 = headings.find((heading) => heading.depth === 1);
+const title = h1?.text ?? meta.title;
+---
+
+<DocsLayout slug={entry.id} title={title} description={meta.summary}>
+  <Content />
+</DocsLayout>

--- a/site/src/pages/docs/_meta.ts
+++ b/site/src/pages/docs/_meta.ts
@@ -1,0 +1,41 @@
+// Hand-curated metadata for each doc so the /docs index can group and
+// summarise pages without requiring frontmatter in the canonical markdown.
+// Order here drives navigation order (index cards, prev/next).
+
+export type DocMeta = {
+  slug: string;
+  title: string;
+  summary: string;
+  section: string;
+};
+
+export const DOC_META: DocMeta[] = [
+  {
+    slug: "cli",
+    title: "CLI",
+    summary: "Run scripts with bashkit-cli: flags, exit codes, opt-in runtimes.",
+    section: "Getting started",
+  },
+  {
+    slug: "security",
+    title: "Security",
+    summary: "Sandbox boundaries, threat model, and what scripts cannot do.",
+    section: "Operations",
+  },
+  {
+    slug: "snapshotting",
+    title: "Snapshotting",
+    summary: "Serialize interpreter state and restore it for checkpoint/resume flows.",
+    section: "Features",
+  },
+  {
+    slug: "builtin_typescript",
+    title: "TypeScript builtin",
+    summary: "Embedded ZapCode TypeScript runtime shared with bash in-memory.",
+    section: "Features",
+  },
+];
+
+export const DOC_META_BY_SLUG: Record<string, DocMeta> = Object.fromEntries(
+  DOC_META.map((doc) => [doc.slug, doc]),
+);

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -1,0 +1,128 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { DOC_META } from "./_meta";
+
+const sectionOrder = ["Getting started", "Features", "Operations"];
+const bySection = sectionOrder
+  .map((section) => ({
+    section,
+    docs: DOC_META.filter((doc) => doc.section === section),
+  }))
+  .filter((group) => group.docs.length > 0);
+---
+
+<BaseLayout
+  title="Bashkit docs — guides for the virtual bash sandbox"
+  description="User-facing guides for the bashkit CLI, security model, snapshotting, and embedded runtimes."
+>
+  <section class="docs-hero section">
+    <div class="container">
+      <span class="docs-eyebrow">Docs</span>
+      <h1>Guides for running bashkit.</h1>
+      <p class="docs-lede">
+        Short, focused articles for the bashkit CLI, security model, and
+        embedded runtimes. For the Rust API, see the
+        <a href="https://docs.rs/bashkit" target="_blank" rel="noopener noreferrer">rustdoc</a>.
+      </p>
+    </div>
+  </section>
+
+  <section class="docs-index section section-alt">
+    <div class="container docs-index__sections">
+      {
+        bySection.map((group) => (
+          <div class="docs-section">
+            <h2 class="docs-section__title">{group.section}</h2>
+            <ul class="docs-cards">
+              {group.docs.map((doc) => (
+                <li>
+                  <a class="docs-card" href={`/docs/${doc.slug}`}>
+                    <span class="docs-card__title">{doc.title}</span>
+                    <span class="docs-card__summary">{doc.summary}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .docs-hero {
+    padding-top: var(--space-xl);
+    padding-bottom: var(--space-lg);
+  }
+  .docs-eyebrow {
+    display: inline-flex;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-navy);
+    margin-bottom: var(--space-sm);
+  }
+  .docs-hero h1 {
+    font-size: clamp(2.2rem, 5vw, 3.6rem);
+    letter-spacing: -0.03em;
+    line-height: 1.02;
+    margin-bottom: var(--space-md);
+  }
+  .docs-lede {
+    max-width: 40rem;
+    font-size: 1.1rem;
+    color: var(--color-slate);
+  }
+
+  .docs-index__sections {
+    display: grid;
+    gap: var(--space-lg);
+  }
+  .docs-section {
+    display: grid;
+    gap: var(--space-md);
+  }
+  .docs-section__title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-navy);
+  }
+  .docs-cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+    gap: var(--space-md);
+  }
+  .docs-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1.1rem 1.2rem;
+    border: 1px solid rgb(10 22 54 / 0.12);
+    background: var(--color-white);
+    color: var(--color-obsidian);
+    text-decoration: none;
+    transition: border-color 0.15s, box-shadow 0.15s, transform 0.1s;
+  }
+  .docs-card:hover {
+    border-color: rgb(10 22 54 / 0.35);
+    box-shadow: 0 6px 20px rgb(10 22 54 / 0.06);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+  .docs-card__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+  .docs-card__summary {
+    color: var(--color-slate);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Wires the four user-facing guides in `docs/` into the Astro site via a content collection with Astro's glob loader pointing at `../docs`, so the repo and the site stay a single source of truth (no copy, no symlink).
- Adds `/docs` landing page grouped by section and a `/docs/[slug]` dynamic route rendered through a new `DocsLayout` with breadcrumb, typography, code blocks, "edit on GitHub", and prev/next.
- Repoints the header "Docs" link at `/docs`; docs.rs stays accessible as "API".

Scope is deliberately small — 4 pages today, no sidebar, no search, no versioning. Room to add ~5-10 more before Starlight becomes worth it.

## Test plan

- [x] `npx astro check` — 0 errors
- [x] `npx astro build` — generates `/docs`, `/docs/cli`, `/docs/security`, `/docs/snapshotting`, `/docs/builtin_typescript`
- [ ] Visit `/docs` and each article in preview; verify breadcrumb, code highlighting, prev/next, edit link
- [ ] Verify header nav on desktop + mobile

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vgbu2UT1BCPUt86NvtDivT)_