### PR TITLE
fix(split): reject zero line and byte sizes

### DIFF
--- a/crates/bashkit/src/builtins/split.rs
+++ b/crates/bashkit/src/builtins/split.rs
@@ -38,12 +38,25 @@ impl Builtin for Split {
             match ctx.args[i].as_str() {
                 "-l" => {
                     i += 1;
-                    lines_per_file =
-                        Some(ctx.args.get(i).and_then(|s| s.parse().ok()).unwrap_or(1000));
+                    let n = ctx.args.get(i).and_then(|s| s.parse().ok()).unwrap_or(1000);
+                    if n == 0 {
+                        return Ok(ExecResult::err(
+                            "split: invalid number of lines: 0\n".to_string(),
+                            1,
+                        ));
+                    }
+                    lines_per_file = Some(n);
                 }
                 "-b" => {
                     i += 1;
-                    bytes_per_file = ctx.args.get(i).and_then(|s| parse_size(s));
+                    let size = ctx.args.get(i).and_then(|s| parse_size(s));
+                    if size == Some(0) {
+                        return Ok(ExecResult::err(
+                            "split: invalid number of bytes: 0\n".to_string(),
+                            1,
+                        ));
+                    }
+                    bytes_per_file = size;
                 }
                 "-n" => {
                     i += 1;
@@ -253,6 +266,22 @@ mod tests {
         let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
         let result = run_split(&["-n", "0"], Some("data"), fs).await;
         assert_eq!(result.exit_code, 1);
+    }
+
+    #[tokio::test]
+    async fn test_split_zero_lines() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        let result = run_split(&["-l", "0"], Some("data"), fs).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid number of lines"));
+    }
+
+    #[tokio::test]
+    async fn test_split_zero_bytes() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        let result = run_split(&["-b", "0"], Some("data"), fs).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid number of bytes"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- The `split` builtin accepted `-l 0` and `-b 0`, which allows a non-advancing loop and CPU DoS for non-empty input.

### Description
- Add input validation to reject zero for `-l` with an explicit error `split: invalid number of lines: 0` and exit code `1`.
- Add input validation to reject zero for `-b` with an explicit error `split: invalid number of bytes: 0` and exit code `1`.
- Preserve existing `-n` behavior which already rejects `0` and avoid changing splitting logic.
- Implement two regression tests `test_split_zero_lines` and `test_split_zero_bytes` in `crates/bashkit/src/builtins/split.rs`.

### Testing
- Ran `cargo test -p bashkit split_zero -- --nocapture` which executed the zero-related tests and reported `3 passed` (the new `test_split_zero_lines` and `test_split_zero_bytes`, plus the existing zero-chunks test).
- A mistaken attempt to run multiple positional test names with `cargo test -p bashkit test_split_zero_lines test_split_zero_bytes test_split_zero_chunks` produced a CLI usage error, so the consolidated `split_zero` test target was used instead and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193c3a64832bab743cd036609583)