### PR TITLE
fix(interpreter): enforce nested bash parser input and timeout limits

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3174,17 +3174,52 @@ impl Interpreter {
             return Ok(ExecResult::ok(String::new()));
         };
 
+        if script_content.len() > self.limits.max_input_bytes {
+            return Ok(ExecResult::err(
+                format!(
+                    "{}: input exceeds maximum size ({} > {})\n",
+                    shell_name,
+                    script_content.len(),
+                    self.limits.max_input_bytes
+                ),
+                2,
+            ));
+        }
+
         // THREAT[TM-DOS-021]: Propagate interpreter's parser limits to child shell
-        let parser = Parser::with_limits(
-            &script_content,
-            self.limits.max_ast_depth,
-            self.limits.max_parser_operations,
-        );
-        let script = match parser.parse() {
-            Ok(s) => s,
-            Err(e) => {
+        let script_owned = script_content.clone();
+        let max_ast_depth = self.limits.max_ast_depth;
+        let max_parser_operations = self.limits.max_parser_operations;
+        let parse_result = tokio::time::timeout(self.limits.parser_timeout, async move {
+            tokio::task::spawn_blocking(move || {
+                let parser =
+                    Parser::with_limits(&script_owned, max_ast_depth, max_parser_operations);
+                parser.parse()
+            })
+            .await
+        })
+        .await;
+        let script = match parse_result {
+            Ok(Ok(Ok(s))) => s,
+            Ok(Ok(Err(e))) => {
                 return Ok(ExecResult::err(
                     format!("{}: syntax error: {}\n", shell_name, e),
+                    2,
+                ));
+            }
+            Ok(Err(e)) => {
+                return Ok(ExecResult::err(
+                    format!("{}: parser task failed: {}\n", shell_name, e),
+                    2,
+                ));
+            }
+            Err(_) => {
+                return Ok(ExecResult::err(
+                    format!(
+                        "{}: parser timeout after {}ms\n",
+                        shell_name,
+                        self.limits.parser_timeout.as_millis()
+                    ),
                     2,
                 ));
             }
@@ -10531,6 +10566,27 @@ mod tests {
         let result = run_script("bash -c 'for i in 1 2 3; do echo $i; done'").await;
         assert_eq!(result.exit_code, 0);
         // Loop executed successfully within limits
+    }
+
+    #[tokio::test]
+    async fn test_bash_script_file_enforces_max_input_bytes() {
+        let fs = Arc::new(InMemoryFs::new());
+        let large_script = "echo x\n".repeat(64);
+        fs.write_file(
+            std::path::Path::new("/tmp/large.sh"),
+            large_script.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        let limits = ExecutionLimits::new().max_input_bytes(64);
+        let mut interpreter = Interpreter::new(fs.clone());
+        interpreter.set_limits(limits);
+        let ast = Parser::new("bash /tmp/large.sh").parse().unwrap();
+        let result = interpreter.execute(&ast).await.unwrap();
+
+        assert_eq!(result.exit_code, 2);
+        assert!(result.stderr.contains("input exceeds maximum size"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Nested `bash`/`sh` invocation parsed child script content with `Parser::new` and no input-size or timeout checks, allowing untrusted `-c`/file/stdin payloads to bypass operator-configured DoS limits. 
- Goal: propagate the interpreter's configured `ExecutionLimits` (input size, `parser_timeout`, `max_ast_depth`, `max_parser_operations`) into the nested-shell path so nested scripts cannot exhaust CPU/memory.

### Description
- Enforce `max_input_bytes` on `script_content` before parsing and return a shell-style error when exceeded (`exit_code=2`).
- Parse nested shell scripts using `tokio::time::timeout` + `tokio::task::spawn_blocking` with `Parser::with_limits`, preserving `max_ast_depth` and `max_parser_operations`.
- Handle parse outcomes explicitly and convert parser syntax errors, spawn/task failures, and timeouts into shell-style `ExecResult::err` messages with `exit_code=2`.
- Add a regression unit test `test_bash_script_file_enforces_max_input_bytes` that verifies `bash /tmp/large.sh` respects `ExecutionLimits::max_input_bytes` when invoked from the interpreter.

### Testing
- Ran `cargo fmt` to format changes and fixed minor formatting diffs; it completed successfully.
- Ran `cargo test -p bashkit test_bash_script_file_enforces_max_input_bytes -- --nocapture` and the new regression test passed (`ok`).
- Ran `cargo test -p bashkit test_bash_nested_limits_respected -- --nocapture` and the related nested-limits test passed (`ok`).
- Targeted tests executed locally and passed; CI should run the full test matrix after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea193fee5c832ba3a5e3f3d8973771)