### PR TITLE
fix(snapshot): preserve legacy function snapshot deserialization

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -490,6 +490,7 @@ impl Default for ShellStateOptions {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SnapshottedFunction {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     source: Option<String>,

--- a/crates/bashkit/tests/snapshot_tests.rs
+++ b/crates/bashkit/tests/snapshot_tests.rs
@@ -350,8 +350,33 @@ async fn snapshot_restores_functions_from_source_when_ast_missing() {
     let bytes = rewritten.to_bytes().unwrap();
     let mut restored = Bash::from_snapshot(&bytes).unwrap();
 
-    let result = restored.exec("greet world").await.unwrap();
-    assert_eq!(result.stdout.trim(), "hi world");
+    let result = restored
+        .exec("type greet >/dev/null 2>&1; echo $?; greet world")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "0\nhi world\n");
+}
+
+#[tokio::test]
+async fn snapshot_restores_legacy_function_shape_without_wrapper() {
+    let mut bash = Bash::new();
+    bash.exec("greet() { echo \"hi $1\"; }").await.unwrap();
+
+    let bytes = bash.snapshot().unwrap();
+    let parsed = Snapshot::from_bytes(&bytes).unwrap();
+    let legacy_func = serde_json::to_value(parsed.shell.functions.get("greet").unwrap()).unwrap();
+    let mut json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    json["shell"]["functions"]["greet"] = legacy_func;
+
+    let rewritten: Snapshot = serde_json::from_value(json).unwrap();
+    let bytes = rewritten.to_bytes().unwrap();
+    let mut restored = Bash::from_snapshot(&bytes).unwrap();
+
+    let result = restored
+        .exec("type greet >/dev/null 2>&1; echo $?; greet world")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "0\nhi world\n");
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Legacy snapshots that stored function entries as raw `FunctionDef` stopped restoring because the new untagged enum attempted the new wrapper form first and optional fields allowed legacy objects to be misparsed as an empty wrapper. 
- Restore backward compatibility so older snapshots can still be deserialized and functions restored.

### Description
- Add `#[serde(deny_unknown_fields)]` to `SnapshottedFunction` so objects with legacy `FunctionDef` fields do not deserialize into the wrapper and instead match the `Legacy(FunctionDef)` variant. 
- Add regression test `snapshot_restores_legacy_function_shape_without_wrapper` to assert a legacy-format function entry roundtrips and is registered on restore. 
- Tighten the existing source-only restore test to assert the function is actually registered (`type greet`) before invoking it.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test -p bashkit --test snapshot_tests snapshot_preserves_functions -- --exact` which passed. 
- Ran `cargo test -p bashkit --test snapshot_tests snapshot_restores_functions_from_source_when_ast_missing -- --exact` which passed. 
- Ran `cargo test -p bashkit --test snapshot_tests snapshot_restores_legacy_function_shape_without_wrapper -- --exact` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf1c5cbd0832bbada3f4852597d1f)