### PR TITLE
fix(parser): preserve literal semantics for single-quoted =~ regex patterns

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -12122,6 +12122,16 @@ echo "count=$COUNT"
     }
 
     #[tokio::test]
+    async fn test_regex_single_quoted_pattern_is_literal() {
+        let mut bash = crate::Bash::new();
+        let result = bash
+            .exec(r#"re="200"; line="hello 200 world"; [[ $line =~ '$re' ]] && echo "match" || echo "no""#)
+            .await
+            .unwrap();
+        assert_eq!(result.stdout.trim(), "no");
+    }
+
+    #[tokio::test]
     async fn test_assoc_array_in_double_quotes() {
         let mut bash = crate::Bash::new();
         let result = bash

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -1464,10 +1464,10 @@ impl<'a> Parser<'a> {
 
                     // After =~, handle regex pattern.
                     // If the pattern contains $ (variable reference), parse it as a
-                    // normal word so variables expand. Otherwise collect as literal
-                    // regex to preserve parens, backslashes, etc.
+                    // normal word so variables expand. Keep quoted/literal tokens as
+                    // literal regex patterns to preserve shell quoting semantics.
                     if saw_regex_op {
-                        if w_clone.contains('$') && !is_quoted {
+                        if w_clone.contains('$') && !is_quoted && !is_literal {
                             // Variable reference — parse normally for expansion
                             let parsed = self.parse_word(w_clone);
                             words.push(parsed);


### PR DESCRIPTION
### Motivation
- Root cause: `parse_conditional` invoked `parse_word` for any regex token containing `$` unless it was a `QuotedWord` (double-quoted), but it did not exclude `LiteralWord` (single-quoted), causing single-quoted patterns like `' $re '` to be expanded.
- Goal: preserve shell quoting semantics so single-quoted regex patterns remain literal and do not perform variable/command/arithmetic expansion.

### Description
- Parser change: in `parse_conditional` only call `parse_word` for `$` expansion when the token is neither quoted nor literal by adding a `!is_literal` check. (file: `crates/bashkit/src/parser/mod.rs`)
- Test added: `test_regex_single_quoted_pattern_is_literal` verifies `[[ $line =~ '$re' ]]` stays literal and returns `no`. (file: `crates/bashkit/src/interpreter/mod.rs`)
- Behavior preserved: unquoted variable regex (`[[ $line =~ $re ]]`) and plain literal regex tests remain unchanged.

### Testing
- Reproduced regression by running the new test before the parser fix which failed (observed `match` instead of expected `no`).
- After the fix ran targeted tests `test_regex_single_quoted_pattern_is_literal`, `test_regex_match_from_variable`, and `test_regex_match_literal`, and all passed.
- Ran package tests for the exercised cases with `cargo test -p bashkit` and observed no regressions for the tested scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf4b268b4832ba0b5948073574abc)