### PR TITLE
fix(interpreter): prevent exec argv reparse injection

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4390,36 +4390,20 @@ impl Interpreter {
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         if !args.is_empty() {
-            // exec cmd args... — execute command and exit with its exit code.
-            // In a real shell this replaces the process; in VFS we run + exit.
-            // Build the command as a script string and execute it.
-            // Single-quote each arg to prevent re-expansion.
-            let mut script_str = String::new();
-            for (i, arg) in args.iter().enumerate() {
-                if i > 0 {
-                    script_str.push(' ');
-                }
-                script_str.push('\'');
-                script_str.push_str(&arg.replace('\'', "'\\''"));
-                script_str.push('\'');
-            }
-
-            let parser = Parser::with_limits(
-                &script_str,
-                self.limits.max_ast_depth,
-                self.limits.max_parser_operations,
-            );
-            let script = match parser.parse() {
-                Ok(s) => s,
-                Err(_) => {
-                    return Ok(ExecResult::err(
-                        format!("-bash: exec: {}: command not found\n", args[0]),
-                        127,
-                    ));
-                }
+            // Security: never reconstruct shell source from argv.
+            // Execute argv directly to avoid quote/parse injection.
+            let target_name = args[0].clone();
+            let target_args = args[1..].to_vec();
+            let target_command = SimpleCommand {
+                name: Word::literal(target_name.clone()),
+                args: target_args.iter().cloned().map(Word::literal).collect(),
+                redirects: redirects.to_vec(),
+                assignments: Vec::new(),
+                span: Span::new(),
             };
-
-            let result = self.execute(&script).await?;
+            let result = self
+                .execute_dispatched_command(&target_name, target_args, &target_command, None)
+                .await?;
 
             // Signal exit so subsequent statements don't execute
             return Ok(ExecResult {

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -237,6 +237,25 @@ mod sandbox_escape {
         assert_eq!(result.exit_code, 127);
     }
 
+    /// Test exec argv is never re-parsed as shell source (quote injection safe).
+    #[tokio::test]
+    async fn threat_exec_argument_quote_injection_blocked() {
+        let mut bash = Bash::new();
+
+        let result = bash
+            .exec("exec echo \"foo' ; touch /tmp/exec_injected #\"")
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "foo' ; touch /tmp/exec_injected #");
+
+        let check = bash.exec("cat /tmp/exec_injected").await.unwrap();
+        assert_ne!(
+            check.exit_code, 0,
+            "injected touch must not execute through exec argv quoting"
+        );
+    }
+
     /// Test external command execution is blocked
     #[tokio::test]
     async fn threat_external_commands_blocked() {


### PR DESCRIPTION
### Motivation
- `exec cmd args...` rebuilt a shell source string from argv and re-parsed it, which allowed crafted single-quote sequences to break token boundaries and inject additional commands. 
- The lexer treats backslashes as literal in single-quote continuation, so the `'\''` escaping pattern used by the rewriter is not safe here. 

### Description
- Stop reconstructing a script string from `exec` argv and stop re-parsing it as shell source. 
- Build a synthetic `SimpleCommand` from the already-expanded `args` and call `dispatch_command` directly to execute the target without reparsing. 
- Preserve `exec` semantics by returning `ControlFlow::Return(exit_code)` so subsequent statements do not run. 
- Add a regression test `threat_exec_argument_quote_injection_blocked` that verifies a payload like `"foo' ; touch /tmp/exec_injected #"` remains a literal argument and does not execute injected commands.

### Testing
- Ran the security regression test with `cargo test -p bashkit threat_exec_argument_quote_injection_blocked -- --nocapture`, and the test passed. 
- Ran `cargo fmt --check` to ensure formatting, and it succeeded. 
- The change is minimal and targeted to the `exec` path; CI should be run to validate the full test matrix before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9733ba0832bab26df95d9edcd69)