### PR TITLE
fix(awk): enforce configured loop iteration limits

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -26,6 +26,7 @@ use super::{Builtin, Context, read_text_file};
 use crate::error::{Error, Result};
 use crate::fs::FileSystem;
 use crate::interpreter::ExecResult;
+use crate::limits::ExecutionLimits;
 
 /// awk command - pattern scanning and processing
 pub struct Awk;
@@ -2146,6 +2147,8 @@ struct AwkInterpreter {
     /// When start pattern matches, range becomes active. When end pattern
     /// matches, that line is included but range becomes inactive.
     range_active: HashMap<usize, bool>,
+    /// Max iterations for a single loop, inherited from execution limits.
+    max_loop_iterations: usize,
 }
 
 impl AwkInterpreter {
@@ -2164,6 +2167,7 @@ impl AwkInterpreter {
             fs: None,
             cwd: PathBuf::from("/"),
             range_active: HashMap::new(),
+            max_loop_iterations: ExecutionLimits::default().max_loop_iterations,
         }
     }
 
@@ -3079,9 +3083,6 @@ impl AwkInterpreter {
 
     /// Execute action. Returns flow control signal.
     fn exec_action(&mut self, action: &AwkAction) -> AwkFlow {
-        // Limit iterations to prevent infinite loops
-        const MAX_LOOP_ITERS: usize = 100_000;
-
         match action {
             AwkAction::Print(exprs, target) => {
                 let parts: Vec<String> = exprs
@@ -3142,7 +3143,7 @@ impl AwkInterpreter {
                 let mut iters = 0;
                 while self.eval_expr(cond).as_bool() {
                     iters += 1;
-                    if iters > MAX_LOOP_ITERS {
+                    if iters > self.max_loop_iterations {
                         break;
                     }
                     let mut do_break = false;
@@ -3167,7 +3168,7 @@ impl AwkInterpreter {
                 let mut iters = 0;
                 loop {
                     iters += 1;
-                    if iters > MAX_LOOP_ITERS {
+                    if iters > self.max_loop_iterations {
                         break;
                     }
                     let mut do_break = false;
@@ -3193,7 +3194,7 @@ impl AwkInterpreter {
                 let mut iters = 0;
                 while self.eval_expr(cond).as_bool() {
                     iters += 1;
-                    if iters > MAX_LOOP_ITERS {
+                    if iters > self.max_loop_iterations {
                         break;
                     }
                     let mut do_break = false;
@@ -3231,7 +3232,12 @@ impl AwkInterpreter {
                     _ => a.cmp(b),
                 });
 
+                let mut iters = 0;
                 for key in keys {
+                    iters += 1;
+                    if iters > self.max_loop_iterations {
+                        break;
+                    }
                     self.state.set_variable(var, AwkValue::String(key));
                     let mut do_break = false;
                     for action in actions {
@@ -3480,6 +3486,10 @@ impl Builtin for Awk {
         let program = parser.parse()?;
 
         let mut interp = AwkInterpreter::new();
+        interp.max_loop_iterations = ctx
+            .execution_extension::<ExecutionLimits>()
+            .map(|limits| limits.max_loop_iterations)
+            .unwrap_or_else(|| ExecutionLimits::default().max_loop_iterations);
         interp.functions = program.functions.clone();
         interp.state.fs = Self::process_escape_sequences(&field_sep);
         interp.fs = Some(ctx.fs.clone());
@@ -4134,7 +4144,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_awk_while_loop_limited() {
-        // Infinite while loop should terminate via MAX_LOOP_ITERS
+        // Infinite while loop should terminate via default max_loop_iterations
         let result = run_awk(
             &[r#"BEGIN { i=0; while(1) { i++; if(i>200000) break } print i }"#],
             Some(""),
@@ -4143,10 +4153,10 @@ mod tests {
         .unwrap();
         assert_eq!(result.exit_code, 0);
         let count: usize = result.stdout.trim().parse().unwrap();
-        // Should be capped at MAX_LOOP_ITERS (100_000), not 200_000
+        // Should be capped at default max_loop_iterations (10_000), not 200_000
         assert!(
-            count <= 100_001,
-            "loop ran {} times, expected <= 100001",
+            count <= 10_001,
+            "loop ran {} times, expected <= 10001",
             count
         );
     }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -590,8 +590,11 @@ impl Bash {
     pub async fn exec_with_extensions(
         &mut self,
         script: &str,
-        extensions: ExecutionExtensions,
+        mut extensions: ExecutionExtensions,
     ) -> Result<ExecResult> {
+        // Expose active execution limits to builtins that need to honor
+        // per-execution sandbox settings.
+        let _ = extensions.insert(self.interpreter.limits().clone());
         let _extensions_guard = self.interpreter.scoped_execution_extensions(extensions);
         self.exec_impl(script).await
     }
@@ -3739,6 +3742,28 @@ fn
             "Expected loop limit error, got: {}",
             err
         );
+    }
+
+    #[tokio::test]
+    async fn test_awk_respects_loop_iteration_limit() {
+        let limits = ExecutionLimits::new().max_loop_iterations(5);
+        let mut bash = Bash::builder().limits(limits).build();
+        let result = bash
+            .exec("awk 'BEGIN { i=0; while(1) { i++; if(i>999) break } print i }'")
+            .await
+            .unwrap();
+        assert_eq!(result.stdout.trim(), "5");
+    }
+
+    #[tokio::test]
+    async fn test_awk_for_in_respects_loop_iteration_limit() {
+        let limits = ExecutionLimits::new().max_loop_iterations(3);
+        let mut bash = Bash::builder().limits(limits).build();
+        let result = bash
+            .exec("awk 'BEGIN { for(i=1;i<=10;i++) a[i]=i; c=0; for(k in a) c++; print c }'")
+            .await
+            .unwrap();
+        assert_eq!(result.stdout.trim(), "3");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation

- AWK loop execution used a hard-coded `100_000` iteration cap and left `for-in` loops unbounded, which bypassed the configured `ExecutionLimits.max_loop_iterations` and enabled CPU exhaustion by untrusted scripts. 
- The sandbox defines `ExecutionLimits::max_loop_iterations` (default `10_000`) that builtins should respect to mitigate infinite-loop DoS. 
- Ensure AWK honors per-execution limits so operator-configured caps are effective for all loop forms.

### Description

- Pass the active `ExecutionLimits` into builtin execution extensions by inserting `self.interpreter.limits().clone()` in `Bash::exec_with_extensions` so builtins can read per-execution sandbox settings via `execution_extension::<ExecutionLimits>()`. 
- Add `max_loop_iterations: usize` to `AwkInterpreter` and initialize it from `ExecutionLimits::default()` in `AwkInterpreter::new()`. 
- Replace the hard-coded `const MAX_LOOP_ITERS` with `self.max_loop_iterations` and apply that cap to `while`, `do-while`, and `for` loops. 
- Add an iteration counter and cap to `for-in` loops (array iteration) so `for (k in arr)` is also limited; update AWK tests and add two regression tests: `test_awk_respects_loop_iteration_limit` and `test_awk_for_in_respects_loop_iteration_limit`.

### Testing

- Ran `cargo fmt --all` — succeeded. 
- Ran `cargo test -p bashkit test_awk_respects_loop_iteration_limit` — test passed. 
- Ran `cargo test -p bashkit test_awk_for_in_respects_loop_iteration_limit` — test passed. 
- Ran `cargo test -p bashkit test_awk_while_loop_limited` — test passed and the AWK loop-limit expectation was updated to the configured default (`10_000`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193c6124832ba4a1bc4b0f14d088)