### PR TITLE
fix(read): split on mixed whitespace/non-whitespace IFS

### DIFF
--- a/crates/bashkit/src/builtins/read.rs
+++ b/crates/bashkit/src/builtins/read.rs
@@ -151,14 +151,58 @@ impl Builtin for Read {
                     .filter(|s| !s.is_empty())
                     .collect()
             } else {
-                // Has non-whitespace delimiters: split on them, trim whitespace from each field
-                let mut fields: Vec<&str> = line.split(|c: char| ifs_non_ws.contains(&c)).collect();
-                // Trim IFS whitespace from each field
-                if !ifs_ws.is_empty() {
-                    fields = fields
-                        .into_iter()
-                        .map(|f| f.trim_matches(|c: char| ifs_ws.contains(&c)))
-                        .collect();
+                // Mixed IFS: split on all IFS chars, collapse whitespace runs,
+                // preserve empty fields for consecutive non-whitespace delimiters.
+                let mut fields: Vec<&str> = Vec::new();
+                let mut field_start = 0usize;
+                let mut i = 0usize;
+                let mut last_delim_was_non_ws = false;
+
+                while i < line.len() {
+                    let mut iter = line[i..].char_indices();
+                    let (_, ch) = iter.next().expect("valid char boundary");
+                    let ch_len = ch.len_utf8();
+                    if !ifs.contains(ch) {
+                        i += ch_len;
+                        last_delim_was_non_ws = false;
+                        continue;
+                    }
+
+                    if ifs_non_ws.contains(&ch) {
+                        fields.push(&line[field_start..i]);
+                        i += ch_len;
+                        while i < line.len() {
+                            let mut ws_iter = line[i..].char_indices();
+                            let (_, ws_ch) = ws_iter.next().expect("valid char boundary");
+                            if ifs_ws.contains(&ws_ch) {
+                                i += ws_ch.len_utf8();
+                            } else {
+                                break;
+                            }
+                        }
+                        field_start = i;
+                        last_delim_was_non_ws = true;
+                    } else {
+                        if field_start != i {
+                            fields.push(&line[field_start..i]);
+                        }
+                        i += ch_len;
+                        while i < line.len() {
+                            let mut ws_iter = line[i..].char_indices();
+                            let (_, ws_ch) = ws_iter.next().expect("valid char boundary");
+                            if ifs_ws.contains(&ws_ch) {
+                                i += ws_ch.len_utf8();
+                            } else {
+                                break;
+                            }
+                        }
+                        field_start = i;
+                        last_delim_was_non_ws = false;
+                    }
+                }
+
+                if field_start < line.len() || last_delim_was_non_ws {
+                    fields.push(&line[field_start..]);
                 }
                 fields
             }
@@ -591,6 +635,28 @@ mod tests {
         assert_eq!(vars.get("B").unwrap(), "");
         assert_eq!(vars.get("C").unwrap(), "three");
         assert_eq!(vars.get("D").unwrap(), "");
+    }
+
+    #[tokio::test]
+    async fn read_mixed_ifs_whitespace_and_non_ws() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let mut env = HashMap::new();
+        env.insert("IFS".to_string(), ": ".to_string());
+        let args = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            Some("one two:three"),
+        );
+        let result = Read.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let vars = extract_vars(&result);
+        assert_eq!(vars.get("A").unwrap(), "one");
+        assert_eq!(vars.get("B").unwrap(), "two");
+        assert_eq!(vars.get("C").unwrap(), "three");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
@@ -75,6 +75,14 @@ echo "a=$a b=$b c=$c"
 a= b=two c=three
 ### end
 
+### read_ifs_mixed_whitespace_and_non_ws
+# Mixed IFS should split on both whitespace and non-whitespace delimiters
+IFS=": " read a b c <<< "one two:three"
+echo "a=$a b=$b c=$c"
+### expect
+a=one b=two c=three
+### end
+
 ### read_nchars
 # read -n N reads N characters
 read -n 3 var <<< "hello"


### PR DESCRIPTION
### Motivation
- Restore POSIX/Bash behavior for `read` when `IFS` mixes whitespace and non-whitespace characters so whitespace still acts as a delimiter (collapsing runs) while non-whitespace delimiters preserve empty fields.

### Description
- Replace previous non-whitespace-only split logic in `crates/bashkit/src/builtins/read.rs` with a mixed-IFS parser that treats all `IFS` chars as delimiters, collapses runs of IFS whitespace, and preserves empty fields produced by consecutive non-whitespace delimiters.
- Keep existing behavior for `IFS` empty and whitespace-only cases (no splitting or collapse+trim respectively).
- Add a unit test `read_mixed_ifs_whitespace_and_non_ws` in `crates/bashkit/src/builtins/read.rs` to cover `IFS=": "` with input `one two:three` producing `one|two|three`.
- Add a shell spec case `read_ifs_mixed_whitespace_and_non_ws` in `crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh` to exercise the same scenario.

### Testing
- Ran `cargo test -p bashkit read_mixed_ifs_whitespace_and_non_ws -- --nocapture`, which passed.
- Ran `cargo fmt --check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaea74baa0832b80bb8f5ad4f92e7a)