### PR TITLE
fix(sed): avoid Unicode panic in command splitting

### DIFF
--- a/crates/bashkit/src/builtins/sed.rs
+++ b/crates/bashkit/src/builtins/sed.rs
@@ -323,9 +323,9 @@ fn split_sed_commands(s: &str) -> Vec<&str> {
     let mut delim: Option<char> = None;
     let mut escaped = false;
     let mut brace_depth = 0;
-    let chars: Vec<char> = s.chars().collect();
+    let chars: Vec<(usize, char)> = s.char_indices().collect();
 
-    for (i, &c) in chars.iter().enumerate() {
+    for (idx, &(byte_pos, c)) in chars.iter().enumerate() {
         if escaped {
             escaped = false;
             continue;
@@ -336,10 +336,10 @@ fn split_sed_commands(s: &str) -> Vec<&str> {
             continue;
         }
 
-        if !in_subst && c == 's' && i + 1 < chars.len() {
+        if !in_subst && c == 's' && idx + 1 < chars.len() {
             // Start of substitution command
             in_subst = true;
-            delim = Some(chars[i + 1]);
+            delim = Some(chars[idx + 1].1);
             delim_count = 0;
         } else if in_subst {
             if Some(c) == delim {
@@ -354,8 +354,8 @@ fn split_sed_commands(s: &str) -> Vec<&str> {
         } else if c == '}' {
             brace_depth -= 1;
         } else if c == ';' && brace_depth == 0 {
-            result.push(&s[start..i]);
-            start = i + 1;
+            result.push(&s[start..byte_pos]);
+            start = byte_pos + c.len_utf8();
         }
     }
 
@@ -1219,6 +1219,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.stdout, "hi there\n");
+    }
+
+    #[tokio::test]
+    async fn test_sed_multiple_commands_with_unicode_delimiter_split() {
+        let result = run_sed(&["s/café/coffee/; s/latte/milk/"], Some("café latte"))
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "coffee milk\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `split_sed_commands` iterated by characters and used character indices to slice the original `&str`, which can produce out-of-bound or invalid UTF-8 slices when multibyte characters precede a `;`, allowing attacker-controlled sed scripts to panic the process (DoS).
- The change prevents this unsafe UTF-8 slicing while preserving existing semicolon-splitting behavior and substitution parsing.

### Description
- Replace character-index iteration with `char_indices()` to obtain stable byte offsets for slicing and keep track of both `byte_pos` and `char` for each iteration. 
- Use byte offsets when creating slices (`&s[start..byte_pos]`) and advance `start` by `byte_pos + c.len_utf8()` to remain UTF-8 safe. 
- Adjust delim detection to use the character value from the `char_indices()` tuple. 
- Add a regression test `test_sed_multiple_commands_with_unicode_delimiter_split` exercising semicolon-separated commands with multibyte text (e.g., `café`).

### Testing
- Ran the new failing test prior to the fix which reproduced the panic (`called Result::unwrap() on Err: Execution("sed: unknown command: ;")`).
- After the fix ran `cargo test -p bashkit test_sed_multiple_commands -- --nocapture` and the relevant sed tests including the new Unicode-regression passed (`test_sed_multiple_commands` and `test_sed_multiple_commands_with_unicode_delimiter_split` both OK).
- The exercised test run finished with the targeted tests passing and no regressions observed for the sed tests exercised by the command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a972c960832ba38b1cb08089e712)