### PR TITLE
fix(jq): enforce depth limit for --argjson values

### DIFF
--- a/crates/bashkit/src/builtins/jq.rs
+++ b/crates/bashkit/src/builtins/jq.rs
@@ -372,6 +372,9 @@ impl Builtin for Jq {
                             ));
                         }
                     };
+                    if let Err(e) = check_json_depth(&json_val, MAX_JQ_JSON_DEPTH) {
+                        return Ok(ExecResult::err(format!("{}\n", e), 2));
+                    }
                     var_bindings.push((name, json_val));
                     i += 3;
                     continue;
@@ -1267,6 +1270,19 @@ mod tests {
         assert!(
             result.exit_code != 0,
             "invalid JSON for --argjson should have non-zero exit"
+        );
+    }
+    #[tokio::test]
+    async fn test_jq_argjson_rejects_deep_nesting() {
+        let deep = format!("{}0{}", "[".repeat(101), "]".repeat(101));
+        let result = run_jq_result_with_args(&["--argjson", "x", &deep, "-n", "$x"], "")
+            .await
+            .unwrap();
+        assert!(result.exit_code != 0, "deep --argjson should be rejected");
+        assert!(
+            result.stderr.contains("nesting too deep"),
+            "error should mention depth limit: {}",
+            result.stderr
         );
     }
 


### PR DESCRIPTION
### Motivation
- Close DoS bypass where `--argjson` parsed JSON was bound without the `MAX_JQ_JSON_DEPTH` guard, allowing deeply nested attacker-controlled JSON to trigger recursion/stack exhaustion (TM-DOS-027).

### Description
- Apply existing `check_json_depth(&json_val, MAX_JQ_JSON_DEPTH)` to values parsed for `--argjson` and return a jq-style error/exit when over the limit.
- Add regression test `test_jq_argjson_rejects_deep_nesting` that asserts deeply nested `--argjson` input is rejected and error text mentions the depth limit.
- No change to external behavior for valid inputs; the same depth guard that protects stdin/file input now protects `--argjson` bindings.

### Testing
- Ran `cargo fmt` which succeeded.
- Ran unit tests `test_jq_argjson_rejects_deep_nesting` and `test_jq_argjson_flag` via `cargo test -p bashkit --all-features` and both tests passed.
- Ran focused library test run for the jq tests; the new regression test passed in the test suite (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae4ee56fc832b88652a05732e4e08)