### PR TITLE
fix(interpreter): preserve truncating redirects with empty mixed fd output

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -3451,25 +3451,32 @@ fn route_fd_table_content(
                  target: &FdTarget,
                  fw: &mut std::collections::HashMap<PathBuf, (String, bool, String)>,
                  out: &mut String,
-                 err: &mut String| {
-        if data.is_empty() {
-            return;
-        }
-        match target {
-            FdTarget::Stdout => out.push_str(data),
-            FdTarget::Stderr => err.push_str(data),
-            FdTarget::DevNull => {}
-            FdTarget::WriteFile(p, d) => {
-                fw.entry(p.clone())
-                    .or_insert_with(|| (String::new(), false, d.clone()))
-                    .0
-                    .push_str(data);
+                 err: &mut String| match target {
+        FdTarget::Stdout => {
+            if !data.is_empty() {
+                out.push_str(data);
             }
-            FdTarget::AppendFile(p, d) => {
-                fw.entry(p.clone())
-                    .or_insert_with(|| (String::new(), true, d.clone()))
-                    .0
-                    .push_str(data);
+        }
+        FdTarget::Stderr => {
+            if !data.is_empty() {
+                err.push_str(data);
+            }
+        }
+        FdTarget::DevNull => {}
+        FdTarget::WriteFile(p, d) => {
+            let entry = fw
+                .entry(p.clone())
+                .or_insert_with(|| (String::new(), false, d.clone()));
+            if !data.is_empty() {
+                entry.0.push_str(data);
+            }
+        }
+        FdTarget::AppendFile(p, d) => {
+            let entry = fw
+                .entry(p.clone())
+                .or_insert_with(|| (String::new(), true, d.clone()));
+            if !data.is_empty() {
+                entry.0.push_str(data);
             }
         }
     };

--- a/crates/bashkit/tests/issue_853_test.rs
+++ b/crates/bashkit/tests/issue_853_test.rs
@@ -91,3 +91,25 @@ cat /tmp/out3.txt
         "file should contain stderr: {stdout}"
     );
 }
+
+/// Regression guard: mixed 2>&1 + >file must still truncate/create file on empty output.
+#[tokio::test]
+async fn redirect_2_to_1_then_file_truncates_on_empty_output() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+echo "stale" >"/tmp/out-empty.txt"
+true 2>&1 >"/tmp/out-empty.txt"
+wc -c <"/tmp/out-empty.txt"
+"#,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.stdout.trim(),
+        "0",
+        "expected redirected file to be truncated to zero bytes"
+    );
+}


### PR DESCRIPTION
### Motivation
- Fix fd-table redirection regression where mixed DupOutput + file redirects (e.g. `true 2>&1 >file`) did not create/truncate the target file when routed data was empty.

### Description
- Update `route_fd_table_content` in `crates/bashkit/src/interpreter/mod.rs` so `WriteFile`/`AppendFile` targets are always registered and only payload bytes are appended when non-empty, removing the early-return that skipped target registration.
- Preserve existing stdout/stderr/devnull routing semantics while ensuring truncate/append redirects run even with empty output.
- Add a regression test `redirect_2_to_1_then_file_truncates_on_empty_output` in `crates/bashkit/tests/issue_853_test.rs` that seeds a stale file, runs `true 2>&1 >file`, and asserts the file is truncated to zero bytes.

### Testing
- Ran `cargo test -p bashkit --test issue_853_test` and all tests passed: 4 passed; 0 failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaea74c158832bb48bf98b79ba59c8)