### PR TITLE
fix(curl): use curl user agent by default

### DIFF
--- a/crates/bashkit/src/builtins/curl.rs
+++ b/crates/bashkit/src/builtins/curl.rs
@@ -19,6 +19,11 @@ use super::{Builtin, Context};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
+// Default curl requests should look like the curl version bashkit advertises.
+// The lower-level HttpClient keeps its bashkit UA for non-curl callers.
+#[cfg(feature = "http_client")]
+const DEFAULT_CURL_USER_AGENT: &str = "curl/8.7.1";
+
 /// The curl builtin - transfer data from URLs.
 ///
 /// Usage: curl [OPTIONS] URL
@@ -364,9 +369,15 @@ async fn execute_curl_request(
         header_pairs.push(("Authorization".to_string(), format!("Basic {}", encoded)));
     }
 
-    // Add custom user agent
+    // Add the user agent after custom -H headers so -A can override them.
     if let Some(ua) = user_agent {
+        header_pairs.retain(|(name, _)| !name.eq_ignore_ascii_case("user-agent"));
         header_pairs.push(("User-Agent".to_string(), ua.to_string()));
+    } else if !has_header(&header_pairs, "user-agent") {
+        header_pairs.push((
+            "User-Agent".to_string(),
+            DEFAULT_CURL_USER_AGENT.to_string(),
+        ));
     }
 
     // Add referer
@@ -708,6 +719,13 @@ fn same_origin(a: &str, b: &str) -> bool {
 
 /// Sensitive headers that must not be forwarded cross-origin on redirect.
 const SENSITIVE_HEADERS: &[&str] = &["authorization", "cookie", "proxy-authorization"];
+
+#[cfg(feature = "http_client")]
+fn has_header(headers: &[(String, String)], needle: &str) -> bool {
+    headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case(needle))
+}
 
 /// Format the -w/--write-out output.
 #[cfg(feature = "http_client")]

--- a/crates/bashkit/tests/network_security_tests.rs
+++ b/crates/bashkit/tests/network_security_tests.rs
@@ -908,6 +908,7 @@ mod decompression_security {
 mod custom_handler {
     use super::*;
     use bashkit::{HttpHandler, HttpResponse as Response};
+    use std::sync::{Arc, Mutex};
 
     struct MockHandler;
 
@@ -938,6 +939,97 @@ mod custom_handler {
 
         let result = bash.exec("curl -s https://example.com").await.unwrap();
         assert_eq!(result.stdout.trim(), "mocked-response");
+    }
+
+    struct HeaderCaptureHandler {
+        headers: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl HttpHandler for HeaderCaptureHandler {
+        async fn request(
+            &self,
+            _method: &str,
+            _url: &str,
+            _body: Option<&[u8]>,
+            headers: &[(String, String)],
+        ) -> std::result::Result<Response, String> {
+            *self.headers.lock().unwrap() = headers.to_vec();
+            Ok(Response {
+                status: 200,
+                headers: vec![("content-type".to_string(), "text/plain".to_string())],
+                body: b"mocked-response".to_vec(),
+            })
+        }
+    }
+
+    fn captured_user_agent(headers: &Arc<Mutex<Vec<(String, String)>>>) -> Option<String> {
+        headers
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("user-agent"))
+            .map(|(_, value)| value.clone())
+    }
+
+    #[tokio::test]
+    async fn curl_sends_curl_user_agent_by_default() {
+        let headers = Arc::new(Mutex::new(Vec::new()));
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .http_handler(Box::new(HeaderCaptureHandler {
+                headers: headers.clone(),
+            }))
+            .build();
+
+        let result = bash.exec("curl -s https://example.com").await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(captured_user_agent(&headers).as_deref(), Some("curl/8.7.1"));
+    }
+
+    #[tokio::test]
+    async fn curl_user_agent_flags_override_default() {
+        let headers = Arc::new(Mutex::new(Vec::new()));
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .http_handler(Box::new(HeaderCaptureHandler {
+                headers: headers.clone(),
+            }))
+            .build();
+
+        let result = bash
+            .exec("curl -s -A 'CustomAgent/1.0' https://example.com")
+            .await
+            .unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            captured_user_agent(&headers).as_deref(),
+            Some("CustomAgent/1.0")
+        );
+    }
+
+    #[tokio::test]
+    async fn curl_user_agent_header_overrides_default() {
+        let headers = Arc::new(Mutex::new(Vec::new()));
+        let mut bash = Bash::builder()
+            .network(NetworkAllowlist::allow_all())
+            .http_handler(Box::new(HeaderCaptureHandler {
+                headers: headers.clone(),
+            }))
+            .build();
+
+        let result = bash
+            .exec("curl -s -H 'User-Agent: HeaderAgent/1.0' https://example.com")
+            .await
+            .unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            captured_user_agent(&headers).as_deref(),
+            Some("HeaderAgent/1.0")
+        );
     }
 
     #[tokio::test]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -666,7 +666,7 @@ async fn read_body_with_limit(&self, response: Response) -> Result<Vec<u8>> {
 | No auto-redirect | Policy::none() | Prevent redirect-based bypass |
 | No auto-decompress | no_gzip/no_brotli/no_deflate | Prevent zip bomb attacks |
 | Content-Length check | Pre-download validation | Fail fast on huge files |
-| User-Agent fixed | "bashkit/0.1.0" | Identify requests, prevent spoofing |
+| User-Agent controlled | HttpClient defaults to "bashkit/*"; curl builtin defaults to "curl/8.7.1" and honors explicit overrides | Identify non-builtin requests while matching curl wire behavior |
 
 #### 5.5 Cryptographic Material Security
 


### PR DESCRIPTION
## What
Set the bashkit curl builtin default User-Agent to `curl/8.7.1`, matching the curl version it advertises. Preserve explicit overrides from `-A/--user-agent` and `-H "User-Agent: ..."`.

## Why
Some endpoints vary responses by User-Agent. `copy.fail/exp` returned only `Redirecting...` to bashkit curl because requests did not look curl-compatible.

## How
- Add a curl-specific default User-Agent in the curl builtin header construction
- Keep lower-level `HttpClient` default behavior unchanged for non-curl callers
- Add custom handler tests covering default, flag override, and header override behavior
- Update the threat model note for controlled User-Agent behavior

## Risk
- Low
- Could affect servers that intentionally distinguish bashkit curl from system curl by default User-Agent; explicit `-A` or `-H` still controls the header

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verified locally:
- `cargo test --all-features`
- `just test`
- `just pre-pr`
- Live smoke against `https://copy.fail/exp` through bashkit curl