### PR TITLE
fix(logging): redact and sanitize execution errors before logging

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -505,7 +505,9 @@ pub use zapcode_core::Value as ZapcodeValue;
 /// Only available when the `logging` feature is enabled.
 #[cfg(feature = "logging")]
 pub mod logging {
-    pub use crate::logging_impl::{LogConfig, format_script_for_log, sanitize_for_log};
+    pub use crate::logging_impl::{
+        LogConfig, format_error_for_log, format_script_for_log, sanitize_for_log,
+    };
 }
 
 #[cfg(feature = "logging")]
@@ -809,9 +811,10 @@ impl Bash {
                 );
             }
             Err(e) => {
+                let error = logging::format_error_for_log(&e.to_string(), &self.log_config);
                 tracing::error!(
                     target: "bashkit::session",
-                    error = %e,
+                    error = %error,
                     "Script execution failed"
                 );
             }

--- a/crates/bashkit/src/logging_impl.rs
+++ b/crates/bashkit/src/logging_impl.rs
@@ -337,6 +337,30 @@ pub fn format_script_for_log(script: &str, config: &LogConfig) -> String {
     config.truncate(&sanitized).into_owned()
 }
 
+/// Format an execution error message for safe logging.
+///
+/// Applies sensitive-data redaction and log-injection sanitization.
+pub fn format_error_for_log(error: &str, config: &LogConfig) -> String {
+    let sanitized = sanitize_for_log(error);
+    let redacted = config.redact_value(&sanitized);
+    if redacted.as_ref() == "[REDACTED]" {
+        return redacted.into_owned();
+    }
+
+    if config.redact_sensitive
+        && sanitized.split_whitespace().any(|chunk| {
+            let token = chunk.trim_matches(|c: char| {
+                !(c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+' | '/' | '='))
+            });
+            !token.is_empty() && is_likely_secret(token)
+        })
+    {
+        return "[REDACTED]".to_string();
+    }
+
+    config.truncate(redacted.as_ref()).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -476,6 +500,14 @@ mod tests {
         let sanitized = sanitize_for_log(malicious);
         assert!(!sanitized.contains('\n'));
         assert!(sanitized.contains("\\n"));
+    }
+
+    #[test]
+    fn test_error_message_redacted_and_sanitized() {
+        let config = LogConfig::new();
+        let input = "grep: invalid max count: sk-1234567890abcdefghij\nforged line";
+        let formatted = format_error_for_log(input, &config);
+        assert_eq!(formatted, "[REDACTED]");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent leaking untrusted script data and log-injection via execution error logs which previously logged raw `Error` strings.
- Ensure execution-failure messages go through the same `LogConfig` redaction and sanitization used elsewhere.

### Description

- Add `format_error_for_log(error, &LogConfig)` in `crates/bashkit/src/logging_impl.rs` that sanitizes control/newline chars, applies `redact_value`, detects embedded secret-like tokens and aggressively redacts, and truncates long values per config.
- Re-export the new formatter via `bashkit::logging` and wire `Bash::exec_impl` to call `logging::format_error_for_log` before emitting the `tracing::error!` entry.
- Add a regression unit test `test_error_message_redacted_and_sanitized` that verifies a grep-style error containing an API-key-like token plus a forged newline is redacted.

### Testing

- Ran the focused unit test `cargo test -p bashkit --features logging test_error_message_redacted_and_sanitized` which failed on the unsafe code path before the fix and passes after the change.
- Ran the logging security test suite `cargo test -p bashkit --features logging --test logging_security_tests` and all tests passed (26 passed, 0 failed).
- Ran `cargo fmt --check` and formatting check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaeee6fd50832bbb663a72bf26efa9)