### PR TITLE
fix(interpreter): preserve control flow in case fallthrough

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2887,13 +2887,22 @@ impl Interpreter {
                 stdout.push_str(&r.stdout);
                 stderr.push_str(&r.stderr);
                 exit_code = r.exit_code;
+                if r.control_flow != ControlFlow::None {
+                    return Ok(ExecResult {
+                        stdout,
+                        stderr,
+                        exit_code,
+                        control_flow: r.control_flow,
+                        ..Default::default()
+                    });
+                }
                 match case_item.terminator {
                     CaseTerminator::Break => {
                         return Ok(ExecResult {
                             stdout,
                             stderr,
                             exit_code,
-                            control_flow: r.control_flow,
+                            control_flow: ControlFlow::None,
                             ..Default::default()
                         });
                     }

--- a/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/control-flow.test.sh
@@ -214,6 +214,22 @@ matched
 fell_through
 ### end
 
+### case_fallthrough_preserves_break
+# break inside ;& case arm must break enclosing loop immediately
+i=0; while true; do echo loop; case a in a) break ;& b) echo wrong ;; esac; echo after; done; echo done
+### expect
+loop
+done
+### end
+
+### case_fallthrough_preserves_return
+# return inside ;& case arm must return from function immediately
+f() { case a in a) echo start; return 7 ;& b) echo wrong ;; esac; echo after; }; f; echo rc=$?
+### expect
+start
+rc=7
+### end
+
 ### and_list_success
 # AND list with success
 true && echo yes


### PR DESCRIPTION
### Motivation
- A regression in `execute_case` caused `;&`/`;;&` (fallthrough/continue-matching) arms to drop `control_flow` from executed bodies, swallowing `break`/`continue`/`return` and breaking loop/function semantics.

### Description
- Propagate non-`None` `control_flow` immediately by returning when a matched case-arm `ExecResult` has `control_flow != ControlFlow::None` in `execute_case` (`crates/bashkit/src/interpreter/mod.rs`).
- Keep `;;` (`CaseTerminator::Break`) behaviour as terminating the `case` without inventing control flow by returning `ControlFlow::None` for the terminator path.
- Add regression specs `case_fallthrough_preserves_break` and `case_fallthrough_preserves_return` to `crates/bashkit/tests/spec_cases/bash/control-flow.test.sh` to lock the intended semantics.

### Testing
- Ran the bash spec suite with `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture` and observed the suite pass (1983 total | 1958 passed | 0 failed | 25 skipped).
- Ran `cargo fmt --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf1a1954832ba06759ef1399b0c6)