### PR TITLE
fix(python): disable `re` imports to mitigate regex DoS

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ Path('/tmp/data.txt').write_text('hello from python')
 bash.exec("cat /tmp/data.txt").await?; // "hello from python"
 ```
 
-Stdlib modules: `math`, `re`, `pathlib`, `os` (getenv/environ), `sys`, `typing`.
+Stdlib modules: `math`, `pathlib`, `os` (getenv/environ), `sys`, `typing`.
+Security note: `re` is intentionally disabled due to regex backtracking DoS risk.
 Limitations: no `open()` (use `pathlib.Path`), no network, no classes, no third-party imports.
 See [crates/bashkit/docs/python.md](crates/bashkit/docs/python.md) for the full guide.
 

--- a/crates/bashkit/docs/python.md
+++ b/crates/bashkit/docs/python.md
@@ -187,7 +187,10 @@ Monty has no network primitives and no OsCall variants for network operations.
 **No classes.** Class definitions are not yet supported by Monty (planned upstream).
 
 **No third-party imports.** Only builtin modules (`sys`, `typing`, `os`, `pathlib`,
-`math`, `re`, `json`, `datetime`) are available. No `pip install`, no `import numpy`.
+`math`, `json`, `datetime`) are available. No `pip install`, no `import numpy`.
+
+**No `re` module.** Disabled due to catastrophic backtracking DoS risk in
+untrusted code execution.
 
 **No `str.format()`.** Use f-strings instead: `f"value={x}"` not `"value={}".format(x)`.
 

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -38,6 +38,9 @@ const DEFAULT_MAX_ALLOCATIONS: usize = 1_000_000;
 const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(30);
 const DEFAULT_MAX_MEMORY: usize = 64 * 1024 * 1024; // 64 MB
 const DEFAULT_MAX_RECURSION: usize = 200;
+// Security hard-stop: catastrophic regex backtracking can bypass cooperative
+// interpreter budget checks, so disable regex stdlib module in untrusted code.
+const DISABLED_STDLIB_MODULES: &[&str] = &["re"];
 
 /// Resource limits for the embedded Python (Monty) interpreter.
 ///
@@ -206,12 +209,74 @@ impl Default for Python {
     }
 }
 
+fn is_disabled_import(code: &str) -> Option<&'static str> {
+    let is_disabled_module = |module: &str| {
+        DISABLED_STDLIB_MODULES.iter().any(|disabled| {
+            module == *disabled
+                || (module.starts_with(disabled)
+                    && module
+                        .as_bytes()
+                        .get(disabled.len())
+                        .is_some_and(|next| *next == b'.'))
+        })
+    };
+
+    for raw_line in code.lines() {
+        let line = raw_line.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        if let Some(imports) = line.strip_prefix("import ") {
+            for import in imports.split(',') {
+                let module = import
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .trim_matches(|c: char| c == '\'' || c == '"')
+                    .trim_end_matches(|c: char| {
+                        !(c.is_ascii_alphanumeric() || c == '_' || c == '.')
+                    })
+                    .to_string();
+                if is_disabled_module(&module) {
+                    return Some("re");
+                }
+            }
+        }
+
+        if let Some(from_stmt) = line.strip_prefix("from ") {
+            let module = from_stmt
+                .split_whitespace()
+                .next()
+                .unwrap_or("")
+                .trim()
+                .trim_matches(|c: char| c == '\'' || c == '"')
+                .trim_end_matches(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '.'))
+                .to_string();
+            if is_disabled_module(&module) {
+                return Some("re");
+            }
+        }
+
+        if line.contains("__import__('re'") || line.contains("__import__(\"re\"") {
+            return Some("re");
+        }
+        if line.contains("importlib.import_module('re'")
+            || line.contains("importlib.import_module(\"re\"")
+        {
+            return Some("re");
+        }
+    }
+    None
+}
+
 #[async_trait]
 impl Builtin for Python {
     fn llm_hint(&self) -> Option<&'static str> {
         Some(
             "python/python3: Embedded Python (Monty). \
-             Stdlib: math, re, pathlib, os.getenv, sys, typing. \
+             Stdlib: math, pathlib, os.getenv, sys, typing. \
              File I/O via pathlib.Path only (no open()). \
              No HTTP/network. No classes. No third-party imports.",
         )
@@ -314,6 +379,15 @@ impl Builtin for Python {
                 1,
             ));
         };
+
+        if let Some(module) = is_disabled_import(&code) {
+            return Ok(ExecResult::err(
+                format!(
+                    "python3: importing module '{module}' is disabled for security reasons (regex DoS risk)\n"
+                ),
+                1,
+            ));
+        }
 
         // Merge env and variables so exported vars (set via `export`) are visible
         // to Python's os.getenv(). Variables override env (bash semantics).
@@ -1444,7 +1518,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_re_module() {
+    async fn test_re_module_is_blocked() {
         let r = run(
             &[
                 "-c",
@@ -1453,8 +1527,15 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(r.exit_code, 0);
-        assert_eq!(r.stdout.trim(), "123");
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stderr.contains("importing module 're' is disabled"));
+    }
+
+    #[tokio::test]
+    async fn test_re_module_dynamic_import_is_blocked() {
+        let r = run(&["-c", "m = __import__('re')"], None).await;
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stderr.contains("importing module 're' is disabled"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -354,7 +354,8 @@
 //! ""#).await?;
 //! ```
 //!
-//! Stdlib modules: `math`, `re`, `pathlib`, `os` (getenv/environ), `sys`, `typing`.
+//! Stdlib modules: `math`, `pathlib`, `os` (getenv/environ), `sys`, `typing`.
+//! Security note: `re` is disabled due to regex backtracking DoS risk.
 //! Limitations: no `open()` (use `pathlib.Path`), no network, no classes,
 //! no third-party imports.
 //!

--- a/specs/python-builtin.md
+++ b/specs/python-builtin.md
@@ -122,7 +122,7 @@ Monty implements a subset of Python 3.12:
 - Exception handling: try/except/finally/raise
 - Property descriptors (`@property`) (since Monty 0.0.4)
 - Built-in functions: print, len, range, enumerate, zip, map, filter, sorted, reversed, sum, min, max, abs, round, int, float, str, bool, list, dict, tuple, set, type, isinstance, hasattr, getattr, id, repr, ord, chr, hex, oct, bin, all, any, input
-- Standard modules: sys, typing, math (~50 functions), re (regex), pathlib, os (getenv/environ), json, datetime
+- Standard modules: sys, typing, math (~50 functions), pathlib, os (getenv/environ), json, datetime
 - `datetime.date.today()`, `datetime.datetime.now()` with optional timezone (since Monty 0.0.11)
 - JSON: `json.dumps()`, `json.loads()` (since Monty 0.0.9)
 - Multi-module imports: `import a, b, c` (since Monty 0.0.10)
@@ -300,7 +300,10 @@ Relative paths are resolved against the shell's cwd. Path traversal via
 When Python is registered via `BashToolBuilder::python()`, the builtin contributes
 a hint to `help()` and `system_prompt()` documenting its limitations:
 
-> python/python3: Embedded Python (Monty). Stdlib: math, re, pathlib, os.getenv, sys, typing. File I/O via pathlib.Path only (no open()). No HTTP/network. No classes. No third-party imports.
+> python/python3: Embedded Python (Monty). Stdlib: math, pathlib, os.getenv, sys, typing. File I/O via pathlib.Path only (no open()). No HTTP/network. No classes. No third-party imports.
+
+Regex module `re` is intentionally disabled in BashKit due to catastrophic
+backtracking DoS risk in untrusted code execution.
 
 This uses the general `Builtin::llm_hint()` mechanism — any builtin can provide
 hints that are automatically deduplicated and included in LLM-facing documentation.


### PR DESCRIPTION
### Motivation

- Monty 0.0.8 exposed the Python `re` stdlib which can trigger catastrophic backtracking via the `fancy-regex` engine, bypassing Monty step-tracking and creating a CPU-exhaustion DoS risk for untrusted code. 
- A minimal, host-side mitigation is required to avoid relying on upstream or vendored fixes before a safe regex timeout/yield mechanism exists. 

### Description

- Add a `DISABLED_STDLIB_MODULES` list and `is_disabled_import(code: &str)` scanner to detect `import re`, `from re ...`, and common dynamic import forms in `crates/bashkit/src/builtins/python.rs`. 
- Block execution early by returning a clear security error if a disabled import is detected, before delegating to Monty. 
- Remove `re` from the builtin `llm_hint()` and update tests to assert that both direct and dynamic `re` imports are denied. 
- Update docs and specs (`specs/python-builtin.md`, `crates/bashkit/docs/python.md`, `README.md`, and crate docs) to reflect `re` is disabled and to document the security rationale. 

### Testing

- Ran `cargo fmt --all` and formatting succeeded. 
- Ran targeted unit tests for the Python builtin: `test_re_module_is_blocked` and `test_re_module_dynamic_import_is_blocked`, and both tests passed. 
- Ran `cargo test -p bashkit re_module --features python` (targeted test run) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b4f5dcc0832b9a5b99425ad167ee)