### PR TITLE
fix(fs): avoid double-counting hidden lower children on recursive delete

### DIFF
--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -321,10 +321,8 @@ impl OverlayFs {
                 }
                 if let Ok(meta) = self.lower.stat(&child).await {
                     match meta.file_type {
-                        FileType::File => {
-                            if !self.upper.exists(&child).await.unwrap_or(false) {
-                                self.hide_lower_file(meta.size);
-                            }
+                        FileType::File if !self.upper.exists(&child).await.unwrap_or(false) => {
+                            self.hide_lower_file(meta.size);
                         }
                         FileType::Directory => {
                             self.hide_lower_dir();

--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -316,9 +316,16 @@ impl OverlayFs {
         if let Ok(entries) = self.lower.read_dir(dir).await {
             for entry in entries {
                 let child = dir.join(&entry.name);
+                if self.is_whiteout(&child) {
+                    continue;
+                }
                 if let Ok(meta) = self.lower.stat(&child).await {
                     match meta.file_type {
-                        FileType::File => self.hide_lower_file(meta.size),
+                        FileType::File => {
+                            if !self.upper.exists(&child).await.unwrap_or(false) {
+                                self.hide_lower_file(meta.size);
+                            }
+                        }
                         FileType::Directory => {
                             self.hide_lower_dir();
                             // Recurse into subdirectories
@@ -1440,6 +1447,34 @@ mod tests {
             after.file_count,
             before.file_count - 2,
             "should deduct all child file counts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recursive_delete_skips_already_hidden_children() {
+        let lower = Arc::new(InMemoryFs::new());
+        lower.mkdir(Path::new("/dir"), true).await.unwrap();
+        lower.write_file(Path::new("/dir/a"), &[b'a'; 10]).await.unwrap();
+        lower.write_file(Path::new("/dir/b"), &[b'b'; 20]).await.unwrap();
+        lower.write_file(Path::new("/keep"), &[b'k'; 50]).await.unwrap();
+
+        let probe = OverlayFs::new(lower.clone());
+        let base = probe.usage();
+        let limits = FsLimits::new()
+            .max_total_bytes(base.total_bytes - 25)
+            .max_file_count(base.file_count + 10)
+            .max_dir_count(base.dir_count + 10);
+        let overlay = OverlayFs::with_limits(lower, limits);
+
+        // First remove a child, then recursively remove parent.
+        // Child must not be deducted twice from lower_hidden.
+        overlay.remove(Path::new("/dir/a"), false).await.unwrap();
+        overlay.remove(Path::new("/dir"), true).await.unwrap();
+
+        let result = overlay.write_file(Path::new("/new.txt"), &[b'n'; 10]).await;
+        assert!(
+            result.is_err(),
+            "write should fail: recursive delete must not undercount usage"
         );
     }
 

--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -1454,9 +1454,18 @@ mod tests {
     async fn test_recursive_delete_skips_already_hidden_children() {
         let lower = Arc::new(InMemoryFs::new());
         lower.mkdir(Path::new("/dir"), true).await.unwrap();
-        lower.write_file(Path::new("/dir/a"), &[b'a'; 10]).await.unwrap();
-        lower.write_file(Path::new("/dir/b"), &[b'b'; 20]).await.unwrap();
-        lower.write_file(Path::new("/keep"), &[b'k'; 50]).await.unwrap();
+        lower
+            .write_file(Path::new("/dir/a"), &[b'a'; 10])
+            .await
+            .unwrap();
+        lower
+            .write_file(Path::new("/dir/b"), &[b'b'; 20])
+            .await
+            .unwrap();
+        lower
+            .write_file(Path::new("/keep"), &[b'k'; 50])
+            .await
+            .unwrap();
 
         let probe = OverlayFs::new(lower.clone());
         let base = probe.usage();


### PR DESCRIPTION
### Motivation
- Recursive delete previously recorded every lower-layer descendant as hidden unconditionally, allowing double-counting when a child was already hidden by a prior whiteout or upper override and enabling quota bypass.

### Description
- Update `hide_lower_children_recursive` to skip descendants that are already whiteouts via `is_whiteout`.
- Skip deducting a lower file's size when that file is already overridden in the upper layer by checking `upper.exists` before calling `hide_lower_file`.
- Add regression test `test_recursive_delete_skips_already_hidden_children` that removes a child, then `rm -r` the parent and verifies writes are still blocked by limits.
- Commit message: `fix(fs): avoid double-counting hidden lower children on rm -r`.

### Testing
- Ran `cargo test -p bashkit test_recursive_delete_skips_already_hidden_children` and the new test passed.
- Ran `cargo test -p bashkit recursive_delete_` to exercise related overlay tests and `test_recursive_delete_whiteouts_children` and `test_recursive_delete_deducts_all_children` all passed.
- Ran package tests for `bashkit` during development; overlay-related tests passed and no regressions were observed (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b5080ad8832bb357aff6f247b5b5)