### PR TITLE
fix(scripted-tool): sanitize custom dry-run handler errors

### DIFF
--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -102,7 +102,19 @@ impl Builtin for ToolBuiltinAdapter {
                         };
                         match cb_result {
                             Ok(stdout) => ExecResult::ok(stdout),
-                            Err(msg) => ExecResult::err(msg, 1),
+                            Err(msg) => {
+                                if self.sanitize_errors {
+                                    #[cfg(feature = "tracing")]
+                                    tracing::debug!(
+                                        tool = %self.name,
+                                        error = %msg,
+                                        "tool dry-run callback error (sanitized)"
+                                    );
+                                    ExecResult::err(format!("{}: callback failed\n", self.name), 1)
+                                } else {
+                                    ExecResult::err(msg, 1)
+                                }
+                            }
                         }
                     } else {
                         // Default: return structured JSON validation result

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -1463,6 +1463,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_custom_dry_run_handler_sanitizes_errors() {
+        let tool = ScriptedTool::builder("dr_sanitize")
+            .tool_with_dry_run(
+                ToolDef::new("check", "Validate input"),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| {
+                    Err("sensitive: /tmp/token.txt postgres://user:pass@localhost/db".to_string())
+                },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "check --dry-run".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+        assert_eq!(resp.exit_code, 1);
+        assert!(resp.stderr.contains("callback failed"));
+        assert!(!resp.stderr.contains("sensitive"));
+        assert!(!resp.stderr.contains("postgres://"));
+    }
+
+    #[tokio::test]
     async fn test_help_flag_returns_help() {
         let tool = build_test_tool();
         let resp = tool


### PR DESCRIPTION
### Motivation
- Prevent information disclosure where custom `--dry-run` handlers returned raw error strings that bypass `sanitize_errors` and could leak sensitive details.

### Description
- Apply `sanitize_errors` behavior to the custom dry-run branch in `ToolBuiltinAdapter` so dry-run handler `Err` results mirror normal callback sanitization. 
- When `sanitize_errors` is true the code now returns `"<tool>: callback failed\n"` instead of the raw message, and preserves raw errors only when sanitization is disabled. 
- Added regression test `test_custom_dry_run_handler_sanitizes_errors` to `crates/bashkit/src/scripted_tool/mod.rs` to ensure sensitive dry-run errors are not leaked. 
- Modified file: `crates/bashkit/src/scripted_tool/execute.rs` and test file: `crates/bashkit/src/scripted_tool/mod.rs`.

### Testing
- Ran targeted unit tests under the `scripted_tool` feature: `cargo test -p bashkit --features scripted_tool --lib custom_dry_run_handler_sanitizes` which passed. 
- Verified both `test_custom_dry_run_handler_sanitizes_errors` and the existing `test_custom_dry_run_handler` pass locally under the `scripted_tool` feature. 
- Note: `git fetch origin main` could not run in this environment because no `origin` remote is configured, but local tests validating the fix passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6576b274832b8cce245fea82142c)