### PR TITLE
fix(grep): avoid quadratic context match lookup

### DIFF
--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -732,6 +732,9 @@ impl Builtin for Grep {
                     let mut sorted_lines: Vec<usize> = printed_lines.iter().copied().collect();
                     sorted_lines.sort_unstable();
 
+                    let match_line_set: std::collections::HashSet<usize> =
+                        match_lines.iter().copied().collect();
+
                     let mut prev_line: Option<usize> = None;
                     for line_idx in sorted_lines {
                         // Print separator if there's a gap
@@ -743,7 +746,7 @@ impl Builtin for Grep {
                         prev_line = Some(line_idx);
 
                         // Determine if this is a match line or context line
-                        let is_match = match_lines.contains(&line_idx);
+                        let is_match = match_line_set.contains(&line_idx);
                         let separator = if is_match { fname_sep } else { '-' };
 
                         if show_filename {


### PR DESCRIPTION
### Motivation
- Context-mode output for `grep -A/-B/-C` used per-line `Vec::contains` on the list of matching line indices, which yields O(n^2) behavior when many lines match and can be abused for CPU exhaustion. 
- Replace the linear lookup with an O(1) membership test to remove the availability risk while keeping existing behavior.

### Description
- Precompute a `HashSet<usize>` from `match_lines` and use it for membership checks when rendering context lines in `crates/bashkit/src/builtins/grep.rs`.
- Change is localized to the context-output path and preserves line ordering, separators, and all existing output semantics. 
- No public API changes, no feature behavior changes, and minimal code churn (few lines added, one line replaced).

### Testing
- Ran `cargo test -p bashkit grep -- --nocapture` and the grep-related unit/spec tests completed successfully. 
- Ran full test invocation that exercised crate tests and the GREP spec suite and observed all tests related to grep/spec pass. 
- Ran `cargo fmt --check` and formatting verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf1c67b3c832ba3eba1bf1d713211)