### PR TITLE
fix(snapshot): verify keyed HMAC in constant time

### DIFF
--- a/crates/bashkit/src/snapshot.rs
+++ b/crates/bashkit/src/snapshot.rs
@@ -162,14 +162,18 @@ impl Snapshot {
     ///
     /// Rejects snapshots where the HMAC does not match, preventing forgery.
     pub fn from_bytes_keyed(data: &[u8], key: &[u8]) -> crate::Result<Self> {
+        use hmac::{Hmac, KeyInit, Mac};
+        type HmacSha256 = Hmac<Sha256>;
+
         if data.len() < DIGEST_LEN {
             return Err(crate::Error::Internal(
                 "snapshot too short: missing integrity digest".to_string(),
             ));
         }
         let (stored_digest, json) = data.split_at(DIGEST_LEN);
-        let expected = Self::compute_hmac(key, json);
-        if stored_digest != expected.as_slice() {
+        let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+        mac.update(json);
+        if mac.verify_slice(stored_digest).is_err() {
             return Err(crate::Error::Internal(
                 "snapshot integrity check failed: HMAC mismatch (wrong key or tampered data)"
                     .to_string(),


### PR DESCRIPTION
### Motivation

- Close a timing side-channel in `Snapshot::from_bytes_keyed` where the stored HMAC was compared to the computed value with slice equality, which short-circuits and can leak prefix matches to an attacker.

### Description

- In `crates/bashkit/src/snapshot.rs` replaced the computed-slice equality in `Snapshot::from_bytes_keyed` with an HMAC verifier using `hmac::Mac::verify_slice` for constant-time verification.
- Added a local `HmacSha256` type alias and construct the `Hmac` with `HmacSha256::new_from_slice(key)`, then `mac.update(json)` and `mac.verify_slice(stored_digest)`.
- Preserved the public API and the existing error message on mismatch (`"snapshot integrity check failed: HMAC mismatch (wrong key or tampered data)"`).

### Testing

- Ran `cargo test -p bashkit keyed_snapshot -- --nocapture` and the keyed snapshot tests passed (`keyed_snapshot_roundtrip`, `keyed_snapshot_wrong_key_rejected`, `keyed_snapshot_tampered_rejected`).
- The change is minimal and unit tests exercising keyed snapshot verification passed (3 tests ran and all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6b5f65b8832ba70697124167cb37)