### PR TITLE
fix(fs): enforce parent existence check in PosixFs::append_file

### DIFF
--- a/crates/bashkit/src/fs/posix.rs
+++ b/crates/bashkit/src/fs/posix.rs
@@ -150,6 +150,9 @@ impl<B: FsBackend + 'static> FileSystem for PosixFs<B> {
 
     async fn append_file(&self, path: &Path, content: &[u8]) -> Result<()> {
         let path = Self::normalize(path);
+        // Check parent exists
+        self.check_parent_exists(&path).await?;
+
         // Check if path is a directory
         if let Ok(meta) = self.backend.stat(&path).await
             && meta.file_type.is_dir()
@@ -286,8 +289,106 @@ impl<B: FsBackend + 'static> From<PosixFs<B>> for Arc<dyn FileSystem> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::Result;
     use crate::fs::InMemoryFs;
-    use std::path::Path;
+    use crate::fs::{DirEntry, FileType, FsBackend};
+    use std::collections::HashSet;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    struct AppendCreatesFileBackend {
+        files: Mutex<HashSet<PathBuf>>,
+    }
+
+    impl AppendCreatesFileBackend {
+        fn new() -> Self {
+            let mut files = HashSet::new();
+            files.insert(PathBuf::from("/"));
+            files.insert(PathBuf::from("/tmp"));
+            Self {
+                files: Mutex::new(files),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl FsBackend for AppendCreatesFileBackend {
+        async fn read(&self, _path: &Path) -> Result<Vec<u8>> {
+            Ok(Vec::new())
+        }
+
+        async fn write(&self, path: &Path, _content: &[u8]) -> Result<()> {
+            self.files
+                .lock()
+                .expect("backend lock poisoned")
+                .insert(path.to_path_buf());
+            Ok(())
+        }
+
+        async fn append(&self, path: &Path, content: &[u8]) -> Result<()> {
+            self.write(path, content).await
+        }
+
+        async fn mkdir(&self, path: &Path, _recursive: bool) -> Result<()> {
+            self.files
+                .lock()
+                .expect("backend lock poisoned")
+                .insert(path.to_path_buf());
+            Ok(())
+        }
+
+        async fn remove(&self, _path: &Path, _recursive: bool) -> Result<()> {
+            Ok(())
+        }
+
+        async fn stat(&self, path: &Path) -> Result<Metadata> {
+            if self
+                .files
+                .lock()
+                .expect("backend lock poisoned")
+                .contains(path)
+            {
+                Ok(Metadata {
+                    file_type: FileType::File,
+                    ..Metadata::default()
+                })
+            } else {
+                Err(std::io::Error::from(std::io::ErrorKind::NotFound).into())
+            }
+        }
+
+        async fn read_dir(&self, _path: &Path) -> Result<Vec<DirEntry>> {
+            Ok(Vec::new())
+        }
+
+        async fn exists(&self, path: &Path) -> Result<bool> {
+            Ok(self
+                .files
+                .lock()
+                .expect("backend lock poisoned")
+                .contains(path))
+        }
+
+        async fn rename(&self, _from: &Path, _to: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        async fn copy(&self, _from: &Path, _to: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        async fn symlink(&self, _target: &Path, _link: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        async fn read_link(&self, _path: &Path) -> Result<PathBuf> {
+            Err(std::io::Error::from(std::io::ErrorKind::NotFound).into())
+        }
+
+        async fn chmod(&self, _path: &Path, _mode: u32) -> Result<()> {
+            Ok(())
+        }
+    }
 
     #[tokio::test]
     async fn test_posix_write_to_directory_fails() {
@@ -368,5 +469,17 @@ mod tests {
             .write_file(Path::new("/tmp/nonexistent/./file.txt"), b"content")
             .await;
         assert!(result.is_err(), "should fail when parent doesn't exist");
+    }
+
+    #[tokio::test]
+    async fn test_posix_append_requires_parent_directory() {
+        let fs = PosixFs::new(AppendCreatesFileBackend::new());
+        let result = fs
+            .append_file(Path::new("/tmp/missing-parent/file.txt"), b"content")
+            .await;
+        assert!(
+            result.is_err(),
+            "append should fail when parent doesn't exist"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- `PosixFs` promised POSIX-like semantics (parent directory must exist for writes) but `append_file` omitted that guard, allowing raw `FsBackend` implementations to create orphaned files on append.
- Add a minimal, targeted fix and regression test to prevent backend-specific behavior from violating the documented contract.

### Description
- Add `self.check_parent_exists(&path).await?;` to `PosixFs::append_file` so append operations require the parent directory like `write_file` does (file: `crates/bashkit/src/fs/posix.rs`).
- Add a regression test `test_posix_append_requires_parent_directory` that wraps a minimal `FsBackend` which would otherwise create files on append and asserts `PosixFs::append_file` fails when the parent is missing (file: `crates/bashkit/src/fs/posix.rs` tests).
- Include a small test-only `AppendCreatesFileBackend` implementation to simulate a backend that creates files on append so the wrapper behavior is verified.

### Testing
- Ran `cargo test -p bashkit fs::posix::tests::test_posix_append_requires_parent_directory`, and the test passed.
- Ran unit tests for the `bashkit` crate during validation and the new test passed without failures (focused regression verified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf1d4248832b9c694eb679b01cd9)