### PR TITLE
fix(interpreter): prevent duplicate shell flags from leaking to parent state

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3342,7 +3342,12 @@ impl Interpreter {
         });
 
         let mut saved_opts: Vec<(String, Option<String>)> = Vec::new();
+        let mut saved_opt_names: HashSet<&'static str> = HashSet::new();
         for (var, val) in &shell_opts {
+            if !saved_opt_names.insert(*var) {
+                self.insert_variable_checked(var.to_string(), val.to_string());
+                continue;
+            }
             let prev = self.variables.get(*var).cloned();
             saved_opts.push((var.to_string(), prev));
             self.insert_variable_checked(var.to_string(), val.to_string());

--- a/crates/bashkit/tests/spec_cases/bash/bash-flags.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/bash-flags.test.sh
@@ -81,6 +81,16 @@ echo "still running"
 still running
 ### end
 
+
+### bash_duplicate_errexit_flags_do_not_leak
+# duplicate errexit flags in child must not leak to parent shell
+bash -e -o errexit -c 'false'
+false
+echo "still running"
+### expect
+still running
+### end
+
 ### bash_o_invalid_option
 # bash -o with invalid option returns error
 bash -o invalidopt -c 'echo hi' 2>/dev/null


### PR DESCRIPTION
### Motivation
- Duplicate shell option entries (for example `-e` plus `-o errexit`) were saved/restored per-entry which could re-enable `SHOPT_*` variables in the parent shell and break subshell isolation.

### Description
- Deduplicate option names when applying shell options in `execute_shell` by tracking seen names with a `HashSet` so the parent value is captured only once while still applying requested values in the child.
- Add a regression spec `bash_duplicate_errexit_flags_do_not_leak` in `crates/bashkit/tests/spec_cases/bash/bash-flags.test.sh` to cover `bash -e -o errexit -c ...`.

### Testing
- Ran `cargo test -p bashkit --test spec_tests bash_spec_tests -- --nocapture` and the bash spec suite passed (Total: 1982 | Passed: 1957 | Failed: 0 | Skipped: 25).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae4ec535c832bb3d565de4b01f48f)