### PR TITLE
feat(site): add canonical sitemap generation

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,4 +1,6 @@
 import { defineConfig } from "astro/config";
+import sitemap from "@astrojs/sitemap";
+import sitemapEnhance from "./integrations/sitemap-enhance.mjs";
 
 export default defineConfig({
   site: "https://bashkit.sh",
@@ -6,4 +8,5 @@ export default defineConfig({
   markdown: {
     shikiConfig: { theme: "github-light" },
   },
+  integrations: [sitemap(), sitemapEnhance()],
 });

--- a/site/integrations/sitemap-enhance.mjs
+++ b/site/integrations/sitemap-enhance.mjs
@@ -1,0 +1,48 @@
+// Decision: keep /sitemap.xml as the only crawl target and remove Astro's
+// generated sitemap index so crawlers do not discover a redundant URL.
+// Decision: use build date for <lastmod>; Cloudflare builds may not have full
+// git history, and freshness is enough for this small static site.
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export default function sitemapEnhance() {
+  return {
+    name: "sitemap-enhance",
+    hooks: {
+      "astro:build:done": async ({ dir }) => {
+        const outDir = fileURLToPath(dir);
+        const sitemapSrc = join(outDir, "sitemap-0.xml");
+
+        let content;
+        try {
+          content = readFileSync(sitemapSrc, "utf-8");
+        } catch {
+          console.warn("[sitemap-enhance] sitemap-0.xml not found, skipping");
+          return;
+        }
+
+        const lastmod = new Date().toISOString().split("T")[0];
+        const enhanced = content.replace(
+          /<url><loc>(.*?)<\/loc><\/url>/g,
+          (_match, url) =>
+            `<url><loc>${url}</loc><lastmod>${lastmod}</lastmod></url>`,
+        );
+
+        const sitemapDest = join(outDir, "sitemap.xml");
+        const sitemapIndexDest = join(outDir, "sitemap-index.xml");
+        writeFileSync(sitemapDest, enhanced);
+
+        unlinkSync(sitemapSrc);
+        if (existsSync(sitemapIndexDest)) {
+          unlinkSync(sitemapIndexDest);
+        }
+
+        const entryCount = (enhanced.match(/<url>/g) || []).length;
+        console.log(
+          `[sitemap-enhance] sitemap.xml written with ${entryCount} entries (lastmod: ${lastmod})`,
+        );
+      },
+    },
+  };
+}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bashkit-site",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/sitemap": "^3.7.2",
         "astro": "^6.1.8"
       },
       "devDependencies": {
@@ -136,6 +137,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -1904,10 +1916,18 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -2102,6 +2122,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4862,6 +4888,40 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -4892,6 +4952,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -5123,7 +5189,6 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unenv": {

--- a/site/package.json
+++ b/site/package.json
@@ -10,11 +10,13 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "postbuild": "node scripts/verify-sitemap.mjs",
     "preview": "wrangler dev",
-    "deploy": "astro build && wrangler deploy",
+    "deploy": "npm run build && wrangler deploy",
     "check": "astro check"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.2",
     "astro": "^6.1.8"
   },
   "devDependencies": {

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://bashkit.sh/sitemap-index.xml
+Sitemap: https://bashkit.sh/sitemap.xml

--- a/site/scripts/verify-sitemap.mjs
+++ b/site/scripts/verify-sitemap.mjs
@@ -1,0 +1,76 @@
+// Decision: verify sitemap coverage from generated HTML files so new pages are
+// checked automatically without duplicating route lists in tests.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SITE_URL = "https://bashkit.sh";
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptDir, "..");
+const distRoot = path.join(siteRoot, "dist");
+const sitemapPath = path.join(distRoot, "sitemap.xml");
+const sitemapIndexPath = path.join(distRoot, "sitemap-index.xml");
+const intermediateSitemapPath = path.join(distRoot, "sitemap-0.xml");
+
+if (!existsSync(sitemapPath)) {
+  throw new Error(`Missing sitemap output: ${sitemapPath}`);
+}
+
+if (existsSync(intermediateSitemapPath)) {
+  throw new Error(
+    `Intermediate sitemap should be removed: ${intermediateSitemapPath}`,
+  );
+}
+
+if (existsSync(sitemapIndexPath)) {
+  throw new Error(`Sitemap index should not be generated: ${sitemapIndexPath}`);
+}
+
+const sitemap = readFileSync(sitemapPath, "utf8");
+
+if (!sitemap.includes("<lastmod>")) {
+  throw new Error("sitemap.xml does not include lastmod entries");
+}
+
+const htmlRoutes = [];
+
+function collectHtmlRoutes(dir) {
+  for (const name of readdirSync(dir)) {
+    const filePath = path.join(dir, name);
+    const stats = statSync(filePath);
+
+    if (stats.isDirectory()) {
+      collectHtmlRoutes(filePath);
+      continue;
+    }
+
+    if (!name.endsWith(".html")) {
+      continue;
+    }
+
+    const relativePath = path.relative(distRoot, filePath);
+    const routePath =
+      relativePath === "index.html"
+        ? "/"
+        : `/${relativePath.replace(/(?:\/index)?\.html$/, "")}`;
+    htmlRoutes.push(routePath);
+  }
+}
+
+collectHtmlRoutes(distRoot);
+
+for (const route of htmlRoutes) {
+  const loc = `${SITE_URL}${route === "/" ? "/" : route}`;
+  const trailingSlashLoc = route === "/" ? loc : `${loc}/`;
+
+  if (
+    !sitemap.includes(`<loc>${loc}</loc>`) &&
+    !sitemap.includes(`<loc>${trailingSlashLoc}</loc>`)
+  ) {
+    throw new Error(`Generated route missing from sitemap.xml: ${route}`);
+  }
+}
+
+console.log(
+  `Verified ${htmlRoutes.length} generated HTML route(s) in sitemap.xml.`,
+);


### PR DESCRIPTION
## What
Add canonical sitemap generation for bashkit.sh. The site now builds `/sitemap.xml`, adds `<lastmod>` entries, removes Astro's intermediate sitemap files, and points `robots.txt` at the canonical sitemap.

## Why
The site advertised a sitemap URL but did not generate one. Crawlers should have a single canonical `/sitemap.xml` target.

## How
- Add `@astrojs/sitemap` to the Astro site
- Add a post-build sitemap enhancer modeled after the Everruns docs app
- Add a post-build verifier that checks all generated HTML routes and rejects `sitemap-index.xml`
- Run deploy through `npm run build` so verification executes before Wrangler deploys

## Risk
- Low
- Site build could fail if Astro changes sitemap output naming; verifier catches that before deploy.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verified:
- `npm run build`
- `npm run check`
- `just pre-pr`