### PR TITLE
fix(fs): enforce max_dir_count for recursive mkdir and dir CoW in OverlayFs

### DIFF
--- a/crates/bashkit/src/fs/overlay.rs
+++ b/crates/bashkit/src/fs/overlay.rs
@@ -371,20 +371,38 @@ impl OverlayFs {
         Ok(())
     }
 
-    /// Check limits before creating a directory.
+    /// Check limits before creating directories.
     ///
     /// THREAT[TM-DOS-037]: Prevents unbounded directory creation via chmod CoW
     /// and other paths that create directories in the upper layer.
-    fn check_dir_limits(&self) -> Result<()> {
+    fn check_dir_limits(&self, dirs_to_create: u64) -> Result<()> {
         let usage = self.compute_usage();
-        if usage.dir_count >= self.limits.max_dir_count {
+        let new_total = usage.dir_count.saturating_add(dirs_to_create);
+        if new_total > self.limits.max_dir_count {
             return Err(IoError::other(format!(
-                "too many directories: {} directories at {} directory limit",
-                usage.dir_count, self.limits.max_dir_count
+                "too many directories: {} + {} would exceed {} directory limit",
+                usage.dir_count, dirs_to_create, self.limits.max_dir_count
             ))
             .into());
         }
         Ok(())
+    }
+
+    /// Count directories that would be created in upper for mkdir/chmod CoW.
+    async fn count_missing_upper_dirs(&self, path: &Path, recursive: bool) -> Result<u64> {
+        if !recursive {
+            return Ok((!self.upper.exists(path).await.unwrap_or(false)) as u64);
+        }
+
+        let mut current = PathBuf::from("/");
+        let mut missing = 0u64;
+        for component in path.components().skip(1) {
+            current.push(component);
+            if !self.upper.exists(&current).await.unwrap_or(false) {
+                missing = missing.saturating_add(1);
+            }
+        }
+        Ok(missing)
     }
 
     /// Normalize a path for consistent lookups
@@ -561,7 +579,8 @@ impl FileSystem for OverlayFs {
         let path = Self::normalize_path(path);
 
         // THREAT[TM-DOS-037]: Check directory count limits before creating
-        self.check_dir_limits()?;
+        let dirs_to_create = self.count_missing_upper_dirs(&path, recursive).await?;
+        self.check_dir_limits(dirs_to_create)?;
 
         // Remove any whiteout for this path
         self.remove_whiteout(&path);
@@ -849,7 +868,8 @@ impl FileSystem for OverlayFs {
                 self.hide_lower_file(stat.size);
             } else if stat.file_type == FileType::Directory {
                 // THREAT[TM-DOS-037]: Check directory limits before CoW mkdir
-                self.check_dir_limits()?;
+                let dirs_to_create = self.count_missing_upper_dirs(&path, true).await?;
+                self.check_dir_limits(dirs_to_create)?;
                 self.upper.mkdir(&path, true).await?;
                 self.hide_lower_dir();
             }
@@ -890,7 +910,8 @@ impl FileSystem for OverlayFs {
                     self.hide_lower_file(stat.size);
                 }
                 FileType::Directory => {
-                    self.check_dir_limits()?;
+                    let dirs_to_create = self.count_missing_upper_dirs(&path, true).await?;
+                    self.check_dir_limits(dirs_to_create)?;
                     self.upper.mkdir(&path, true).await?;
                     self.hide_lower_dir();
                 }

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -2928,6 +2928,24 @@ mod overlay_limit_accounting {
         );
     }
 
+    /// TM-DOS-037: recursive mkdir must account for all missing components.
+    #[tokio::test]
+    async fn tm_dos_037_recursive_mkdir_counts_all_new_dirs() {
+        let lower = make_lower();
+        let temp = OverlayFs::new(lower.clone());
+        let base_dirs = temp.usage().dir_count;
+
+        // Only allow one additional directory, but recursive mkdir needs three.
+        let limits = FsLimits::new().max_dir_count(base_dirs + 1);
+        let overlay = OverlayFs::with_limits(lower, limits);
+
+        let result = overlay.mkdir(Path::new("/a/b/c"), true).await;
+        assert!(
+            result.is_err(),
+            "TM-DOS-037: recursive mkdir should fail when total new dirs exceed limit"
+        );
+    }
+
     // --- TM-DOS-038: Incomplete recursive whiteout ---
 
     /// TM-DOS-038: Recursive delete must hide all lower children.


### PR DESCRIPTION
### Motivation
- Recursive `mkdir` and directory copy-on-write (CoW) could create multiple directories in the upper layer after a single pre-check, allowing `max_dir_count` to be exceeded in one operation.
- Prevent a denial-of-service bypass where a single `mkdir -p` or `chmod` CoW pushes directory count past the configured limit.

### Description
- Change `check_dir_limits` to accept a `dirs_to_create: u64` parameter and enforce `current + pending <= max_dir_count` instead of only current usage.
- Add `count_missing_upper_dirs(&self, path: &Path, recursive: bool) -> Result<u64>` to compute how many directories an operation would create in the upper layer (accounts for recursive `mkdir`).
- Call the new counting/checking flow from `mkdir`, directory `chmod` CoW, and directory `set_modified_time` CoW paths so multi-component creations are considered.
- Add regression test `tm_dos_037_recursive_mkdir_counts_all_new_dirs` in `crates/bashkit/tests/threat_model_tests.rs` demonstrating that `mkdir -p /a/b/c` is rejected when insufficient directory budget remains.

### Testing
- Ran `cargo test -p bashkit tm_dos_037 -- --nocapture` which executed relevant TM-DOS-037 tests and the new regression test, and all targeted tests passed.
- Ran `cargo fmt --all` to ensure formatting; it completed without changes/errors.
- The change is minimal and focused only on counting and enforcing directory creation budget in `OverlayFs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea707ef2a0832b85737b8d3402aaba)