### PR TITLE
fix(interpreter): prevent recursive ERR trap reentry

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -9646,6 +9646,11 @@ impl Interpreter {
     }
 
     async fn run_err_trap(&mut self, stdout: &mut String, stderr: &mut String) {
+        // THREAT[TM-DOS-035]: Suppress ERR trap re-entrancy while executing trap
+        // handlers to prevent recursive ERR -> ERR amplification.
+        if self.in_trap {
+            return;
+        }
         if let Some(trap_cmd) = self.traps.get("ERR").cloned() {
             // THREAT[TM-DOS-030]: Propagate interpreter parser limits
             if let Ok(trap_script) = Parser::with_limits(

--- a/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
@@ -304,6 +304,13 @@ trap 'echo ERR' ERR; true; echo ok
 ok
 ### end
 
+### trap_err_non_recursive
+# ERR trap failures must not recursively retrigger ERR
+trap 'false; false' ERR; false; echo after
+### expect
+after
+### end
+
 ### trap_multiple
 # Multiple traps can coexist
 trap 'echo BYE' EXIT; trap 'echo ERR' ERR; false; echo done


### PR DESCRIPTION
### Motivation
- Prevent an ERR-trap re-entrancy DoS where a failing `ERR` trap body (for example a semicolon list like `false; false`) can re-trigger `run_err_trap` recursively until stack/limits are exhausted.
- Ensure trap handlers execute but do not amplify ERR handling by re-entering the trap machinery.

### Description
- Add a re-entrancy guard in `run_err_trap` by returning early when `self.in_trap` is already set to suppress ERR -> ERR recursion (`if self.in_trap { return; }`).
- Preserve existing behavior of capturing and emitting trap output by keeping the `self.in_trap = true/false` window around `execute_command_sequence`.
- Add a regression spec `trap_err_non_recursive` to `crates/bashkit/tests/spec_cases/bash/control-flow.test.sh` that verifies a failing `ERR` trap body does not recursively retrigger ERR and execution continues.

### Testing
- Ran `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture` and the bash spec tests passed (no failures reported).
- Ran `cargo test -p bashkit --test spec_runner -- --list` and `cargo test -p bashkit --test spec_tests -- --list` as smoke checks and both completed successfully.
- Ran `cargo test -p bashkit trap_err -- --nocapture` as a compile/smoke invocation which completed successfully (no matching tests filtered, acted as build/smoke pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9728a88832bbcf13c75e8ab8893)