### PR TITLE
fix(glob): honor dotglob during globstar directory traversal

### DIFF
--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -766,7 +766,7 @@ impl Interpreter {
         let mut all_dirs = vec![base_dir.clone()];
         // THREAT[TM-DOS-049]: Cap recursion depth using filesystem path depth limit
         let max_depth = self.fs.limits().max_path_depth;
-        self.collect_dirs_recursive(&base_dir, &mut all_dirs, max_depth)
+        self.collect_dirs_recursive(&base_dir, &mut all_dirs, max_depth, dotglob)
             .await;
 
         let mut matches = Vec::new();
@@ -812,6 +812,7 @@ impl Interpreter {
         dir: &'a Path,
         result: &'a mut Vec<PathBuf>,
         max_depth: usize,
+        dotglob: bool,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
         Box::pin(async move {
             if max_depth == 0 {
@@ -820,9 +821,12 @@ impl Interpreter {
             if let Ok(entries) = self.fs.read_dir(dir).await {
                 for entry in entries {
                     if entry.metadata.file_type.is_dir() {
+                        if entry.name.starts_with('.') && !dotglob {
+                            continue;
+                        }
                         let subdir = dir.join(&entry.name);
                         result.push(subdir.clone());
-                        self.collect_dirs_recursive(&subdir, result, max_depth - 1)
+                        self.collect_dirs_recursive(&subdir, result, max_depth - 1, dotglob)
                             .await;
                     }
                 }

--- a/crates/bashkit/tests/spec_cases/bash/glob-options.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/glob-options.test.sh
@@ -144,3 +144,13 @@ echo /tmp/gs_on/**/*.txt
 ### expect
 /tmp/gs_on/sub/deep.txt /tmp/gs_on/top.txt
 ### end
+
+### globstar_dotglob_off_does_not_descend_hidden_dirs
+# With globstar enabled but dotglob off, ** should not traverse dot directories
+mkdir -p /tmp/gs_dot/sub /tmp/gs_dot/.hidden
+touch /tmp/gs_dot/sub/visible.txt /tmp/gs_dot/.hidden/secret.txt
+shopt -s globstar
+echo /tmp/gs_dot/**/*.txt
+### expect
+/tmp/gs_dot/sub/visible.txt
+### end


### PR DESCRIPTION
### Motivation
- `collect_dirs_recursive` descended into dot-prefixed directories unconditionally, allowing `**` to traverse hidden folders even when `dotglob` is off and exposing hidden files.
- Behavior violated existing matching semantics where entries starting with `.` are skipped unless `dotglob` is set or the pattern explicitly starts with `.`.

### Description
- Thread the `dotglob` flag from `expand_glob_recursive` into `collect_dirs_recursive` so traversal policy matches matching policy.
- Make `collect_dirs_recursive` skip directories whose names start with `.` when `dotglob` is `false` to prevent hidden-directory descent.
- Add a regression spec `globstar_dotglob_off_does_not_descend_hidden_dirs` to `crates/bashkit/tests/spec_cases/bash/glob-options.test.sh` that asserts `**/*.txt` does not return files under `.hidden/` with default `dotglob` off.
- Changes are localized to `crates/bashkit/src/interpreter/glob.rs` and the new test in `crates/bashkit/tests/spec_cases/bash/glob-options.test.sh`.

### Testing
- Ran `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture` and the spec suite passed with the new test (100% pass rate for the invoked suite).
- Ran `cargo fmt --check` which returned clean.
- Added the spec test to prevent regressions in `globstar` + `dotglob` semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead8dc2684832b9341d3d263864b89)