### PR TITLE
fix(expr): avoid UTF-8 panic in capture-group matches

### DIFF
--- a/crates/bashkit/src/builtins/expr.rs
+++ b/crates/bashkit/src/builtins/expr.rs
@@ -253,7 +253,7 @@ fn count_match(s: &str, pattern: &str) -> usize {
 /// Simple match returning the matched portion
 fn simple_match(s: &str, pattern: &str) -> String {
     let count = count_match(s, pattern);
-    s[..count].to_string()
+    s.chars().take(count).collect()
 }
 
 fn char_matches(c: char, pattern: char) -> bool {
@@ -678,5 +678,19 @@ mod tests {
             "日本",
             "should extract chars, not bytes"
         );
+    }
+
+    // Issue #434: match with capture groups should not slice on byte offsets
+    #[tokio::test]
+    async fn test_match_capture_group_multibyte_utf8() {
+        let fs = Arc::new(crate::fs::InMemoryFs::new());
+        let mut variables = HashMap::new();
+        let mut cwd = std::path::PathBuf::from("/");
+        let env = HashMap::new();
+        let args = vec!["match".to_string(), "é".to_string(), "\\(.*\\)".to_string()];
+        let ctx = Context::new_for_test(&args, &env, &mut variables, &mut cwd, fs.clone(), None);
+        let result = Expr.execute(ctx).await.unwrap();
+        assert_eq!(result.stdout.trim(), "é");
+        assert_eq!(result.exit_code, 0);
     }
 }


### PR DESCRIPTION
### Motivation
- `expr` had a panic path when returning capturing-group matches because `simple_match` sliced the input with byte offsets, which can cut a multibyte UTF-8 character in half (e.g. `expr match "é" '\\(.*\\)'`).
- The change prevents panics on non-ASCII input while preserving existing `expr` behavior and exit-code semantics.

### Description
- Replace byte-based slicing in `simple_match` (`s[..count].to_string()`) with a char-safe implementation using `s.chars().take(count).collect()` to return the matched portion.
- Add a regression test `test_match_capture_group_multibyte_utf8` that exercises `expr match "é" "\(.*\)"` and asserts the matched UTF-8 character is returned without panicking.

### Testing
- Ran the focused regression: `cargo test -p bashkit test_match_capture_group_multibyte_utf8 -- --nocapture` and it passed.
- Ran the related grouping of UTF-8 tests: `cargo test -p bashkit multibyte_utf8 -- --nocapture` and all included tests passed.
- Verified the failing panic case reproduced before the fix and is resolved by the change (regression test now green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae4f23bd4832b8b7a24119ec68f2a)