### PR TITLE
fix(examples): pin ticket-cli upstream commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
           bash examples/realfs_mount.sh
 
       - name: Run ticket CLI example
+        env:
+          TICKET_REF: 194b71a8bbc3771da1ce9f579395937c976bbddc
         run: bash examples/ticket-cli.sh
 
       # External API dependency — don't block CI on Anthropic outages

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,9 @@ cargo build -p bashkit-cli --features realfs
 bash examples/ticket-cli.sh
 ```
 
+`ticket-cli.sh` checks out a pinned `wedow/ticket` commit by default for
+reproducibility/supply-chain safety. Override with `TICKET_REF=<commit>`.
+
 ## Python
 
 Python examples use [PEP 723](https://peps.python.org/pep-0723/) inline script metadata.

--- a/examples/ticket-cli.sh
+++ b/examples/ticket-cli.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Security decision: pin wedow/ticket to immutable commit by default.
 # Run the wedow/ticket issue tracker inside bashkit with plugin support.
 #
 # Demonstrates: VFS mounts, PATH-based plugin discovery, complex bash scripts
@@ -23,11 +24,18 @@ fi
 
 TICKET_DIR="${TICKET_DIR:-/tmp/bashkit-ticket}"
 WORK_DIR="${WORK_DIR:-/tmp/bashkit-ticket-work}"
+TICKET_REPO="${TICKET_REPO:-https://github.com/wedow/ticket}"
+TICKET_REF="${TICKET_REF:-194b71a8bbc3771da1ce9f579395937c976bbddc}"
 
-if [[ ! -d "$TICKET_DIR" ]]; then
-  echo "Cloning wedow/ticket..."
-  git clone --depth 1 https://github.com/wedow/ticket "$TICKET_DIR"
+if [[ ! -d "$TICKET_DIR/.git" ]]; then
+  echo "Cloning wedow/ticket repo metadata..."
+  rm -rf "$TICKET_DIR"
+  git clone --no-checkout --filter=blob:none "$TICKET_REPO" "$TICKET_DIR"
 fi
+
+echo "Checking out pinned wedow/ticket commit: $TICKET_REF"
+git -C "$TICKET_DIR" fetch --depth 1 origin "$TICKET_REF"
+git -C "$TICKET_DIR" checkout --detach --force FETCH_HEAD
 
 mkdir -p "$WORK_DIR"
 


### PR DESCRIPTION
### Motivation
- The `examples/ticket-cli.sh` script cloned and executed `wedow/ticket` at moving `HEAD`, creating a CI supply‑chain RCE risk. 
- The CI `examples` job ran that script on every push, exposing runners and tokens to upstream changes. 
- Make example execution deterministic and reviewable by default to remove the network-originated code execution vector. 

### Description
- Add `TICKET_REPO` and `TICKET_REF` knobs and default `TICKET_REF` to an immutable commit hash. 
- Replace an unpinned `git clone` with a metadata-only clone (`--no-checkout --filter=blob:none`) and then `git fetch --depth 1` + detached checkout of the pinned `TICKET_REF`. 
- Set `TICKET_REF` in the CI `examples` step so the example runs a reviewed, pinned commit in CI. 
- Document the pinned-ref behavior and override via `TICKET_REF` in `examples/README.md`. 

### Testing
- Ran `bash -n examples/ticket-cli.sh` to validate syntax and it succeeded. 
- Executed the example in a smoke run with `BASHKIT=/bin/true WORK_DIR=/tmp/... TICKET_DIR=/tmp/... bash examples/ticket-cli.sh` and observed a metadata clone and successful checkout of `TICKET_REF`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a42985bc832bbe7d93bdda86976c)