### PR TITLE
fix(interpreter): enforce memory limits for local assignments

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5273,39 +5273,19 @@ impl Interpreter {
                             }
                         }
                         // Mark local
-                        self.call_stack
-                            .last_mut()
-                            .unwrap()
-                            .locals
-                            .insert(var_name.to_string(), String::new());
+                        self.insert_local_checked(var_name.to_string(), String::new());
                     } else if flags.nameref {
-                        self.call_stack
-                            .last_mut()
-                            .unwrap()
-                            .locals
-                            .insert(var_name.to_string(), String::new());
+                        self.insert_local_checked(var_name.to_string(), String::new());
                     } else if flags.integer {
                         let int_val = self.evaluate_arithmetic_with_assign(value);
-                        self.call_stack
-                            .last_mut()
-                            .unwrap()
-                            .locals
-                            .insert(var_name.to_string(), int_val.to_string());
+                        self.insert_local_checked(var_name.to_string(), int_val.to_string());
                         self.variables
                             .insert(format!("_INTEGER_{}", var_name), "1".to_string());
                     } else {
-                        self.call_stack
-                            .last_mut()
-                            .unwrap()
-                            .locals
-                            .insert(var_name.to_string(), value.to_string());
+                        self.insert_local_checked(var_name.to_string(), value.to_string());
                     }
                 } else if !is_internal_variable(arg) {
-                    self.call_stack
-                        .last_mut()
-                        .unwrap()
-                        .locals
-                        .insert(arg.to_string(), String::new());
+                    self.insert_local_checked(arg.to_string(), String::new());
                     if flags.assoc {
                         self.assoc_arrays.entry(arg.to_string()).or_default();
                     } else if flags.array {
@@ -5391,8 +5371,7 @@ impl Interpreter {
                         self.variables
                             .insert(format!("_NAMEREF_{}", var_name), value.to_string());
                     } else {
-                        self.variables
-                            .insert(var_name.to_string(), value.to_string());
+                        self.insert_variable_checked(var_name.to_string(), value.to_string());
                     }
                 } else if !is_internal_variable(arg) {
                     if flags.assoc {
@@ -9137,6 +9116,48 @@ impl Interpreter {
             );
         }
         self.variables.insert(key, value);
+    }
+
+    /// Insert a variable into the current local frame with memory budget checking.
+    /// Silently drops the insert if the budget would be exceeded.
+    fn insert_local_checked(&mut self, key: String, value: String) {
+        let Some(frame) = self.call_stack.last() else {
+            return;
+        };
+        let is_new = !frame.locals.contains_key(&key);
+        let old_value_len = frame.locals.get(&key).map_or(0, String::len);
+        let (old_key_len, old_value_len) = if is_new {
+            (0, 0)
+        } else {
+            (key.len(), old_value_len)
+        };
+
+        if self
+            .memory_budget
+            .check_variable_insert(
+                key.len(),
+                value.len(),
+                is_new,
+                old_key_len,
+                old_value_len,
+                &self.memory_limits,
+            )
+            .is_err()
+        {
+            return; // silently reject — budget exceeded
+        }
+
+        self.memory_budget.record_variable_insert(
+            key.len(),
+            value.len(),
+            is_new,
+            old_key_len,
+            old_value_len,
+        );
+
+        if let Some(frame) = self.call_stack.last_mut() {
+            frame.locals.insert(key, value);
+        }
     }
 
     /// Insert/update an environment variable with memory limit checks.

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -3484,6 +3484,28 @@ echo ${#big2}
         assert!(!lines.is_empty(), "should have produced some output");
     }
 
+    /// TM-DOS-060: local builtin assignments must honor variable count budget.
+    #[tokio::test]
+    async fn tm_dos_060_local_assignment_respects_budget() {
+        let mem = MemoryLimits::new().max_variable_count(2);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+local a=1 b=2 c=3
+printf "%s\n" "${a:-unset}" "${b:-unset}" "${c:-unset}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "1");
+        assert_eq!(lines[2], "unset");
+    }
+
     /// TM-DOS-060: Array entry bomb — indexed array with many entries.
     #[tokio::test]
     async fn tm_dos_060_array_entry_bomb() {


### PR DESCRIPTION
### Motivation
- The `local` builtin was inserting variables directly into `frame.locals` (and top-level `local name=value` into `self.variables`), bypassing `MemoryBudget` checks and allowing memory exhaustion via local variable/assignment storms.
- Memory limits must apply to function-local variables as well as globals to prevent TM-DOS-060 style DoS attacks.

### Description
- Route all `local`-builtin writes through budget-checked insertion paths instead of direct `insert` calls by using a new `insert_local_checked` helper for frame-local variables and `insert_variable_checked` for top-level assignments.
- Add `fn insert_local_checked(&mut self, key: String, value: String)` which mirrors global budget checks (`check_variable_insert` / `record_variable_insert`) and silently drops over-budget inserts.
- Replace direct `frame.locals.insert(...)` calls and top-level `self.variables.insert(...)` in `execute_local_builtin` with the checked insertion functions.
- Add a regression test `tm_dos_060_local_assignment_respects_budget` in `threat_model_tests.rs` asserting `local a=1 b=2 c=3` respects a tight `max_variable_count` budget.

### Testing
- Ran `cargo test --test threat_model_tests tm_dos_060_local_assignment_respects_budget` and the test passed (`ok`).
- Ran `cargo test --test threat_model_tests memory_limits` and the full `memory_limits` test group passed (`10 passed`).
- Ran `cargo fmt --check` and formatting check passed (no changes required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adad2488832b8e18d217b8f545c7)