### PR TITLE
fix(parser): require exact heredoc delimiter match

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1730,8 +1730,16 @@ impl<'a> Lexer<'a> {
         )
     }
 
-    /// Read here document content until the delimiter line is found
+    /// Read here document content until the delimiter line is found.
+    /// When `strip_tabs` is true (for `<<-`), leading tabs on the delimiter line
+    /// are stripped before comparing.
     pub fn read_heredoc(&mut self, delimiter: &str) -> String {
+        self.read_heredoc_with_strip(delimiter, false)
+    }
+
+    /// Read here document content with optional leading-tab stripping on the
+    /// delimiter match (for `<<-`).
+    pub fn read_heredoc_with_strip(&mut self, delimiter: &str, strip_tabs: bool) -> String {
         let mut content = String::new();
         let mut current_line = String::new();
 
@@ -1770,8 +1778,14 @@ impl<'a> Lexer<'a> {
             match self.peek_char() {
                 Some('\n') => {
                     self.advance();
-                    // Check if current line matches delimiter
-                    if current_line == delimiter {
+                    // Check if current line matches delimiter.
+                    // For `<<-`, strip leading tabs from the delimiter line.
+                    let line_for_match: &str = if strip_tabs {
+                        current_line.trim_start_matches('\t')
+                    } else {
+                        &current_line
+                    };
+                    if line_for_match == delimiter {
                         break;
                     }
                     content.push_str(&current_line);
@@ -1783,8 +1797,13 @@ impl<'a> Lexer<'a> {
                     self.advance();
                 }
                 None => {
-                    // End of input - check last line
-                    if current_line == delimiter {
+                    // End of input - check last line (strip tabs for `<<-`)
+                    let line_for_match: &str = if strip_tabs {
+                        current_line.trim_start_matches('\t')
+                    } else {
+                        &current_line
+                    };
+                    if line_for_match == delimiter {
                         break;
                     }
                     if !current_line.is_empty() {

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1771,7 +1771,7 @@ impl<'a> Lexer<'a> {
                 Some('\n') => {
                     self.advance();
                     // Check if current line matches delimiter
-                    if current_line.trim() == delimiter {
+                    if current_line == delimiter {
                         break;
                     }
                     content.push_str(&current_line);
@@ -1784,7 +1784,7 @@ impl<'a> Lexer<'a> {
                 }
                 None => {
                     // End of input - check last line
-                    if current_line.trim() == delimiter {
+                    if current_line == delimiter {
                         break;
                     }
                     if !current_line.is_empty() {
@@ -1958,6 +1958,13 @@ mod tests {
             lexer.next_token(),
             Some(Token::Word("file.txt".to_string()))
         );
+    }
+
+    #[test]
+    fn test_read_heredoc_requires_exact_delimiter_match() {
+        let mut lexer = Lexer::new("\nhello\n EOF\nEOF\n");
+        let content = lexer.read_heredoc("EOF");
+        assert_eq!(content, "hello\n EOF\n");
     }
 
     #[test]

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -536,7 +536,7 @@ impl<'a> Parser<'a> {
                         | Some(tokens::Token::QuotedGlobWord(w)) => (w.clone(), true),
                         _ => break,
                     };
-                    let content = self.lexer.read_heredoc(&delimiter);
+                    let content = self.lexer.read_heredoc_with_strip(&delimiter, strip_tabs);
                     let content = if strip_tabs {
                         let had_trailing_newline = content.ends_with('\n');
                         let mut stripped: String = content
@@ -2149,7 +2149,7 @@ impl<'a> Parser<'a> {
             _ => return Err(Error::parse("expected delimiter after <<".to_string())),
         };
 
-        let content = self.lexer.read_heredoc(&delimiter);
+        let content = self.lexer.read_heredoc_with_strip(&delimiter, strip_tabs);
 
         // Strip leading tabs for <<-
         let content = if strip_tabs {


### PR DESCRIPTION
### Motivation
- The heredoc reader used `trim()` when comparing lines to the delimiter, allowing lines like " EOF" or "EOF " to terminate a `<<EOF` heredoc early and enabling heredoc breakout and command injection. 
- Match real bash semantics for `<<` (exact match) while preserving `<<-` handling elsewhere.

### Description
- Change `Lexer::read_heredoc` in `crates/bashkit/src/parser/lexer.rs` to compare `current_line == delimiter` instead of `current_line.trim() == delimiter` at newline and EOF checks. 
- Add regression test `test_read_heredoc_requires_exact_delimiter_match` to ensure whitespace-padded delimiter lines are treated as content and not terminators. 
- Commit message: `fix(parser): require exact heredoc delimiter match`.

### Testing
- Ran the new unit test `parser::lexer::tests::test_read_heredoc_requires_exact_delimiter_match` which failed on the old behavior and passed after the fix. 
- Ran related heredoc lexer tests (`parser::lexer::tests::test_read_heredoc`, `test_read_heredoc_single_line`, `test_read_heredoc_full_scenario`, `test_read_heredoc_with_redirect`) and all passed. 
- Ran `cargo fmt --all --check` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a972df24832b87cc7d16dc99a5ed)