### PR TITLE
fix(network): bind bot-auth signatures to method and target URI

### DIFF
--- a/crates/bashkit/src/network/bot_auth.rs
+++ b/crates/bashkit/src/network/bot_auth.rs
@@ -1,5 +1,5 @@
 // Decision: Implement draft-meunier-web-bot-auth-architecture using Ed25519 signatures
-// over RFC 9421 HTTP Message Signatures. Sign @authority as the primary covered component.
+// over RFC 9421 HTTP Message Signatures. Bind signatures to request method + target URI.
 // Feature-gated behind `bot-auth` to avoid pulling crypto deps by default.
 // Non-blocking: signing failures log a warning and send the request unsigned.
 
@@ -101,10 +101,14 @@ impl BotAuthConfig {
         jwk_thumbprint_ed25519(&signing_key.verifying_key())
     }
 
-    /// Sign a request targeting the given authority and return headers to attach.
+    /// Sign a request and return headers to attach.
     ///
     /// Returns `Err` on clock errors; callers should log and send unsigned.
-    pub(crate) fn sign_request(&self, authority: &str) -> Result<BotAuthHeaders, BotAuthError> {
+    pub(crate) fn sign_request(
+        &self,
+        method: &str,
+        target_uri: &str,
+    ) -> Result<BotAuthHeaders, BotAuthError> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|_| BotAuthError::Clock)?
@@ -114,7 +118,7 @@ impl BotAuthConfig {
         let nonce = generate_nonce();
 
         // Build covered components list
-        let mut covered = String::from("\"@authority\"");
+        let mut covered = String::from("\"@method\" \"@target-uri\"");
         if self.agent_fqdn.is_some() {
             covered.push_str(" \"signature-agent\"");
         }
@@ -127,7 +131,7 @@ impl BotAuthConfig {
         );
 
         // Build signature base per RFC 9421 Section 2.5
-        let mut sig_base = format!("\"@authority\": {authority}\n");
+        let mut sig_base = format!("\"@method\": {method}\n\"@target-uri\": {target_uri}\n");
         if let Some(ref fqdn) = self.agent_fqdn {
             sig_base.push_str(&format!("\"signature-agent\": {fqdn}\n"));
         }
@@ -248,7 +252,7 @@ mod tests {
     #[test]
     fn sign_request_produces_valid_headers() {
         let config = BotAuthConfig::from_seed([3u8; 32]);
-        let headers = config.sign_request("example.com").unwrap();
+        let headers = config.sign_request("GET", "https://example.com").unwrap();
 
         assert!(headers.signature.starts_with("sig=:"));
         assert!(headers.signature.ends_with(':'));
@@ -263,7 +267,7 @@ mod tests {
     #[test]
     fn sign_request_with_agent_fqdn() {
         let config = BotAuthConfig::from_seed([4u8; 32]).with_agent_fqdn("bot.example.com");
-        let headers = config.sign_request("example.com").unwrap();
+        let headers = config.sign_request("GET", "https://example.com").unwrap();
 
         assert_eq!(headers.signature_agent.as_deref(), Some("bot.example.com"));
         assert!(headers.signature_input.contains("\"signature-agent\""));
@@ -276,12 +280,15 @@ mod tests {
         let signing_key = SigningKey::from_bytes(&seed);
         let verifying_key = signing_key.verifying_key();
 
-        let headers = config.sign_request("verify.example.com").unwrap();
+        let headers = config
+            .sign_request("POST", "https://verify.example.com/v1/items?q=1")
+            .unwrap();
 
         // Reconstruct signature base
         let sig_params = headers.signature_input.strip_prefix("sig=").unwrap();
-        let sig_base =
-            format!("\"@authority\": verify.example.com\n\"@signature-params\": {sig_params}");
+        let sig_base = format!(
+            "\"@method\": POST\n\"@target-uri\": https://verify.example.com/v1/items?q=1\n\"@signature-params\": {sig_params}"
+        );
 
         // Extract raw signature bytes
         let sig_b64 = headers
@@ -301,6 +308,45 @@ mod tests {
     }
 
     #[test]
+    fn signature_rejects_method_or_target_tampering() {
+        let seed = [15u8; 32];
+        let config = BotAuthConfig::from_seed(seed);
+        let signing_key = SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key();
+
+        let headers = config
+            .sign_request("POST", "https://verify.example.com/v1/items?q=1")
+            .unwrap();
+        let sig_params = headers.signature_input.strip_prefix("sig=").unwrap();
+        let sig_b64 = headers
+            .signature
+            .strip_prefix("sig=:")
+            .unwrap()
+            .strip_suffix(':')
+            .unwrap();
+        let sig_bytes = URL_SAFE_NO_PAD.decode(sig_b64).unwrap();
+        let signature = ed25519_dalek::Signature::from_slice(&sig_bytes).unwrap();
+
+        let tampered_method = format!(
+            "\"@method\": GET\n\"@target-uri\": https://verify.example.com/v1/items?q=1\n\"@signature-params\": {sig_params}"
+        );
+        let tampered_target = format!(
+            "\"@method\": POST\n\"@target-uri\": https://verify.example.com/admin/delete\n\"@signature-params\": {sig_params}"
+        );
+
+        assert!(
+            verifying_key
+                .verify(tampered_method.as_bytes(), &signature)
+                .is_err()
+        );
+        assert!(
+            verifying_key
+                .verify(tampered_target.as_bytes(), &signature)
+                .is_err()
+        );
+    }
+
+    #[test]
     fn jwk_thumbprint_deterministic() {
         let key = SigningKey::from_bytes(&[6u8; 32]).verifying_key();
         let t1 = jwk_thumbprint_ed25519(&key);
@@ -312,7 +358,7 @@ mod tests {
     #[test]
     fn validity_secs_respected() {
         let config = BotAuthConfig::from_seed([7u8; 32]).with_validity_secs(600);
-        let headers = config.sign_request("example.com").unwrap();
+        let headers = config.sign_request("GET", "https://example.com").unwrap();
         let input = &headers.signature_input;
         let created: u64 = input
             .split("created=")

--- a/crates/bashkit/src/network/client.rs
+++ b/crates/bashkit/src/network/client.rs
@@ -207,20 +207,17 @@ impl HttpClient {
         self.bot_auth = Some(config);
     }
 
-    /// Produce bot-auth signing headers for the given URL.
+    /// Produce bot-auth signing headers for the given request.
     /// Non-blocking: signing failures return an empty vec (request sent unsigned).
     #[cfg(feature = "bot-auth")]
-    fn bot_auth_headers(&self, url: &str) -> Vec<(String, String)> {
+    fn bot_auth_headers(&self, method: Method, url: &str) -> Vec<(String, String)> {
         let Some(ref bot_auth) = self.bot_auth else {
             return Vec::new();
         };
         let Ok(parsed) = url::Url::parse(url) else {
             return Vec::new();
         };
-        let Some(authority) = parsed.host_str() else {
-            return Vec::new();
-        };
-        match bot_auth.sign_request(authority) {
+        match bot_auth.sign_request(method.as_str(), parsed.as_str()) {
             Ok(headers) => {
                 let mut result = vec![
                     ("signature".to_string(), headers.signature),
@@ -427,7 +424,7 @@ impl HttpClient {
 
         // Compute bot-auth signing headers (transparent, non-blocking)
         #[cfg(feature = "bot-auth")]
-        let signing_headers = self.bot_auth_headers(url);
+        let signing_headers = self.bot_auth_headers(method, url);
         #[cfg(not(feature = "bot-auth"))]
         let signing_headers: Vec<(String, String)> = Vec::new();
 
@@ -648,7 +645,7 @@ impl HttpClient {
 
         // Compute bot-auth signing headers (transparent, non-blocking)
         #[cfg(feature = "bot-auth")]
-        let signing_headers = self.bot_auth_headers(url);
+        let signing_headers = self.bot_auth_headers(method, url);
         #[cfg(not(feature = "bot-auth"))]
         let signing_headers: Vec<(String, String)> = Vec::new();
 

--- a/specs/request-signing.md
+++ b/specs/request-signing.md
@@ -28,7 +28,7 @@ BashBuilder::bot_auth(config)
 HttpClient::set_bot_auth(config)
     │
     ▼  (on every request, after allowlist check)
-BotAuthConfig::sign_request(authority)
+BotAuthConfig::sign_request(method, target_uri)
     │
     ▼
 Signature + Signature-Input + Signature-Agent headers
@@ -95,7 +95,7 @@ Consumer uses this to serve the well-known key directory endpoint.
 
 Per RFC 9421 with web-bot-auth tag:
 
-- **Covered components**: `@authority` (+ `signature-agent` when FQDN set)
+- **Covered components**: `@method`, `@target-uri` (+ `signature-agent` when FQDN set)
 - **Algorithm**: Ed25519 (`alg="ed25519"`)
 - **Key identity**: JWK Thumbprint (RFC 7638) as `keyid`
 - **Tag**: `"web-bot-auth"`
@@ -107,7 +107,7 @@ Per RFC 9421 with web-bot-auth tag:
 | Header | Value |
 |--------|-------|
 | `Signature` | `sig=:<base64url-encoded-signature>:` |
-| `Signature-Input` | `sig=("@authority");created=...;expires=...;keyid="...";alg="ed25519";nonce="...";tag="web-bot-auth"` |
+| `Signature-Input` | `sig=("@method" "@target-uri");created=...;expires=...;keyid="...";alg="ed25519";nonce="...";tag="web-bot-auth"` |
 | `Signature-Agent` | FQDN (only when `agent_fqdn` is set) |
 
 ## Consumer Wiring


### PR DESCRIPTION
### Motivation
- Close a request-integrity gap where bot-auth signatures only covered `@authority`, allowing on-path attackers or proxies to replay/tamper requests to different methods/paths on the same host.
- Ensure signatures are bound to the full request target and method per HTTP message-signature principles so servers can trust the signed request semantics.

### Description
- Change `BotAuthConfig::sign_request` to take `method` and `target_uri` and include `@method` and `@target-uri` in the covered components and signature base instead of only `@authority`.
- Update `HttpClient::bot_auth_headers` to pass the request `Method` and the parsed URL string into the signer for both normal and timeout request paths.
- Add a regression test `signature_rejects_method_or_target_tampering` that verifies a signature fails verification if method or target URI are tampered.
- Update `specs/request-signing.md` and comments to reflect the new covered components (`@method`, `@target-uri`) and API change (`sign_request(method, target_uri)`).

### Testing
- Ran `cargo fmt --check` which completed successfully.
- Ran unit tests for the modified signing logic with `cargo test -p bashkit signature_rejects_method_or_target_tampering --features bot-auth` and the test passed.
- Ran `cargo test -p bashkit signature_is_verifiable --features bot-auth` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a429a714832b86c453678b8d76d8)