### PR TITLE
fix(strings): restore `-NUM` shorthand argument handling

### DIFF
--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -54,16 +54,20 @@ fn parse_strings_args(
             });
         } else if p.flag("-a") {
             // Default behavior, ignore
-        } else if let Some(arg) = p.positional() {
-            files.push(arg.to_string());
         } else if let Some(arg) = p.current() {
-            // Try parsing as -NUM shorthand
-            if let Some(rest) = arg.strip_prefix('-')
-                && let Ok(n) = rest.parse::<usize>()
-            {
-                opts.min_length = n;
+            if arg != "-" && arg.starts_with('-') {
+                // Try parsing as -NUM shorthand
+                if let Some(rest) = arg.strip_prefix('-')
+                    && let Ok(n) = rest.parse::<usize>()
+                {
+                    opts.min_length = n;
+                }
+                p.advance();
+            } else if let Some(file) = p.positional() {
+                files.push(file.to_string());
+            } else {
+                p.advance();
             }
-            p.advance();
         } else {
             p.advance();
         }
@@ -289,6 +293,14 @@ mod tests {
         let result = run_strings_with_fs(&["-n", "4", "/test.bin"], &[("/test.bin", &data)]).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "cdef\nghijklm\n");
+    }
+
+    #[tokio::test]
+    async fn test_strings_min_length_shorthand() {
+        let data = b"short\0longest-string\0";
+        let result = run_strings_with_fs(&["-8", "/test.bin"], &[("/test.bin", data)]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "longest-string\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- A recent refactor to use `ArgParser` caused `positional()` to consume any remaining argument before the old `-NUM` shorthand could be recognized, so invocations like `strings -5 file` treated `-5` as a filename instead of setting the minimum string length.

### Description
- Reworked `parse_strings_args` to inspect `p.current()` first and treat `-<digits>` (except the lone `-` sentinel) as the `-NUM` shorthand, advancing the parser when shorthand is consumed.
- Fall back to `p.positional()` only when the current arg is not a `-NUM` shorthand, preserving the `-` stdin/file sentinel behavior.
- Added regression test `test_strings_min_length_shorthand` to verify `strings -8 /test.bin` sets `min_length` and filters output as expected.
- Kept existing handling for `-n`, `-t`, `-a` and the `min_length == 0` normalization.

### Testing
- Ran `cargo test -p bashkit test_strings_min_length_shorthand`, which passed.
- Ran `cargo test -p bashkit test_strings_min_length_filter`, which passed.
- Ran the crate tests for `bashkit` as part of validation, and the test suite completed with warnings but all relevant tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaea749e9c832bbef0af92fc25c64c)