### PR TITLE
chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-30
+
+### Highlights
+
+- **Filesystem interop ABI** — New `bashkit::interop::fs` (behind the `interop` cargo feature) exposes a versioned `repr(C)` filesystem handle + vtable, plus Python `FileSystem.from_capsule()` / `to_capsule()` and Node `FileSystem.fromExternal()` / `toExternal()` so downstream native extensions can mount custom filesystems without sharing addon-private layouts ([#1353](https://github.com/everruns/bashkit/pull/1353))
+- **Python `network=` constructor kwarg** — `Bash(network=...)` now controls outbound network access at construction time, the first phase of the network policy work tracked in [#1348](https://github.com/everruns/bashkit/pull/1348) ([#1489](https://github.com/everruns/bashkit/pull/1489))
+- **jq compatibility** — Added `input_filename` / `input_line_number` / `$ENV` stubs ([#1490](https://github.com/everruns/bashkit/pull/1490)) and bounded, jq-like runtime error messages that no longer dump full input values to stderr ([#1488](https://github.com/everruns/bashkit/pull/1488))
+
+### What's Changed
+
+* feat(jq): add input_filename / input_line_number / $ENV stubs ([#1490](https://github.com/everruns/bashkit/pull/1490)) by @chaliy
+* feat(python): add network= constructor kwarg (phase 1 of #1348) ([#1489](https://github.com/everruns/bashkit/pull/1489)) by @chaliy
+* fix(jq): format runtime errors without value dumps ([#1488](https://github.com/everruns/bashkit/pull/1488)) by @chaliy
+* feat(site): add canonical sitemap generation ([#1485](https://github.com/everruns/bashkit/pull/1485)) by @chaliy
+* chore(deps): bump the rust-dependencies group with 5 updates ([#1483](https://github.com/everruns/bashkit/pull/1483)) by @dependabot
+* feat(interop): add filesystem ABI handles ([#1353](https://github.com/everruns/bashkit/pull/1353)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.1.21...v0.2.0
+
 ## [0.1.21] - 2026-04-25
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -363,7 +363,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.1.21"
+version = "0.2.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.21"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -30,7 +30,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.1.9", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.2.0", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.1.21",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.1.21",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.1.21",
+  "version": "0.2.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",


### PR DESCRIPTION
## Summary

Minor release v0.2.0 — bumps workspace version, updates `Cargo.lock`, JS package files, and the `bashkit-cli` → `bashkit` pin, and adds the v0.2.0 entry to `CHANGELOG.md` for 6 commits since v0.1.21.

Bumped to **minor** (not patch) because this batch introduces new public API surface, per `specs/release-process.md`:

- `feat(interop)`: new `bashkit::interop::fs` ABI (Python capsule + Node external) for downstream native filesystem extensions ([#1353](https://github.com/everruns/bashkit/pull/1353))
- `feat(python)`: new `Bash(network=...)` constructor kwarg, phase 1 of the network policy work ([#1489](https://github.com/everruns/bashkit/pull/1489))
- `feat(jq)`: new `input_filename` / `input_line_number` / `$ENV` stubs ([#1490](https://github.com/everruns/bashkit/pull/1490))

### Highlights

- **Filesystem interop ABI** — versioned `repr(C)` filesystem handle + vtable behind the `interop` cargo feature, exposed via Python `FileSystem.from_capsule()` / `to_capsule()` and Node `FileSystem.fromExternal()` / `toExternal()`.
- **Python `network=` constructor kwarg** — `Bash(network=...)` now controls outbound network access at construction time.
- **jq compatibility** — `input_filename` / `input_line_number` / `$ENV` stubs plus bounded, jq-like runtime error messages that no longer dump full input values to stderr.

### What's Changed

* feat(jq): add input_filename / input_line_number / $ENV stubs ([#1490](https://github.com/everruns/bashkit/pull/1490)) by @chaliy
* feat(python): add network= constructor kwarg (phase 1 of #1348) ([#1489](https://github.com/everruns/bashkit/pull/1489)) by @chaliy
* fix(jq): format runtime errors without value dumps ([#1488](https://github.com/everruns/bashkit/pull/1488)) by @chaliy
* feat(site): add canonical sitemap generation ([#1485](https://github.com/everruns/bashkit/pull/1485)) by @chaliy
* chore(deps): bump the rust-dependencies group with 5 updates ([#1483](https://github.com/everruns/bashkit/pull/1483)) by @dependabot
* feat(interop): add filesystem ABI handles ([#1353](https://github.com/everruns/bashkit/pull/1353)) by @chaliy

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.1.21...v0.2.0

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green on PR
- [ ] On merge: `release.yml` creates GitHub Release and tag `v0.2.0`
- [ ] `publish.yml` publishes `bashkit` and `bashkit-cli` to crates.io
- [ ] `publish-python.yml` publishes wheels to PyPI
- [ ] `publish-js.yml` publishes `@everruns/bashkit` to npm
- [ ] `cli-binaries.yml` builds CLI binaries and updates Homebrew tap

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxskYLa4vUUTQfLLbMC8nn)_