### PR TITLE
fix(rg): propagate -m missing-value parse error

### DIFF
--- a/crates/bashkit/src/builtins/rg.rs
+++ b/crates/bashkit/src/builtins/rg.rs
@@ -60,7 +60,7 @@ impl RgOptions {
         let mut p = super::arg_parser::ArgParser::new(args);
 
         while !p.is_done() {
-            if let Ok(Some(val)) = p.flag_value("-m", "rg") {
+            if let Some(val) = p.flag_value("-m", "rg").map_err(Error::Execution)? {
                 opts.max_count = Some(
                     val.parse()
                         .map_err(|_| Error::Execution(format!("rg: invalid -m value: {val}")))?,
@@ -435,6 +435,16 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         let lines: Vec<&str> = result.stdout.trim().lines().collect();
         assert_eq!(lines.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_rg_max_count_requires_value() {
+        let args: Vec<String> = vec!["hello".to_string(), "-m".to_string()];
+        let result = RgOptions::parse(&args);
+        assert!(matches!(
+            result,
+            Err(Error::Execution(msg)) if msg == "rg: -m requires an argument"
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- ArgParser::flag_value returns `Err` when a required value is missing, but `RgOptions::parse` previously ignored the `Err` and continued, allowing `rg -m` (missing value) to be silently accepted and bypass `max_count` handling.
- Restore prior behavior: a missing `-m` value should produce an error `rg: -m requires an argument` instead of being swallowed.

### Description
- Update `RgOptions::parse` in `crates/bashkit/src/builtins/rg.rs` to propagate `flag_value("-m", "rg")` errors using `.map_err(Error::Execution)?` so parse-time missing-value errors are returned.
- Add regression test `test_rg_max_count_requires_value` in `crates/bashkit/src/builtins/rg.rs` to assert `RgOptions::parse` returns `Err(Error::Execution("rg: -m requires an argument"))` when `-m` is missing its value.

### Testing
- Ran `cargo test -p bashkit test_rg_max_count -- --nocapture` and `cargo test -p bashkit test_rg_max_count_requires_value -- --nocapture`, both relevant tests passed locally.
- Ran `cargo fmt` and fixed formatting, after which `cargo fmt --check` passes for the changed file.
- Note: `git fetch origin main && git rebase origin/main` could not be executed in this environment because the repository has no configured `origin` remote; changes were made on the current worktree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf1bc7c8832b9876eacd90f524dd)