### PR TITLE
fix(python): require explicit opt-in for in-process Python execution

### DIFF
--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -2087,7 +2087,8 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
         }
     }
 
-    // Enable Python/Monty
+    // Enable Python/Monty. Passing `python: true` from JS is the explicit
+    // opt-in that must also flip the in-process Python env gate.
     if state.python {
         if let Some(ref handler) = state.external_handler {
             let h = handler.clone();
@@ -2104,6 +2105,7 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
         } else {
             builder = builder.python();
         }
+        builder = builder.env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1");
     }
 
     builder.build()

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2522,9 +2522,13 @@ fn apply_python_config(
                 fn_names,
                 make_external_handler(h, external_handler_reentry_depth),
             );
+            // Passing python=True from Python is itself the explicit opt-in for
+            // in-process Python execution; propagate that to the builtin's env gate.
+            builder = builder.env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1");
         }
         (true, None) => {
             builder = builder.python();
+            builder = builder.env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1");
         }
         (false, _) => {}
     }

--- a/crates/bashkit/docs/python.md
+++ b/crates/bashkit/docs/python.md
@@ -23,7 +23,10 @@ use bashkit::Bash;
 
 # #[tokio::main]
 # async fn main() -> bashkit::Result<()> {
-let mut bash = Bash::builder().python().build();
+let mut bash = Bash::builder()
+    .python()
+    .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+    .build();
 
 let result = bash.exec("python3 -c \"print('hello from Monty')\"").await?;
 assert_eq!(result.stdout, "hello from Monty\n");

--- a/crates/bashkit/examples/python_external_functions.rs
+++ b/crates/bashkit/examples/python_external_functions.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<()> {
 
     let mut bash = Bash::builder()
         .python_with_external_handler(PythonLimits::default(), vec!["add".to_string()], handler)
+        .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
         .build();
 
     let result = bash.exec("python3 -c \"print(add(20, 22))\"").await?;

--- a/crates/bashkit/examples/python_scripts.rs
+++ b/crates/bashkit/examples/python_scripts.rs
@@ -13,7 +13,10 @@ use bashkit::Bash;
 async fn main() -> anyhow::Result<()> {
     println!("=== BashKit Python Integration ===\n");
 
-    let mut bash = Bash::builder().python().build();
+    let mut bash = Bash::builder()
+        .python()
+        .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+        .build();
 
     // --- 1. Inline expressions ---
     println!("--- Inline Expressions ---");

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -935,9 +935,15 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    fn opt_in_env() -> HashMap<String, String> {
+        let mut env = HashMap::new();
+        env.insert(PYTHON_INPROCESS_OPT_IN_ENV.to_string(), "1".to_string());
+        env
+    }
+
     async fn run(args: &[&str], stdin: Option<&str>) -> ExecResult {
         let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-        let env = HashMap::new();
+        let env = opt_in_env();
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());
@@ -947,7 +953,7 @@ mod tests {
 
     async fn run_with_file(args: &[&str], file_path: &str, content: &str) -> ExecResult {
         let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-        let env = HashMap::new();
+        let env = opt_in_env();
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());
@@ -965,10 +971,11 @@ mod tests {
         env_vars: &[(&str, &str)],
     ) -> ExecResult {
         let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-        let env: HashMap<String, String> = env_vars
+        let mut env: HashMap<String, String> = env_vars
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
+        env.insert(PYTHON_INPROCESS_OPT_IN_ENV.to_string(), "1".to_string());
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());
@@ -1308,7 +1315,7 @@ mod tests {
         let limits = PythonLimits::default().max_memory(1024);
         let py = Python::with_limits(limits);
         let args = vec!["-c".to_string(), "x = list(range(100000))".to_string()];
-        let env = HashMap::new();
+        let env = opt_in_env();
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());
@@ -1325,7 +1332,7 @@ mod tests {
             .max_memory(128 * 1024 * 1024);
         let py = Python::with_limits(limits);
         let args = vec!["-c".to_string(), "print(sum(range(100)))".to_string()];
-        let env = HashMap::new();
+        let env = opt_in_env();
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());
@@ -1366,7 +1373,7 @@ mod tests {
         handler: PythonExternalFnHandler,
     ) -> ExecResult {
         let args = vec!["-c".to_string(), code.to_string()];
-        let env = HashMap::new();
+        let env = opt_in_env();
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -42,6 +42,19 @@ const DEFAULT_MAX_RECURSION: usize = 200;
 // interpreter budget checks, so disable regex stdlib module in untrusted code.
 const DISABLED_STDLIB_MODULES: &[&str] = &["re"];
 
+const PYTHON_INPROCESS_OPT_IN_ENV: &str = "BASHKIT_ALLOW_INPROCESS_PYTHON";
+
+fn python_inprocess_enabled(ctx: &Context<'_>) -> bool {
+    let is_enabled = |v: &str| matches!(v, "1" | "true" | "TRUE" | "yes" | "YES");
+    ctx.env
+        .get(PYTHON_INPROCESS_OPT_IN_ENV)
+        .is_some_and(|v| is_enabled(v))
+        || ctx
+            .variables
+            .get(PYTHON_INPROCESS_OPT_IN_ENV)
+            .is_some_and(|v| is_enabled(v))
+}
+
 /// Resource limits for the embedded Python (Monty) interpreter.
 ///
 /// Use the builder pattern to customize, or `Default` for the standard virtual execution limits:
@@ -304,6 +317,16 @@ impl Builtin for Python {
                  -      : read code from stdin\n  \
                  -V     : print version\n"
                     .to_string(),
+            ));
+        }
+
+        if !python_inprocess_enabled(&ctx) {
+            return Ok(ExecResult::err(
+                format!(
+                    "python3: in-process Python disabled by default for security; set {}=1 to enable\n",
+                    PYTHON_INPROCESS_OPT_IN_ENV
+                ),
+                1,
             ));
         }
 

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1582,6 +1582,10 @@ impl BashBuilder {
     /// Monty runs directly in the host process with resource limits enforced
     /// by Monty's runtime (memory, allocations, time, recursion).
     ///
+    /// For security, execution is runtime-gated: set
+    /// `BASHKIT_ALLOW_INPROCESS_PYTHON=1` (builder `.env(...)` or `export`)
+    /// before invoking `python`/`python3`.
+    ///
     /// Requires the `python` feature flag. Python `pathlib.Path` operations are
     /// bridged to the virtual filesystem.
     ///

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -540,6 +540,9 @@ impl BashToolBuilder {
     /// Requires the `python` feature flag. Python `pathlib.Path` operations are
     /// bridged to the virtual filesystem. Limitations (no `open()`, no HTTP) are
     /// automatically documented in `help()` and `system_prompt()`.
+    ///
+    /// For security, execution is runtime-gated: set
+    /// `BASHKIT_ALLOW_INPROCESS_PYTHON=1` before invoking `python`/`python3`.
     #[cfg(feature = "python")]
     pub fn python(self) -> Self {
         self.python_with_limits(crate::builtins::PythonLimits::default())

--- a/crates/bashkit/tests/python_integration_tests.rs
+++ b/crates/bashkit/tests/python_integration_tests.rs
@@ -856,7 +856,11 @@ mod environment {
 
     #[tokio::test]
     async fn getenv_existing() {
-        let mut bash = Bash::builder().python().env("MY_VAR", "test_value").build();
+        let mut bash = Bash::builder()
+            .python()
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+            .env("MY_VAR", "test_value")
+            .build();
         let r = bash
             .exec("python3 -c \"import os\nprint(os.getenv('MY_VAR'))\"")
             .await
@@ -891,6 +895,7 @@ mod environment {
     async fn environ_dict() {
         let mut bash = Bash::builder()
             .python()
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
             .env("FOO", "bar")
             .env("BAZ", "qux")
             .build();
@@ -906,7 +911,11 @@ mod environment {
     #[tokio::test]
     async fn builder_env_visible_to_python() {
         // Use builder .env() to set env vars visible to Python
-        let mut bash = Bash::builder().python().env("GREETING", "hello").build();
+        let mut bash = Bash::builder()
+            .python()
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+            .env("GREETING", "hello")
+            .build();
         let r = bash
             .exec("python3 -c \"import os\nprint(os.getenv('GREETING'))\"")
             .await

--- a/crates/bashkit/tests/python_integration_tests.rs
+++ b/crates/bashkit/tests/python_integration_tests.rs
@@ -11,12 +11,18 @@ use std::time::Duration;
 
 /// Helper: create Bash with python builtins using default limits.
 fn bash_python() -> Bash {
-    Bash::builder().python().build()
+    Bash::builder()
+        .python()
+        .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+        .build()
 }
 
 /// Helper: create Bash with custom python limits.
 fn bash_python_limits(limits: PythonLimits) -> Bash {
-    Bash::builder().python_with_limits(limits).build()
+    Bash::builder()
+        .python_with_limits(limits)
+        .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+        .build()
 }
 
 // =============================================================================

--- a/crates/bashkit/tests/python_security_tests.rs
+++ b/crates/bashkit/tests/python_security_tests.rs
@@ -16,11 +16,17 @@ use bashkit::{Bash, ExecutionLimits, PythonLimits};
 use std::time::Duration;
 
 fn bash_python() -> Bash {
-    Bash::builder().python().build()
+    Bash::builder()
+        .python()
+        .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+        .build()
 }
 
 fn bash_python_limits(limits: PythonLimits) -> Bash {
-    Bash::builder().python_with_limits(limits).build()
+    Bash::builder()
+        .python_with_limits(limits)
+        .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+        .build()
 }
 
 fn bash_python_tight() -> Bash {
@@ -31,6 +37,19 @@ fn bash_python_tight() -> Bash {
             .max_allocations(100_000)
             .max_recursion(50),
     )
+}
+
+#[tokio::test]
+async fn python_requires_explicit_inprocess_opt_in() {
+    let mut bash = Bash::builder().python().build();
+    let r = bash.exec("python3 -c \"print('blocked')\"").await.unwrap();
+    assert_ne!(r.exit_code, 0);
+    assert!(
+        r.stderr
+            .contains("in-process Python disabled by default for security"),
+        "expected security gate message, got stderr={:?}",
+        r.stderr
+    );
 }
 
 // =============================================================================
@@ -1075,7 +1094,11 @@ mod whitebox_limit_interaction {
     #[tokio::test]
     async fn bash_max_commands_limits_python_invocations() {
         let limits = ExecutionLimits::new().max_commands(10);
-        let mut bash = Bash::builder().python().limits(limits).build();
+        let mut bash = Bash::builder()
+            .python()
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+            .limits(limits)
+            .build();
         // Each python3 invocation is a command; with limit=10 a few should work
         let r = bash
             .exec("python3 -c \"print(1)\"\npython3 -c \"print(2)\"")

--- a/crates/bashkit/tests/spec_tests.rs
+++ b/crates/bashkit/tests/spec_tests.rs
@@ -205,7 +205,12 @@ async fn python_spec_tests() {
     }
 
     // Python tests need the python builtin registered via builder
-    let make_bash = || Bash::builder().python().build();
+    let make_bash = || {
+        Bash::builder()
+            .python()
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+            .build()
+    };
 
     let mut summary = TestSummary::default();
     let mut failures = Vec::new();

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -1433,7 +1433,11 @@ mod python_security {
     #[tokio::test]
     async fn threat_python_respects_bash_limits() {
         let limits = ExecutionLimits::new().max_commands(5);
-        let mut bash = Bash::builder().python().limits(limits).build();
+        let mut bash = Bash::builder()
+            .python()
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+            .limits(limits)
+            .build();
 
         // Each python3 invocation is 1 command; but with limit=5 we can still run some
         let result = bash.exec("python3 -c \"print('ok')\"").await.unwrap();
@@ -1638,7 +1642,10 @@ mod python_security_regressions {
     #[tokio::test]
     async fn threat_python_pow_exhaustion() {
         let limits = PythonLimits::default().max_memory(1024 * 1024); // 1MB
-        let mut bash = Bash::builder().python_with_limits(limits).build();
+        let mut bash = Bash::builder()
+            .python_with_limits(limits)
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+            .build();
         // 2 ** 1_000_000 produces ~300KB number; with tight 1MB limit the
         // allocation check should reject it before completion.
         let result = bash

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -1235,6 +1235,7 @@ mod python_security {
     fn bash_with_python() -> Bash {
         Bash::builder()
             .python_with_limits(PythonLimits::default())
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
             .build()
     }
 
@@ -1585,6 +1586,7 @@ mod python_security_regressions {
     fn bash_with_python() -> Bash {
         Bash::builder()
             .python_with_limits(PythonLimits::default())
+            .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
             .build()
     }
 

--- a/specs/python-builtin.md
+++ b/specs/python-builtin.md
@@ -30,7 +30,10 @@ Python builtins are **not** auto-registered. Enable via builder:
 use bashkit::Bash;
 
 // Default limits
-let bash = Bash::builder().python().build();
+let bash = Bash::builder()
+    .python()
+    .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+    .build();
 
 // Custom limits
 use bashkit::PythonLimits;
@@ -202,13 +205,20 @@ stack overflow from deeply nested expressions.
 use bashkit::{Bash, PythonLimits};
 
 // Default limits
-let bash = Bash::builder().python().build();
+let bash = Bash::builder()
+    .python()
+    .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
+    .build();
 
 // Custom limits
 let bash = Bash::builder()
     .python_with_limits(PythonLimits::default().max_duration(Duration::from_secs(5)))
+    .env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")
     .build();
 ```
+
+For security, `python`/`python3` execution is runtime-gated and requires
+`BASHKIT_ALLOW_INPROCESS_PYTHON=1` (builder `.env(...)` or `export`).
 
 ### External Functions
 


### PR DESCRIPTION
### Motivation
- Direct Monty integration runs the embedded Python VM in-process which increases risk that Monty crashes or UB could take down the host, so runtime exposure must be reduced.
- Prevent accidental enabling of in-process Python in deployments that compile the `python` feature but should not execute untrusted Python code.

### Description
- Add a runtime gate via the `BASHKIT_ALLOW_INPROCESS_PYTHON` env/variable check implemented by `python_inprocess_enabled()` and constant `PYTHON_INPROCESS_OPT_IN_ENV` in `crates/bashkit/src/builtins/python.rs` to require explicit opt-in before executing code. 
- Block code execution paths while preserving `--help` and `--version` behavior; returning a clear error message instructing to set `BASHKIT_ALLOW_INPROCESS_PYTHON=1` when not enabled. 
- Add a regression test `python_requires_explicit_inprocess_opt_in` that verifies execution is denied by default in `crates/bashkit/tests/python_security_tests.rs`. 
- Update Python-enabled test builders and specs to opt in where tests expect Python to run by adding `.env("BASHKIT_ALLOW_INPROCESS_PYTHON", "1")` and update docs/comments in `crates/bashkit/src/lib.rs`, `crates/bashkit/src/tool.rs` and `specs/python-builtin.md` to document the runtime opt-in requirement.

### Testing
- Ran `cargo test --features python --test python_security_tests python_requires_explicit_inprocess_opt_in` and the test passed (`ok`).
- Ran `cargo test --features python --test python_integration_tests basic_execution::print_hello` and the test passed (`ok`).
- Ran `cargo test --features python --test spec_tests python_spec_tests` and the test passed (`ok`).
- Ran `cargo test --features python --test threat_model_tests python_security::threat_python_no_os_operations` and the test passed (`ok`).
- Ran `cargo fmt --check` after formatting and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193d38ec832b9ff4f18fd86ad5c8)