### PR TITLE
ci(python): build aarch64 wheels on native ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -56,9 +56,14 @@ jobs:
           - os: linux
             target: x86_64
             runs-on: ubuntu-latest
+          # aarch64 wheel builds natively on ubuntu-24.04-arm. Cross-compiling
+          # from x86_64 inside the manylinux container fails with toolchain
+          # gaps in C-built crypto deps (e.g. ring's asm needs `__ARM_ARCH`,
+          # aws-lc-sys's cpu_aarch64_linux.c needs `AT_HWCAP2`). Native arm64
+          # avoids both. Same pattern as publish-js.yml.
           - os: linux
             target: aarch64
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04-arm
 
           # Linux musl
           - os: linux
@@ -68,7 +73,7 @@ jobs:
           - os: linux
             target: aarch64
             manylinux: musllinux_1_1
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04-arm
 
           # macOS
           - os: macos


### PR DESCRIPTION
## Summary

Build aarch64 Python wheels on a native `ubuntu-24.04-arm` runner instead of cross-compiling from x86_64 inside the manylinux container.

The cross-compile path has now broken our publish twice in a row, each time on a different transitive C dep:

- **v0.2.0** — `aws-lc-sys 0.39.1` references `AT_HWCAP2`, missing from the manylinux2014 cross sysroot's glibc 2.17 headers.
- **v0.2.1** — switched rustls to ring (#1493) to drop `aws-lc-sys`, and ring's aarch64 `.S` files now fail to compile with `error: ARM assembler must define __ARM_ARCH` because the cross `aarch64-linux-gnu-gcc` doesn't predefine the macro.

Both are cross-compile-toolchain gaps, not bugs in our code or the crypto crates. The clean fix is to build natively: maturin sees `host == target` and never involves the cross gcc. `publish-js.yml` already uses `ubuntu-24.04-arm` for its aarch64 NAPI binding (see the JS native binding matrix in `specs/release-process.md`); this brings the Python wheel build in line.

## Change

```diff
   - os: linux
     target: aarch64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm

   - os: linux
     target: aarch64
     manylinux: musllinux_1_1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
```

Commit message has the full background.

## Test plan

- [x] YAML lint passes
- [ ] CI green on PR (workflow file change only — actual exercise comes from dispatch)
- [ ] After merge: `workflow_dispatch` `publish-python.yml` against `main`. The workflow checks out main where `Cargo.toml` is already at `0.2.1`, so the wheels built will be `bashkit-0.2.1-*.whl`. PyPI trusted publishing then uploads v0.2.1.
- [ ] `pip index versions bashkit` shows `0.2.1`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxskYLa4vUUTQfLLbMC8nn)_