### PR TITLE
fix(parser): validate quoted command/process substitutions in budget pass

### DIFF
--- a/crates/bashkit/src/parser/budget.rs
+++ b/crates/bashkit/src/parser/budget.rs
@@ -201,27 +201,23 @@ fn validate_compound(
 }
 
 fn validate_word(word: &Word, ctx: &mut ValidationContext) -> Result<(), BudgetError> {
-    // Check for literal brace ranges that would be too large
-    if !word.quoted {
-        for part in &word.parts {
-            validate_word_part(part, ctx)?;
-        }
-
-        // Also check if the whole word is a literal brace range like {1..999999}
-        if word.parts.len() == 1
-            && let WordPart::Literal(s) = &word.parts[0]
-        {
-            check_brace_range(s)?;
-        }
+    // Always validate dynamic substitutions regardless of quoting.
+    // Quoting suppresses brace expansion only for literal text.
+    for part in &word.parts {
+        validate_word_part(part, ctx, word.quoted)?;
     }
     Ok(())
 }
 
-fn validate_word_part(part: &WordPart, ctx: &mut ValidationContext) -> Result<(), BudgetError> {
+fn validate_word_part(
+    part: &WordPart,
+    ctx: &mut ValidationContext,
+    word_is_quoted: bool,
+) -> Result<(), BudgetError> {
     match part {
         WordPart::CommandSubstitution(commands) => validate_commands(commands, ctx),
         WordPart::ProcessSubstitution { commands, .. } => validate_commands(commands, ctx),
-        WordPart::Literal(s) => check_brace_range(s),
+        WordPart::Literal(s) if !word_is_quoted => check_brace_range(s),
         _ => Ok(()),
     }
 }
@@ -446,6 +442,14 @@ mod tests {
     fn command_substitution_in_word_checked() {
         // Command substitution with nested loops should be checked
         let ast = parse("echo $(for i in {1..999999999}; do echo $i; done)");
+        let limits = ExecutionLimits::default();
+        let err = validate(&ast, &limits).unwrap_err();
+        assert!(matches!(err, BudgetError::BraceRangeTooLarge { .. }));
+    }
+
+    #[test]
+    fn quoted_command_substitution_is_still_checked() {
+        let ast = parse(r#"echo "$(for i in {1..999999999}; do echo $i; done)""#);
         let limits = ExecutionLimits::default();
         let err = validate(&ast, &limits).unwrap_err();
         assert!(matches!(err, BudgetError::BraceRangeTooLarge { .. }));


### PR DESCRIPTION
### Motivation
- Static budget validation skipped all `WordPart`s when `Word::quoted == true`, allowing attackers to hide expensive `$(...)`/`<(...)` constructs in quotes and bypass pre-execution budget checks.
- Need to ensure dynamic substitutions are validated regardless of quoting while preserving the semantics that literal quoted text does not perform brace expansion.

### Description
- Always traverse and validate dynamic word parts by calling `validate_word_part` for every `WordPart` in `validate_word` regardless of `word.quoted`.
- Propagate a `word_is_quoted` flag to `validate_word_part` and only run `check_brace_range` for `WordPart::Literal` when the parent word is not quoted.
- Add regression test `quoted_command_substitution_is_still_checked` to ensure quoted `$(...)` containing oversized brace ranges is rejected by the static validator.

### Testing
- Ran `cargo test -p bashkit parser::budget -- --nocapture` and all budget unit tests passed (`15 passed; 0 failed`).
- The new regression test `quoted_command_substitution_is_still_checked` passes and prevents the quoted-substitution bypass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea707f3884832b94e36cdaa152dabc)