### PR TITLE
fix(interpreter): suppress coproc output in streaming callbacks

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2960,8 +2960,14 @@ impl Interpreter {
         let write_fd = self.coproc_next_fd - 1;
         self.coproc_next_fd -= 2; // reserve pair for next coproc
 
-        // Execute the command body, capturing output
-        let result = self.execute_command(&coproc.body).await?;
+        // Execute the command body while suppressing streaming callbacks.
+        // Coproc output must stay internal and be consumed only via read -u / <&FD.
+        let saved_callback = self.output_callback.take();
+        let result = self.execute_command(&coproc.body).await;
+        if let Some(callback) = saved_callback {
+            self.output_callback = Some(callback);
+        }
+        let result = result?;
 
         // Buffer stdout lines for reading via the virtual read FD.
         // Lines are stored in reverse order so pop() yields the first line.

--- a/crates/bashkit/tests/coproc_tests.rs
+++ b/crates/bashkit/tests/coproc_tests.rs
@@ -5,6 +5,7 @@
 //! named coprocs, and default COPROC name.
 
 use bashkit::Bash;
+use std::sync::{Arc, Mutex};
 
 /// Basic coproc: sets COPROC array and COPROC_PID
 #[tokio::test]
@@ -198,4 +199,35 @@ echo "$!"
     let pid = result.stdout.trim();
     assert!(!pid.is_empty());
     assert!(pid.parse::<i64>().is_ok());
+}
+
+/// Coproc stdout should not be emitted to streaming callbacks.
+#[tokio::test]
+async fn coproc_stdout_not_streamed() {
+    let streamed_stdout = Arc::new(Mutex::new(Vec::new()));
+    let cb_stdout = streamed_stdout.clone();
+    let mut bash = Bash::new();
+
+    let result = bash
+        .exec_streaming(
+            r#"
+coproc { echo hidden_value; }
+read -u ${COPROC[0]} line
+echo "visible:$line"
+"#,
+            Box::new(move |stdout, _stderr| {
+                if !stdout.is_empty() {
+                    cb_stdout.lock().unwrap().push(stdout.to_string());
+                }
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout.trim(), "visible:hidden_value");
+    assert_eq!(
+        streamed_stdout.lock().unwrap().as_slice(),
+        ["visible:hidden_value\n"],
+        "coproc body output must not be visible to streaming consumers",
+    );
 }


### PR DESCRIPTION
### Motivation
- Coprocess bodies were executed via the normal command path while streaming callbacks were active, which allowed coproc stdout to be emitted to streaming consumers and leaked data intended to be private to `read -u`/`<&FD`.
- Preventing this leakage preserves coproc semantics (stdout is buffered for virtual FDs) and avoids unintended information disclosure when `exec_streaming` is used.

### Description
- Temporarily detach the streaming `output_callback` in `execute_coproc` by `take()`-ing `self.output_callback` before running the coproc body and restoring it immediately after, so inner commands do not trigger `maybe_emit_output` to streaming clients.
- Keep existing behavior of buffering the coproc stdout into `self.coproc_buffers` and setting the NAME array and PID variables unchanged.
- Add an integration regression test `coproc_stdout_not_streamed` that uses `exec_streaming` and asserts the coproc body output is not emitted via the streaming callback but is visible after reading from the coproc FD.

### Testing
- Ran `cargo test -p bashkit --test coproc_tests coproc_stdout_not_streamed` and the single test passed (`ok`).
- Ran the full integration suite `cargo test -p bashkit --test coproc_tests` and all coproc tests passed (`10 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea753c2a78832bba351b6b5db17c99)