### PR TITLE
fix(interpreter): restore env after path-script subprocess

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4848,6 +4848,7 @@ impl Interpreter {
         let saved_exit = self.last_exit_code;
         let saved_aliases = self.aliases.clone();
         let saved_coproc = self.coproc_buffers.clone();
+        let saved_env = self.env.clone();
         let saved_memory_budget = self.memory_budget.clone();
 
         // Child only sees exported variables (env), not all shell variables.
@@ -4893,6 +4894,7 @@ impl Interpreter {
         self.last_exit_code = saved_exit;
         self.aliases = saved_aliases;
         self.coproc_buffers = saved_coproc;
+        self.env = saved_env;
         self.memory_budget = saved_memory_budget;
         self.bash_source_stack = saved_source_stack;
         self.pipeline_stdin = prev_pipeline_stdin;

--- a/crates/bashkit/tests/spec_cases/bash/subprocess-isolation.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/subprocess-isolation.test.sh
@@ -141,3 +141,22 @@ PATH="/usr/local/bin:${PATH}" check-isolation
 visible=yes
 hidden=unset
 ### end
+
+
+### subprocess_child_export_does_not_leak_to_parent
+# Export inside child script must not persist in parent env
+unset CHILD_ONLY
+
+cat > /tmp/export-child.sh <<'SCRIPT'
+#!/usr/bin/env bash
+export CHILD_ONLY="from-child"
+echo "child: ${CHILD_ONLY}"
+SCRIPT
+chmod +x /tmp/export-child.sh
+
+/tmp/export-child.sh
+echo "parent: ${CHILD_ONLY:-unset}"
+### expect
+child: from-child
+parent: unset
+### end


### PR DESCRIPTION
### Motivation
- Path-based script execution claimed subprocess isolation but child `export` mutated shared `self.env`, causing exported variables to persist in the parent shell and enabling environment poisoning.
- The root cause was that `execute_script_content` replaced `self.variables` with `self.env.clone()` but never snapshots/restores `self.env` itself while builtins (e.g. `export`) write into `self.env`.

### Description
- Snapshot `self.env` before entering path-based script execution by adding `let saved_env = self.env.clone();`.
- Restore `self.env` after the child script returns by assigning `self.env = saved_env;`, preventing child `export` from leaking into parent state.
- Add a regression spec `subprocess_child_export_does_not_leak_to_parent` in `tests/spec_cases/bash/subprocess-isolation.test.sh` that verifies an exported variable in a path-executed child does not persist in the parent.

### Testing
- Ran the bash spec tests with `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture`; the new regression failed prior to the fix and the suite completed with one failing spec.
- Re-ran `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture` after the change and the spec suite passed (`Total: 1979 | Passed: 1954 | Failed: 0 | Skipped: 25`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adaf88b8832b8cc06c3b15b513da)