### PR TITLE
fix(security): keep unwind panics in release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,7 @@ napi-build = "2"
 [profile.release]
 lto = "thin"
 codegen-units = 1
-panic = "abort"
+# Security: interpreter relies on catch_unwind around builtins.
+# Keep release unwinding enabled so panic containment works.
+panic = "unwind"
 strip = "symbols"


### PR DESCRIPTION
### Motivation
- Prevent a high-severity DoS regression introduced by `panic = "abort"` in the workspace release profile that disables `catch_unwind`-based builtin panic containment used by the interpreter.

### Description
- Change `Cargo.toml` release profile from `panic = "abort"` to `panic = "unwind"` and add an inline security comment explaining why unwinding is required to allow `catch_unwind` to operate.

### Testing
- Ran `cargo test -p bashkit-cli` and all tests passed (`89 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea287afb58832ba647da407a55a1b4)