### PR TITLE
fix(interpreter): prevent alpha brace step wrap to zero

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -9866,16 +9866,16 @@ impl Interpreter {
                 } else {
                     1
                 };
-                let abs_step = step.unsigned_abs() as u8;
+                let abs_step = step.unsigned_abs();
 
                 let mut results = Vec::new();
-                let start_byte = start_char as u8;
-                let end_byte = end_char as u8;
+                let start_byte = u64::from(start_char as u8);
+                let end_byte = u64::from(end_char as u8);
 
                 if start_byte <= end_byte {
                     let mut b = start_byte;
                     while b <= end_byte {
-                        results.push((b as char).to_string());
+                        results.push(((b as u8) as char).to_string());
                         b = match b.checked_add(abs_step) {
                             Some(v) => v,
                             None => break,
@@ -9884,7 +9884,7 @@ impl Interpreter {
                 } else {
                     let mut b = start_byte;
                     while b >= end_byte {
-                        results.push((b as char).to_string());
+                        results.push(((b as u8) as char).to_string());
                         b = match b.checked_sub(abs_step) {
                             Some(v) => v,
                             None => break,
@@ -9934,6 +9934,20 @@ mod tests {
     use super::*;
     use crate::fs::InMemoryFs;
     use crate::parser::Parser;
+
+    #[test]
+    fn test_try_expand_range_alpha_large_step_does_not_loop() {
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let interp = Interpreter::new(Arc::clone(&fs));
+        assert_eq!(
+            interp.try_expand_range("a..z..256"),
+            Some(vec!["a".to_string()])
+        );
+        assert_eq!(
+            interp.try_expand_range("z..a..-256"),
+            Some(vec!["z".to_string()])
+        );
+    }
 
     /// Test timeout with paused time for deterministic behavior
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
### Motivation
- Alphabetic brace-range step parsing cast `step.unsigned_abs()` to `u8`, which makes steps that are multiples of 256 (including `i64::MIN`) become `0` and causes the expansion loop to never advance, enabling a CPU DoS via inputs like `{a..z..256}`.
- The change must prevent infinite loops while keeping existing brace expansion semantics for valid step values.

### Description
- Stop narrowing the absolute step to `u8` and compute `abs_step` as an unsigned integer (`u64`) to avoid wrap-to-zero for large `i64` steps in alphabetic ranges inside `try_expand_range`.
- Promote `start`/`end` bytes to `u64` and run loop progression with checked arithmetic (`checked_add`/`checked_sub`) so the loop either advances or terminates safely.
- Convert loop-produced `u64` back to `u8` when producing result characters to preserve original output type and semantics.
- Add a regression unit test `test_try_expand_range_alpha_large_step_does_not_loop` exercising `a..z..256` and `z..a..-256` to assert finite expansions.

### Testing
- Ran the new unit test via `cargo test -p bashkit --lib test_try_expand_range_alpha_large_step_does_not_loop`, which passed (`1 passed`).
- Ran `cargo fmt --check`, which succeeded with no formatting changes required.
- Ran the crate test build during development; no regressions were observed for the targeted change (unit test suite for this code path passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea15bd0614832bbdd9538bc21716aa)