### PR TITLE
fix(js): retain ScriptedTool callbacks for weak TSFN

### DIFF
--- a/crates/bashkit-js/__test__/integration.spec.ts
+++ b/crates/bashkit-js/__test__/integration.spec.ts
@@ -237,6 +237,14 @@ test("integration: loop with accumulation in scripted tool", async (t) => {
   t.deepEqual(result.stdout.trim().split(/\s+/), ["2", "4", "6", "8", "10"]);
 });
 
+test("integration: scripted tool keeps callback references alive", (t) => {
+  const tool = new ScriptedTool({ name: "gc_guard" });
+  tool.addTool("one", "One", () => "1\n");
+  tool.addTool("two", "Two", () => "2\n");
+
+  t.is((tool as unknown as { callbackRefs: unknown[] }).callbackRefs.length, 2);
+});
+
 // ============================================================================
 // Reset behavior
 // ============================================================================

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -1091,6 +1091,8 @@ export type ToolCallback = (
  */
 export class ScriptedTool {
   private native: NativeScriptedToolType;
+  // Keep strong JS refs while native TSFN callbacks are weak.
+  private callbackRefs: Array<(requestJson: string) => string> = [];
 
   constructor(options: ScriptedToolOptions) {
     this.native = new NativeScriptedTool({
@@ -1126,6 +1128,7 @@ export class ScriptedTool {
       };
       return callback(request.params, request.stdin);
     };
+    this.callbackRefs.push(wrappedCallback);
     this.native.addTool(
       name,
       description,


### PR DESCRIPTION
### Motivation
- Weak N-API ThreadsafeFunctions are used for `ScriptedTool` callbacks but the JS wrapper created a `wrappedCallback` and did not keep a strong JS reference, allowing GC to collect the function and break later tool invocations.

### Description
- Add a `callbackRefs` array to `ScriptedTool` in `crates/bashkit-js/wrapper.ts` and push each `wrappedCallback` into it before calling the native `addTool` so JS retains a strong reference.
- Add an integration test `integration: scripted tool keeps callback references alive` in `crates/bashkit-js/__test__/integration.spec.ts` asserting `callbackRefs.length` matches the number of registered tools.

### Testing
- Ran `cd crates/bashkit-js && npm install` and the install completed successfully.
- Built the package with `npm run build` and the native/JS bundles compiled successfully.
- Ran the integration suite with `npx ava __test__/integration.spec.ts` and all integration tests passed (41 passed).
- Ran type checking with `npm run type-check` (`tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf1c5d830832b8794c2d7e697c321)