### PR TITLE
fix(builtins): cap dirstack size from shell vars

### DIFF
--- a/crates/bashkit/src/builtins/dirstack.rs
+++ b/crates/bashkit/src/builtins/dirstack.rs
@@ -9,10 +9,14 @@ use super::{Builtin, Context};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
+// Security decision: bound mutable `_DIRSTACK_SIZE` to avoid unbounded builtin loops.
+const MAX_DIRSTACK_SIZE: usize = 4096;
+
 fn get_stack_size(ctx: &Context<'_>) -> usize {
     ctx.variables
         .get("_DIRSTACK_SIZE")
         .and_then(|s| s.parse().ok())
+        .map(|size: usize| size.min(MAX_DIRSTACK_SIZE))
         .unwrap_or(0)
 }
 
@@ -456,6 +460,20 @@ mod tests {
         // Verbose format has numbered entries
         assert!(result.stdout.contains(" 0  "));
         assert!(result.stdout.contains(" 1  "));
+    }
+
+    #[tokio::test]
+    async fn dirs_limits_user_declared_size() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let env = HashMap::new();
+        variables.insert("_DIRSTACK_SIZE".to_string(), "999999999999".to_string());
+        variables.insert("_DIRSTACK_0".to_string(), "/tmp".to_string());
+
+        let args = vec!["-p".to_string()];
+        let ctx = Context::new_for_test(&args, &env, &mut variables, &mut cwd, fs.clone(), None);
+        let result = Dirs.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "/home/user\n/tmp\n");
     }
 
     fn get_stack_size_from_vars(vars: &HashMap<String, String>) -> usize {


### PR DESCRIPTION
### Motivation
- The dirstack builtins read the stack size from the mutable shell variable `_DIRSTACK_SIZE` without validation, which can be set by scripts and used to drive unbounded loops causing CPU/memory exhaustion (DoS). 
- Prevent attacker-controlled values from forcing O(size) work inside a single builtin call.

### Description
- Add `MAX_DIRSTACK_SIZE` (`4096`) and clamp parsed `_DIRSTACK_SIZE` reads via `get_stack_size` so loops use `size.min(MAX_DIRSTACK_SIZE)` instead of an unbounded value in `crates/bashkit/src/builtins/dirstack.rs`.
- Preserve existing behavior for normal sizes while bounding maliciously large values to a safe limit.
- Add a regression test `dirs_limits_user_declared_size` that sets a huge `_DIRSTACK_SIZE` and verifies `dirs -p` output remains bounded and correct.

### Testing
- Ran `cargo test -p bashkit dirstack::tests::dirs_limits_user_declared_size` and the new test passed (`ok`).
- Ran `cargo test -p bashkit dirstack::tests::` (module tests) and relevant dirstack tests passed; the test suite executed successfully for the focused targets.
- Note: could not rebase onto `origin/main` in this environment because no `origin` remote is configured, but changes were unit-tested locally against the crate tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a974004c832b9fb9406080e803c7)