### PR TITLE
fix(date): guard quote stripping against lone-quote panic

### DIFF
--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -88,7 +88,9 @@ fn validate_format(format: &str) -> std::result::Result<(), String> {
 /// `--date="value"` passes literal quotes to the builtin).
 fn strip_surrounding_quotes(s: &str) -> &str {
     let s = s.trim();
-    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+    if s.len() >= 2
+        && ((s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')))
+    {
         &s[1..s.len() - 1]
     } else {
         s
@@ -836,6 +838,20 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         let date = result.stdout.trim();
         assert_eq!(date.len(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_date_lone_single_quote_input_no_panic() {
+        let result = run_date(&["-d", "'", "+%Y-%m-%d"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid date"));
+    }
+
+    #[tokio::test]
+    async fn test_date_lone_double_quote_input_no_panic() {
+        let result = run_date(&["-d", "\"", "+%Y-%m-%d"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid date"));
     }
 
     // === --date with RFC 2822 input ===


### PR DESCRIPTION
### Motivation

- Prevent a DoS panic caused by `strip_surrounding_quotes` slicing `&s[1..s.len()-1]` when given a one-character quote (`'` or `"`) from untrusted `-d/--date` input.

### Description

- Add a length guard `s.len() >= 2` before stripping surrounding quotes in `strip_surrounding_quotes` to avoid invalid slice ranges.
- Preserve existing behavior for normal quoted inputs while returning the original input when it is too short to strip.
- Add two regression tests `test_date_lone_single_quote_input_no_panic` and `test_date_lone_double_quote_input_no_panic` that assert the builtin returns an `invalid date` error (exit 1) instead of crashing.

### Testing

- Ran the new unit tests `test_date_lone_single_quote_input_no_panic` and `test_date_lone_double_quote_input_no_panic` and both passed.
- Ran the package unit tests for `bashkit` (`cargo test -p bashkit`) while exercising the targeted tests; no failures were observed for the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193d8f40832b9f9593edce611e4a)