### PR TITLE
fix(interpreter): clean up background jobs after each exec

### DIFF
--- a/crates/bashkit/src/interpreter/jobs.rs
+++ b/crates/bashkit/src/interpreter/jobs.rs
@@ -157,5 +157,4 @@ mod tests {
         let result = table.wait_for(999).await;
         assert!(result.is_none());
     }
-
 }

--- a/crates/bashkit/src/interpreter/jobs.rs
+++ b/crates/bashkit/src/interpreter/jobs.rs
@@ -157,4 +157,5 @@ mod tests {
         let result = table.wait_for(999).await;
         assert!(result.is_none());
     }
+
 }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1526,7 +1526,11 @@ impl Interpreter {
             .check_session_limits(&self.session_limits)
             .map_err(|e| crate::error::Error::Execution(e.to_string()))?;
 
-        self.execute_script_body(script, true, true).await
+        let result = self.execute_script_body(script, true, true).await;
+        // Script boundary cleanup: background jobs are scoped to a single exec()
+        // call, so they cannot accumulate across long-lived sessions.
+        let _ = self.jobs.lock().await.wait_all_results().await;
+        result
     }
 
     /// Clean up process substitution temp files (`/dev/fd/proc_sub_*`).

--- a/crates/bashkit/tests/background_exec_tests.rs
+++ b/crates/bashkit/tests/background_exec_tests.rs
@@ -100,3 +100,16 @@ async fn background_and_foreground() {
     assert_eq!(result.exit_code, 0);
     assert!(result.stdout.contains("fg"));
 }
+
+/// Completed background jobs should not accumulate across exec() calls.
+#[tokio::test]
+async fn background_jobs_do_not_leak_across_exec_calls() {
+    let mut bash = Bash::new();
+    for _ in 0..20 {
+        bash.exec("false &").await.unwrap();
+    }
+
+    let result = bash.exec("wait\necho $?").await.unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout.trim(), "0");
+}


### PR DESCRIPTION
### Motivation
- Background jobs spawned with `cmd &` were stored in the shared `JobTable` and only removed on explicit `wait`, allowing completed job handles to accumulate across repeated `Bash::exec()` calls and cause unbounded memory growth in long‑lived sessions.
- Need a minimal change that prevents cross‑exec leakage while preserving in-script `wait` semantics and output behavior.

### Description
- Drain the interpreter job table at the script boundary by awaiting `self.jobs.lock().await.wait_all_results()` at the end of `Interpreter::execute`, ensuring completed background jobs do not persist across top‑level `exec()` calls (`crates/bashkit/src/interpreter/mod.rs`).
- Add a regression integration test `background_jobs_do_not_leak_across_exec_calls` that runs repeated `false &` across separate `exec()` calls and asserts a later `wait` does not observe leaked prior jobs (`crates/bashkit/tests/background_exec_tests.rs`).
- Minor test file update to `jobs.rs` (nonfunctional housekeeping change).

### Testing
- Reproduced the failure locally: the regression test failed before the fix (observed `1` where `0` expected).
- Ran the targeted regression: `cargo test -p bashkit background_jobs_do_not_leak_across_exec_calls -- --nocapture` and it passed after the fix.
- Ran crate tests (`cargo test -p bashkit`) to exercise the change in context; the test run completed with the new test included and no new failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193d9474832baf26766c3b44e86e)