### PR TITLE
fix(python): harden in-process opt-in against script overrides

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -216,6 +216,8 @@ pub use git::Git;
 pub use ssh::{Scp, Sftp, Ssh};
 
 #[cfg(feature = "python")]
+pub(crate) use python::PythonInprocessOptIn;
+#[cfg(feature = "python")]
 pub use python::{Python, PythonExternalFnHandler, PythonExternalFns, PythonLimits};
 
 #[cfg(feature = "typescript")]

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -44,15 +44,27 @@ const DISABLED_STDLIB_MODULES: &[&str] = &["re"];
 
 const PYTHON_INPROCESS_OPT_IN_ENV: &str = "BASHKIT_ALLOW_INPROCESS_PYTHON";
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PythonInprocessOptIn(pub bool);
+
 fn python_inprocess_enabled(ctx: &Context<'_>) -> bool {
-    let is_enabled = |v: &str| matches!(v, "1" | "true" | "TRUE" | "yes" | "YES");
-    ctx.env
-        .get(PYTHON_INPROCESS_OPT_IN_ENV)
-        .is_some_and(|v| is_enabled(v))
-        || ctx
-            .variables
-            .get(PYTHON_INPROCESS_OPT_IN_ENV)
-            .is_some_and(|v| is_enabled(v))
+    ctx.execution_extension::<PythonInprocessOptIn>()
+        .is_some_and(|opt_in| opt_in.0)
+        // Unit tests in this module build Context::new_for_test without
+        // execution extensions. Keep local test ergonomics only under cfg(test).
+        || {
+            #[cfg(test)]
+            {
+                let is_enabled = |v: &str| matches!(v, "1" | "true" | "TRUE" | "yes" | "YES");
+                ctx.env
+                    .get(PYTHON_INPROCESS_OPT_IN_ENV)
+                    .is_some_and(|v| is_enabled(v))
+            }
+            #[cfg(not(test))]
+            {
+                false
+            }
+        }
 }
 
 /// Resource limits for the embedded Python (Monty) interpreter.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -517,6 +517,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+#[cfg(feature = "python")]
+fn env_opt_in_enabled(env: &HashMap<String, String>, key: &str) -> bool {
+    env.get(key)
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+}
+
 /// Main entry point for Bashkit.
 ///
 /// Provides a virtual bash interpreter with an in-memory virtual filesystem.
@@ -536,6 +542,9 @@ pub struct Bash {
     /// Logging configuration
     #[cfg(feature = "logging")]
     log_config: logging::LogConfig,
+    /// Operator-approved in-process Python opt-in captured at build time.
+    #[cfg(feature = "python")]
+    python_inprocess_opt_in: bool,
 }
 
 impl Default for Bash {
@@ -565,6 +574,8 @@ impl Bash {
             max_parser_operations,
             #[cfg(feature = "logging")]
             log_config: logging::LogConfig::default(),
+            #[cfg(feature = "python")]
+            python_inprocess_opt_in: false,
         }
     }
 
@@ -592,6 +603,8 @@ impl Bash {
         // Expose active execution limits to builtins that need to honor
         // per-execution sandbox settings.
         let _ = extensions.insert(self.interpreter.limits().clone());
+        #[cfg(feature = "python")]
+        let _ = extensions.insert(builtins::PythonInprocessOptIn(self.python_inprocess_opt_in));
         let _extensions_guard = self.interpreter.scoped_execution_extensions(extensions);
         self.exec_impl(script).await
     }
@@ -1584,8 +1597,8 @@ impl BashBuilder {
     /// by Monty's runtime (memory, allocations, time, recursion).
     ///
     /// For security, execution is runtime-gated: set
-    /// `BASHKIT_ALLOW_INPROCESS_PYTHON=1` (builder `.env(...)` or `export`)
-    /// before invoking `python`/`python3`.
+    /// `BASHKIT_ALLOW_INPROCESS_PYTHON=1` via builder `.env(...)` before
+    /// invoking `python`/`python3`.
     ///
     /// Requires the `python` feature flag. Python `pathlib.Path` operations are
     /// bridged to the virtual filesystem.
@@ -2554,6 +2567,8 @@ impl BashBuilder {
             // so they take precedence over the defaults
             interpreter.set_var(key, value);
         }
+        #[cfg(feature = "python")]
+        let python_inprocess_opt_in = env_opt_in_enabled(&env, "BASHKIT_ALLOW_INPROCESS_PYTHON");
         drop(env);
 
         // If username is set, automatically set USER env var
@@ -2614,7 +2629,6 @@ impl BashBuilder {
             trace_collector.set_callback(cb);
         }
         interpreter.set_trace(trace_collector);
-
         Bash {
             fs,
             mountable,
@@ -2625,6 +2639,8 @@ impl BashBuilder {
             max_parser_operations,
             #[cfg(feature = "logging")]
             log_config,
+            #[cfg(feature = "python")]
+            python_inprocess_opt_in,
         }
     }
 }

--- a/crates/bashkit/tests/python_security_tests.rs
+++ b/crates/bashkit/tests/python_security_tests.rs
@@ -52,6 +52,23 @@ async fn python_requires_explicit_inprocess_opt_in() {
     );
 }
 
+#[tokio::test]
+async fn python_opt_in_cannot_be_enabled_from_script() {
+    let mut bash = Bash::builder().python().build();
+    let r = bash
+        .exec("BASHKIT_ALLOW_INPROCESS_PYTHON=1 python3 -c \"print('should_not_run')\"")
+        .await
+        .unwrap();
+    assert_ne!(r.exit_code, 0);
+    assert!(!r.stdout.contains("should_not_run"));
+    assert!(
+        r.stderr
+            .contains("in-process Python disabled by default for security"),
+        "expected security gate message, got stderr={:?}",
+        r.stderr
+    );
+}
+
 // =============================================================================
 // 1. BLACK-BOX: DANGEROUS MODULE IMPORTS
 //


### PR DESCRIPTION
### Motivation
- The in-process Python opt-in previously read `ctx.env` and `ctx.variables`, which are controllable by untrusted scripts and allowed self-enabling of the embedded Python runtime. 
- The intent is to ensure the operator explicitly opts in at build/creation time and prevent runtime script mutations from bypassing the security gate.

### Description
- Replace script-trusted check with a typed execution extension by introducing `PythonInprocessOptIn` and having `python_inprocess_enabled` consult `execution_extension::<PythonInprocessOptIn>()` instead of `ctx.env`/`ctx.variables`, keeping a `#[cfg(test)]` fallback for unit tests. 
- Export the new flag type from `crates/bashkit/src/builtins/mod.rs` and wire it into `Bash` so the builder captures the opt-in once at construction time and stores it as `python_inprocess_opt_in`. 
- Capture the builder env `BASHKIT_ALLOW_INPROCESS_PYTHON` at `BashBuilder::build()` and inject `PythonInprocessOptIn(self.python_inprocess_opt_in)` into per-exec `ExecutionExtensions` via `exec_with_extensions`. 
- Add a regression test `python_opt_in_cannot_be_enabled_from_script` that verifies inline/script assignment like `BASHKIT_ALLOW_INPROCESS_PYTHON=1 python3 ...` cannot bypass the gate, and update builder docs to clarify that opt-in must be provided via the builder `.env(...)`.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo test --features python --test python_security_tests python_opt_in_cannot_be_enabled_from_script` and the test passed (`ok`). 
- Ran `cargo test --features python --test python_security_tests python_requires_explicit_inprocess_opt_in` and the test passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb960413c4832b88028500c30fc4f2)