### PR TITLE
fix(interpreter): avoid UTF-8 panic in extglob backtracking

### DIFF
--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -354,6 +354,11 @@ impl Interpreter {
             }
             b'+' => {
                 // +(a|b) — one or more of the alternatives
+                let split_points = value
+                    .char_indices()
+                    .map(|(i, _)| i)
+                    .skip(1)
+                    .chain(std::iter::once(value.len()));
                 for alt in alts {
                     let full = format!("{}{}", alt, rest);
                     if self.glob_match_impl(value, &full, nocase, depth + 1) {
@@ -361,7 +366,7 @@ impl Interpreter {
                     }
                     // Try alt followed by more +(a|b)rest
                     // We need to try consuming `alt` prefix then matching +(...)rest again
-                    for split in 1..=value.len() {
+                    for split in split_points.clone() {
                         let prefix = &value[..split];
                         let suffix = &value[split..];
                         if self.glob_match_impl(prefix, alt, nocase, depth + 1) {
@@ -382,13 +387,18 @@ impl Interpreter {
                 if self.glob_match_impl(value, rest, nocase, depth + 1) {
                     return true;
                 }
+                let split_points = value
+                    .char_indices()
+                    .map(|(i, _)| i)
+                    .skip(1)
+                    .chain(std::iter::once(value.len()));
                 // Try one or more (same as +(...))
                 for alt in alts {
                     let full = format!("{}{}", alt, rest);
                     if self.glob_match_impl(value, &full, nocase, depth + 1) {
                         return true;
                     }
-                    for split in 1..=value.len() {
+                    for split in split_points.clone() {
                         let prefix = &value[..split];
                         let suffix = &value[split..];
                         if self.glob_match_impl(prefix, alt, nocase, depth + 1) {
@@ -412,7 +422,12 @@ impl Interpreter {
                     && self.glob_match_impl(value, rest, nocase, depth + 1)
                     || {
                         // !(pat) can also consume characters — try each split
-                        for split in 1..=value.len() {
+                        for split in value
+                            .char_indices()
+                            .map(|(i, _)| i)
+                            .skip(1)
+                            .chain(std::iter::once(value.len()))
+                        {
                             let prefix = &value[..split];
                             let suffix = &value[split..];
                             // prefix must not match any alt

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -11085,6 +11085,15 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extglob_utf8_no_panic() {
+        let result =
+            run_script(r#"shopt -s extglob; v="é"; [[ "$v" == +(a) ]] && echo yes || echo no"#)
+                .await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "no");
+    }
+
+    #[tokio::test]
     async fn test_extglob_no_hang() {
         use std::time::{Duration, Instant};
         let start = Instant::now();

--- a/crates/bashkit/tests/spec_cases/bash/extglob.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/extglob.test.sh
@@ -116,3 +116,12 @@ case "@(foo)" in '@(foo)') echo "literal";; *) echo "no";; esac
 ### expect
 literal
 ### end
+
+### extglob_plus_utf8_no_panic
+# Regression: non-ASCII value must not panic while backtracking +(...)
+shopt -s extglob
+v="é"
+[[ "$v" == +(a) ]] && echo "yes" || echo "no"
+### expect
+no
+### end


### PR DESCRIPTION
### Motivation
- Extglob backtracking used byte-index slicing (`&value[..split]` with `value.len()`), which can slice inside a UTF-8 codepoint and panic on non-ASCII input, allowing untrusted scripts to cause a DoS.
- The fix ensures extglob backtracking only splits on valid UTF-8 character boundaries so multibyte values (e.g. `"é"`) cannot trigger a panic.

### Description
- Replace byte-index split loops in `crates/bashkit/src/interpreter/glob.rs` for the `+`, `*`, and `!` extglob cases to iterate split points from `value.char_indices()` (character boundaries) and include `value.len()` as the final split point, avoiding invalid slices while preserving behavior.
- Add a regression unit test `test_extglob_utf8_no_panic` in `crates/bashkit/src/interpreter/mod.rs` that runs `shopt -s extglob; v="é"; [[ "$v" == +(a) ]]` and asserts no panic and expected `no` result.
- Add a spec-case regression `extglob_plus_utf8_no_panic` in `crates/bashkit/tests/spec_cases/bash/extglob.test.sh` covering the same UTF-8 scenario.
- Run `cargo fmt` on modified files.

### Testing
- Ran `cargo test -p bashkit test_extglob_utf8_no_panic -- --nocapture`; the new unit test passed after the fix (it failed with a char-boundary panic before the change).
- Ran `cargo test -p bashkit test_extglob_no_hang -- --nocapture`; the existing extglob performance test passed.
- Ran `cargo fmt --all` to format changes; formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9adae52c0832ba25d3056feddeedb)