### PR TITLE
fix(interpreter): restore full assoc subscript parameter expansion

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -9409,19 +9409,16 @@ impl Interpreter {
         s.to_string()
     }
 
-    /// Fully expand an associative array key, including command substitutions.
-    /// Falls back to `expand_variable_or_literal` for keys without `$(` or backtick.
+    /// Fully expand an associative array key using standard word expansion.
+    /// This preserves literal bare names (e.g. `x` -> `x`) while correctly
+    /// expanding embedded/multiple parameter references (e.g. `foo$bar`).
     async fn expand_assoc_key(&mut self, s: &str) -> Result<String> {
-        if s.contains("$(") || s.contains('`') {
-            let word = Parser::parse_word_string_with_limits(
-                s,
-                self.limits.max_ast_depth,
-                self.limits.max_parser_operations,
-            );
-            self.expand_word(&word).await
-        } else {
-            Ok(self.expand_variable_or_literal(s))
-        }
+        let word = Parser::parse_word_string_with_limits(
+            s,
+            self.limits.max_ast_depth,
+            self.limits.max_parser_operations,
+        );
+        self.expand_word(&word).await
     }
 
     /// THREAT[TM-INJ-009]: Check if a variable name is an internal marker.

--- a/crates/bashkit/tests/spec_cases/bash/assoc-arrays.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/assoc-arrays.test.sh
@@ -212,6 +212,19 @@ count: 1
 key=[hello] val=[world]
 ### end
 
+### assoc_key_embedded_parameter_expansions
+declare -A m=()
+foo="left"
+bar="right"
+m["$foo$bar"]="combined"
+m["prefix-$foo-$bar"]="mixed"
+echo "${m[leftright]}"
+echo "${m[prefix-left-right]}"
+### expect
+combined
+mixed
+### end
+
 ### assoc_iteration
 declare -A m
 m[a]="1"


### PR DESCRIPTION
### Motivation
- A recent change only ran full word expansion for associative array keys containing `$()` or backticks, which caused keys with embedded or multiple parameter expansions (e.g. `"$foo$bar"`, `"prefix-$foo-$bar"`) to be treated incorrectly or left unexpanded.

### Description
- Unconditionally perform full word parsing with `Parser::parse_word_string_with_limits` and expand via `expand_word` in `expand_assoc_key` so embedded/multiple parameter references are handled correctly.
- Remove the heuristic fallback to `expand_variable_or_literal` that only handled a single leading `$var`/`${var}` reference.
- Add a spec test `assoc_key_embedded_parameter_expansions` in `crates/bashkit/tests/spec_cases/bash/assoc-arrays.test.sh` to cover `"$foo$bar"` and `"prefix-$foo-$bar"` cases.

### Testing
- Ran `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture` and the spec suite completed successfully (`Total: 1982 | Passed: 1957 | Failed: 0 | Skipped: 25`).
- The new assoc-array spec (including `assoc_key_embedded_parameter_expansions`) passed under the spec runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf194b34832b8f02bed79ea7123f)