### PR TITLE
fix(builtins): reject invalid unexpand tab-stop values

### DIFF
--- a/crates/bashkit/src/builtins/expand.rs
+++ b/crates/bashkit/src/builtins/expand.rs
@@ -127,7 +127,14 @@ impl Builtin for Unexpand {
                             1,
                         ));
                     }
-                    tab_stops = parse_tab_stops(&ctx.args[i]);
+                    let parsed_tab_stops = parse_tab_stops(&ctx.args[i]);
+                    if parsed_tab_stops.is_empty() {
+                        return Ok(ExecResult::err(
+                            format!("unexpand: invalid tab size: '{}'\n", ctx.args[i]),
+                            1,
+                        ));
+                    }
+                    tab_stops = parsed_tab_stops;
                     all = true; // -t implies -a
                 }
                 _ => files.push(&ctx.args[i]),
@@ -356,5 +363,19 @@ mod tests {
     async fn test_expand_empty() {
         let result = run_expand(&[], Some("")).await;
         assert_eq!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn test_unexpand_invalid_zero_tab_stop() {
+        let result = run_unexpand(&["-t", "0"], Some("        hello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.stderr, "unexpand: invalid tab size: '0'\n");
+    }
+
+    #[tokio::test]
+    async fn test_unexpand_invalid_non_numeric_tab_stop() {
+        let result = run_unexpand(&["-t", "foo"], Some("        hello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.stderr, "unexpand: invalid tab size: 'foo'\n");
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent a panic/DoS where `unexpand` indexed `tab_stops[0]` after `parse_tab_stops` returned an empty vector for inputs like `-t 0` or `-t foo`.
- Surface a clear user-facing error instead of letting the interpreter process crash when given invalid tab-stop arguments.

### Description
- Validate the result of `parse_tab_stops` when handling `unexpand -t` and return `unexpand: invalid tab size: '<value>'` with exit code `1` for empty/invalid parses.
- Preserve existing behavior for valid tab-stop values by assigning the parsed vector to `tab_stops` when non-empty.
- Add two regression tests: `test_unexpand_invalid_zero_tab_stop` and `test_unexpand_invalid_non_numeric_tab_stop` to assert error exit and stderr message.
- Commit message: `fix(builtins): reject invalid unexpand tab-stop values`.

### Testing
- Ran the new unit tests with `cargo test -p bashkit unexpand_invalid`, and the two new tests passed (`test_unexpand_invalid_zero_tab_stop`, `test_unexpand_invalid_non_numeric_tab_stop`).
- Ran crate tests as part of `cargo test -p bashkit` which executed the test binary and reported the new tests as passing with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adaf02d4832bb196d640fd6705cc)