### PR TITLE
fix(cli): keep network default-deny unless explicitly enabled

### DIFF
--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -1,5 +1,6 @@
-// Decision: enable http, git, python by default for CLI users.
-// Provide --no-http, --no-git, --no-python to disable individually.
+// Decision: keep network default-deny in CLI mode. --http-allow-all is explicit
+// opt-in for trusted scripts only; --no-http remains for symmetry with other
+// feature toggles.
 // Decision: keep one-shot CLI on a current-thread runtime; reserve multi-thread
 // runtime for MCP only so cold-start work stays off the common path.
 // Decision: interactive mode uses relaxed execution limits (ExecutionLimits::cli())
@@ -48,6 +49,10 @@ struct Args {
     /// Disable HTTP builtins (curl/wget)
     #[arg(long)]
     no_http: bool,
+
+    /// Enable HTTP builtins with unrestricted outbound access (trusted scripts only)
+    #[arg(long, conflicts_with = "no_http")]
+    http_allow_all: bool,
 
     /// Disable git builtin
     #[arg(long)]
@@ -130,7 +135,7 @@ fn build_bash(args: &Args, mode: CliMode) -> bashkit::Bash {
 fn configure_bash(args: &Args, mode: CliMode) -> bashkit::BashBuilder {
     let mut builder = bashkit::Bash::builder();
 
-    if !args.no_http {
+    if args.http_allow_all && !args.no_http {
         builder = builder.network(bashkit::NetworkAllowlist::allow_all());
     }
 
@@ -368,16 +373,25 @@ mod tests {
             "echo hi",
         ]);
         assert!(args.no_http);
+        assert!(!args.http_allow_all);
         assert!(args.no_git);
         assert!(args.no_python);
     }
 
     #[test]
-    fn defaults_all_enabled() {
+    fn defaults_keep_http_disabled() {
         let args = Args::parse_from(["bashkit", "-c", "echo hi"]);
         assert!(!args.no_http);
+        assert!(!args.http_allow_all);
         assert!(!args.no_git);
         assert!(!args.no_python);
+    }
+
+    #[test]
+    fn parse_http_allow_all_flag() {
+        let args = Args::parse_from(["bashkit", "--http-allow-all", "-c", "curl --help"]);
+        assert!(args.http_allow_all);
+        assert!(!args.no_http);
     }
 
     #[test]
@@ -439,20 +453,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn http_enabled_by_default() {
-        // curl should be recognized (not "command not found") even if network fails
-        let args = Args::parse_from(["bashkit", "-c", "curl --help"]);
+    async fn http_disabled_by_default() {
+        let args = Args::parse_from(["bashkit", "-c", "curl https://example.com"]);
         let mut bash = build_bash(&args, CliMode::Command);
-        let result = bash.exec("curl --help").await.expect("exec");
-        assert!(!result.stderr.contains("command not found"));
+        let result = bash.exec("curl https://example.com").await.expect("exec");
+        assert!(result.stderr.contains("network access not configured"));
     }
 
     #[tokio::test]
-    async fn http_can_be_disabled() {
-        let args = Args::parse_from(["bashkit", "--no-http", "-c", "curl https://example.com"]);
+    async fn http_can_be_enabled_explicitly() {
+        let args = Args::parse_from([
+            "bashkit",
+            "--http-allow-all",
+            "-c",
+            "curl https://example.com",
+        ]);
         let mut bash = build_bash(&args, CliMode::Command);
         let result = bash.exec("curl https://example.com").await.expect("exec");
-        assert!(result.stderr.contains("not configured"));
+        assert!(!result.stderr.contains("not configured"));
     }
 
     #[tokio::test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,15 +47,19 @@ cargo build -p bashkit-cli --no-default-features
 
 Builtins enabled out of the box:
 
-- **HTTP** (`curl`, `wget`) — all URLs allowed
 - **Git** (`git`) — local VFS operations (init, add, commit, log, …)
 - **Python** (`python`, `python3`) — embedded via [Monty](https://github.com/pydantic/monty) (requires `python` feature)
+
+Disabled by default (security):
+
+- **HTTP** (`curl`, `wget`) — network access stays blocked unless explicitly enabled
 
 Disable per-run:
 
 | Flag | Effect |
 |------|--------|
-| `--no-http` | Disable curl/wget builtins |
+| `--http-allow-all` | Enable curl/wget with unrestricted outbound access (trusted scripts only) |
+| `--no-http` | Force-disable curl/wget builtins |
 | `--no-git` | Disable git builtin |
 | `--no-python` | Disable python/python3 builtins |
 

--- a/examples/harness-openai-joke.sh
+++ b/examples/harness-openai-joke.sh
@@ -71,6 +71,7 @@ is_openai_quota_error() {
 }
 
 "$BASHKIT" \
+  --http-allow-all \
   --mount-ro "${HARNESS_DIR}:/harness" \
   --mount-rw "${WORK_DIR}:/work" \
   --timeout 120 \


### PR DESCRIPTION
### Motivation

- A previous change made `bashkit-cli` call `NetworkAllowlist::allow_all()` by default, which enables unrestricted outbound HTTP and is documented as dangerous for untrusted scripts. 
- Restore a secure default-deny network posture for CLI runs so shared or automated invocation cannot exfiltrate data or perform SSRF without explicit opt-in.

### Description

- Add an explicit opt-in flag `--http-allow-all` (conflicts with `--no-http`) and change `configure_bash` to only call `NetworkAllowlist::allow_all()` when this opt-in is present. 
- Keep `--no-http` for symmetry and explicit disable semantics. 
- Update unit tests in `crates/bashkit-cli/src/main.rs` to verify HTTP is disabled by default and can be enabled only via `--http-allow-all`, and add parsing coverage for the new flag. 
- Update CLI documentation (`docs/cli.md`) to reflect that HTTP is disabled by default and to document the new `--http-allow-all` flag as a trusted, explicit opt-in.

### Testing

- Ran targeted CLI tests covering HTTP behavior (`cargo test -p bashkit-cli` with HTTP-related tests) and observed the updated tests pass. 
- Ran `cargo fmt --check` and it passed with no formatting changes required. 
- Ran the `http_*` test subset locally to validate both the default-deny and explicit opt-in behavior and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea707ee060832b84a35b45671fb4f9)