### PR TITLE
fix(builtins): cap retry attempts in retry builtin

### DIFF
--- a/crates/bashkit/src/builtins/retry.rs
+++ b/crates/bashkit/src/builtins/retry.rs
@@ -21,6 +21,10 @@ use crate::interpreter::ExecResult;
 ///   -v           Verbose mode (show detailed retry info)
 pub struct Retry;
 
+// Security bound: prevent untrusted scripts from requesting effectively
+// unbounded verbose output/work inside a single builtin invocation.
+const MAX_RETRY_ATTEMPTS: u32 = 10_000;
+
 struct RetryConfig {
     max_attempts: u32,
     delay_secs: f64,
@@ -47,6 +51,9 @@ fn parse_retry_args(args: &[String]) -> std::result::Result<RetryConfig, String>
                 .map_err(|_| format!("retry: invalid number '{}'", val))?;
             if max_attempts == 0 {
                 return Err("retry: -n must be at least 1".to_string());
+            }
+            if max_attempts > MAX_RETRY_ATTEMPTS {
+                return Err(format!("retry: -n must be at most {MAX_RETRY_ATTEMPTS}"));
             }
         } else if let Some(val) = p.flag_value("-d", "retry")? {
             delay_secs = val
@@ -217,6 +224,13 @@ mod tests {
         let result = run_retry(&["-n", "0", "--", "cmd"]).await;
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("must be at least 1"));
+    }
+
+    #[tokio::test]
+    async fn test_attempts_upper_bound() {
+        let result = run_retry(&["-n", "10001", "--", "cmd"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("must be at most 10000"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent an untrusted script from causing CPU/memory DoS by passing an extremely large `-n` to `retry -v`, which previously looped and buffered one line per attempt with no upper bound.
- Keep existing behavior for normal inputs while enforcing a safe upper bound inside the builtin.

### Description
- Add a security bound `const MAX_RETRY_ATTEMPTS: u32 = 10_000` and reject `-n` values larger than the cap with a clear parse error in `parse_retry_args`.
- Preserve existing verbose and quiet behavior and message formatting when `-n` is within the allowed range.
- Add a regression test `test_attempts_upper_bound` that verifies oversized `-n` is rejected with the expected error text.

### Testing
- Ran `cargo fmt` and then `cargo fmt --check`, both succeeded after formatting.
- Ran the retry test suite with `cargo test -p bashkit retry::tests`, which passed (all retry tests, including the new `test_attempts_upper_bound`).
- Ran the package tests used in CI spot checks; no failures were observed for the exercised targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193d7e34832bbc1fec0ee577ff9b)