### PR TITLE
fix(parser): preserve literal dollars in concatenated single quotes

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -450,6 +450,12 @@ impl<'a> Lexer<'a> {
                         }
                         continue;
                     }
+                    if quote_char == '\'' && c == '$' {
+                        // Preserve literal '$' semantics from single-quoted
+                        // segments when concatenated into an existing word
+                        // (e.g. foo'$(id)' or VAR='${HOME}').
+                        word.push('\x00');
+                    }
                     word.push(c);
                     self.advance();
                 }
@@ -588,6 +594,12 @@ impl<'a> Lexer<'a> {
                             continue;
                         }
                         continue;
+                    }
+                    if quote_char == '\'' && c == '$' {
+                        // Preserve literal '$' semantics from single-quoted
+                        // segments when concatenated into an existing word
+                        // (e.g. foo'$(id)' or VAR='${HOME}').
+                        word.push('\x00');
                     }
                     word.push(c);
                     self.advance();
@@ -1894,6 +1906,17 @@ mod tests {
         assert_eq!(
             lexer.next_token(),
             Some(Token::QuotedWord("hello world".to_string()))
+        );
+        assert_eq!(lexer.next_token(), None);
+    }
+
+    #[test]
+    fn test_single_quoted_segment_in_word_escapes_dollar() {
+        let mut lexer = Lexer::new("echo foo'$(id)'");
+        assert_eq!(lexer.next_token(), Some(Token::Word("echo".to_string())));
+        assert_eq!(
+            lexer.next_token(),
+            Some(Token::Word("foo\x00$(id)".to_string()))
         );
         assert_eq!(lexer.next_token(), None);
     }

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -3843,6 +3843,27 @@ mod tests {
     }
 
     #[test]
+    fn test_single_quoted_segment_concatenation_stays_literal() {
+        let parser = Parser::new("echo foo'$(id)'");
+        let script = parser.parse().unwrap();
+
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.args.len(), 1);
+            assert_eq!(cmd.args[0].to_string(), "foo$(id)");
+            assert!(
+                cmd.args[0]
+                    .parts
+                    .iter()
+                    .all(|p| matches!(p, WordPart::Literal(_))),
+                "single-quoted segment should not produce expansions: {:?}",
+                cmd.args[0].parts
+            );
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
     fn test_locale_quote_marks_word_as_quoted_without_expansion() {
         let parser = Parser::new("echo $\"*.txt\"");
         let script = parser.parse().unwrap();
@@ -3853,6 +3874,30 @@ mod tests {
                 "locale-quoted argument must be marked quoted"
             );
             assert_eq!(cmd.args[0].to_string(), "*.txt");
+        } else {
+            panic!("expected simple command");
+        }
+    }
+
+    #[test]
+    fn test_single_quoted_assignment_value_stays_literal() {
+        let parser = Parser::new("VAR='$(id)'");
+        let script = parser.parse().unwrap();
+
+        if let Command::Simple(cmd) = &script.commands[0] {
+            assert_eq!(cmd.assignments.len(), 1);
+            assert_eq!(cmd.assignments[0].name, "VAR");
+            match &cmd.assignments[0].value {
+                AssignmentValue::Scalar(word) => {
+                    assert_eq!(word.to_string(), "$(id)");
+                    assert!(
+                        word.parts.iter().all(|p| matches!(p, WordPart::Literal(_))),
+                        "single-quoted assignment should remain literal: {:?}",
+                        word.parts
+                    );
+                }
+                AssignmentValue::Array(_) => panic!("expected scalar assignment"),
+            }
         } else {
             panic!("expected simple command");
         }


### PR DESCRIPTION
### Motivation

- Fix regression where the lexer concatenated quoted segments into words while stripping quote chars, which made single-quoted content (e.g. `foo'$(id)'`, `VAR='${HOME}'`) be treated as unquoted and allowed unintended `$()` / `${}` substitution.

### Description

- Update `crates/bashkit/src/parser/lexer.rs` to insert the existing NUL-literal sentinel before `$` when a single-quoted segment is concatenated into an existing word in both `read_word` and `read_word_starting_with` paths, preserving literal-dollar semantics.
- Add a lexer unit test `test_single_quoted_segment_in_word_escapes_dollar` to assert tokenization produces the NUL sentinel form `foo\x00$(id)`.
- Add parser regression tests `test_single_quoted_segment_concatenation_stays_literal` and `test_single_quoted_assignment_value_stays_literal` in `crates/bashkit/src/parser/mod.rs` to ensure concatenated single-quoted content remains literal in command args and assignment values.

### Testing

- Ran `cargo test -p bashkit --lib parser::lexer::tests::test_single_quoted_segment_in_word_escapes_dollar -- --exact` and it passed.
- Ran `cargo test -p bashkit --lib parser::tests::test_single_quoted_segment_concatenation_stays_literal -- --exact` and it passed.
- Ran `cargo test -p bashkit --lib parser::tests::test_single_quoted_assignment_value_stays_literal -- --exact` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf1adc3c832b8dfa81d010a4e666)