### PR TITLE
fix(snapshot): enforce limit checks during snapshot restore

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1390,6 +1390,44 @@ impl Interpreter {
         );
     }
 
+    /// Validate restored shell state against configured memory limits.
+    ///
+    /// Used by snapshot restore paths before applying untrusted state.
+    pub(crate) fn validate_shell_state_restore_limits(&self, state: &ShellState) -> Result<()> {
+        let budget = crate::limits::MemoryBudget::recompute_from_state(
+            &state.variables,
+            &state.arrays,
+            &state.assoc_arrays,
+            0,
+            0,
+            Self::is_internal_variable,
+        );
+
+        if budget.variable_count > self.memory_limits.max_variable_count {
+            return Err(crate::limits::LimitExceeded::Memory(format!(
+                "variable count limit ({}) exceeded",
+                self.memory_limits.max_variable_count
+            ))
+            .into());
+        }
+        if budget.variable_bytes > self.memory_limits.max_total_variable_bytes {
+            return Err(crate::limits::LimitExceeded::Memory(format!(
+                "variable byte limit ({}) exceeded",
+                self.memory_limits.max_total_variable_bytes
+            ))
+            .into());
+        }
+        if budget.array_entries > self.memory_limits.max_array_entries {
+            return Err(crate::limits::LimitExceeded::Memory(format!(
+                "array entry limit ({}) exceeded",
+                self.memory_limits.max_array_entries
+            ))
+            .into());
+        }
+
+        Ok(())
+    }
+
     /// Get a reference to the current execution counters.
     pub fn counters(&self) -> &crate::limits::ExecutionCounters {
         &self.counters

--- a/crates/bashkit/src/snapshot.rs
+++ b/crates/bashkit/src/snapshot.rs
@@ -1,7 +1,7 @@
 // Decision: Snapshot format uses serde_json for Phase 1 (debuggable, human-readable).
 // Phase 2 can add bincode/postcard for compactness.
 // VFS contents are included by default; SnapshotOptions can opt out for shell-only restores.
-// Session limit budgets are transferred (not reset) to preserve resource accounting.
+// Session counters are serialized for observability; restore paths do not trust them.
 
 //! Snapshot/resume — serialize interpreter state between `exec()` calls.
 //!
@@ -302,7 +302,7 @@ impl crate::Bash {
     pub fn from_snapshot(data: &[u8]) -> crate::Result<Self> {
         let snap = Snapshot::from_bytes(data)?;
         let mut bash = Self::new();
-        bash.restore_snapshot_inner(&snap);
+        bash.restore_snapshot_inner(&snap)?;
         Ok(bash)
     }
 
@@ -316,17 +316,17 @@ impl crate::Bash {
     /// Returns an error if deserialization fails.
     pub fn restore_snapshot(&mut self, data: &[u8]) -> crate::Result<()> {
         let snap = Snapshot::from_bytes(data)?;
-        self.restore_snapshot_inner(&snap);
-        Ok(())
+        self.restore_snapshot_inner(&snap)
     }
 
-    fn restore_snapshot_inner(&mut self, snap: &Snapshot) {
+    fn restore_snapshot_inner(&mut self, snap: &Snapshot) -> crate::Result<()> {
+        self.interpreter
+            .validate_shell_state_restore_limits(&snap.shell)?;
         self.interpreter.restore_shell_state(&snap.shell);
         if let Some(ref vfs) = snap.vfs {
             self.fs.vfs_restore(vfs);
         }
-        self.interpreter
-            .restore_session_counters(snap.session_commands, snap.session_exec_calls);
+        Ok(())
     }
 
     /// Capture snapshot and serialize with HMAC-SHA256 using a secret key.
@@ -352,14 +352,13 @@ impl crate::Bash {
     pub fn from_snapshot_keyed(data: &[u8], key: &[u8]) -> crate::Result<Self> {
         let snap = Snapshot::from_bytes_keyed(data, key)?;
         let mut bash = Self::new();
-        bash.restore_snapshot_inner(&snap);
+        bash.restore_snapshot_inner(&snap)?;
         Ok(bash)
     }
 
     /// Restore state from a keyed snapshot into this Bash instance.
     pub fn restore_snapshot_keyed(&mut self, data: &[u8], key: &[u8]) -> crate::Result<()> {
         let snap = Snapshot::from_bytes_keyed(data, key)?;
-        self.restore_snapshot_inner(&snap);
-        Ok(())
+        self.restore_snapshot_inner(&snap)
     }
 }

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -1,7 +1,8 @@
 //! Tests for VFS snapshot/restore and shell state snapshot/restore
 
 use bashkit::{
-    Bash, ExecutionLimits, FileSystem, InMemoryFs, MemoryLimits, Snapshot, SnapshotOptions,
+    Bash, ExecutionLimits, FileSystem, InMemoryFs, MemoryLimits, SessionLimits, Snapshot,
+    SnapshotOptions,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -518,6 +519,53 @@ async fn snapshot_session_counters_transferred() {
     // Session counters should be > 0
     assert!(snap.session_commands > 0);
     assert!(snap.session_exec_calls > 0);
+}
+
+#[tokio::test]
+async fn snapshot_restore_does_not_reset_session_exec_limit_with_tampered_counter() {
+    let session_limits = SessionLimits::new().max_exec_calls(2);
+    let mut bash = Bash::builder().session_limits(session_limits).build();
+    bash.exec("echo first").await.unwrap();
+    let bytes = bash.snapshot().unwrap();
+
+    let mut tampered_json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    tampered_json["session_exec_calls"] = serde_json::json!(0);
+    let tampered_snapshot: Snapshot = serde_json::from_value(tampered_json).unwrap();
+    let tampered_bytes = tampered_snapshot.to_bytes().unwrap();
+
+    bash.restore_snapshot(&tampered_bytes).unwrap();
+    bash.exec("echo second").await.unwrap();
+    let third = bash.exec("echo third").await;
+    assert!(
+        third.is_err(),
+        "session exec-call budget must remain monotonic across restore"
+    );
+}
+
+#[tokio::test]
+async fn snapshot_restore_rejects_tampered_shell_state_that_exceeds_memory_limits() {
+    let mut src = Bash::new();
+    src.exec("x=ok").await.unwrap();
+    let bytes = src.snapshot().unwrap();
+
+    let mut tampered_json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    let oversized_vars = serde_json::json!({
+        "a": "1",
+        "b": "2",
+        "c": "3"
+    });
+    tampered_json["shell"]["variables"] = oversized_vars;
+
+    let tampered_snapshot: Snapshot = serde_json::from_value(tampered_json).unwrap();
+    let tampered_bytes = tampered_snapshot.to_bytes().unwrap();
+
+    let limits = MemoryLimits::new().max_variable_count(2);
+    let mut restored = Bash::builder().memory_limits(limits).build();
+    let result = restored.restore_snapshot(&tampered_bytes);
+    assert!(
+        result.is_err(),
+        "restore must reject shell state above configured memory limits"
+    );
 }
 
 // ==================== Integrity verification (Issue #977) ====================


### PR DESCRIPTION
### Motivation

- Prevent untrusted/tampered snapshot bytes from resetting session counters or injecting oversized shell state that bypasses `MemoryLimits` and `SessionLimits` protections.

### Description

- Add `Interpreter::validate_shell_state_restore_limits(&self, &ShellState) -> Result<()>` to recompute a memory budget from the serialized state and reject it if it exceeds current `MemoryLimits`.
- Call the new validator from snapshot restore entry paths and make `restore_snapshot_inner` return `crate::Result<()>`, propagating restore failures out of `from_snapshot`, `restore_snapshot`, and keyed variants.
- Stop applying serialized session counters during restore (snapshot still serializes counters for observability, but restore no longer overwrites runtime counters) to avoid resetting session budgets.
- Add regression tests in `crates/bashkit/tests/snapshot_tests.rs` that assert tampered `session_exec_calls` cannot reset `max_exec_calls` and that oversized variable maps are rejected when `MemoryLimits` are strict.

### Testing

- Ran `cargo test --test snapshot_tests` and all snapshot-related tests passed (34 passed, 0 failed). 
- Ran `cargo fmt --all` to ensure formatting is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a429d7c4832bafde01b23c6d3890)