### PR TITLE
fix(python): validate timeout_seconds before Duration conversion

### DIFF
--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -26,7 +26,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Runtime;
 use tokio::sync::{Mutex, oneshot};
 
@@ -229,6 +229,15 @@ fn parse_custom_builtins(
         )?);
     }
     Ok(builtins)
+}
+
+fn parse_timeout_seconds(timeout_seconds: f64) -> PyResult<Duration> {
+    if !timeout_seconds.is_finite() || timeout_seconds < 0.0 {
+        return Err(PyValueError::new_err(
+            "timeout_seconds must be a finite number >= 0",
+        ));
+    }
+    Ok(Duration::from_secs_f64(timeout_seconds))
 }
 
 fn clone_file_mounts(py: Python<'_>, mounts: &[PyFileMount]) -> Vec<PyFileMount> {
@@ -2446,7 +2455,7 @@ impl PyBash {
                 .max_loop_iterations(usize::try_from(max_loop_iterations).unwrap_or(usize::MAX));
         }
         if let Some(timeout_seconds) = self.timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(timeout_seconds));
+            limits = limits.timeout(parse_timeout_seconds(timeout_seconds)?);
         }
         builder = builder.limits(limits);
 
@@ -2522,7 +2531,7 @@ impl PyBash {
             limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
         }
         if let Some(ts) = timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
+            limits = limits.timeout(parse_timeout_seconds(ts)?);
         }
         builder = builder.limits(limits);
 
@@ -3061,7 +3070,7 @@ impl BashTool {
                 .max_loop_iterations(usize::try_from(max_loop_iterations).unwrap_or(usize::MAX));
         }
         if let Some(timeout_seconds) = self.timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(timeout_seconds));
+            limits = limits.timeout(parse_timeout_seconds(timeout_seconds)?);
         }
         builder = builder.limits(limits);
 
@@ -3078,7 +3087,7 @@ impl BashTool {
         ))
     }
 
-    fn build_rust_tool(&self) -> RustBashTool {
+    fn build_rust_tool(&self) -> PyResult<RustBashTool> {
         let mut builder = RustBashTool::builder();
 
         if let Some(ref username) = self.username {
@@ -3096,7 +3105,7 @@ impl BashTool {
             limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
         }
         if let Some(ts) = self.timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
+            limits = limits.timeout(parse_timeout_seconds(ts)?);
         }
 
         if !self.custom_builtins.is_empty() {
@@ -3108,7 +3117,7 @@ impl BashTool {
             }
         }
 
-        builder.limits(limits).build()
+        Ok(builder.limits(limits).build())
     }
 }
 
@@ -3156,7 +3165,7 @@ impl BashTool {
             limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
         }
         if let Some(ts) = timeout_seconds {
-            limits = limits.timeout(std::time::Duration::from_secs_f64(ts));
+            limits = limits.timeout(parse_timeout_seconds(ts)?);
         }
         builder = builder.limits(limits);
 
@@ -3533,25 +3542,25 @@ impl BashTool {
     }
 
     fn description(&self) -> PyResult<String> {
-        Ok(self.build_rust_tool().description().to_string())
+        Ok(self.build_rust_tool()?.description().to_string())
     }
 
     fn help(&self) -> PyResult<String> {
-        Ok(self.build_rust_tool().help())
+        Ok(self.build_rust_tool()?.help())
     }
 
     fn system_prompt(&self) -> PyResult<String> {
-        Ok(self.build_rust_tool().system_prompt())
+        Ok(self.build_rust_tool()?.system_prompt())
     }
 
     fn input_schema(&self) -> PyResult<String> {
-        let schema = self.build_rust_tool().input_schema();
+        let schema = self.build_rust_tool()?.input_schema();
         serde_json::to_string_pretty(&schema)
             .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
     }
 
     fn output_schema(&self) -> PyResult<String> {
-        let schema = self.build_rust_tool().output_schema();
+        let schema = self.build_rust_tool()?.output_schema();
         serde_json::to_string_pretty(&schema)
             .map_err(|e| PyValueError::new_err(format!("Schema serialization failed: {}", e)))
     }

--- a/crates/bashkit-python/tests/test_ai_adapters.py
+++ b/crates/bashkit-python/tests/test_ai_adapters.py
@@ -201,6 +201,18 @@ def test_bash_timeout_seconds_aborts_long_command():
     assert result.exit_code != 0
 
 
+@pytest.mark.parametrize("value", [-1.0, float("nan"), float("inf"), float("-inf")])
+def test_timeout_seconds_rejects_invalid_float_values(value):
+    """Bash/BashTool reject timeout_seconds values that cannot map to Duration."""
+    from bashkit import Bash, BashTool
+
+    with pytest.raises(ValueError, match="timeout_seconds must be a finite number >= 0"):
+        Bash(timeout_seconds=value)
+
+    with pytest.raises(ValueError, match="timeout_seconds must be a finite number >= 0"):
+        BashTool(timeout_seconds=value)
+
+
 def test_langchain_bashtool_accepts_timeout_seconds():
     """BashkitTool constructor accepts timeout_seconds param."""
     from bashkit.langchain import LANGCHAIN_AVAILABLE


### PR DESCRIPTION
### Motivation
- Prevent panics from `std::time::Duration::from_secs_f64` when Python callers pass negative, NaN, or infinite `timeout_seconds`, which can abort the hosting process and cause a DoS.

### Description
- Add `parse_timeout_seconds(timeout_seconds: f64) -> PyResult<Duration>` that rejects non-finite or negative values and returns a safe `Duration` via `Duration::from_secs_f64`.
- Replace direct `Duration::from_secs_f64(...)` calls in Python binding entry points with `parse_timeout_seconds(...)` for `PyBash` constructors, live builder paths, and `BashTool` flows.
- Change `BashTool::build_rust_tool` to return `PyResult<RustBashTool>` so validation failures propagate cleanly, and update metadata accessors to call the fallible builder accordingly.
- Add a regression test `test_timeout_seconds_rejects_invalid_float_values` in `crates/bashkit-python/tests/test_ai_adapters.py` that asserts `Bash` and `BashTool` raise `ValueError` for `-1.0`, `NaN`, `inf`, and `-inf` inputs.

### Testing
- Ran `cargo fmt --check`, which passed.
- Ran `cargo test -p bashkit-python --lib`, which compiled and completed successfully (unit test binary ran with 0 tests filtered in this environment).
- Ran `pytest crates/bashkit-python/tests/test_ai_adapters.py -k timeout_seconds_rejects_invalid_float_values -q`, which failed during test collection in this environment with `ModuleNotFoundError: No module named 'bashkit'` because the Python extension/package was not installed for pytest collection; the test itself verifies the new validation behavior when run in a properly configured Python test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea707f138c832baccfad11bd52fd9b)