### PR TITLE
fix(awk): avoid double evaluation in boolean binops

### DIFF
--- a/crates/bashkit/src/builtins/awk.rs
+++ b/crates/bashkit/src/builtins/awk.rs
@@ -2209,6 +2209,23 @@ impl AwkInterpreter {
                 value
             }
             AwkExpr::BinOp(left, op, right) => {
+                if op == "&&" {
+                    let lb = self.eval_expr_as_bool(left);
+                    if !lb {
+                        return AwkValue::Number(0.0);
+                    }
+                    let rb = self.eval_expr_as_bool(right);
+                    return AwkValue::Number(if rb { 1.0 } else { 0.0 });
+                }
+                if op == "||" {
+                    let lb = self.eval_expr_as_bool(left);
+                    if lb {
+                        return AwkValue::Number(1.0);
+                    }
+                    let rb = self.eval_expr_as_bool(right);
+                    return AwkValue::Number(if rb { 1.0 } else { 0.0 });
+                }
+
                 let l = self.eval_expr(left);
                 let r = self.eval_expr(right);
 
@@ -2249,16 +2266,6 @@ impl AwkInterpreter {
                     } else {
                         0.0
                     }),
-                    "&&" => {
-                        let lb = self.eval_expr_as_bool(left);
-                        let rb = self.eval_expr_as_bool(right);
-                        AwkValue::Number(if lb && rb { 1.0 } else { 0.0 })
-                    }
-                    "||" => {
-                        let lb = self.eval_expr_as_bool(left);
-                        let rb = self.eval_expr_as_bool(right);
-                        AwkValue::Number(if lb || rb { 1.0 } else { 0.0 })
-                    }
                     "~" => {
                         if let Ok(re) = build_regex(&r.as_string()) {
                             AwkValue::Number(if re.is_match(&l.as_string()) {

--- a/crates/bashkit/tests/awk_pattern_tests.rs
+++ b/crates/bashkit/tests/awk_pattern_tests.rs
@@ -26,3 +26,21 @@ flag && /^status:/ { print "status matched: " $0 }
     assert_eq!(lines[0], "id matched: id: t1");
     assert_eq!(lines[1], "status matched: status: open");
 }
+
+/// Regression test: boolean ops must not evaluate operands twice.
+#[tokio::test]
+async fn awk_boolean_ops_do_not_double_evaluate_side_effects() {
+    let mut bash = Bash::new();
+
+    let and_result = bash
+        .exec(r#"awk 'BEGIN { a=0; b=0; if (a++ && b++) {} ; print a, b }'"#)
+        .await
+        .unwrap();
+    assert_eq!(and_result.stdout.trim(), "1 0");
+
+    let or_result = bash
+        .exec(r#"awk 'BEGIN { a=1; b=0; if (a++ || b++) {} ; print a, b }'"#)
+        .await
+        .unwrap();
+    assert_eq!(or_result.stdout.trim(), "2 0");
+}


### PR DESCRIPTION
### Motivation
- Fix a regression where `eval_expr_as_bool()` re-invokes `eval_expr()` causing `&&`/`||` to evaluate both operands twice, breaking short-circuit semantics and doubling side effects (e.g. `a++`).
- Preserve the special-case boolean behavior for regex literals (match `/regex/` against `$0`).

### Description
- Special-case `&&` and `||` in `AwkInterpreter::eval_expr` to call `eval_expr_as_bool(left)` and short-circuit-return when the left operand decides the result. 
- Defer eager evaluation of `l`/`r` until after `&&`/`||` are handled so other binary operators keep existing behavior.
- Add regression test `awk_boolean_ops_do_not_double_evaluate_side_effects` in `crates/bashkit/tests/awk_pattern_tests.rs` to assert side-effectful expressions are not double-evaluated.

### Testing
- Ran `cargo test -p bashkit --test awk_pattern_tests`, which ran 2 tests and both passed.
- Ran `cargo test -p bashkit test_awk_gsub_with_print`, and the target test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaea758a28832bbf8fa5dc6de3d35f)