### PR TITLE
fix(awk): close range when start and end match same record

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -3341,7 +3341,9 @@ impl AwkInterpreter {
                 } else {
                     // Not in range — check if start pattern matches
                     if self.matches_pattern(start) {
-                        self.range_active.insert(rule_idx, true);
+                        // If end also matches this same line, range closes immediately.
+                        let end_matches = self.matches_pattern(end);
+                        self.range_active.insert(rule_idx, !end_matches);
                         true
                     } else {
                         false

--- a/crates/bashkit/tests/awk_range_pattern_tests.rs
+++ b/crates/bashkit/tests/awk_range_pattern_tests.rs
@@ -95,3 +95,14 @@ async fn awk_range_pattern_default_action() {
         .unwrap();
     assert_eq!(result.stdout, "a\nb\nc\n");
 }
+
+/// Start/end matching same record should only match that single record.
+#[tokio::test]
+async fn awk_range_pattern_start_end_same_line() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"printf "a\nb\na\nc\n" | awk '/a/,/a/{print}'"#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "a\na\n");
+}


### PR DESCRIPTION
### Motivation
- Range `/start/,/end/` activated on a start match was not checking whether the end pattern also matches the same record, causing ranges like `/a/,/a/` to remain active and overmatch subsequent lines.
- Aim to follow awk semantics where a start and end match on the same record should include only that record and immediately close the range.

### Description
- Update `matches_pattern_with_index()` in `crates/bashkit/src/builtins/awk.rs` to evaluate the end pattern immediately when the start pattern matches and store `!end_matches` as the new `range_active` state.
- Add regression test `awk_range_pattern_start_end_same_line` in `crates/bashkit/tests/awk_range_pattern_tests.rs` that verifies `/a/,/a/{print}` only prints the matching record(s).
- Commit message: `fix(awk): close range when start and end match same record`.

### Testing
- Ran `cargo test --test awk_range_pattern_tests` and all tests passed: `8 passed; 0 failed`.
- The added regression test `awk_range_pattern_start_end_same_line` passes under the same test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf1c5c59c832b876fade70ec8f63d)