### PR TITLE
fix(interpreter): avoid overflow panic in array slice length

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7129,7 +7129,7 @@ impl Interpreter {
 
                         let sliced = if let Some(len_expr) = length {
                             let len_val = self.evaluate_arithmetic(len_expr) as usize;
-                            let end = (start + len_val).min(values.len());
+                            let end = start.saturating_add(len_val).min(values.len());
                             &values[start..end]
                         } else {
                             &values[start..]

--- a/crates/bashkit/tests/spec_cases/bash/arrays.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arrays.test.sh
@@ -115,13 +115,6 @@ arr=(a b c d e); echo ${arr[@]:0:2}
 a b
 ### end
 
-### array_slice_negative_length_no_panic
-# Negative length should not panic interpreter
-arr=(a b c d e); echo ${arr[@]:1:-1}
-### expect
-b c d e
-### end
-
 ### array_at_expansion_as_args
 # "${arr[@]}" expands to separate arguments for commands
 arr=(one two three)

--- a/crates/bashkit/tests/spec_cases/bash/arrays.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arrays.test.sh
@@ -115,6 +115,13 @@ arr=(a b c d e); echo ${arr[@]:0:2}
 a b
 ### end
 
+### array_slice_negative_length_no_panic
+# Negative length should not panic interpreter
+arr=(a b c d e); echo ${arr[@]:1:-1}
+### expect
+b c d e
+### end
+
 ### array_at_expansion_as_args
 # "${arr[@]}" expands to separate arguments for commands
 arr=(one two three)


### PR DESCRIPTION
### Motivation
- Prevent interpreter panic when `${arr[@]:offset:length}` uses negative or overflowing `length`, which could wrap and produce invalid slice bounds and cause a denial-of-service.

### Description
- Compute slice end with `start.saturating_add(len_val).min(values.len())` to avoid overflow/wraparound and add a spec test `array_slice_negative_length_no_panic` covering `${arr[@]:1:-1}`.

### Testing
- Ran `cargo test --test spec_tests bash_spec_tests -- --nocapture` and the bash spec suite passed (Total: 1982 | Passed: 1957 | Failed: 0 | Skipped: 25).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2b71c8a8832ba70be46532a20cc8)