### PR TITLE
fix(parser): preserve quoting semantics for $'...' and $"..."

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -600,13 +600,20 @@ impl<'a> Lexer<'a> {
                 // $'...' — ANSI-C quoting: resolve escapes at parse time
                 if self.peek_char() == Some('\'') {
                     self.advance(); // consume opening '
-                    word.push_str(&self.read_dollar_single_quoted_content());
+                    Self::push_literal_with_escaped_dollar(
+                        &mut word,
+                        &self.read_dollar_single_quoted_content(),
+                    );
+                    // ANSI-C quotes are single-quote semantics: quoted context.
+                    has_quoted_expansion = true;
                     continue;
                 }
 
                 // $"..." — locale translation synonym, treated like "..."
                 if self.peek_char() == Some('"') {
                     self.advance(); // consume opening "
+                    // Locale quotes are double-quote semantics: quoted context.
+                    has_quoted_expansion = true;
                     while let Some(c) = self.peek_char() {
                         if c == '"' {
                             self.advance();
@@ -1059,7 +1066,10 @@ impl<'a> Lexer<'a> {
                     if lookahead.next() == Some('\'') {
                         self.advance(); // consume $
                         self.advance(); // consume opening '
-                        content.push_str(&self.read_dollar_single_quoted_content());
+                        Self::push_literal_with_escaped_dollar(
+                            content,
+                            &self.read_dollar_single_quoted_content(),
+                        );
                     } else {
                         content.push('$');
                         self.advance();
@@ -1183,6 +1193,16 @@ impl<'a> Lexer<'a> {
             self.advance();
         }
         out
+    }
+
+    /// Append a literal segment while protecting `$` from parse_word expansion.
+    fn push_literal_with_escaped_dollar(dst: &mut String, segment: &str) {
+        for ch in segment.chars() {
+            if ch == '$' {
+                dst.push('\x00');
+            }
+            dst.push(ch);
+        }
     }
 
     fn read_double_quoted_string(&mut self) -> Option<Token> {

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -3826,6 +3826,43 @@ mod tests {
     }
 
     #[test]
+    fn test_ansi_c_quoted_dollar_is_literal_and_quoted() {
+        let parser = Parser::new("echo $'$(printf pwned)'");
+        let script = parser.parse().unwrap();
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.args.len(), 1);
+            let arg = &cmd.args[0];
+            assert!(arg.quoted, "ANSI-C quoted argument must be quoted");
+            assert!(
+                arg.parts
+                    .iter()
+                    .all(|part| matches!(part, WordPart::Literal(_))),
+                "ANSI-C quoted argument must remain literal, got {:?}",
+                arg.parts
+            );
+            assert_eq!(arg.to_string(), "$(printf pwned)");
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
+    fn test_locale_quote_marks_word_as_quoted_without_expansion() {
+        let parser = Parser::new("echo $\"*.txt\"");
+        let script = parser.parse().unwrap();
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.args.len(), 1);
+            assert!(
+                cmd.args[0].quoted,
+                "locale-quoted argument must be marked quoted"
+            );
+            assert_eq!(cmd.args[0].to_string(), "*.txt");
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
     fn test_top_level_reserved_word_errors_immediately() {
         let parser = Parser::with_fuel("fi", usize::MAX);
         let err = parser.parse().unwrap_err();


### PR DESCRIPTION
### Motivation
- `$'...'` (ANSI-C) and `$"..."` segments were being inlined into plain `Word` tokens and lost their quoted/literal semantics, allowing `$()`/`${}` expansions and globbing to occur.
- This permits untrusted input embedded via `$'...'` to be reinterpreted and executed, violating intended literal quoting semantics and creating a security risk.

### Description
- Mark `$'...'` and `$"..."` segments as quoted context during lexing by setting the lexer `has_quoted_expansion` flag so downstream logic treats the whole token as quoted (prevents IFS-splitting and unwanted glob application). (`crates/bashkit/src/parser/lexer.rs`)
- Preserve literal `$` inside ANSI-C quoted content by inserting the NUL sentinel used by the parser to indicate a literal `$` via a new helper `push_literal_with_escaped_dollar`. (`crates/bashkit/src/parser/lexer.rs`)
- Apply the same `$`-escaping in the quoted-segment continuation path so concatenated `$'...'` pieces remain literal. (`crates/bashkit/src/parser/lexer.rs`)
- Add parser regression tests that assert `$'$(printf pwned)'` remains a quoted literal and that `$"*.txt"` is marked quoted and not expanded. (`crates/bashkit/src/parser/mod.rs`)

### Testing
- Added unit tests: `test_ansi_c_quoted_dollar_is_literal_and_quoted` and `test_locale_quote_marks_word_as_quoted_without_expansion` in `crates/bashkit/src/parser/mod.rs`.
- Verified failure of `test_ansi_c_quoted_dollar_is_literal_and_quoted` before the fix and verified both new tests pass after the fix using `cargo test -p bashkit <TESTNAME> -- --nocapture`.
- Ran the package test run for `bashkit` (`cargo test -p bashkit`) and observed targeted tests passing with no regressions in the executed suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead8dc2b24832b964a72c38637e716)