### PR TITLE
fix(timeout): prevent panic on oversized duration values

### DIFF
--- a/crates/bashkit/src/builtins/timeout.rs
+++ b/crates/bashkit/src/builtins/timeout.rs
@@ -64,11 +64,22 @@ pub(crate) fn parse_duration(s: &str) -> Option<Duration> {
         return None;
     }
 
-    let total_secs_f64 = seconds * multiplier as f64;
-    // Cap at max while preserving subsecond precision
     let max = Duration::from_secs(MAX_TIMEOUT_SECONDS);
-    let d = Duration::from_secs_f64(total_secs_f64);
-    Some(if d > max { max } else { d })
+    if !seconds.is_finite() {
+        return if seconds.is_sign_positive() {
+            Some(max)
+        } else {
+            None
+        };
+    }
+
+    let total_secs_f64 = seconds * multiplier as f64;
+    // Cap at max while preserving subsecond precision.
+    if !total_secs_f64.is_finite() || total_secs_f64 >= max.as_secs_f64() {
+        return Some(max);
+    }
+
+    Some(Duration::from_secs_f64(total_secs_f64))
 }
 
 /// Parse timeout arguments, returning (preserve_status, duration, cmd_name, cmd_args)
@@ -279,6 +290,14 @@ mod tests {
         assert_eq!(parse_duration(""), None);
         assert_eq!(parse_duration("abc"), None);
         assert_eq!(parse_duration("-5"), None);
+    }
+
+    #[test]
+    fn test_parse_duration_huge_value_caps_without_panic() {
+        assert_eq!(
+            parse_duration("1e309"),
+            Some(Duration::from_secs(MAX_TIMEOUT_SECONDS))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `parse_duration` previously called `Duration::from_secs_f64` on unbounded user-controlled floats which can panic on non-finite/overflowed values and allow a DoS before the later cap is applied.

### Description
- Validate parsed `seconds` with `is_finite()` and return `None` for negative/invalid inputs or cap positive non-finite values to `MAX_TIMEOUT_SECONDS`.
- Compute `total_secs_f64` and return `MAX_TIMEOUT_SECONDS` when the product is non-finite or >= `max.as_secs_f64()` to avoid calling `Duration::from_secs_f64` on dangerous values.
- Only call `Duration::from_secs_f64` after finite, bounded checks so no panic path remains from attacker-supplied input.
- Add regression test `test_parse_duration_huge_value_caps_without_panic` that asserts `parse_duration("1e309")` yields `Some(Duration::from_secs(MAX_TIMEOUT_SECONDS))`.

### Testing
- Added unit test `builtins::timeout::tests::test_parse_duration_huge_value_caps_without_panic` to cover huge numeric input handling.
- Attempted to run `cargo test -p bashkit builtins::timeout::tests::test_parse_duration_huge_value_caps_without_panic -- --exact` in this environment but the run was blocked by a persistent Cargo package-cache lock (and intermittent missing `cargo` in PATH), so the targeted test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a973de5c832b829e1bc3a89f2f38)