### PR TITLE
fix(find): preserve missing-path errors in -exec execution plans

### DIFF
--- a/crates/bashkit/src/builtins/ls.rs
+++ b/crates/bashkit/src/builtins/ls.rs
@@ -612,13 +612,21 @@ fn parse_find_args(args: &[String]) -> std::result::Result<(Vec<String>, FindOpt
     Ok((paths, opts))
 }
 
-/// Collect matched paths for find, without -exec output.
-async fn collect_find_paths(
+struct FindPlanData {
+    matched_paths: Vec<String>,
+    errors: String,
+    had_error: bool,
+}
+
+/// Collect matched paths and path/traversal errors for find execution planning.
+async fn collect_find_plan_data(
     ctx: &Context<'_>,
     search_paths: &[String],
     opts: &FindOptions,
-) -> Result<Vec<String>> {
+) -> Result<FindPlanData> {
     let mut matched: Vec<String> = Vec::new();
+    let mut errors = String::new();
+    let mut had_error = false;
     // Reuse find_recursive but with a temporary output buffer
     let temp_opts = FindOptions {
         name_pattern: opts.name_pattern.clone(),
@@ -636,13 +644,17 @@ async fn collect_find_paths(
     for path_str in search_paths {
         let path = resolve_path(ctx.cwd, path_str);
         if !ctx.fs.exists(&path).await.unwrap_or(false) {
+            errors.push_str(&format!(
+                "find: '{}': No such file or directory\n",
+                path_str
+            ));
+            had_error = true;
             continue;
         }
-        // Intentionally swallowing errors (`let _ =`) rather than propagating (`?`):
-        // this feeds execution_plan(), which is only an optimization hint. Propagating
-        // would bubble up as Err and abort the entire command. Real error handling
-        // (stderr messages, exit codes) lives in execute(), which is always called.
-        let _ = find_recursive(ctx, &path, path_str, &temp_opts, 0, &mut output).await;
+        if let Err(e) = find_recursive(ctx, &path, path_str, &temp_opts, 0, &mut output).await {
+            errors.push_str(&format!("find: '{}': {}\n", path_str, e));
+            had_error = true;
+        }
     }
     // Parse the output back into paths (each line is a path)
     for line in output.lines() {
@@ -650,7 +662,11 @@ async fn collect_find_paths(
             matched.push(line.to_string());
         }
     }
-    Ok(matched)
+    Ok(FindPlanData {
+        matched_paths: matched,
+        errors,
+        had_error,
+    })
 }
 
 /// Build exec sub-commands from matched paths and exec_args template.
@@ -763,15 +779,24 @@ impl Builtin for Find {
             return Ok(None);
         }
 
-        // Collect matched paths (collect_find_paths skips missing paths)
-        let matched_paths = collect_find_paths(ctx, &search_paths, &opts).await?;
-        if matched_paths.is_empty() {
+        // Collect matched paths plus any path/traversal errors.
+        let plan_data = collect_find_plan_data(ctx, &search_paths, &opts).await?;
+        if plan_data.matched_paths.is_empty() && !plan_data.had_error {
             return Ok(None);
         }
 
-        let commands = build_find_exec_commands(&opts.exec_args, &matched_paths, opts.exec_batch);
-        if commands.is_empty() {
+        let commands =
+            build_find_exec_commands(&opts.exec_args, &plan_data.matched_paths, opts.exec_batch);
+        if commands.is_empty() && !plan_data.had_error {
             return Ok(None);
+        }
+
+        if plan_data.had_error {
+            return Ok(Some(ExecutionPlan::BatchWithStatus {
+                commands,
+                stderr_prefix: plan_data.errors,
+                force_error_exit: true,
+            }));
         }
 
         Ok(Some(ExecutionPlan::Batch { commands }))
@@ -3526,5 +3551,55 @@ mod tests {
 
         let plan = Find.execution_plan(&ctx).await.unwrap();
         assert!(plan.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_find_plan_exec_with_missing_path_returns_status_plan() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        fs.write_file(&PathBuf::from("/home/user/a.txt"), b"hello")
+            .await
+            .unwrap();
+
+        let args = vec![
+            "/home/user".to_string(),
+            "/home/missing".to_string(),
+            "-name".to_string(),
+            "*.txt".to_string(),
+            "-exec".to_string(),
+            "echo".to_string(),
+            "{}".to_string(),
+            ";".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let plan = Find.execution_plan(&ctx).await.unwrap();
+        match plan {
+            Some(ExecutionPlan::BatchWithStatus {
+                commands,
+                stderr_prefix,
+                force_error_exit,
+            }) => {
+                assert_eq!(commands.len(), 1);
+                assert!(stderr_prefix.contains("No such file or directory"));
+                assert!(force_error_exit);
+            }
+            _ => panic!("expected BatchWithStatus plan"),
+        }
     }
 }

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -379,6 +379,15 @@ pub enum ExecutionPlan {
         /// Commands to execute in order.
         commands: Vec<SubCommand>,
     },
+    /// Run a sequence of commands, then merge builtin-generated stderr/exit semantics.
+    BatchWithStatus {
+        /// Commands to execute in order.
+        commands: Vec<SubCommand>,
+        /// Builtin-generated stderr to prepend to command stderr.
+        stderr_prefix: String,
+        /// Force non-zero exit (1) when command sequence would otherwise succeed.
+        force_error_exit: bool,
+    },
 }
 
 /// Resolve a path relative to the current working directory.

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6597,6 +6597,59 @@ impl Interpreter {
                     ..Default::default()
                 }
             }
+            builtins::ExecutionPlan::BatchWithStatus {
+                commands,
+                stderr_prefix,
+                force_error_exit,
+            } => {
+                let mut combined_stdout = String::new();
+                let mut combined_stderr = stderr_prefix;
+                let mut last_exit_code = 0;
+
+                for cmd in commands {
+                    let cmd_redirects = if let Some(ref stdin_data) = cmd.stdin {
+                        vec![Redirect {
+                            fd: None,
+                            fd_var: None,
+                            kind: RedirectKind::HereString,
+                            target: Word::literal(stdin_data.trim_end_matches('\n').to_string()),
+                        }]
+                    } else {
+                        Vec::new()
+                    };
+
+                    let inner_cmd = Command::Simple(SimpleCommand {
+                        name: Word::quoted_literal(cmd.name),
+                        args: cmd
+                            .args
+                            .iter()
+                            .map(|s| Word::quoted_literal(s.clone()))
+                            .collect(),
+                        redirects: cmd_redirects,
+                        assignments: Vec::new(),
+                        span: Span::new(),
+                    });
+
+                    let result = self.execute_command(&inner_cmd).await?;
+                    combined_stdout.push_str(&result.stdout);
+                    combined_stderr.push_str(&result.stderr);
+                    last_exit_code = result.exit_code;
+                }
+
+                let exit_code = if force_error_exit && last_exit_code == 0 {
+                    1
+                } else {
+                    last_exit_code
+                };
+
+                ExecResult {
+                    stdout: combined_stdout,
+                    stderr: combined_stderr,
+                    exit_code,
+                    control_flow: ControlFlow::None,
+                    ..Default::default()
+                }
+            }
         };
 
         self.apply_redirections(result, redirects).await

--- a/crates/bashkit/tests/find_multi_path_tests.rs
+++ b/crates/bashkit/tests/find_multi_path_tests.rs
@@ -147,3 +147,29 @@ async fn find_multi_path_mixed_has_exit_one() {
         "Valid path results should still appear"
     );
 }
+
+#[tokio::test]
+async fn find_exec_with_missing_path_preserves_error_and_exec_output() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/find_exec_ok && touch /tmp/find_exec_ok/y.txt")
+        .await
+        .unwrap();
+
+    let result = bash
+        .exec("find /tmp/find_exec_ok /tmp/find_exec_missing -name '*.txt' -exec echo {} \\;")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 1);
+    assert!(
+        result.stdout.contains("/tmp/find_exec_ok/y.txt"),
+        "Expected -exec output for valid path, got: {:?}",
+        result.stdout
+    );
+    assert!(
+        result.stderr.contains("No such file or directory"),
+        "Expected missing path error in stderr, got: {:?}",
+        result.stderr
+    );
+}


### PR DESCRIPTION
### Motivation
- A recent change caused `find` planning to swallow missing-root and traversal errors, letting `find -exec` run subcommands without emitting stderr or returning exit code `1` when at least one search root failed.
- Restore Unix-like semantics: keep optimized `-exec` execution plans but preserve builtin-generated stderr and non-zero exit behavior when any path fails.

### Description
- Add `ExecutionPlan::BatchWithStatus` to carry planned `commands`, a `stderr_prefix`, and a `force_error_exit` flag. 
- Replace the old silent collector with `collect_find_plan_data()` that returns matched paths plus accumulated `errors` and a `had_error` flag. 
- Update `Find::execution_plan()` to return `BatchWithStatus` when any search path failed while still returning a normal `Batch` for the pure-success case. 
- Extend the interpreter to execute `BatchWithStatus` by prepending builtin stderr, merging subcommand stderr/stdout, and forcing exit code `1` when builtin-level errors occurred but subcommands would otherwise succeed. 
- Add unit and integration tests: `test_find_plan_exec_with_missing_path_returns_status_plan` and `find_exec_with_missing_path_preserves_error_and_exec_output`.

### Testing
- Ran formatter: `cargo fmt --all` (succeeded). 
- Ran unit test for plan generation: `cargo test -p bashkit test_find_plan_exec_with_missing_path_returns_status_plan` (passed). 
- Ran end-to-end test for `find -exec` behavior: `cargo test -p bashkit find_exec_with_missing_path_preserves_error_and_exec_output` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaea74811c832b971b664ec32e7b99)