### PR TITLE
fix(hooks): honor on_exit cancel and modified exit code

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1623,10 +1623,22 @@ impl Interpreter {
 
             // Stop on control flow (e.g. nounset error uses Return to abort)
             if result.control_flow != ControlFlow::None {
-                if fire_exit_hook && let ControlFlow::Exit(code) = result.control_flow {
-                    self.hooks.fire_on_exit(crate::hooks::ExitEvent { code });
+                if let ControlFlow::Exit(code) = result.control_flow {
+                    if fire_exit_hook {
+                        match self.hooks.fire_on_exit(crate::hooks::ExitEvent { code }) {
+                            Some(event) => {
+                                exit_code = event.code;
+                                self.last_exit_code = exit_code;
+                                break;
+                            }
+                            None => continue,
+                        }
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
                 }
-                break;
             }
 
             // Run ERR trap on non-zero exit (unless in conditional chain)

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -6517,6 +6517,32 @@ echo missing fi"#,
     }
 
     #[tokio::test]
+    async fn test_on_exit_hook_cancel_prevents_exit() {
+        let mut bash = Bash::builder()
+            .on_exit(Box::new(|_event| {
+                hooks::HookAction::Cancel("blocked by policy".to_string())
+            }))
+            .build();
+
+        let result = bash.exec("echo before\nexit 5\necho after").await.unwrap();
+        assert_eq!(result.stdout.trim(), "before\nafter");
+        assert_eq!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn test_on_exit_hook_can_modify_exit_code() {
+        let mut bash = Bash::builder()
+            .on_exit(Box::new(|mut event| {
+                event.code = 17;
+                hooks::HookAction::Continue(event)
+            }))
+            .build();
+
+        let result = bash.exec("exit 5").await.unwrap();
+        assert_eq!(result.exit_code, 17);
+    }
+
+    #[tokio::test]
     async fn test_bash_versinfo_reports_bash_compatible_major() {
         let mut bash = Bash::new();
 


### PR DESCRIPTION
### Motivation
- The interpreter fired `on_exit` hooks but ignored their return value, making `HookAction::Cancel` and modified `ExitEvent` ineffective and allowing script exits to bypass host policies.

### Description
- Change `Interpreter::execute_script_body` to consume `Hooks::fire_on_exit` return and apply its result when `ControlFlow::Exit` is encountered, propagating a modified exit code or honoring cancellation. 
- When a hook returns `Cancel`, the interpreter continues script execution instead of breaking, and when a hook returns `Continue(event)` the `exit_code` (and `last_exit_code`) is updated from `event.code` before breaking. 
- Add regression tests `test_on_exit_hook_cancel_prevents_exit` and `test_on_exit_hook_can_modify_exit_code` in `crates/bashkit/src/lib.rs` to cover cancel and exit-code-rewrite scenarios.

### Testing
- Ran `cargo test -p bashkit test_on_exit_hook_cancel_prevents_exit` and it passed. 
- Ran `cargo test -p bashkit test_on_exit_hook_can_modify_exit_code` and it passed. 
- Ran `cargo fmt --check` which succeeded. 
- Note: attempted to rebase on `origin/main` per repository guidance but the environment has no `origin` remote configured, so the rebase was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf1951fc832b9039c096773785aa)