### PR TITLE
fix(interpreter): restore call-stack and counters after timeout cancellation

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6232,11 +6232,17 @@ impl Interpreter {
                     span: Span::new(),
                 });
 
+                let baseline_call_stack_len = self.call_stack.len();
+                let baseline_bash_source_len = self.bash_source_stack.len();
                 let exec_future = self.execute_command(&inner_cmd);
                 match timeout(duration, exec_future).await {
                     Ok(Ok(result)) => result,
                     Ok(Err(e)) => return Err(e),
                     Err(_) => {
+                        self.reconcile_cancelled_execution_state(
+                            baseline_call_stack_len,
+                            baseline_bash_source_len,
+                        );
                         // Timeout expired.
                         // --preserve-status: in real bash, returns the signal+128 status
                         // of the killed child.  We can't capture that from tokio::timeout,
@@ -6289,6 +6295,47 @@ impl Interpreter {
         };
 
         self.apply_redirections(result, redirects).await
+    }
+
+    /// Restore interpreter stacks/counters after an in-flight command future is cancelled.
+    fn reconcile_cancelled_execution_state(
+        &mut self,
+        baseline_call_stack_len: usize,
+        baseline_bash_source_len: usize,
+    ) {
+        let leaked_call_frames = self
+            .call_stack
+            .len()
+            .saturating_sub(baseline_call_stack_len);
+        let leaked_bash_source_entries = self
+            .bash_source_stack
+            .len()
+            .saturating_sub(baseline_bash_source_len);
+
+        if leaked_call_frames > 0 {
+            self.call_stack.truncate(baseline_call_stack_len);
+        }
+        if leaked_bash_source_entries > 0 {
+            self.bash_source_stack.truncate(baseline_bash_source_len);
+            self.update_bash_source();
+        }
+
+        for _ in 0..leaked_call_frames.max(leaked_bash_source_entries) {
+            self.counters.pop_function();
+        }
+
+        if self.call_stack.is_empty() {
+            self.arrays.remove("FUNCNAME");
+        } else {
+            let funcname_arr: HashMap<usize, String> = self
+                .call_stack
+                .iter()
+                .rev()
+                .enumerate()
+                .map(|(i, f)| (i, f.name.clone()))
+                .collect();
+            self.arrays.insert("FUNCNAME".to_string(), funcname_arr);
+        }
     }
 
     /// Process structured side effects from builtin execution.
@@ -9869,6 +9916,17 @@ mod tests {
             "124",
             "Expected exit code 124 for zero timeout"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_does_not_leak_function_locals() {
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mut interp = Interpreter::new(Arc::clone(&fs));
+        let parser =
+            Parser::new("f(){ local secret=shh; sleep 10; }\ntimeout 0.001 f\necho \"<$secret>\"");
+        let ast = parser.parse().unwrap();
+        let result = interp.execute(&ast).await.unwrap();
+        assert_eq!(result.stdout.trim(), "<>");
     }
 
     /// Test that parse_duration preserves subsecond precision


### PR DESCRIPTION
### Motivation

- Prevent leaked function locals and corrupted interpreter state when an execution wrapped by `tokio::time::timeout` is cancelled and its inner future is dropped.
- Ensure timeouts do not leave call frames, BASH_SOURCE entries, or function-depth counters dangling, which could expose `local` variables after timeout.

### Description

- Capture baseline lengths of `call_stack` and `bash_source_stack` before running the timeout-wrapped command plan and call `execute_command` as a future under `timeout`.
- Add `reconcile_cancelled_execution_state(baseline_call_stack_len, baseline_bash_source_len)` that truncates leaked call frames and bash-source entries, updates `FUNCNAME`, calls `counters.pop_function()` to rebalance depth counters, and updates BASH_SOURCE via `update_bash_source()`.
- Invoke the reconciler on timeout expiry before returning the timeout `ExecResult`.
- Add regression test `test_timeout_does_not_leak_function_locals` which times out a function that sets a `local` and asserts the local is not visible after timeout.

### Testing

- Ran `cargo fmt --check` and fixed formatting issues; the check passed after changes.
- Ran `cargo test -p bashkit test_timeout_does_not_leak_function_locals -- --nocapture` and the test passed.
- Ran `cargo test -p bashkit test_timeout_expires_deterministically -- --nocapture` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9737308832bb56180567482dba9)