### PR TITLE
fix(interpreter): bound and filter captured final_env

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1661,7 +1661,31 @@ impl Interpreter {
         }
 
         let final_env = if self.limits.capture_final_env {
-            Some(self.variables.clone())
+            // THREAT[TM-INF-031]: final_env is a user-visible output channel.
+            // Apply visibility filtering + output-byte cap to prevent marker leaks
+            // and bypass of stdout/stderr output limits.
+            let mut final_env = HashMap::new();
+            let mut remaining = self.limits.max_stdout_bytes;
+            let mut keys: Vec<&String> = self.variables.keys().collect();
+            keys.sort_unstable();
+            for key in keys {
+                if is_hidden_variable(key) {
+                    continue;
+                }
+                let Some(value) = self.variables.get(key) else {
+                    continue;
+                };
+                let entry_bytes = key.len().saturating_add(value.len());
+                if entry_bytes > remaining {
+                    continue;
+                }
+                final_env.insert(key.clone(), value.clone());
+                remaining = remaining.saturating_sub(entry_bytes);
+                if remaining == 0 {
+                    break;
+                }
+            }
+            Some(final_env)
         } else {
             None
         };

--- a/crates/bashkit/tests/final_env_tests.rs
+++ b/crates/bashkit/tests/final_env_tests.rs
@@ -80,3 +80,28 @@ async fn final_env_on_error_still_captured() {
         .expect("final_env should be Some even on error");
     assert_eq!(env.get("BEFORE_ERR").map(|s| s.as_str()), Some("yes"));
 }
+
+#[tokio::test]
+async fn final_env_hides_hidden_markers() {
+    let limits = ExecutionLimits::new().capture_final_env(true);
+    let mut bash = Bash::builder().limits(limits).build();
+    let result = bash.exec("_TTY_TEST=secret; VISIBLE=ok").await.unwrap();
+    let env = result.final_env.expect("final_env should be Some");
+    assert_eq!(env.get("VISIBLE").map(|s| s.as_str()), Some("ok"));
+    assert!(!env.contains_key("_TTY_TEST"));
+}
+
+#[tokio::test]
+async fn final_env_respects_output_byte_cap() {
+    let limits = ExecutionLimits::new()
+        .capture_final_env(true)
+        .max_stdout_bytes(4096);
+    let mut bash = Bash::builder().limits(limits).build();
+    let script = format!("SMALL=ok; BIG={}", "x".repeat(10_000));
+    let result = bash.exec(&script).await.unwrap();
+    let env = result.final_env.expect("final_env should be Some");
+    let total_bytes: usize = env.iter().map(|(k, v)| k.len() + v.len()).sum();
+    assert!(total_bytes <= 4096);
+    assert_eq!(env.get("SMALL").map(|s| s.as_str()), Some("ok"));
+    assert!(!env.contains_key("BIG"));
+}


### PR DESCRIPTION
### Motivation
- `capture_final_env` previously cloned the entire shell `variables` map and returned it, creating an unbounded, unfiltered output channel that can leak secrets or bypass `stdout`/`stderr` caps.
- Need to prevent data exfiltration and unbounded memory use while keeping the feature opt-in.

### Description
- Filter `final_env` to exclude hidden/internal variables using `is_hidden_variable` before returning it.
- Enforce a byte cap on the captured `final_env` using `ExecutionLimits.max_stdout_bytes` and include only entries that fit within the remaining budget.
- Iterate keys deterministically (`sort_unstable`) to make selection reproducible under the cap while preserving `capture_final_env` opt-in behavior.
- Add regression tests `final_env_hides_hidden_markers` and `final_env_respects_output_byte_cap` to cover filtering and byte-cap enforcement.

### Testing
- Ran `cargo test -p bashkit --test final_env_tests` and all tests passed (`10 passed; 0 failed`).
- Ran `cargo fmt --check` and formatting check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15b75e0c832b9b674f99ef639592)