### PR TITLE
chore(release): prepare v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-30
+
+### Highlights
+
+- **Windows mount path validation** — `MountableFs::mount` now uses `Path::has_root` instead of `Path::is_absolute`, so POSIX-style mount points like `/workspace` are accepted on every host. The v0.2.0 interop FS roundtrip test (`vfs › filesystem external roundtrip mounts into bash`) regressed silently on Windows because PR CI runs Rust tests on Linux only ([#1492](https://github.com/everruns/bashkit/pull/1492)).
+- **rustls switched to ring** — Replaces the `aws-lc-rs`/`aws-lc-sys` C crypto stack with pure-Rust ring across the workspace. Unblocks the aarch64 manylinux wheel build, which had failed in v0.2.0 with `'AT_HWCAP2' undeclared` from the cross-compiled `aws-lc-sys 0.39.1`. `cargo tree -i aws-lc-sys` now returns no match ([#1493](https://github.com/everruns/bashkit/pull/1493)).
+
+### What's Changed
+
+* fix(fs): validate mount paths with POSIX semantics on Windows ([#1492](https://github.com/everruns/bashkit/pull/1492)) by @chaliy
+* fix(http): switch rustls crypto provider to ring ([#1493](https://github.com/everruns/bashkit/pull/1493)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.2.0...v0.2.1
+
 ## [0.2.0] - 2026-04-30
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bashkit",
  "napi",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -30,7 +30,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.2.0", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.2.1", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",


### PR DESCRIPTION
## Summary

Patch release shipping the two fixes that landed after v0.2.0's publish pipeline failed:

- **`fix(fs)`** — `MountableFs::mount` now uses `Path::has_root` instead of `Path::is_absolute`, accepting POSIX-style mount points like `/workspace` on Windows. v0.2.0's `vfs › filesystem external roundtrip mounts into bash` failure on Windows is gone ([#1492](https://github.com/everruns/bashkit/pull/1492)).
- **`fix(http)`** — Workspace-wide rustls crypto provider switched from `aws-lc-rs` to `ring`. `aws-lc-sys` is no longer in the dep tree, so the aarch64 manylinux wheel cross-build no longer needs `AT_HWCAP2` from the cross sysroot ([#1493](https://github.com/everruns/bashkit/pull/1493)).

### Highlights

- **Windows mount path validation** — POSIX-style absolute paths (`/workspace`, `/data/sub`) are accepted by `MountableFs::mount` on every host. Previously rejected on Windows because `Path::is_absolute` requires a drive prefix there.
- **rustls switched to ring** — `cargo tree -i aws-lc-sys` now returns "did not match any packages". ring is pure-Rust + asm and builds on every wheel target without depending on the cross-toolchain glibc headers.

### What's Changed

* fix(fs): validate mount paths with POSIX semantics on Windows ([#1492](https://github.com/everruns/bashkit/pull/1492)) by @chaliy
* fix(http): switch rustls crypto provider to ring ([#1493](https://github.com/everruns/bashkit/pull/1493)) by @chaliy

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.2.0...v0.2.1

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (84 suites green, 0 failures)
- [ ] CI green on PR
- [ ] On merge: `release.yml` creates GitHub Release and tag `v0.2.1`
- [ ] `publish.yml` publishes `bashkit` and `bashkit-cli` to crates.io
- [ ] `publish-python.yml` publishes wheels to PyPI (especially aarch64 manylinux)
- [ ] `publish-js.yml` publishes `@everruns/bashkit` to npm (especially Windows tests)
- [ ] `cli-binaries.yml` builds CLI binaries and updates Homebrew tap

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxskYLa4vUUTQfLLbMC8nn)_