### PR TITLE
fix(interpreter): parse arithmetic parameter operators at first operator

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -8927,45 +8927,39 @@ impl Interpreter {
     /// Expand a parameter expansion with operators inside arithmetic context.
     /// Handles common cases like ${var%%-*}, ${var##prefix}, etc.
     fn expand_param_op_in_arithmetic(&self, inner: &str) -> String {
-        // ${var%%pattern} — remove longest suffix
-        if let Some(pos) = inner.find("%%") {
-            let name = &inner[..pos];
-            let pattern = &inner[pos + 2..];
-            let value = self.expand_variable(name);
-            return self.remove_pattern(&value, pattern, false, true);
-        }
-        // ${var%pattern} — remove shortest suffix
-        if let Some(pos) = inner.find('%') {
-            let name = &inner[..pos];
-            let pattern = &inner[pos + 1..];
-            let value = self.expand_variable(name);
-            return self.remove_pattern(&value, pattern, false, false);
-        }
-        // ${var##pattern} — remove longest prefix
-        if let Some(pos) = inner.find("##") {
-            let name = &inner[..pos];
-            let pattern = &inner[pos + 2..];
-            let value = self.expand_variable(name);
-            return self.remove_pattern(&value, pattern, true, true);
-        }
-        // ${var#pattern} — remove shortest prefix (but not ${#var} length)
-        if let Some(pos) = inner.find('#')
-            && pos > 0
-        {
-            let name = &inner[..pos];
-            let pattern = &inner[pos + 1..];
-            let value = self.expand_variable(name);
-            return self.remove_pattern(&value, pattern, true, false);
-        }
-        // ${var:-default}
-        if let Some(pos) = inner.find(":-") {
-            let name = &inner[..pos];
-            let default = &inner[pos + 2..];
-            let value = self.expand_variable(name);
-            if value.is_empty() {
-                return default.to_string();
+        for (pos, ch) in inner.char_indices() {
+            match ch {
+                '%' => {
+                    let name = &inner[..pos];
+                    let value = self.expand_variable(name);
+                    if inner[pos..].starts_with("%%") {
+                        let pattern = &inner[pos + 2..];
+                        return self.remove_pattern(&value, pattern, false, true);
+                    }
+                    let pattern = &inner[pos + 1..];
+                    return self.remove_pattern(&value, pattern, false, false);
+                }
+                '#' if pos > 0 => {
+                    let name = &inner[..pos];
+                    let value = self.expand_variable(name);
+                    if inner[pos..].starts_with("##") {
+                        let pattern = &inner[pos + 2..];
+                        return self.remove_pattern(&value, pattern, true, true);
+                    }
+                    let pattern = &inner[pos + 1..];
+                    return self.remove_pattern(&value, pattern, true, false);
+                }
+                ':' if inner[pos..].starts_with(":-") => {
+                    let name = &inner[..pos];
+                    let default = &inner[pos + 2..];
+                    let value = self.expand_variable(name);
+                    if value.is_empty() {
+                        return default.to_string();
+                    }
+                    return value;
+                }
+                _ => {}
             }
-            return value;
         }
         // Fallback
         self.expand_variable(inner)
@@ -11666,6 +11660,20 @@ mod tests {
         // Invalid char for base — should return 0
         let result = run_script("echo $(( 37#! ))").await;
         assert_eq!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn test_arithmetic_base_suffix_pattern_with_double_percent() {
+        let result = run_script("var='123foo%%bar'; echo $(( 10#${var%foo%%bar} ))").await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "123");
+    }
+
+    #[tokio::test]
+    async fn test_arithmetic_base_prefix_pattern_with_double_hash() {
+        let result = run_script("var='foo##bar123'; echo $(( 10#${var#foo##bar} ))").await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "123");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/bash/arithmetic-base-expansion.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/arithmetic-base-expansion.test.sh
@@ -29,3 +29,20 @@ echo $(( 10#${x} ))
 ### expect
 99
 ### end
+
+
+### arithmetic_base_suffix_pattern_contains_double_percent
+# Ensure %% inside pattern is not treated as operator location
+var="123foo%%bar"
+echo $(( 10#${var%foo%%bar} ))
+### expect
+123
+### end
+
+### arithmetic_base_prefix_pattern_contains_double_hash
+# Ensure ## inside pattern is not treated as operator location
+var="foo##bar123"
+echo $(( 10#${var#foo##bar} ))
+### expect
+123
+### end


### PR DESCRIPTION
### Motivation
- A naive search for `"%%"`/`"##"` inside `expand_param_op_in_arithmetic` could match those sequences inside the pattern portion (e.g. `${var%foo%%bar}`), which truncated the variable name and produced incorrect arithmetic results. 
- The regression affects arithmetic-base expansions like `10#${var%foo%%bar}` and `10#${var#foo##bar}` and was introduced when adding operator handling for arithmetic contexts. 
- The goal is to detect the operator at the first operator boundary (left-to-right) so patterns containing `%%`/`##` are not misinterpreted as the operator location.

### Description
- Replace the global `find`-based detection in `expand_param_op_in_arithmetic` with a left-to-right `char_indices()` scan that identifies the first operator boundary and then dispatches handling for `%%`/`%`/`##`/`#` and `:-` accordingly in `crates/bashkit/src/interpreter/mod.rs`. 
- Add regression unit tests exercising `${var%foo%%bar}` and `${var#foo##bar}` inside arithmetic base expressions in `mod tests` of `crates/bashkit/src/interpreter/mod.rs`. 
- Extend spec coverage by adding matching spec cases to `crates/bashkit/tests/spec_cases/bash/arithmetic-base-expansion.test.sh` to ensure the behavior remains covered by the spec runner.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran targeted unit tests with `cargo test --features http_client` for the new tests and `arithmetic_base` scenarios, and the added tests `test_arithmetic_base_suffix_pattern_with_double_percent` and `test_arithmetic_base_prefix_pattern_with_double_hash` passed. 
- Ran the `arithmetic_base` test grouping and observed no regressions in existing arithmetic base tests (all executed tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eadf19cfa4832ba2ad750974669892)