### PR TITLE
fix(limits): close loop and pipeline resource-limit bypasses

### DIFF
--- a/crates/bashkit-js/__test__/security.spec.ts
+++ b/crates/bashkit-js/__test__/security.spec.ts
@@ -79,7 +79,10 @@ test("WB: loop limit — while true capped (TM-DOS-017)", (t) => {
 });
 
 test("WB: nested loop multiplication attack (TM-DOS-018)", (t) => {
-  const bash = new Bash({ maxLoopIterations: 10 });
+  // TM-DOS-018 is enforced via maxTotalLoopIterations (aggregate cap across
+  // nested loops). maxLoopIterations is per-loop and does not by itself stop
+  // the multiplication attack.
+  const bash = new Bash({ maxTotalLoopIterations: 10 });
   // Outer × inner = potential 100 iterations
   const r = bash.executeSync(
     "for i in 1 2 3 4 5 6 7 8 9 10; do for j in 1 2 3 4 5 6 7 8 9 10; do echo $i$j; done; done",

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -36,6 +36,7 @@ export interface BashOptions {
   hostname?: string;
   maxCommands?: number;
   maxLoopIterations?: number;
+  maxTotalLoopIterations?: number;
   /**
    * Maximum interpreter memory in bytes (variables, arrays, functions).
    *
@@ -292,6 +293,7 @@ function toNativeOptions(
     hostname: options?.hostname,
     maxCommands: options?.maxCommands,
     maxLoopIterations: options?.maxLoopIterations,
+    maxTotalLoopIterations: options?.maxTotalLoopIterations,
     maxMemory: options?.maxMemory,
     timeoutMs: options?.timeoutMs,
     files: resolvedFiles,

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2027,29 +2027,32 @@ impl Interpreter {
                 .unwrap_or_default()
         };
 
-        // Reset loop counter for this loop
-        self.counters.reset_loop();
+        self.counters.enter_loop();
+        let result = async {
+            for value in values {
+                // Check loop iteration limit
+                self.counters.tick_loop(&self.limits)?;
 
-        for value in values {
-            // Check loop iteration limit
-            self.counters.tick_loop(&self.limits)?;
+                // Set loop variable (respects nameref)
+                self.set_variable(for_cmd.variable.clone(), value.clone());
 
-            // Set loop variable (respects nameref)
-            self.set_variable(for_cmd.variable.clone(), value.clone());
-
-            // Execute body
-            let emit_before = self.output_emit_count;
-            let result = self.execute_command_sequence(&for_cmd.body).await?;
-            self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-            match acc.accumulate(result) {
-                state::LoopAction::None => {}
-                state::LoopAction::Break => break,
-                state::LoopAction::Continue => continue,
-                state::LoopAction::Exit(r) => return Ok(r),
+                // Execute body
+                let emit_before = self.output_emit_count;
+                let result = self.execute_command_sequence(&for_cmd.body).await?;
+                self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                match acc.accumulate(result) {
+                    state::LoopAction::None => {}
+                    state::LoopAction::Break => break,
+                    state::LoopAction::Continue => continue,
+                    state::LoopAction::Exit(r) => return Ok(r),
+                }
             }
-        }
 
-        Ok(acc.finish())
+            Ok(acc.finish())
+        }
+        .await;
+        self.counters.exit_loop();
+        result
     }
 
     /// Execute a select loop: select var in list; do body; done
@@ -2112,125 +2115,128 @@ impl Interpreter {
             .cloned()
             .unwrap_or_else(|| "#? ".to_string());
 
-        // Reset loop counter
-        self.counters.reset_loop();
+        self.counters.enter_loop();
+        let result = async {
+            loop {
+                self.counters.tick_loop(&self.limits)?;
 
-        loop {
-            self.counters.tick_loop(&self.limits)?;
+                // Output menu to stderr
+                stderr.push_str(&menu);
+                stderr.push('\n');
+                stderr.push_str(&ps3);
 
-            // Output menu to stderr
-            stderr.push_str(&menu);
-            stderr.push('\n');
-            stderr.push_str(&ps3);
-
-            // Read a line from pipeline_stdin
-            let line = if let Some(ref ps) = self.pipeline_stdin {
-                if ps.is_empty() {
-                    // EOF: bash prints newline and exits with code 1
+                // Read a line from pipeline_stdin
+                let line = if let Some(ref ps) = self.pipeline_stdin {
+                    if ps.is_empty() {
+                        // EOF: bash prints newline and exits with code 1
+                        stdout.push('\n');
+                        exit_code = 1;
+                        break;
+                    }
+                    let data = ps.clone();
+                    if let Some(newline_pos) = data.find('\n') {
+                        let line = data[..newline_pos].to_string();
+                        self.pipeline_stdin = Some(data[newline_pos + 1..].to_string());
+                        line
+                    } else {
+                        self.pipeline_stdin = Some(String::new());
+                        data
+                    }
+                } else {
+                    // No stdin: bash prints newline and exits with code 1
                     stdout.push('\n');
                     exit_code = 1;
                     break;
-                }
-                let data = ps.clone();
-                if let Some(newline_pos) = data.find('\n') {
-                    let line = data[..newline_pos].to_string();
-                    self.pipeline_stdin = Some(data[newline_pos + 1..].to_string());
-                    line
-                } else {
-                    self.pipeline_stdin = Some(String::new());
-                    data
-                }
-            } else {
-                // No stdin: bash prints newline and exits with code 1
-                stdout.push('\n');
-                exit_code = 1;
-                break;
-            };
+                };
 
-            // Set REPLY to raw input
-            self.insert_variable_checked("REPLY".to_string(), line.clone());
+                // Set REPLY to raw input
+                self.insert_variable_checked("REPLY".to_string(), line.clone());
 
-            // Parse selection number
-            let selected = line
-                .trim()
-                .parse::<usize>()
-                .ok()
-                .and_then(|n| {
-                    if n >= 1 && n <= values.len() {
-                        Some(values[n - 1].clone())
-                    } else {
-                        None
+                // Parse selection number
+                let selected = line
+                    .trim()
+                    .parse::<usize>()
+                    .ok()
+                    .and_then(|n| {
+                        if n >= 1 && n <= values.len() {
+                            Some(values[n - 1].clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_default();
+
+                self.insert_variable_checked(select_cmd.variable.clone(), selected);
+
+                // Execute body
+                let emit_before = self.output_emit_count;
+                let result = self.execute_command_sequence(&select_cmd.body).await?;
+                self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                stdout.push_str(&result.stdout);
+                stderr.push_str(&result.stderr);
+                exit_code = result.exit_code;
+
+                // Check for break/continue
+                match result.control_flow {
+                    ControlFlow::Break(n) => {
+                        if n <= 1 {
+                            break;
+                        } else {
+                            return Ok(ExecResult {
+                                stdout,
+                                stderr,
+                                exit_code,
+                                control_flow: ControlFlow::Break(n - 1),
+                                ..Default::default()
+                            });
+                        }
                     }
-                })
-                .unwrap_or_default();
-
-            self.insert_variable_checked(select_cmd.variable.clone(), selected);
-
-            // Execute body
-            let emit_before = self.output_emit_count;
-            let result = self.execute_command_sequence(&select_cmd.body).await?;
-            self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-            stdout.push_str(&result.stdout);
-            stderr.push_str(&result.stderr);
-            exit_code = result.exit_code;
-
-            // Check for break/continue
-            match result.control_flow {
-                ControlFlow::Break(n) => {
-                    if n <= 1 {
-                        break;
-                    } else {
+                    ControlFlow::Continue(n) => {
+                        if n <= 1 {
+                            continue;
+                        } else {
+                            return Ok(ExecResult {
+                                stdout,
+                                stderr,
+                                exit_code,
+                                control_flow: ControlFlow::Continue(n - 1),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                    ControlFlow::Return(code) => {
                         return Ok(ExecResult {
                             stdout,
                             stderr,
-                            exit_code,
-                            control_flow: ControlFlow::Break(n - 1),
+                            exit_code: code,
+                            control_flow: ControlFlow::Return(code),
                             ..Default::default()
                         });
                     }
-                }
-                ControlFlow::Continue(n) => {
-                    if n <= 1 {
-                        continue;
-                    } else {
+                    ControlFlow::Exit(code) => {
                         return Ok(ExecResult {
                             stdout,
                             stderr,
-                            exit_code,
-                            control_flow: ControlFlow::Continue(n - 1),
+                            exit_code: code,
+                            control_flow: ControlFlow::Exit(code),
                             ..Default::default()
                         });
                     }
+                    ControlFlow::None => {}
                 }
-                ControlFlow::Return(code) => {
-                    return Ok(ExecResult {
-                        stdout,
-                        stderr,
-                        exit_code: code,
-                        control_flow: ControlFlow::Return(code),
-                        ..Default::default()
-                    });
-                }
-                ControlFlow::Exit(code) => {
-                    return Ok(ExecResult {
-                        stdout,
-                        stderr,
-                        exit_code: code,
-                        control_flow: ControlFlow::Exit(code),
-                        ..Default::default()
-                    });
-                }
-                ControlFlow::None => {}
             }
-        }
 
-        Ok(ExecResult {
-            stdout,
-            stderr,
-            exit_code,
-            control_flow: ControlFlow::None,
-            ..Default::default()
-        })
+            Ok(ExecResult {
+                stdout,
+                stderr,
+                exit_code,
+                control_flow: ControlFlow::None,
+                ..Default::default()
+            })
+        }
+        .await;
+        self.counters.exit_loop();
+        result
     }
 
     /// Execute a C-style arithmetic for loop: for ((init; cond; step))
@@ -2245,38 +2251,41 @@ impl Interpreter {
             self.execute_arithmetic_with_side_effects(&arith_for.init);
         }
 
-        // Reset loop counter for this loop
-        self.counters.reset_loop();
+        self.counters.enter_loop();
+        let result = async {
+            loop {
+                // Check loop iteration limit
+                self.counters.tick_loop(&self.limits)?;
 
-        loop {
-            // Check loop iteration limit
-            self.counters.tick_loop(&self.limits)?;
+                // Check condition (if empty, always true)
+                if !arith_for.condition.is_empty() {
+                    let cond_result = self.evaluate_arithmetic(&arith_for.condition);
+                    if cond_result == 0 {
+                        break;
+                    }
+                }
 
-            // Check condition (if empty, always true)
-            if !arith_for.condition.is_empty() {
-                let cond_result = self.evaluate_arithmetic(&arith_for.condition);
-                if cond_result == 0 {
-                    break;
+                // Execute body
+                let emit_before = self.output_emit_count;
+                let result = self.execute_command_sequence(&arith_for.body).await?;
+                self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                match acc.accumulate(result) {
+                    state::LoopAction::None | state::LoopAction::Continue => {}
+                    state::LoopAction::Break => break,
+                    state::LoopAction::Exit(r) => return Ok(r),
+                }
+
+                // Execute step
+                if !arith_for.step.is_empty() {
+                    self.execute_arithmetic_with_side_effects(&arith_for.step);
                 }
             }
 
-            // Execute body
-            let emit_before = self.output_emit_count;
-            let result = self.execute_command_sequence(&arith_for.body).await?;
-            self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-            match acc.accumulate(result) {
-                state::LoopAction::None | state::LoopAction::Continue => {}
-                state::LoopAction::Break => break,
-                state::LoopAction::Exit(r) => return Ok(r),
-            }
-
-            // Execute step
-            if !arith_for.step.is_empty() {
-                self.execute_arithmetic_with_side_effects(&arith_for.step);
-            }
+            Ok(acc.finish())
         }
-
-        Ok(acc.finish())
+        .await;
+        self.counters.exit_loop();
+        result
     }
 
     /// Execute an arithmetic command ((expression))
@@ -2728,46 +2737,49 @@ impl Interpreter {
     ) -> Result<ExecResult> {
         let mut acc = state::LoopAccumulator::new();
 
-        // Reset loop counter for this loop
-        self.counters.reset_loop();
+        self.counters.enter_loop();
+        let result = async {
+            loop {
+                // Check loop iteration limit
+                self.counters.tick_loop(&self.limits)?;
 
-        loop {
-            // Check loop iteration limit
-            self.counters.tick_loop(&self.limits)?;
+                // Check condition (no errexit - conditions are expected to fail)
+                let emit_before_cond = self.output_emit_count;
+                let condition_result = self.execute_condition_sequence(condition).await?;
+                // Condition commands produce visible output (e.g., `while cat <<EOF; do ... done`)
+                self.maybe_emit_output(
+                    &condition_result.stdout,
+                    &condition_result.stderr,
+                    emit_before_cond,
+                );
+                acc.stdout.push_str(&condition_result.stdout);
+                acc.stderr.push_str(&condition_result.stderr);
+                let should_break = if break_on_zero {
+                    condition_result.exit_code == 0
+                } else {
+                    condition_result.exit_code != 0
+                };
+                if should_break {
+                    break;
+                }
 
-            // Check condition (no errexit - conditions are expected to fail)
-            let emit_before_cond = self.output_emit_count;
-            let condition_result = self.execute_condition_sequence(condition).await?;
-            // Condition commands produce visible output (e.g., `while cat <<EOF; do ... done`)
-            self.maybe_emit_output(
-                &condition_result.stdout,
-                &condition_result.stderr,
-                emit_before_cond,
-            );
-            acc.stdout.push_str(&condition_result.stdout);
-            acc.stderr.push_str(&condition_result.stderr);
-            let should_break = if break_on_zero {
-                condition_result.exit_code == 0
-            } else {
-                condition_result.exit_code != 0
-            };
-            if should_break {
-                break;
+                // Execute body
+                let emit_before = self.output_emit_count;
+                let result = self.execute_command_sequence(body).await?;
+                self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                match acc.accumulate(result) {
+                    state::LoopAction::None => {}
+                    state::LoopAction::Break => break,
+                    state::LoopAction::Continue => continue,
+                    state::LoopAction::Exit(r) => return Ok(r),
+                }
             }
 
-            // Execute body
-            let emit_before = self.output_emit_count;
-            let result = self.execute_command_sequence(body).await?;
-            self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-            match acc.accumulate(result) {
-                state::LoopAction::None => {}
-                state::LoopAction::Break => break,
-                state::LoopAction::Continue => continue,
-                state::LoopAction::Exit(r) => return Ok(r),
-            }
+            Ok(acc.finish())
         }
-
-        Ok(acc.finish())
+        .await;
+        self.counters.exit_loop();
+        result
     }
 
     /// Execute a case statement
@@ -3453,6 +3465,7 @@ impl Interpreter {
 
             let result = match command {
                 Command::Simple(simple) => {
+                    self.counters.tick_command(&self.limits)?;
                     self.execute_simple_command(simple, stdin_data.take())
                         .await?
                 }
@@ -9964,6 +9977,38 @@ mod tests {
         let result = run_script_with_limits(&script, limits, memory_limits).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout.trim(), "4");
+    }
+
+    #[tokio::test]
+    async fn test_nested_loops_enforce_outer_loop_limit() {
+        let limits = ExecutionLimits::new()
+            .max_loop_iterations(2)
+            .max_total_loop_iterations(100);
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mut interp = Interpreter::new(Arc::clone(&fs));
+        interp.set_limits(limits);
+        let parser = Parser::new("for i in 1 2 3; do for j in 1; do :; done; done; echo done");
+        let ast = parser.parse().unwrap();
+        let err = interp.execute(&ast).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::ResourceLimit(crate::limits::LimitExceeded::MaxLoopIterations(2))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_counts_each_stage_toward_command_limit() {
+        let limits = ExecutionLimits::new().max_commands(2);
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mut interp = Interpreter::new(Arc::clone(&fs));
+        interp.set_limits(limits);
+        let parser = Parser::new("echo a | cat | cat");
+        let ast = parser.parse().unwrap();
+        let err = interp.execute(&ast).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::ResourceLimit(crate::limits::LimitExceeded::MaxCommands(2))
+        ));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -432,12 +432,16 @@ impl ExecutionCounters {
             match action.as_deref() {
                 Some("skip_check") => {
                     // Simulate limit check being bypassed
-                    self.loop_iterations += 1;
+                    if let Some(current) = self.loop_iterations.last_mut() {
+                        *current += 1;
+                    }
                     return Ok(());
                 }
                 Some("reset_counter") => {
                     // Simulate counter being reset (infinite loop potential)
-                    self.loop_iterations = 0;
+                    if let Some(current) = self.loop_iterations.last_mut() {
+                        *current = 0;
+                    }
                     return Ok(());
                 }
                 _ => {}

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -330,8 +330,8 @@ pub struct ExecutionCounters {
     /// Current function call depth
     pub function_depth: usize,
 
-    /// Number of iterations in current loop (reset per-loop)
-    pub loop_iterations: usize,
+    /// Per-loop iteration counters by nesting depth (top = current loop)
+    pub loop_iterations: Vec<usize>,
 
     // THREAT[TM-DOS-018]: Nested loop multiplication
     // This counter never resets, tracking total iterations across all loops.
@@ -361,7 +361,7 @@ impl ExecutionCounters {
     /// This prevents a prior exec() from permanently poisoning the session.
     pub fn reset_for_execution(&mut self) {
         self.commands = 0;
-        self.loop_iterations = 0;
+        self.loop_iterations.clear();
         self.total_loop_iterations = 0;
         // function_depth and subst_depth should already be 0 between exec() calls,
         // but reset defensively to avoid stuck state
@@ -445,9 +445,17 @@ impl ExecutionCounters {
             Ok(())
         });
 
-        self.loop_iterations += 1;
+        if self.loop_iterations.is_empty() {
+            // Defensive fallback for direct tick_loop() calls outside loop helpers.
+            self.loop_iterations.push(0);
+        }
+        let current = self
+            .loop_iterations
+            .last_mut()
+            .expect("loop stack initialized above");
+        *current += 1;
         self.total_loop_iterations += 1;
-        if self.loop_iterations > limits.max_loop_iterations {
+        if *current > limits.max_loop_iterations {
             return Err(LimitExceeded::MaxLoopIterations(limits.max_loop_iterations));
         }
         // THREAT[TM-DOS-018]: Check global cap to prevent nested loop multiplication
@@ -459,9 +467,14 @@ impl ExecutionCounters {
         Ok(())
     }
 
-    /// Reset loop iteration counter (called when entering a new loop)
-    pub fn reset_loop(&mut self) {
-        self.loop_iterations = 0;
+    /// Enter a new loop scope.
+    pub fn enter_loop(&mut self) {
+        self.loop_iterations.push(0);
+    }
+
+    /// Exit the current loop scope.
+    pub fn exit_loop(&mut self) {
+        self.loop_iterations.pop();
     }
 
     /// Push function call, returns error if depth exceeded
@@ -892,6 +905,7 @@ mod tests {
     fn test_loop_counter() {
         let limits = ExecutionLimits::new().max_loop_iterations(3);
         let mut counters = ExecutionCounters::new();
+        counters.enter_loop();
 
         for _ in 0..3 {
             assert!(counters.tick_loop(&limits).is_ok());
@@ -903,8 +917,9 @@ mod tests {
             Err(LimitExceeded::MaxLoopIterations(3))
         ));
 
-        // Reset and try again
-        counters.reset_loop();
+        // New loop scope should reset current-loop count
+        counters.exit_loop();
+        counters.enter_loop();
         assert!(counters.tick_loop(&limits).is_ok());
     }
 
@@ -914,6 +929,7 @@ mod tests {
             .max_loop_iterations(5)
             .max_total_loop_iterations(8);
         let mut counters = ExecutionCounters::new();
+        counters.enter_loop();
 
         // First loop: 5 iterations (per-loop limit)
         for _ in 0..5 {
@@ -921,9 +937,10 @@ mod tests {
         }
         assert_eq!(counters.total_loop_iterations, 5);
 
-        // Reset per-loop counter (entering new loop)
-        counters.reset_loop();
-        assert_eq!(counters.loop_iterations, 0);
+        // New loop should reset current-loop counter
+        counters.exit_loop();
+        counters.enter_loop();
+        assert_eq!(counters.loop_iterations.last().copied(), Some(0));
         // total_loop_iterations should NOT reset
         assert_eq!(counters.total_loop_iterations, 5);
 
@@ -937,6 +954,26 @@ mod tests {
             counters.tick_loop(&limits),
             Err(LimitExceeded::MaxTotalLoopIterations(8))
         ));
+    }
+
+    #[test]
+    fn test_nested_loops_track_independently() {
+        let limits = ExecutionLimits::new().max_loop_iterations(2);
+        let mut counters = ExecutionCounters::new();
+
+        counters.enter_loop();
+        assert!(counters.tick_loop(&limits).is_ok()); // outer=1
+
+        counters.enter_loop();
+        assert!(counters.tick_loop(&limits).is_ok()); // inner=1
+        assert!(counters.tick_loop(&limits).is_ok()); // inner=2
+        counters.exit_loop();
+
+        assert!(counters.tick_loop(&limits).is_ok()); // outer=2 (still tracked)
+        assert!(matches!(
+            counters.tick_loop(&limits),
+            Err(LimitExceeded::MaxLoopIterations(2))
+        )); // outer=3 -> fail
     }
 
     #[test]
@@ -970,14 +1007,14 @@ mod tests {
         assert!(counters.tick_command(&limits).is_err());
 
         // Also accumulate some loop/function state
-        counters.loop_iterations = 42;
+        counters.loop_iterations = vec![42];
         counters.total_loop_iterations = 999;
         counters.function_depth = 3;
 
         // Reset should restore all counters
         counters.reset_for_execution();
         assert_eq!(counters.commands, 0);
-        assert_eq!(counters.loop_iterations, 0);
+        assert!(counters.loop_iterations.is_empty());
         assert_eq!(counters.total_loop_iterations, 0);
         assert_eq!(counters.function_depth, 0);
 


### PR DESCRIPTION
### Motivation
- Nested loops used a single global loop counter that was reset on entering any loop, allowing inner loops to hide outer-loop iterations and bypass `max_loop_iterations` limits.
- Pipeline stages did not increment the global command counter, so multi-stage pipelines could exceed `max_commands` without being counted.

### Description
- Replace scalar `loop_iterations: usize` with a per-nesting stack `loop_iterations: Vec<usize>` in `ExecutionCounters` and clear it in `reset_for_execution` to avoid cross-exec leakage (`crates/bashkit/src/limits.rs`).
- Add `enter_loop()` and `exit_loop()` APIs and update `tick_loop()` to increment the current nesting slot and also maintain `total_loop_iterations` for global caps (`crates/bashkit/src/limits.rs`).
- Scope loop execution with `enter_loop()`/`exit_loop()` in all loop executors (`for`, `select`, `arithmetic for`, `while`/`until`) so nested loops track independently and early returns/pop control-flow still restore loop stack state (`crates/bashkit/src/interpreter/mod.rs`).
- Count simple pipeline stages toward `max_commands` by calling `tick_command()` for `Command::Simple` stages inside `execute_pipeline()` so each pipeline stage consumes command budget (`crates/bashkit/src/interpreter/mod.rs`).
- Add regression/unit tests for nested-loop isolation, outer-loop enforcement, and pipeline-stage command counting (`crates/bashkit/src/limits.rs` and `crates/bashkit/src/interpreter/mod.rs`).

### Testing
- Ran formatting with `cargo fmt` successfully.
- Ran unit tests covering counters: `test_nested_loops_track_independently` passed.
- Ran interpreter tests: `test_nested_loops_enforce_outer_loop_limit` passed and `test_pipeline_counts_each_stage_toward_command_limit` passed.
- Ran targeted `cargo test -p bashkit` invocations for the modified features and observed the new/updated tests succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9727c00832bb26802ebb0e3e05b)