### PR TITLE
fix(parser): preserve quoted expansion semantics in mixed words

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -12356,6 +12356,18 @@ cat /tmp/test_fd_leak.txt"#,
         assert_eq!(result.stdout.trim(), "prefixa b c");
     }
 
+    // Mixed-quoting starting with quote: "$var"suffix must stay one word.
+    #[tokio::test]
+    async fn test_mixed_quote_starts_with_var_no_split() {
+        let result = run_script(
+            r#"v="a b c"; set -- "${v}"suffix; echo "count:$#"; echo "arg1:$1"; echo "arg2:${2:-<none>}""#,
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["count:1", "arg1:a b csuffix", "arg2:<none>"]);
+    }
+
     /// Issue #1184: input process substitution temp files must be cleaned up
     #[tokio::test]
     async fn test_proc_sub_input_cleanup() {

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1189,6 +1189,7 @@ impl<'a> Lexer<'a> {
         self.advance(); // consume opening "
         let mut content = String::new();
         let mut closed = false;
+        let mut has_quoted_expansion = false;
 
         while let Some(ch) = self.peek_char() {
             match ch {
@@ -1228,6 +1229,13 @@ impl<'a> Lexer<'a> {
                 '$' => {
                     content.push('$');
                     self.advance();
+                    if self.peek_char().is_some_and(|nc| {
+                        nc.is_ascii_alphanumeric()
+                            || nc == '_'
+                            || matches!(nc, '{' | '(' | '?' | '#' | '@' | '*' | '!' | '$' | '-')
+                    }) {
+                        has_quoted_expansion = true;
+                    }
                     if self.peek_char() == Some('(') {
                         // $(...) command substitution — track paren depth
                         content.push('(');
@@ -1243,6 +1251,7 @@ impl<'a> Lexer<'a> {
                 }
                 '`' => {
                     // Backtick command substitution inside double quotes
+                    has_quoted_expansion = true;
                     self.advance(); // consume opening `
                     content.push_str("$(");
                     while let Some(c) = self.peek_char() {
@@ -1294,8 +1303,11 @@ impl<'a> Lexer<'a> {
             let has_glob = content[before_len..]
                 .chars()
                 .any(|c| matches!(c, '*' | '?' | '['));
-            if has_glob && content[..before_len].contains('$') {
+            if has_quoted_expansion && has_glob {
                 return Some(Token::QuotedGlobWord(content));
+            }
+            if has_quoted_expansion {
+                return Some(Token::QuotedWord(content));
             }
             return Some(Token::Word(content));
         }


### PR DESCRIPTION
### Motivation
- Mixed quoted+unquoted words like `"$DIR"/*` were lexed as `Token::Word` after concatenation, dropping the quoted flag and causing IFS splitting and unintended glob/brace expansion of the quoted segment.

### Description
- Track a `has_quoted_expansion` flag while scanning double-quoted content in `read_double_quoted_string` so the lexer knows if the quoted segment contains an expansion (`$` or backtick subs).
- When a quoted segment is concatenated with adjacent unquoted continuation, return `QuotedGlobWord` if `has_quoted_expansion && has_glob`, return `QuotedWord` if `has_quoted_expansion`, otherwise return `Word`; this preserves IFS-suppression for quoted expansions while still allowing globbing on unquoted suffixes.
- Added a regression test `test_mixed_quote_starts_with_var_no_split` in `crates/bashkit/src/interpreter/mod.rs` to ensure `"${v}"suffix` does not get IFS-split into multiple args.
- Files changed: `crates/bashkit/src/parser/lexer.rs`, `crates/bashkit/src/interpreter/mod.rs`.

### Testing
- Ran `cargo test -p bashkit test_glob_with_quoted_prefix -- --nocapture` and it passed.
- Ran `cargo test -p bashkit test_mixed_quote_starts_with_var_no_split -- --nocapture` and it passed.
- Verified the regression scenario by exercising mixed quoted/unquoted token handling in unit tests; no new failures observed in the targeted tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead5316b58832ba68db3dff7163452)