### PR TITLE
fix(builtins): cap yes output to prevent memory exhaustion

### DIFF
--- a/crates/bashkit/src/builtins/yes.rs
+++ b/crates/bashkit/src/builtins/yes.rs
@@ -16,6 +16,35 @@ pub struct Yes;
 
 /// Maximum number of lines to output (safety limit)
 const MAX_LINES: usize = 10_000;
+/// Maximum stdout bytes produced by yes.
+/// THREAT[TM-DOS-059]: Bound repeated output to prevent memory exhaustion.
+const MAX_OUTPUT_BYTES: usize = 1_048_576;
+
+fn truncate_to_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+fn build_yes_output(text: &str) -> String {
+    let max_text_bytes = MAX_OUTPUT_BYTES.saturating_sub(1);
+    let line_text = truncate_to_char_boundary(text, max_text_bytes);
+    let bytes_per_line = line_text.len() + 1; // newline
+    let max_lines_by_bytes = (MAX_OUTPUT_BYTES / bytes_per_line).max(1);
+    let line_count = MAX_LINES.min(max_lines_by_bytes);
+
+    let mut output = String::with_capacity(bytes_per_line * line_count);
+    for _ in 0..line_count {
+        output.push_str(line_text);
+        output.push('\n');
+    }
+    output
+}
 
 #[async_trait]
 impl Builtin for Yes {
@@ -33,12 +62,25 @@ impl Builtin for Yes {
             ctx.args.join(" ")
         };
 
-        let mut output = String::new();
-        for _ in 0..MAX_LINES {
-            output.push_str(&text);
-            output.push('\n');
-        }
+        Ok(ExecResult::ok(build_yes_output(&text)))
+    }
+}
 
-        Ok(ExecResult::ok(output))
+#[cfg(test)]
+mod tests {
+    use super::{MAX_OUTPUT_BYTES, build_yes_output};
+
+    #[test]
+    fn yes_output_is_bounded_for_large_input() {
+        let huge = "a".repeat(MAX_OUTPUT_BYTES * 2);
+        let out = build_yes_output(&huge);
+        assert!(out.len() <= MAX_OUTPUT_BYTES);
+        assert_eq!(out.lines().count(), 1);
+    }
+
+    #[test]
+    fn yes_output_stays_at_existing_line_limit_for_small_input() {
+        let out = build_yes_output("y");
+        assert_eq!(out.lines().count(), 10_000);
     }
 }


### PR DESCRIPTION
### Motivation
- The `yes` builtin previously concatenated user-controlled input into a single in-memory string repeated up to 10,000 times, enabling memory-exhaustion DoS for large arguments.
- Apply a safe output bound while preserving normal behavior for typical inputs.

### Description
- Add a hard stdout byte cap `MAX_OUTPUT_BYTES = 1_048_576` to bound total output size to ~1 MiB.
- Add `truncate_to_char_boundary` to safely truncate oversized input at UTF-8 character boundaries before repetition.
- Compute `bytes_per_line` and limit the number of repeated lines to `min(MAX_LINES, max_lines_by_bytes)` and replace the previous unbounded loop with `build_yes_output`.
- Add unit tests verifying large-input output is capped and small-input behavior still emits 10,000 lines.

### Testing
- Ran the crate unit tests targeting the new helpers; both new tests passed (`yes_output_is_bounded_for_large_input`, `yes_output_stays_at_existing_line_limit_for_small_input`).
- Ran `cargo fmt --all` to ensure formatting compliance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9735f14832bb8401455d69439ef)