### PR TITLE
fix(parser): enforce parser timeout in wasm parse path

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -526,7 +526,6 @@ pub struct Bash {
     mountable: Arc<MountableFs>,
     interpreter: Interpreter,
     /// Parser timeout (stored separately for use before interpreter runs)
-    #[cfg(not(target_family = "wasm"))]
     parser_timeout: std::time::Duration,
     /// Maximum input script size in bytes
     max_input_bytes: usize,
@@ -552,7 +551,6 @@ impl Bash {
         let mountable = Arc::new(MountableFs::new(base_fs));
         let fs: Arc<dyn FileSystem> = Arc::clone(&mountable) as Arc<dyn FileSystem>;
         let interpreter = Interpreter::new(Arc::clone(&fs));
-        #[cfg(not(target_family = "wasm"))]
         let parser_timeout = ExecutionLimits::default().parser_timeout;
         let max_input_bytes = ExecutionLimits::default().max_input_bytes;
         let max_ast_depth = ExecutionLimits::default().max_ast_depth;
@@ -561,7 +559,6 @@ impl Bash {
             fs,
             mountable,
             interpreter,
-            #[cfg(not(target_family = "wasm"))]
             parser_timeout,
             max_input_bytes,
             max_ast_depth,
@@ -660,7 +657,6 @@ impl Bash {
             )));
         }
 
-        #[cfg(not(target_family = "wasm"))]
         let parser_timeout = self.parser_timeout;
         let max_ast_depth = self.max_ast_depth;
         let max_parser_operations = self.max_parser_operations;
@@ -679,7 +675,12 @@ impl Bash {
         // work (no blocking thread pool, timer driver unreliable). Parse inline.
         #[cfg(target_family = "wasm")]
         let ast = {
-            let parser = Parser::with_limits(&script_owned, max_ast_depth, max_parser_operations);
+            let parser = Parser::with_limits_and_timeout(
+                &script_owned,
+                max_ast_depth,
+                max_parser_operations,
+                Some(parser_timeout),
+            );
             parser.parse()?
         };
 
@@ -2601,7 +2602,6 @@ impl BashBuilder {
             interpreter.set_history_file(hf);
         }
 
-        #[cfg(not(target_family = "wasm"))]
         let parser_timeout = limits.parser_timeout;
         let max_input_bytes = limits.max_input_bytes;
         let max_ast_depth = limits.max_ast_depth;
@@ -2619,7 +2619,6 @@ impl BashBuilder {
             fs,
             mountable,
             interpreter,
-            #[cfg(not(target_family = "wasm"))]
             parser_timeout,
             max_input_bytes,
             max_ast_depth,

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -25,6 +25,8 @@ pub use lexer::{Lexer, SpannedToken};
 pub use span::{Position, Span};
 
 use crate::error::{Error, Result};
+use crate::limits::LimitExceeded;
+use std::time::{Duration, Instant};
 
 /// Default maximum AST depth (matches ExecutionLimits default)
 const DEFAULT_MAX_AST_DEPTH: usize = 100;
@@ -60,6 +62,10 @@ pub struct Parser<'a> {
     fuel: usize,
     /// Maximum fuel (for error reporting)
     max_fuel: usize,
+    /// Optional parser timeout enforced via cooperative checks in `tick`.
+    timeout: Option<Duration>,
+    /// Parse start time used with `timeout`.
+    started_at: Instant,
 }
 
 impl<'a> Parser<'a> {
@@ -84,6 +90,16 @@ impl<'a> Parser<'a> {
     /// to prevent stack overflow from misconfiguration. Even if the caller passes
     /// `max_depth = 1_000_000`, the parser will cap it at 500.
     pub fn with_limits(input: &'a str, max_depth: usize, max_fuel: usize) -> Self {
+        Self::with_limits_and_timeout(input, max_depth, max_fuel, None)
+    }
+
+    /// Create a new parser with custom limits and optional timeout.
+    pub fn with_limits_and_timeout(
+        input: &'a str,
+        max_depth: usize,
+        max_fuel: usize,
+        timeout: Option<Duration>,
+    ) -> Self {
         let mut lexer = Lexer::with_max_subst_depth(input, max_depth.min(HARD_MAX_AST_DEPTH));
         let spanned = lexer.next_spanned_token();
         let (current_token, current_span) = match spanned {
@@ -100,6 +116,8 @@ impl<'a> Parser<'a> {
             current_depth: 0,
             fuel: max_fuel,
             max_fuel,
+            timeout,
+            started_at: Instant::now(),
         }
     }
 
@@ -145,6 +163,11 @@ impl<'a> Parser<'a> {
 
     /// Consume one unit of fuel, returning an error if exhausted
     fn tick(&mut self) -> Result<()> {
+        if let Some(timeout) = self.timeout
+            && self.started_at.elapsed() > timeout
+        {
+            return Err(Error::ResourceLimit(LimitExceeded::ParserTimeout(timeout)));
+        }
         if self.fuel == 0 {
             let used = self.max_fuel;
             return Err(Error::parse(format!(
@@ -3508,6 +3531,7 @@ impl<'a> Parser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn test_parse_simple_command() {
@@ -3523,6 +3547,17 @@ mod tests {
         } else {
             panic!("expected simple command");
         }
+    }
+
+    #[test]
+    fn test_parse_timeout_exceeded() {
+        let parser =
+            Parser::with_limits_and_timeout("echo hello", 100, 100_000, Some(Duration::ZERO));
+        let err = parser.parse().expect_err("expected parser timeout");
+        assert!(matches!(
+            err,
+            Error::ResourceLimit(LimitExceeded::ParserTimeout(timeout)) if timeout == Duration::ZERO
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- WASM/wasip1 build parsed scripts inline and compiled out `parser_timeout`, allowing pathological parses to monopolize the single-threaded WASM runtime and cause DoS. 
- Need cooperative timeout enforcement on WASM that preserves existing fuel/depth limits and respects `ExecutionLimits::parser_timeout`.

### Description
- Keep `parser_timeout` configured and stored on all targets (remove WASM-only compile-out) so the configured timeout is available at parse-time. 
- Add `Parser::with_limits_and_timeout(..., Option<Duration>)` and parser fields `timeout` and `started_at` to track parse start and optional timeout. 
- Enforce timeout cooperatively inside `Parser::tick()` by returning `LimitExceeded::ParserTimeout` when elapsed time exceeds the configured timeout. 
- Wire the WASM parse path in `Bash::exec` to call `Parser::with_limits_and_timeout(..., Some(parser_timeout))` so WASM parsing respects `parser_timeout`. 
- Add unit test `test_parse_timeout_exceeded` to validate the timeout path.

### Testing
- Ran `cargo fmt --check` after formatting, which passed. 
- Ran `cargo test -p bashkit test_parse_timeout_exceeded -- --nocapture`, and the test passed. 
- Ran `cargo test -p bashkit test_parser_timeout_normal_script -- --nocapture`, and the test passed. 
- Executed the crate test run during development (focused and package tests); no test failures were observed in the runs performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea70810e10832bb108e078c6b5aef8)