### PR TITLE
fix(interpreter): avoid panic when truncating utf8 output

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -723,6 +723,17 @@ pub struct Interpreter {
 }
 
 impl Interpreter {
+    fn utf8_prefix_at_most(s: &str, max_bytes: usize) -> &str {
+        if s.len() <= max_bytes {
+            return s;
+        }
+        let mut end = max_bytes;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+
     const MAX_GLOB_DEPTH: usize = 50;
 
     /// Create a new interpreter with the given filesystem.
@@ -1577,7 +1588,7 @@ impl Interpreter {
                 } else if result.stdout.len() <= remaining {
                     stdout.push_str(&result.stdout);
                 } else {
-                    stdout.push_str(&result.stdout[..remaining]);
+                    stdout.push_str(Self::utf8_prefix_at_most(&result.stdout, remaining));
                     stdout_truncated = true;
                 }
             }
@@ -1592,7 +1603,7 @@ impl Interpreter {
                 } else if result.stderr.len() <= remaining {
                     stderr.push_str(&result.stderr);
                 } else {
-                    stderr.push_str(&result.stderr[..remaining]);
+                    stderr.push_str(Self::utf8_prefix_at_most(&result.stderr, remaining));
                     stderr_truncated = true;
                 }
             }

--- a/crates/bashkit/tests/output_truncation_tests.rs
+++ b/crates/bashkit/tests/output_truncation_tests.rs
@@ -65,6 +65,13 @@ async fn stdout_one_byte_over_limit_truncated() {
     assert!(result.stdout_truncated);
 }
 
+#[tokio::test]
+async fn stdout_truncation_preserves_utf8_boundaries() {
+    let result = run_with_limits("echo é", 1, 1_048_576).await;
+    assert_eq!(result.stdout, "");
+    assert!(result.stdout_truncated);
+}
+
 // --- stderr truncation ---
 
 #[tokio::test]
@@ -78,6 +85,13 @@ async fn stderr_truncated_when_exceeds_limit() {
 async fn stderr_not_truncated_when_within_limit() {
     let result = run_with_limits("echo oops >&2", 1_048_576, 100).await;
     assert!(!result.stderr_truncated);
+}
+
+#[tokio::test]
+async fn stderr_truncation_preserves_utf8_boundaries() {
+    let result = run_with_limits("echo é >&2", 1_048_576, 1).await;
+    assert_eq!(result.stderr, "");
+    assert!(result.stderr_truncated);
 }
 
 // --- Execution continues after truncation ---


### PR DESCRIPTION
### Motivation
- Prevent panic-based DoS when output capture limits slice `String` at byte offsets that cut multibyte UTF-8 characters. 
- Keep truncation behavior (stop accumulating after limit) while making it safe for attacker-controlled output.

### Description
- Add `Interpreter::utf8_prefix_at_most(s: &str, max_bytes: usize) -> &str` to obtain a UTF-8-boundary-safe prefix. 
- Replace byte-index slices `result.stdout[..remaining]` / `result.stderr[..remaining]` with `utf8_prefix_at_most(&result.stdout, remaining)` and `utf8_prefix_at_most(&result.stderr, remaining)` in `crates/bashkit/src/interpreter/mod.rs`. 
- Add regression tests `stdout_truncation_preserves_utf8_boundaries` and `stderr_truncation_preserves_utf8_boundaries` in `crates/bashkit/tests/output_truncation_tests.rs` to verify multibyte truncation does not produce invalid slices.

### Testing
- Ran `cargo test -p bashkit --test output_truncation_tests` and all tests passed (`14 passed; 0 failed`).
- Ran `cargo fmt --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15b9a6ac832bb2d741cf036b15f8)