### PR TITLE
fix(interpreter): restore function pipeline stdin on error

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5161,8 +5161,8 @@ impl Interpreter {
         let prev_pipeline_stdin = self.pipeline_stdin.take();
         self.pipeline_stdin = stdin;
 
-        // Execute function body
-        let mut result = self.execute_command(&func_def.body).await?;
+        // Execute function body. Always restore call state even on error.
+        let result = self.execute_command(&func_def.body).await;
 
         // Restore previous pipeline stdin
         self.pipeline_stdin = prev_pipeline_stdin;
@@ -5179,6 +5179,8 @@ impl Interpreter {
         } else if let Some(prev) = prev_funcname {
             self.arrays.insert("FUNCNAME".to_string(), prev);
         }
+
+        let mut result = result?;
 
         // Handle return - convert Return control flow to exit code
         if let ControlFlow::Return(code) = result.control_flow {

--- a/crates/bashkit/tests/issue_274_test.rs
+++ b/crates/bashkit/tests/issue_274_test.rs
@@ -29,3 +29,20 @@ async fn issue_274_pipeline_stdin_to_sourced_function() {
         .unwrap();
     assert_eq!(r.stdout.trim(), "HELLO WORLD");
 }
+
+#[tokio::test]
+async fn issue_274_pipeline_stdin_not_leaked_after_function_error() {
+    let limits = bashkit::ExecutionLimits::new().max_commands(3);
+    let mut bash = Bash::builder().limits(limits).build();
+
+    let first = bash
+        .exec("leak() { read x; echo $x; }\necho SECRET | leak")
+        .await;
+    assert!(
+        first.is_err(),
+        "expected first exec to fail due command limit"
+    );
+
+    let second = bash.exec("read x; echo ${x:-EMPTY}").await.unwrap();
+    assert_eq!(second.stdout.trim(), "EMPTY");
+}


### PR DESCRIPTION
### Motivation

- Fix a state-leak where `pipeline_stdin` could remain set if a user-defined function body returned an `Err`, allowing pipeline input to be visible to subsequent `exec()` calls.
- Ensure interpreter call-frame state (pipeline stdin, call stack, BASH_SOURCE, FUNCNAME) is always restored even on function-body errors.

### Description

- Change function-dispatch in `crates/bashkit/src/interpreter/mod.rs` to capture the `execute_command` `Result` and defer `result?` until after restoring interpreter state so restoration runs on both `Ok` and `Err` paths.
- Restore `pipeline_stdin`, pop the call frame, revert `BASH_SOURCE`, and restore `FUNCNAME` before propagating the function-body error.
- Add a regression test `issue_274_pipeline_stdin_not_leaked_after_function_error` to `crates/bashkit/tests/issue_274_test.rs` that forces a function error during a pipeline and verifies no stdin leak into the next `exec()`.

### Testing

- Ran `cargo test -p bashkit --test issue_274_test` and all tests in that file passed, including the new regression test.
- Verified the regression reproduced the leak prior to the fix and is fixed after the change.
- Ran `cargo fmt --check` which succeeded after formatting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9b4f42b54832ba2a1c810d3bddb59)