### PR TITLE
fix(parsers): harden unicode and nesting guards

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -10,8 +10,9 @@
 //!   awk '/pattern/{print}' file
 //!   awk 'NR==2{print}' file
 
-// AWK parser uses chars().nth().unwrap() after validating position.
-// This is safe because we check bounds before accessing.
+// Parser invariant: `pos` is always a byte offset on a UTF-8 char boundary.
+// Move across user-controlled text with `advance()`/`consume_while()`, and use
+// raw `pos += N` only for known ASCII tokens and delimiters.
 #![allow(clippy::unwrap_used)]
 
 use async_trait::async_trait;
@@ -467,6 +468,14 @@ struct AwkParser<'a> {
 }
 
 impl<'a> AwkParser<'a> {
+    fn is_identifier_start(c: char) -> bool {
+        c.is_alphabetic() || c == '_'
+    }
+
+    fn is_identifier_continue(c: char) -> bool {
+        c.is_alphanumeric() || c == '_'
+    }
+
     fn new(input: &'a str) -> Self {
         Self {
             input,
@@ -486,6 +495,17 @@ impl<'a> AwkParser<'a> {
     fn advance(&mut self) {
         if let Some(c) = self.current_char() {
             self.pos += c.len_utf8();
+        }
+    }
+
+    fn consume_while(&mut self, predicate: fn(char) -> bool) {
+        while self.pos < self.input.len() {
+            let c = self.current_char().unwrap();
+            if predicate(c) {
+                self.advance();
+            } else {
+                break;
+            }
         }
     }
 
@@ -611,14 +631,7 @@ impl<'a> AwkParser<'a> {
     /// Read an identifier (alphanumeric + underscore)
     fn read_identifier(&mut self) -> Result<String> {
         let start = self.pos;
-        while self.pos < self.input.len() {
-            let c = self.current_char().unwrap();
-            if c.is_alphanumeric() || c == '_' {
-                self.advance();
-            } else {
-                break;
-            }
-        }
+        self.consume_while(Self::is_identifier_continue);
         if self.pos == start {
             return Err(Error::Execution("awk: expected identifier".to_string()));
         }
@@ -1054,14 +1067,7 @@ impl<'a> AwkParser<'a> {
                 self.skip_whitespace();
                 // Parse array name
                 let start = self.pos;
-                while self.pos < self.input.len() {
-                    let c = self.current_char().unwrap();
-                    if c.is_alphanumeric() || c == '_' {
-                        self.pos += 1;
-                    } else {
-                        break;
-                    }
-                }
+                self.consume_while(Self::is_identifier_continue);
                 let arr_name = self.input[start..self.pos].to_string();
 
                 self.skip_whitespace();
@@ -1216,14 +1222,7 @@ impl<'a> AwkParser<'a> {
 
         // Parse array name
         let start = self.pos;
-        while self.pos < self.input.len() {
-            let c = self.current_char().unwrap();
-            if c.is_alphanumeric() || c == '_' {
-                self.pos += 1;
-            } else {
-                break;
-            }
-        }
+        self.consume_while(Self::is_identifier_continue);
         let arr_name = self.input[start..self.pos].to_string();
 
         self.skip_whitespace();
@@ -1261,16 +1260,10 @@ impl<'a> AwkParser<'a> {
         if self.pos < self.input.len() {
             let c = self.current_char().unwrap();
             // If next char is an identifier start (not '<', ';', '}', etc.), parse variable
-            if c.is_alphabetic() || c == '_' {
+            if Self::is_identifier_start(c) {
                 let start = self.pos;
-                while self.pos < self.input.len() {
-                    let ch = self.current_char().unwrap();
-                    if ch.is_alphanumeric() || ch == '_' {
-                        self.pos += 1;
-                    } else {
-                        break;
-                    }
-                }
+                self.advance();
+                self.consume_while(Self::is_identifier_continue);
                 var = Some(self.input[start..self.pos].to_string());
                 self.skip_whitespace();
             }
@@ -1299,16 +1292,10 @@ impl<'a> AwkParser<'a> {
 
         if self.pos < self.input.len() {
             let c = self.current_char().unwrap();
-            if c.is_alphabetic() || c == '_' {
+            if Self::is_identifier_start(c) {
                 let start = self.pos;
-                while self.pos < self.input.len() {
-                    let ch = self.current_char().unwrap();
-                    if ch.is_alphanumeric() || ch == '_' {
-                        self.pos += 1;
-                    } else {
-                        break;
-                    }
-                }
+                self.advance();
+                self.consume_while(Self::is_identifier_continue);
                 var = Some(self.input[start..self.pos].to_string());
                 self.skip_whitespace();
             }
@@ -1504,14 +1491,7 @@ impl<'a> AwkParser<'a> {
         if self.matches_keyword("in") {
             self.skip_whitespace();
             let start = self.pos;
-            while self.pos < self.input.len() {
-                let c = self.current_char().unwrap();
-                if c.is_alphanumeric() || c == '_' {
-                    self.pos += 1;
-                } else {
-                    break;
-                }
-            }
+            self.consume_while(Self::is_identifier_continue);
             let arr_name = self.input[start..self.pos].to_string();
             return Ok(AwkExpr::InArray(Box::new(left), arr_name));
         }
@@ -1571,7 +1551,7 @@ impl<'a> AwkParser<'a> {
 
             let c = self.current_char().unwrap();
             // Check if this could be the start of another value for concatenation
-            if c == '"' || c == '$' || c.is_alphabetic() || c == '(' {
+            if c == '"' || c == '$' || Self::is_identifier_start(c) || c == '(' {
                 // But not if it's a keyword or operator
                 let remaining = &self.input[self.pos..];
                 if !remaining.starts_with("||")
@@ -1909,16 +1889,10 @@ impl<'a> AwkParser<'a> {
         }
 
         // Variable or function call
-        if c.is_alphabetic() || c == '_' {
+        if Self::is_identifier_start(c) {
             let start = self.pos;
-            while self.pos < self.input.len() {
-                let c = self.current_char().unwrap();
-                if c.is_alphanumeric() || c == '_' {
-                    self.pos += 1;
-                } else {
-                    break;
-                }
-            }
+            self.advance();
+            self.consume_while(Self::is_identifier_continue);
             let name = self.input[start..self.pos].to_string();
 
             // getline [var] [< file] as expression (returns 1/0/-1)
@@ -3761,6 +3735,12 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.stdout, "10\n");
+    }
+
+    #[tokio::test]
+    async fn test_awk_unicode_identifier_no_panic() {
+        let result = run_awk(&["BEGIN{café=7; print café}"], None).await.unwrap();
+        assert_eq!(result.stdout, "7\n");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/sed.rs
+++ b/crates/bashkit/src/builtins/sed.rs
@@ -492,6 +492,68 @@ fn parse_address(s: &str) -> Result<(Option<Address>, &str)> {
 
 const MAX_GROUP_NESTING_DEPTH: usize = 128;
 
+fn validate_group_nesting(s: &str, base_depth: usize) -> Result<()> {
+    let mut in_subst = false;
+    let mut subst_delim = None;
+    let mut subst_delim_count = 0;
+    let mut escaped = false;
+    let mut group_depth = 0;
+
+    for c in s.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if c == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if !in_subst && c == 's' {
+            in_subst = true;
+            subst_delim = None;
+            subst_delim_count = 0;
+            continue;
+        }
+
+        if in_subst {
+            if subst_delim.is_none() {
+                subst_delim = Some(c);
+                continue;
+            }
+
+            if Some(c) == subst_delim {
+                subst_delim_count += 1;
+                if subst_delim_count >= 3 {
+                    in_subst = false;
+                    subst_delim = None;
+                    subst_delim_count = 0;
+                }
+            }
+            continue;
+        }
+
+        match c {
+            '{' => {
+                group_depth += 1;
+                if base_depth + group_depth > MAX_GROUP_NESTING_DEPTH {
+                    return Err(Error::Execution(format!(
+                        "sed: grouped command nesting exceeds max depth {}",
+                        MAX_GROUP_NESTING_DEPTH
+                    )));
+                }
+            }
+            '}' => {
+                group_depth = group_depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
 fn parse_sed_command(s: &str, extended_regex: bool) -> Result<(Option<Address>, bool, SedCommand)> {
     parse_sed_command_with_depth(s, extended_regex, 0)
 }
@@ -682,12 +744,7 @@ fn parse_sed_command_with_depth(
             Ok((address, negate, SedCommand::BranchIfSub(label)))
         }
         '{' => {
-            if depth >= MAX_GROUP_NESTING_DEPTH {
-                return Err(Error::Execution(format!(
-                    "sed: grouped command nesting exceeds max depth {}",
-                    MAX_GROUP_NESTING_DEPTH
-                )));
-            }
+            validate_group_nesting(rest, depth)?;
             // Grouped commands: { cmd1; cmd2; ... }
             // Find matching closing brace
             let inner = rest[1..].trim();


### PR DESCRIPTION
## What
Fix two parser safety issues in builtins:
- keep the awk parser on UTF-8 byte boundaries while scanning identifiers and related tokens
- reject excessively nested sed grouped commands before recursive descent can overflow the stack

## Why
Untrusted awk programs with non-ASCII source could panic due to mixed byte/char indexing, and the existing sed grouped-command depth test was aborting the process before the intended nesting guard triggered.

## How
- added shared UTF-8-safe identifier scanning helpers in the awk parser and routed identifier-like scans through them
- added an awk regression for a Unicode identifier in the program source
- added a flat grouped-command nesting validator in the sed parser so deep nesting is rejected before recursive parsing

## Risk
- Low
- Parser behavior changed around identifier scanning and grouped-command validation; risk is limited to awk/sed parsing paths and covered by focused regressions plus full pre-PR checks

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
