### PR TITLE
docs(cli): rewrite public CLI reference

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,22 +1,19 @@
 # bashkit-cli
 
-Command-line interface for running bash scripts in a sandboxed virtual filesystem.
+Command-line interface for running bash scripts in a sandboxed virtual
+filesystem. One binary, four modes.
 
-## Defaults
+## Modes
 
-Enabled out of the box:
+| Invocation | Mode | Runtime |
+|------------|------|---------|
+| `bashkit -c '…'` | Execute command string, print stdout/stderr, exit | current-thread tokio |
+| `bashkit script.sh` | Execute script file | current-thread tokio |
+| `bashkit` | Interactive shell (REPL) | current-thread tokio |
+| `bashkit mcp` | Model Context Protocol server over stdio | multi-thread tokio |
 
-- **HTTP** (`curl`, `wget`) — all URLs allowed
-- **Git** (`git`) — local VFS operations (init, add, commit, log, etc.)
-- **Python** (`python`, `python3`) — embedded via [Monty](https://github.com/pydantic/monty)
-
-Disable per-run:
-
-| Flag | Effect |
-|------|--------|
-| `--no-http` | Disable curl/wget builtins |
-| `--no-git` | Disable git builtin |
-| `--no-python` | Disable python/python3 builtins |
+Mode is detected from arguments — `mcp` subcommand wins, then `-c`, then
+positional script, otherwise REPL.
 
 ## Install
 
@@ -28,6 +25,153 @@ cd bashkit
 cargo install --path crates/bashkit-cli
 ```
 
+Prebuilt binaries via `cargo-binstall` (see releases page) or `cargo install
+bashkit-cli`.
+
+### Build features
+
+| Feature | Default | Effect |
+|---------|---------|--------|
+| `interactive` | on | Interactive REPL (rustyline, signal-hook, terminal_size) |
+| `python` | on | `python`/`python3` builtin via Monty |
+| `realfs` | off | `--mount-ro` / `--mount-rw` host filesystem mounts |
+| `scripted_tool` | off | Scripted tool orchestration |
+
+Build without interactive (library-only deps):
+
+```bash
+cargo build -p bashkit-cli --no-default-features
+```
+
+## Defaults
+
+Builtins enabled out of the box:
+
+- **HTTP** (`curl`, `wget`) — all URLs allowed
+- **Git** (`git`) — local VFS operations (init, add, commit, log, …)
+- **Python** (`python`, `python3`) — embedded via [Monty](https://github.com/pydantic/monty) (requires `python` feature)
+
+Disable per-run:
+
+| Flag | Effect |
+|------|--------|
+| `--no-http` | Disable curl/wget builtins |
+| `--no-git` | Disable git builtin |
+| `--no-python` | Disable python/python3 builtins |
+
+## Execution limits
+
+CLI and script modes start from `ExecutionLimits::cli()` — counting-based
+limits are effectively unlimited, timeout is off (user has Ctrl-C). Memory
+guards (function depth, AST depth, parser fuel) stay on.
+
+MCP mode starts from `ExecutionLimits::new()` — the sandboxed defaults
+(10 000 commands, 30 s timeout, …).
+
+Override any mode with:
+
+| Flag | Meaning |
+|------|---------|
+| `--max-commands N` | Max commands per run |
+| `--max-loop-iterations N` | Max iterations in a single loop |
+| `--max-total-loop-iterations N` | Max iterations across all loops |
+| `--timeout SECONDS` | Wall-clock execution timeout |
+
+## Host filesystem mounts (`realfs` feature)
+
+By default the VFS is in-memory — scripts cannot reach the host. With
+`realfs`:
+
+| Flag | Effect |
+|------|--------|
+| `--mount-ro HOST[:VFS]` | Overlay host dir as read-only |
+| `--mount-rw HOST[:VFS]` | Overlay host dir as read-write |
+
+Omit `:VFS` to overlay at VFS root. Both flags repeat.
+
+```bash
+bashkit --mount-ro /path/to/project -c 'ls /'
+bashkit --mount-ro /data:/mnt/data -c 'wc -l /mnt/data/*.csv'
+bashkit --mount-rw /tmp/out:/mnt/out script.sh
+```
+
+**Warning.** `--mount-rw` breaks the sandbox boundary. Using it with `mcp`
+prints a warning to stderr — LLM agents get read-write access to host files.
+Prefer `--mount-ro` unless writes are required.
+
+## Interactive shell
+
+Run `bashkit` with no arguments. The REPL uses `rustyline` for line editing
+and reuses the same sandbox as `-c`. Lightweight deps, no SQLite, no
+crossterm.
+
+### Features
+
+- Emacs / vi line editing, in-memory history (1 000 entries)
+- Multiline input — unterminated quotes, `if`/`for`/`while`/`case`/functions
+  reprompt with PS2 until closed
+- Ctrl-C cancels the running command (propagates via the cancellation token);
+  at an empty prompt it clears the line
+- Ctrl-D exits the shell
+- `exit [N]` exits via an `on_exit` hook (works from pipelines and
+  conditionals: `echo bye; exit 1`)
+- Streaming output — stdout/stderr flushed as produced
+- TTY detection: `[ -t 0 ]`, `[ -t 1 ]`, `[ -t 2 ]` all return true
+- Tab completion — builtins, aliases, `$VAR`, VFS paths (directories get
+  trailing `/`)
+- Fish-style history hints inline (dim gray); accept with right arrow
+- `COLUMNS`, `LINES` exported from the real terminal size; `SHLVL`
+  incremented from parent
+
+### Prompt (PS1 / PS2)
+
+Default `PS1`: `\u@bashkit:\w\$ ` (e.g. `user@bashkit:~$ `). Override with
+`export PS1='…'`. `PS2` (continuation) defaults to `> `.
+
+Supported escapes:
+
+| Escape | Meaning |
+|--------|---------|
+| `\u` | Username (`$USER`) |
+| `\h` | Short hostname (up to first `.`) |
+| `\H` | Full hostname |
+| `\w` | Working directory, `~` for `$HOME` |
+| `\W` | Basename of cwd |
+| `\$` | `$` for non-root, `#` if `EUID=0` |
+| `\n` `\r` `\a` `\e` | Newline, CR, bell, ESC |
+| `\[` `\]` | Non-printing sequence markers (ANSI codes) |
+| `\\` | Literal backslash |
+
+### Startup file
+
+Sources `~/.bashkitrc` from the VFS on startup if present. Put it on the
+host and expose it via `--mount-rw /path:/home/user` (or `--mount-ro` for a
+read-only rc). Typical contents: aliases, `PS1`, environment.
+
+### Not implemented (by design)
+
+- Job control (`bg`/`fg`/`jobs`) — no real processes
+- History expansion (`!!`, `!N`) — complexity vs. value
+- Persistent history file — would leak across sessions, breaks isolation
+- `exec` — excluded for security
+
+## MCP server
+
+Speak JSON-RPC 2.0 over stdio. Exposes bashkit as an MCP tool for agent
+frameworks.
+
+```bash
+bashkit mcp
+bashkit mcp --max-requests-per-minute 60
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--max-requests-per-minute N` | Rate limit tool calls; `0` = unlimited (default) |
+
+MCP mode keeps the sandboxed defaults (command caps, timeout). Each request
+builds a fresh `Bash`. See `crates/bashkit-cli/src/mcp.rs`.
+
 ## Examples
 
 Text processing:
@@ -37,14 +181,14 @@ bashkit -c 'echo "hello world" | tr a-z A-Z'
 # HELLO WORLD
 ```
 
-Python (enabled by default):
+Python (default):
 
 ```bash
 bashkit -c 'python3 -c "print(2 + 2)"'
 # 4
 ```
 
-Git on the virtual filesystem:
+Git on the VFS:
 
 ```bash
 bashkit -c '
@@ -57,7 +201,7 @@ git log --oneline
 '
 ```
 
-Disable python:
+Disable a builtin:
 
 ```bash
 bashkit --no-python -c 'python --version'
@@ -67,11 +211,45 @@ bashkit --no-python -c 'python --version'
 Run a script file:
 
 ```bash
-bashkit script.sh
+bashkit script.sh arg1 arg2
 ```
 
-MCP server mode:
+Interactive shell:
+
+```bash
+bashkit
+user@bashkit:~$ echo hi
+hi
+user@bashkit:~$ exit
+```
+
+Mount host workspace read-only and inspect:
+
+```bash
+bashkit --mount-ro "$PWD:/mnt/repo" -c 'wc -l /mnt/repo/**/*.rs'
+```
+
+Tighten limits for an untrusted script:
+
+```bash
+bashkit --max-commands 1000 --timeout 5 untrusted.sh
+```
+
+MCP server:
 
 ```bash
 bashkit mcp
 ```
+
+## Error handling
+
+Stack backtraces are suppressed. Panics emit a single sanitized line
+(`bashkit: internal error: …`) — no paths, line numbers, or dependency
+versions. THREAT `TM-INF-021`.
+
+## See also
+
+- [`docs/security.md`](security.md) — threat model and mitigations
+- [`specs/interactive-shell.md`](../specs/interactive-shell.md) — REPL design
+- [`specs/threat-model.md`](../specs/threat-model.md) — full threat catalogue
+- [`README.md`](../README.md) — library usage and features

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,16 +16,17 @@ otherwise REPL.
 
 ## Install
 
-From source:
+From crates.io:
 
 ```bash
-git clone https://github.com/everruns/bashkit
-cd bashkit
-cargo install --path crates/bashkit-cli
+cargo install bashkit-cli
 ```
 
-Prebuilt binaries via `cargo-binstall` (see releases page) or `cargo install
-bashkit-cli`.
+Prebuilt binary via [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```bash
+cargo binstall bashkit-cli
+```
 
 ### Build features
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,19 +1,18 @@
 # bashkit-cli
 
 Command-line interface for running bash scripts in a sandboxed virtual
-filesystem. One binary, four modes.
+filesystem. One binary, three modes.
 
 ## Modes
 
-| Invocation | Mode | Runtime |
-|------------|------|---------|
-| `bashkit -c '…'` | Execute command string, print stdout/stderr, exit | current-thread tokio |
-| `bashkit script.sh` | Execute script file | current-thread tokio |
-| `bashkit` | Interactive shell (REPL) | current-thread tokio |
-| `bashkit mcp` | Model Context Protocol server over stdio | multi-thread tokio |
+| Invocation | Mode |
+|------------|------|
+| `bashkit -c '…'` | Execute command string, print stdout/stderr, exit |
+| `bashkit script.sh` | Execute script file |
+| `bashkit` | Interactive shell (REPL) |
 
-Mode is detected from arguments — `mcp` subcommand wins, then `-c`, then
-positional script, otherwise REPL.
+Mode is detected from arguments — `-c` wins, then positional script,
+otherwise REPL.
 
 ## Install
 
@@ -61,14 +60,11 @@ Disable per-run:
 
 ## Execution limits
 
-CLI and script modes start from `ExecutionLimits::cli()` — counting-based
-limits are effectively unlimited, timeout is off (user has Ctrl-C). Memory
-guards (function depth, AST depth, parser fuel) stay on.
+All modes start from `ExecutionLimits::cli()` — counting-based limits are
+effectively unlimited, timeout is off (user has Ctrl-C). Memory guards
+(function depth, AST depth, parser fuel) stay on.
 
-MCP mode starts from `ExecutionLimits::new()` — the sandboxed defaults
-(10 000 commands, 30 s timeout, …).
-
-Override any mode with:
+Override with:
 
 | Flag | Meaning |
 |------|---------|
@@ -95,9 +91,8 @@ bashkit --mount-ro /data:/mnt/data -c 'wc -l /mnt/data/*.csv'
 bashkit --mount-rw /tmp/out:/mnt/out script.sh
 ```
 
-**Warning.** `--mount-rw` breaks the sandbox boundary. Using it with `mcp`
-prints a warning to stderr — LLM agents get read-write access to host files.
-Prefer `--mount-ro` unless writes are required.
+**Warning.** `--mount-rw` breaks the sandbox boundary — scripts can modify
+host files. Prefer `--mount-ro` unless writes are required.
 
 ## Interactive shell
 
@@ -154,23 +149,6 @@ read-only rc). Typical contents: aliases, `PS1`, environment.
 - History expansion (`!!`, `!N`) — complexity vs. value
 - Persistent history file — would leak across sessions, breaks isolation
 - `exec` — excluded for security
-
-## MCP server
-
-Speak JSON-RPC 2.0 over stdio. Exposes bashkit as an MCP tool for agent
-frameworks.
-
-```bash
-bashkit mcp
-bashkit mcp --max-requests-per-minute 60
-```
-
-| Flag | Meaning |
-|------|---------|
-| `--max-requests-per-minute N` | Rate limit tool calls; `0` = unlimited (default) |
-
-MCP mode keeps the sandboxed defaults (command caps, timeout). Each request
-builds a fresh `Bash`. See `crates/bashkit-cli/src/mcp.rs`.
 
 ## Examples
 
@@ -233,12 +211,6 @@ Tighten limits for an untrusted script:
 
 ```bash
 bashkit --max-commands 1000 --timeout 5 untrusted.sh
-```
-
-MCP server:
-
-```bash
-bashkit mcp
 ```
 
 ## Error handling

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -218,11 +218,9 @@ bashkit --max-commands 1000 --timeout 5 untrusted.sh
 
 Stack backtraces are suppressed. Panics emit a single sanitized line
 (`bashkit: internal error: …`) — no paths, line numbers, or dependency
-versions. THREAT `TM-INF-021`.
+versions.
 
 ## See also
 
 - [`docs/security.md`](security.md) — threat model and mitigations
-- [`specs/interactive-shell.md`](../specs/interactive-shell.md) — REPL design
-- [`specs/threat-model.md`](../specs/threat-model.md) — full threat catalogue
 - [`README.md`](../README.md) — library usage and features


### PR DESCRIPTION
## Summary

Rewrite `docs/cli.md` end-to-end against the actual `bashkit-cli` source
(`main.rs`, `interactive.rs`). The prior doc listed only `-c`, script,
and `mcp` with three `--no-*` flags — it missed the REPL, mounts,
execution limits, and build features.

## What's in

- **Modes** — `-c`, script file, interactive shell (REPL).
- **Install** — `cargo install bashkit-cli` and `cargo binstall bashkit-cli`.
- **Build features** — `interactive`, `python`, `realfs`, `scripted_tool`.
- **Defaults & `--no-*` flags** — HTTP, git, python.
- **Execution limits** — `--max-commands`, `--max-loop-iterations`,
  `--max-total-loop-iterations`, `--timeout`.
- **Host mounts** (`realfs`) — `--mount-ro` / `--mount-rw`, HOST[:VFS]
  syntax, sandbox warning.
- **Interactive shell** — line editing, multiline, Ctrl-C/Ctrl-D, `exit`
  hook, TTY, tab completion, history hints, `COLUMNS`/`LINES`/`SHLVL`;
  full PS1/PS2 escape table; `~/.bashkitrc` sourcing; deliberate omissions.
- **Examples** covering every mode and flag.
- **Error handling** note about sanitized panic output.

## What's out

- MCP section removed per review — CLI-user doc shouldn't describe the
  MCP server surface.
- No spec links / internal threat IDs in the public doc.

## Test plan

- [x] Doc reviewed against `crates/bashkit-cli/src/main.rs` and
  `crates/bashkit-cli/src/interactive.rs` — every flag, escape, and
  default matches the code.
- [x] No broken links (`docs/security.md`, `README.md` both exist).
- [x] No stale references in tree (`grep -r 'docs/cli'` clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kde8u4UR68nykDJqPktyku)_