### PR TITLE
fix(fs): validate mount paths with POSIX semantics on Windows

### DIFF
--- a/crates/bashkit/src/fs/mountable.rs
+++ b/crates/bashkit/src/fs/mountable.rs
@@ -19,6 +19,16 @@ use super::traits::{DirEntry, FileSystem, FileSystemExt, FileType, Metadata};
 use crate::error::Result;
 use std::io::ErrorKind;
 
+/// Returns `true` if `path` is absolute under POSIX semantics (starts with `/`).
+///
+/// This differs from [`Path::is_absolute`], which on Windows requires a drive
+/// prefix (`C:\…`) and rejects POSIX-style absolute paths like `/workspace`.
+/// The bashkit VFS is always POSIX-style on every host, so we cannot use the
+/// platform-aware predicate.
+fn is_posix_absolute(path: &Path) -> bool {
+    path.has_root()
+}
+
 /// Filesystem with Unix-style mount points.
 ///
 /// `MountableFs` allows mounting different filesystem implementations at
@@ -213,12 +223,16 @@ impl MountableFs {
     /// # }
     /// ```
     pub fn mount(&self, path: impl AsRef<Path>, fs: Arc<dyn FileSystem>) -> Result<()> {
-        let path = Self::normalize_path(path.as_ref());
-
-        if !path.is_absolute() {
+        // Validate against the *input* path: the bashkit VFS is always
+        // POSIX-style, so mount points must start with `/`. We use
+        // `Path::has_root()` rather than `Path::is_absolute()` because the
+        // latter requires a drive prefix on Windows and rejects `/foo`,
+        // which would silently break Windows hosts.
+        if !is_posix_absolute(path.as_ref()) {
             return Err(IoError::other("mount path must be absolute").into());
         }
 
+        let path = Self::normalize_path(path.as_ref());
         let mut mounts = self.mounts.write().unwrap();
         mounts.insert(path, fs);
         Ok(())
@@ -657,5 +671,48 @@ mod tests {
 
         // Should no longer exist (falls back to root which doesn't have it)
         assert!(!mfs.exists(Path::new("/mnt/data.txt")).await.unwrap());
+    }
+
+    #[test]
+    fn test_is_posix_absolute_accepts_root_paths() {
+        // Paths starting with `/` are POSIX-absolute on every host.
+        // `Path::is_absolute` would reject these on Windows.
+        assert!(is_posix_absolute(Path::new("/")));
+        assert!(is_posix_absolute(Path::new("/workspace")));
+        assert!(is_posix_absolute(Path::new("/data/sub")));
+    }
+
+    #[test]
+    fn test_is_posix_absolute_rejects_relative_paths() {
+        assert!(!is_posix_absolute(Path::new("relative")));
+        assert!(!is_posix_absolute(Path::new("relative/path")));
+        assert!(!is_posix_absolute(Path::new("./foo")));
+        assert!(!is_posix_absolute(Path::new("")));
+    }
+
+    #[test]
+    fn test_mount_accepts_posix_absolute_path_on_any_host() {
+        // Regression: mount("/workspace", ...) must succeed on Windows.
+        // Before the `has_root` switch, `Path::is_absolute` rejected POSIX
+        // paths on Windows, breaking the JS interop FS roundtrip test.
+        let root = Arc::new(InMemoryFs::new());
+        let mounted = Arc::new(InMemoryFs::new());
+
+        let mfs = MountableFs::new(root);
+        mfs.mount("/workspace", mounted.clone()).unwrap();
+        mfs.mount("/data/sub", mounted).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mount_rejects_relative_path() {
+        let root = Arc::new(InMemoryFs::new());
+        let mounted = Arc::new(InMemoryFs::new());
+
+        let mfs = MountableFs::new(root);
+        let err = mfs.mount("relative/path", mounted).unwrap_err();
+        assert!(
+            err.to_string().contains("absolute"),
+            "expected 'absolute' in error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`MountableFs::mount` validated paths with `Path::is_absolute`, which on Windows requires a drive prefix (`C:\…`) and rejects POSIX-style absolute paths like `/workspace`. Bashkit's VFS is always POSIX-style on every host, so this broke `bash.mount("/workspace", fs)` on Windows.

This surfaced after the v0.2.0 release as the publish-only test failure:

```
vfs › filesystem external roundtrip mounts into bash
Error: io error: mount path must be absolute
  at Bash.mount (...wrapper.ts:855:19)
  at vfs.spec.ts:159
```

The interop FS feature in #1353 exercised `mount()` from JS for the first time, and the JS publish workflow runs the full Windows × Node 20/22/24 matrix that PR CI doesn't.

## Why this regressed silently

PR CI runs Rust tests on `ubuntu-latest` only. Windows coverage exists exclusively in `publish-js.yml`, which only runs on `release: published`. So the bug rode all the way to the v0.2.0 GitHub Release before it was observed.

## Fix

- Use `Path::has_root` instead of `Path::is_absolute`. `has_root` returns true for any leading `/` on both Unix and Windows.
- Move the validation ahead of normalization so the caller's intent (absolute vs. relative) is checked against the original input — `normalize_path` always returns a rooted path, which would have masked the check entirely had we left it after.
- Extract the check into a small `is_posix_absolute` helper so the platform-portability invariant is unit-testable in isolation.

## Test coverage

Added in `crates/bashkit/src/fs/mountable.rs`:

- `test_is_posix_absolute_accepts_root_paths` — `/`, `/workspace`, `/data/sub`
- `test_is_posix_absolute_rejects_relative_paths` — `relative`, `relative/path`, `./foo`, `""`
- `test_mount_accepts_posix_absolute_path_on_any_host` — regression test asserting `mount("/workspace", …)` and `mount("/data/sub", …)` succeed (post-fix this passes on Windows; pre-fix it would fail there)
- `test_mount_rejects_relative_path` — error path still rejects relative inputs with an `absolute` message

PR CI verifies the Linux behavior is unchanged. Windows behavior will be verified by the JS publish workflow's `vfs.spec.ts` once v0.2.1 is cut (or by re-dispatching `publish-js.yml` against `v0.2.0` after this lands on main).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (84 suites green)
- [ ] CI green on PR
- [ ] After merge: re-dispatch `publish-js.yml` for v0.2.0 and confirm Windows tests pass + npm publishes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxskYLa4vUUTQfLLbMC8nn)_