### PR TITLE
fix(fs): enforce limits for pre-mounted overlay files

### DIFF
--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -15,9 +15,9 @@
 //!
 //! - **Writes never reach the host filesystem.** All mutations go to in-memory
 //!   storage regardless of what the lower layer is.
-//! - **Limit enforcement is centralized.** `OverlayFs` checks `FsLimits` before
-//!   every write; the upper `InMemoryFs` uses `FsLimits::unlimited()` so that
-//!   the overlay layer is the single enforcement point.
+//! - **Limit enforcement is defense in depth.** `OverlayFs` checks `FsLimits`
+//!   before writes, and the upper `InMemoryFs` mirrors those limits so
+//!   pre-populated files cannot bypass quotas.
 //! - **Lower-layer usage is advisory.** `compute_usage()` combines upper + lower
 //!   usage. When the lower layer is `RealFs`, its `usage()` returns zeros
 //!   (walking the host tree is expensive and not useful for limit accounting).
@@ -166,8 +166,8 @@ pub struct OverlayFs {
     lower: Arc<dyn FileSystem>,
     /// Upper (writable) filesystem — typed as InMemoryFs (not dyn FileSystem)
     /// to guarantee writes never escape to the host filesystem.
-    /// Uses FsLimits::unlimited() because limit enforcement happens at the
-    /// OverlayFs level via check_write_limits() / check_dir_limits().
+    /// Mirrors overlay limits for defense-in-depth and to enforce quotas on
+    /// pre-populated files.
     upper: InMemoryFs,
     /// Paths that have been deleted (whiteouts)
     whiteouts: RwLock<HashSet<PathBuf>>,
@@ -240,10 +240,10 @@ impl OverlayFs {
     /// # }
     /// ```
     pub fn with_limits(lower: Arc<dyn FileSystem>, limits: FsLimits) -> Self {
-        // Upper layer uses unlimited limits - we enforce limits at the OverlayFs level
+        // Mirror limits on upper layer so pre-populated files cannot bypass quotas.
         Self {
             lower,
-            upper: InMemoryFs::with_limits(FsLimits::unlimited()),
+            upper: InMemoryFs::with_limits(limits.clone()),
             whiteouts: RwLock::new(HashSet::new()),
             limits,
             lower_hidden: RwLock::new(FsUsage::default()),

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -5494,6 +5494,25 @@ done"#,
         assert!(write_err.is_err(), "custom fs limits should still apply");
     }
 
+    #[tokio::test]
+    async fn test_mount_text_respects_filesystem_limits() {
+        let limited_fs = std::sync::Arc::new(InMemoryFs::with_limits(
+            FsLimits::new().max_total_bytes(5).max_file_size(5),
+        ));
+
+        let bash = Bash::builder()
+            .fs(limited_fs)
+            .mount_text("/too-large.txt", "123456")
+            .build();
+
+        let exists = bash
+            .fs()
+            .exists(std::path::Path::new("/too-large.txt"))
+            .await
+            .unwrap();
+        assert!(!exists, "mount_text should not bypass configured FsLimits");
+    }
+
     // ============================================================
     // Parser Error Location Tests
     // ============================================================


### PR DESCRIPTION
### Motivation
- Prevent pre-mounted files from bypassing `FsLimits` and enabling DoS via memory exhaustion when mounted into the overlay upper layer during construction.

### Description
- Mirror the overlay `FsLimits` into the upper `InMemoryFs` by using `InMemoryFs::with_limits(limits.clone())` in `OverlayFs::with_limits` so pre-populated files are subject to the same quotas.
- Construct the overlay with the base filesystem's limits in `BashBuilder::build()` by calling `OverlayFs::with_limits(Arc::clone(&base_fs), base_fs.limits())` so `add_file`/`add_lazy_file` prepopulation cannot bypass limits.
- Update trust-model comments to document the defense-in-depth change.
- Add regression test `test_mount_text_respects_filesystem_limits` to verify oversized mounted content is rejected under configured `FsLimits`.

### Testing
- Ran `cargo test -p bashkit test_mount_text_respects_filesystem_limits` and the test passed.
- Ran `cargo test -p bashkit test_mount_overwrites_base_file` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193d7154832b9019d674edc46f24)