### PR TITLE
fix(grep): avoid panic in quoted include/exclude parsing

### DIFF
--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -302,8 +302,10 @@ impl GrepOptions {
 
 /// Strip surrounding single or double quotes from a value
 fn strip_quotes(s: &str) -> String {
-    if (s.starts_with('\'') && s.ends_with('\'')) || (s.starts_with('"') && s.ends_with('"')) {
-        s[1..s.len() - 1].to_string()
+    if let Some(inner) = s.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+        inner.to_string()
+    } else if let Some(inner) = s.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+        inner.to_string()
     } else {
         s.to_string()
     }
@@ -1122,6 +1124,12 @@ mod tests {
 
         assert!(should_include_file("foo.txt", &inc, &exc));
         assert!(!should_include_file("foo.log", &inc, &exc));
+    }
+
+    #[test]
+    fn test_strip_quotes_single_quote_char_does_not_panic() {
+        assert_eq!(strip_quotes("'"), "'");
+        assert_eq!(strip_quotes("\""), "\"");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent a panic when parsing `--include=`/`--exclude=` values that are a single quote character, because the previous `strip_quotes` used a byte-slice `s[1..s.len()-1]` which is invalid for length 1 inputs.

### Description
- Harden `strip_quotes` to use `strip_prefix`/`strip_suffix` for single/double quotes so surrounding quotes are removed safely and existing behavior for normally quoted values is preserved, and add `test_strip_quotes_single_quote_char_does_not_panic` to cover the regression.

### Testing
- Ran `cargo test -p bashkit test_strip_quotes_single_quote_char_does_not_panic`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadc412fa4832bb7a4d07393e8b7b1)