### PR TITLE
fix(interpreter): prevent xargs stdin glob/brace expansion

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6221,11 +6221,11 @@ impl Interpreter {
                 };
 
                 let inner_cmd = Command::Simple(SimpleCommand {
-                    name: Word::literal(command.name),
+                    name: Word::quoted_literal(command.name),
                     args: command
                         .args
                         .iter()
-                        .map(|s| Word::literal(s.clone()))
+                        .map(|s| Word::quoted_literal(s.clone()))
                         .collect(),
                     redirects: inner_redirects,
                     assignments: Vec::new(),
@@ -6265,8 +6265,12 @@ impl Interpreter {
                     };
 
                     let inner_cmd = Command::Simple(SimpleCommand {
-                        name: Word::literal(cmd.name),
-                        args: cmd.args.iter().map(|s| Word::literal(s.clone())).collect(),
+                        name: Word::quoted_literal(cmd.name),
+                        args: cmd
+                            .args
+                            .iter()
+                            .map(|s| Word::quoted_literal(s.clone()))
+                            .collect(),
                         redirects: cmd_redirects,
                         assignments: Vec::new(),
                         span: Span::new(),
@@ -10776,6 +10780,31 @@ mod tests {
 
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout.trim(), "Hello!");
+    }
+
+    #[tokio::test]
+    async fn test_xargs_treats_stdin_as_literal_args() {
+        // xargs should not glob-expand stdin-derived arguments.
+        let fs = Arc::new(InMemoryFs::new());
+        fs.mkdir(std::path::Path::new("/workspace"), true)
+            .await
+            .unwrap();
+        fs.write_file(std::path::Path::new("/workspace/a.txt"), b"A")
+            .await
+            .unwrap();
+        fs.write_file(std::path::Path::new("/workspace/b.txt"), b"B")
+            .await
+            .unwrap();
+
+        let mut interp = Interpreter::new(fs.clone());
+        interp.set_cwd(std::path::PathBuf::from("/workspace"));
+
+        let parser = Parser::new("printf '*\\n' | xargs -I {} echo {}");
+        let ast = parser.parse().unwrap();
+        let result = interp.execute(&ast).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "*");
     }
 
     // ==================== find -exec tests ====================


### PR DESCRIPTION
### Motivation
- Interpreter-dispatched commands (used by `xargs`, `timeout`, `find -exec`, etc.) were built from stdin tokens with `Word::literal`, leaving `quoted=false` and causing a second pass of brace/glob expansion which lets attacker-controlled stdin like `*` or `{a,b}` expand against the filesystem.

### Description
- Treat dispatched command `name` and `args` as quoted literals by using `Word::quoted_literal(...)` instead of `Word::literal(...)` in the `ExecutionPlan` handling paths (`Timeout` and `Batch`).
- This prevents brace and glob expansion on stdin-derived tokens while preserving execution via `execute_command`.
- Add regression test `test_xargs_treats_stdin_as_literal_args` that verifies `xargs -I {}` does not glob-expand a `*` from stdin.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran the new unit test via `cargo test -p bashkit test_xargs_treats_stdin_as_literal_args -- --nocapture` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adaf47d0832bac3f203aea60f3e1)