### PR TITLE
fix(parser): reject leading pipeline and list operators

### DIFF
--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -247,6 +247,12 @@ impl<'a> Parser<'a> {
     /// Parse a command list (commands connected by && or ||)
     fn parse_command_list(&mut self) -> Result<Option<Command>> {
         self.tick()?;
+        match self.current_token {
+            Some(tokens::Token::Pipe) => return Err(self.error("unexpected token: |")),
+            Some(tokens::Token::And) => return Err(self.error("unexpected token: &&")),
+            Some(tokens::Token::Or) => return Err(self.error("unexpected token: ||")),
+            _ => {}
+        }
         let start_span = self.current_span;
         let first = match self.parse_pipeline()? {
             Some(cmd) => cmd,
@@ -3702,6 +3708,24 @@ mod tests {
             parser.parse().is_err(),
             "unterminated double quote should be rejected"
         );
+    }
+
+    #[test]
+    fn test_leading_pipe_rejected() {
+        let parser = Parser::new("| cat");
+        assert!(parser.parse().is_err(), "leading | should be rejected");
+    }
+
+    #[test]
+    fn test_leading_and_rejected() {
+        let parser = Parser::new("&& echo hi");
+        assert!(parser.parse().is_err(), "leading && should be rejected");
+    }
+
+    #[test]
+    fn test_leading_or_rejected() {
+        let parser = Parser::new("|| echo hi");
+        assert!(parser.parse().is_err(), "leading || should be rejected");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The parser could loop indefinitely on inputs starting with `|`, `&&`, or `||` because `parse_simple_command`/`parse_pipeline` returned `Ok(None)` without consuming the unexpected token, letting the top-level parse loop retry the same token repeatedly.
- This is an availability regression enabling a CPU DoS on malformed input and must be rejected at parse entry instead of being silently skipped.

### Description
- At the start of `parse_command_list` add explicit checks to return a syntax error when the current token is `Pipe`, `And`, or `Or` (i.e., leading `|`, `&&`, `||`).
- This causes an immediate parse error for scripts beginning with those operators and prevents the parser from reprocessing the same token.
- Added unit tests `test_leading_pipe_rejected`, `test_leading_and_rejected`, and `test_leading_or_rejected` to guard against regressions.

### Testing
- Ran the targeted parser tests via `cargo test -p bashkit leading_` and the new tests passed (leading operator tests succeeded).
- Ran `cargo fmt --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a9757694832b929b4b8aad943ac8)