### PR TITLE
fix(interpreter): restore env once per prefix assignment name

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4221,14 +4221,18 @@ impl Interpreter {
                 });
             }
 
-            // Inject prefix assignments into env for command duration
-            let mut env_saves: Vec<(String, Option<String>)> = Vec::new();
+            // Inject prefix assignments into env for command duration.
+            // Save original env value once per name so duplicate assignments
+            // (e.g., `A=1 A=2 cmd`) restore to pre-command state.
+            let mut env_saves: HashMap<String, Option<String>> = HashMap::new();
             for assignment in &command.assignments {
                 if assignment.index.is_none()
                     && let Some(value) = self.variables.get(&assignment.name).cloned()
                 {
-                    let old = self.env.insert(assignment.name.clone(), value);
-                    env_saves.push((assignment.name.clone(), old));
+                    env_saves
+                        .entry(assignment.name.clone())
+                        .or_insert_with(|| self.env.get(&assignment.name).cloned());
+                    self.env.insert(assignment.name.clone(), value);
                 }
             }
 

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -3253,6 +3253,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_prefix_assignment_duplicate_name_temporary() {
+        let mut bash = Bash::new();
+        // Duplicate prefix assignments should still restore original env.
+        let result = bash.exec("A=1 A=2 printenv A").await.unwrap();
+        assert_eq!(result.stdout, "2\n");
+        let result = bash.exec("echo ${A:-unset}").await.unwrap();
+        assert_eq!(result.stdout, "unset\n");
+    }
+
+    #[tokio::test]
     async fn test_prefix_assignment_does_not_clobber_existing_env() {
         let mut bash = Bash::new();
         // Set up existing env var


### PR DESCRIPTION
### Motivation
- Duplicate prefix assignments (e.g., `A=1 A=2 cmd`) were saving/restoring env state per assignment entry, which could reapply a temporary value after the command and leave the environment mutated.
- The change restores bash-compatible semantics: prefix assignments are visible to the command but do not persist after it returns.

### Description
- Replace per-assignment `Vec<(String, Option<String>)>` with a `HashMap<String, Option<String>>` to snapshot the original environment once per variable name before injecting prefix values (`crates/bashkit/src/interpreter/mod.rs`).
- Insert the final prefix value into `self.env` for the command, while preserving the original env value in the snapshot so restore uses the pre-command state.
- Add a regression unit test `test_prefix_assignment_duplicate_name_temporary` verifying `A=1 A=2 printenv A` yields `2` during the command and that `A` is unset after the command (`crates/bashkit/src/lib.rs`).

### Testing
- Ran `cargo test -p bashkit prefix_assignment` and the prefix-assignment-related unit tests completed successfully, including the new `test_prefix_assignment_duplicate_name_temporary` (all passed).
- The differential proptest for prefix assignments (`prefix_assignments_match_bash`) also ran and passed in the test run.
- A full `cargo test` for the package was executed as part of the run and completed with tests passing for the exercised suites.
- Could not rebase onto remote `main` prior to the change because the checkout has no configured remote, so no upstream rebase was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf194a00832b82ac35b7dfd12bf1)