### PR TITLE
feat(python): add credentials + credential_placeholders to network= (phase 2 of #1348)

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -223,9 +223,51 @@ local = Bash(network={"allow": ["http://127.0.0.1:8080"], "block_private_ips": F
 
 `network=` is also accepted by `BashTool(...)` and persists across `reset()`
 and `from_snapshot(...)`. An explicit `network={"allow": []}` blocks every
-URL but is distinct from omitting `network=` entirely. Phase 1 of #1348
-covers the allowlist surface; credential injection, request callbacks, and
-bot-auth ship in follow-ups.
+URL but is distinct from omitting `network=` entirely.
+
+### Credential injection
+
+Inject per-host credentials transparently so scripts never see the real
+secret. Two modes are supported (mirroring the Rust `BashBuilder::credential`
+and `BashBuilder::credential_placeholder` APIs):
+
+```python
+from bashkit import Bash
+
+bash = Bash(
+    network={
+        "allow": ["https://api.github.com", "https://api.openai.com/v1"],
+        # Direct injection — script has no knowledge of the credential.
+        "credentials": [
+            {
+                "pattern": "https://api.github.com",
+                "kind": "bearer",
+                "token": "ghp_xxx",
+            },
+        ],
+        # Placeholder mode — script sees an opaque placeholder via env var.
+        "credential_placeholders": [
+            {
+                "env": "OPENAI_API_KEY",
+                "pattern": "https://api.openai.com",
+                "kind": "bearer",
+                "token": "sk-real-key",
+            },
+        ],
+    },
+)
+# Scripts can: curl -s https://api.github.com/repos/foo/bar
+#   → Authorization: Bearer ghp_xxx is added on the wire.
+# Scripts can: curl -s -H "Authorization: Bearer $OPENAI_API_KEY" \
+#                   https://api.openai.com/v1/chat
+#   → the placeholder is replaced with sk-real-key on the wire.
+```
+
+Each credential dict accepts `kind: "bearer"` (`token`),
+`kind: "header"` (`name`, `value`), or `kind: "headers"` (a list of
+`(name, value)` pairs). Injected headers overwrite script-provided headers
+with the same name to prevent credential spoofing. Phase 2 of #1348 covers
+the credential surface; request callbacks and bot-auth ship in follow-ups.
 
 ## Error Handling
 
@@ -467,7 +509,7 @@ from bashkit.deepagents import BashkitBackend, BashkitMiddleware
 - `snapshot() -> bytes`
 - `restore_snapshot(data: bytes)`
 - `from_snapshot(data: bytes, **kwargs) -> Bash`
-- constructor kwarg: `network={"allow": [...], "block_private_ips": True}` or `network={"allow_all": True}`
+- constructor kwarg: `network={"allow": [...], "block_private_ips": True}` or `network={"allow_all": True}`, optionally with `credentials=[...]` and `credential_placeholders=[...]`
 - `mount(vfs_path: str, fs: FileSystem)`
 - `unmount(vfs_path: str)`
 - Direct VFS helpers: `read_file`, `write_file`, `append_file`, `mkdir`, `remove`, `exists`, `stat`, `read_dir`, `ls`, `glob`, `copy`, `rename`, `symlink`, `chmod`, `read_link`

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -1,20 +1,83 @@
 """Type stubs for bashkit native module."""
 
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, Protocol, TypedDict
+from typing import Any, Literal, Protocol, TypedDict
+
+class BearerCredentialInjection(TypedDict):
+    """Inject ``Authorization: Bearer <token>`` for matching URLs."""
+
+    pattern: str
+    kind: Literal["bearer"]
+    token: str
+
+class HeaderCredentialInjection(TypedDict):
+    """Inject a single custom header for matching URLs."""
+
+    pattern: str
+    kind: Literal["header"]
+    name: str
+    value: str
+
+class HeadersCredentialInjection(TypedDict):
+    """Inject multiple custom headers for matching URLs."""
+
+    pattern: str
+    kind: Literal["headers"]
+    headers: list[tuple[str, str]]
+
+CredentialInjection = BearerCredentialInjection | HeaderCredentialInjection | HeadersCredentialInjection
+
+class BearerCredentialPlaceholder(TypedDict):
+    """Placeholder-mode bearer-token injection.
+
+    Sets ``env`` to an opaque placeholder visible to scripts; the placeholder
+    is replaced with the real ``token`` on the wire for requests matching
+    ``pattern``.
+    """
+
+    env: str
+    pattern: str
+    kind: Literal["bearer"]
+    token: str
+
+class HeaderCredentialPlaceholder(TypedDict):
+    """Placeholder-mode single-header injection."""
+
+    env: str
+    pattern: str
+    kind: Literal["header"]
+    name: str
+    value: str
+
+class HeadersCredentialPlaceholder(TypedDict):
+    """Placeholder-mode multi-header injection."""
+
+    env: str
+    pattern: str
+    kind: Literal["headers"]
+    headers: list[tuple[str, str]]
+
+CredentialPlaceholder = BearerCredentialPlaceholder | HeaderCredentialPlaceholder | HeadersCredentialPlaceholder
 
 class NetworkConfig(TypedDict, total=False):
     """Outbound HTTP / network configuration for ``Bash`` and ``BashTool``.
 
-    Phase 1 of #1348 — only the allowlist surface is wired through. Provide
-    either ``allow`` (a list of URL patterns) or ``allow_all=True``; passing
-    both raises ``ValueError``. Omitting ``network=`` keeps the network
-    disabled (the existing default).
+    Covers phases 1 and 2 of #1348 — allowlist plus credential injection.
+    Provide either ``allow`` (a list of URL patterns) or ``allow_all=True``;
+    passing both raises ``ValueError``. Omitting ``network=`` keeps the
+    network disabled (the existing default).
+
+    ``credentials`` injects headers transparently for matching URLs without
+    the script ever seeing the secret. ``credential_placeholders`` exposes
+    the credential to the script as an opaque placeholder via an env var,
+    and replaces the placeholder with the real value in outbound headers.
     """
 
     allow: list[str]
     allow_all: bool
     block_private_ips: bool
+    credentials: list[CredentialInjection]
+    credential_placeholders: list[CredentialPlaceholder]
 
 # Synchronous chunk callback for live stdout/stderr streaming.
 OutputHandler = Callable[[str, str], None]
@@ -433,8 +496,13 @@ class Bash:
                 ``{"allow_all": True}`` to allow every URL (mirrors
                 ``NetworkAllowlist::allow_all()`` in the Rust core). Set
                 ``"block_private_ips": False`` to relax the SSRF guard.
-                When omitted, network access is disabled (current default).
-                Preserved across ``reset()`` and ``from_snapshot()``.
+                Add ``"credentials": [...]`` to inject headers transparently
+                for matching URLs and ``"credential_placeholders": [...]``
+                to expose opaque placeholder env vars that are replaced with
+                the real secret on the wire. When omitted, network access
+                is disabled (current default). Preserved across ``reset()``
+                and ``from_snapshot()`` — placeholder env vars are
+                regenerated on each rebuild.
 
         Example::
 
@@ -442,7 +510,16 @@ class Bash:
             ...     timeout_seconds=30,
             ...     files={"/input.txt": "some data"},
             ...     custom_builtins={"ping": lambda ctx: "pong\\n"},
-            ...     network={"allow": ["https://api.github.com"]},
+            ...     network={
+            ...         "allow": ["https://api.github.com"],
+            ...         "credentials": [
+            ...             {
+            ...                 "pattern": "https://api.github.com",
+            ...                 "kind": "bearer",
+            ...                 "token": "ghp_xxx",
+            ...             }
+            ...         ],
+            ...     },
             ... )
         """
         ...

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -8,8 +8,8 @@
 use bashkit::interop::fs::{BashkitFsAbiOwnedHandleV1, export_filesystem, import_owned_filesystem};
 use bashkit::tool::VERSION;
 use bashkit::{
-    Bash, BashTool as RustBashTool, Builtin, BuiltinContext, DirEntry as FsDirEntry, ExcType,
-    ExecResult as RustExecResult, ExecutionExtensions, ExecutionLimits, ExtFunctionResult,
+    Bash, BashTool as RustBashTool, Builtin, BuiltinContext, Credential, DirEntry as FsDirEntry,
+    ExcType, ExecResult as RustExecResult, ExecutionExtensions, ExecutionLimits, ExtFunctionResult,
     FileSystem, FileSystemExt, FileType as FsFileType, InMemoryFs, Metadata as FsMetadata,
     MontyException, MontyObject, NetworkAllowlist, OutputCallback as RustOutputCallback, OverlayFs,
     PosixFs, PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode,
@@ -161,14 +161,47 @@ fn make_runtime() -> PyResult<Arc<Runtime>> {
 /// Each dict: { "host_path": str, "vfs_path"?: str, "writable"?: bool }.
 /// Internal storage for the Python `network=` kwarg.
 ///
-/// Phase 1 of `feat(python): expose outbound HTTP/network config` (#1348):
-/// allowlist patterns, `allow_all`, and `block_private_ips` are supported here.
-/// Credential injection, callbacks, and bot-auth land in later phases.
+/// Covers phases 1 and 2 of `feat(python): expose outbound HTTP/network config` (#1348):
+/// allowlist patterns, `allow_all`, `block_private_ips`, plus credential
+/// injection (`credentials`) and placeholder-mode credential injection
+/// (`credential_placeholders`). Callbacks and bot-auth land in later phases.
 #[derive(Debug, Clone, Default)]
 struct PyNetworkConfig {
     allow: Vec<String>,
     allow_all: bool,
     block_private_ips: bool,
+    credentials: Vec<PyCredentialInjection>,
+    credential_placeholders: Vec<PyCredentialPlaceholder>,
+}
+
+#[derive(Debug, Clone)]
+struct PyCredentialInjection {
+    pattern: String,
+    spec: PyCredentialSpec,
+}
+
+#[derive(Debug, Clone)]
+struct PyCredentialPlaceholder {
+    env: String,
+    pattern: String,
+    spec: PyCredentialSpec,
+}
+
+#[derive(Debug, Clone)]
+enum PyCredentialSpec {
+    Bearer { token: String },
+    Header { name: String, value: String },
+    Headers { headers: Vec<(String, String)> },
+}
+
+impl PyCredentialSpec {
+    fn into_credential(self) -> Credential {
+        match self {
+            Self::Bearer { token } => Credential::bearer(token),
+            Self::Header { name, value } => Credential::header(name, value),
+            Self::Headers { headers } => Credential::headers(headers),
+        }
+    }
 }
 
 impl PyNetworkConfig {
@@ -179,6 +212,21 @@ impl PyNetworkConfig {
             NetworkAllowlist::new().allow_many(self.allow.iter().cloned())
         };
         base.block_private_ips(self.block_private_ips)
+    }
+
+    fn apply(&self, mut builder: bashkit::BashBuilder) -> bashkit::BashBuilder {
+        builder = builder.network(self.to_allowlist());
+        for inj in &self.credentials {
+            builder = builder.credential(&inj.pattern, inj.spec.clone().into_credential());
+        }
+        for ph in &self.credential_placeholders {
+            builder = builder.credential_placeholder(
+                &ph.env,
+                &ph.pattern,
+                ph.spec.clone().into_credential(),
+            );
+        }
+        builder
     }
 }
 
@@ -193,12 +241,18 @@ fn parse_network_config(network: Option<&Bound<'_, PyDict>>) -> PyResult<Option<
         return Ok(None);
     };
 
-    const KNOWN_KEYS: &[&str] = &["allow", "allow_all", "block_private_ips"];
+    const KNOWN_KEYS: &[&str] = &[
+        "allow",
+        "allow_all",
+        "block_private_ips",
+        "credentials",
+        "credential_placeholders",
+    ];
     for (key_obj, _) in dict.iter() {
         let key: String = key_obj.extract()?;
         if !KNOWN_KEYS.contains(&key.as_str()) {
             return Err(PyValueError::new_err(format!(
-                "network: unknown key '{key}' (supported: allow, allow_all, block_private_ips)"
+                "network: unknown key '{key}' (supported: allow, allow_all, block_private_ips, credentials, credential_placeholders)"
             )));
         }
     }
@@ -237,11 +291,183 @@ fn parse_network_config(network: Option<&Bound<'_, PyDict>>) -> PyResult<Option<
         .transpose()?
         .unwrap_or(true);
 
+    let credentials = parse_credential_injections(dict.get_item("credentials")?.as_ref())?;
+    let credential_placeholders =
+        parse_credential_placeholders(dict.get_item("credential_placeholders")?.as_ref())?;
+
     Ok(Some(PyNetworkConfig {
         allow,
         allow_all,
         block_private_ips,
+        credentials,
+        credential_placeholders,
     }))
+}
+
+fn parse_credential_injections(
+    value: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Vec<PyCredentialInjection>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let list = value.cast::<PyList>().map_err(|_| {
+        PyValueError::new_err("network['credentials'] must be a list of credential dicts")
+    })?;
+    let mut out = Vec::with_capacity(list.len());
+    for (idx, item) in list.iter().enumerate() {
+        let dict = item.cast::<PyDict>().map_err(|_| {
+            PyValueError::new_err(format!(
+                "network['credentials'][{idx}] must be a dict with 'pattern' and 'kind'"
+            ))
+        })?;
+        let label = format!("credentials[{idx}]");
+        let pattern = require_string(dict, "pattern", &label)?;
+        let spec = parse_credential_spec(dict, &label, &["pattern"])?;
+        out.push(PyCredentialInjection { pattern, spec });
+    }
+    Ok(out)
+}
+
+fn parse_credential_placeholders(
+    value: Option<&Bound<'_, PyAny>>,
+) -> PyResult<Vec<PyCredentialPlaceholder>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let list = value.cast::<PyList>().map_err(|_| {
+        PyValueError::new_err(
+            "network['credential_placeholders'] must be a list of credential placeholder dicts",
+        )
+    })?;
+    let mut out = Vec::with_capacity(list.len());
+    for (idx, item) in list.iter().enumerate() {
+        let dict = item.cast::<PyDict>().map_err(|_| {
+            PyValueError::new_err(format!(
+                "network['credential_placeholders'][{idx}] must be a dict with 'env', 'pattern', and 'kind'"
+            ))
+        })?;
+        let label = format!("credential_placeholders[{idx}]");
+        let env = require_string(dict, "env", &label)?;
+        if env.is_empty() {
+            return Err(PyValueError::new_err(format!(
+                "network['{label}']['env'] must be a non-empty environment variable name"
+            )));
+        }
+        let pattern = require_string(dict, "pattern", &label)?;
+        let spec = parse_credential_spec(dict, &label, &["env", "pattern"])?;
+        out.push(PyCredentialPlaceholder { env, pattern, spec });
+    }
+    Ok(out)
+}
+
+fn require_string(dict: &Bound<'_, PyDict>, key: &str, label: &str) -> PyResult<String> {
+    let value = dict.get_item(key)?.ok_or_else(|| {
+        PyValueError::new_err(format!("network['{label}'] missing required '{key}' key"))
+    })?;
+    value
+        .extract::<String>()
+        .map_err(|_| PyValueError::new_err(format!("network['{label}']['{key}'] must be a string")))
+}
+
+fn parse_credential_spec(
+    dict: &Bound<'_, PyDict>,
+    label: &str,
+    extra_keys: &[&str],
+) -> PyResult<PyCredentialSpec> {
+    let kind = require_string(dict, "kind", label)?;
+    let spec = match kind.as_str() {
+        "bearer" => {
+            let allowed = build_allowed_keys(&["kind", "token"], extra_keys);
+            reject_unknown_keys(dict, &allowed, label)?;
+            let token = require_string(dict, "token", label)?;
+            PyCredentialSpec::Bearer { token }
+        }
+        "header" => {
+            let allowed = build_allowed_keys(&["kind", "name", "value"], extra_keys);
+            reject_unknown_keys(dict, &allowed, label)?;
+            let name = require_string(dict, "name", label)?;
+            if name.is_empty() {
+                return Err(PyValueError::new_err(format!(
+                    "network['{label}']['name'] must be a non-empty header name"
+                )));
+            }
+            let value = require_string(dict, "value", label)?;
+            PyCredentialSpec::Header { name, value }
+        }
+        "headers" => {
+            let allowed = build_allowed_keys(&["kind", "headers"], extra_keys);
+            reject_unknown_keys(dict, &allowed, label)?;
+            let raw = dict.get_item("headers")?.ok_or_else(|| {
+                PyValueError::new_err(format!("network['{label}'] missing required 'headers' key"))
+            })?;
+            let list = raw.cast::<PyList>().map_err(|_| {
+                PyValueError::new_err(format!(
+                    "network['{label}']['headers'] must be a list of (name, value) pairs"
+                ))
+            })?;
+            if list.is_empty() {
+                return Err(PyValueError::new_err(format!(
+                    "network['{label}']['headers'] must contain at least one (name, value) pair"
+                )));
+            }
+            let mut headers = Vec::with_capacity(list.len());
+            for (idx, item) in list.iter().enumerate() {
+                let pair = extract_string_pair(&item).map_err(|_| {
+                    PyValueError::new_err(format!(
+                        "network['{label}']['headers'][{idx}] must be a (name, value) pair of strings"
+                    ))
+                })?;
+                if pair.0.is_empty() {
+                    return Err(PyValueError::new_err(format!(
+                        "network['{label}']['headers'][{idx}] header name must be non-empty"
+                    )));
+                }
+                headers.push(pair);
+            }
+            PyCredentialSpec::Headers { headers }
+        }
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "network['{label}']['kind'] must be one of 'bearer', 'header', 'headers' (got '{other}')"
+            )));
+        }
+    };
+    Ok(spec)
+}
+
+fn extract_string_pair(item: &Bound<'_, PyAny>) -> PyResult<(String, String)> {
+    if let Ok(tup) = item.cast::<PyTuple>() {
+        if tup.len() != 2 {
+            return Err(PyValueError::new_err("expected a (name, value) pair"));
+        }
+        return Ok((tup.get_item(0)?.extract()?, tup.get_item(1)?.extract()?));
+    }
+    if let Ok(list) = item.cast::<PyList>() {
+        if list.len() != 2 {
+            return Err(PyValueError::new_err("expected a [name, value] pair"));
+        }
+        return Ok((list.get_item(0)?.extract()?, list.get_item(1)?.extract()?));
+    }
+    Err(PyValueError::new_err("expected a 2-element pair"))
+}
+
+fn build_allowed_keys(base: &[&str], extra: &[&str]) -> Vec<String> {
+    let mut all: Vec<String> = base.iter().map(|s| s.to_string()).collect();
+    all.extend(extra.iter().map(|s| s.to_string()));
+    all
+}
+
+fn reject_unknown_keys(dict: &Bound<'_, PyDict>, allowed: &[String], label: &str) -> PyResult<()> {
+    for (key_obj, _) in dict.iter() {
+        let key: String = key_obj.extract()?;
+        if !allowed.iter().any(|k| k == &key) {
+            return Err(PyValueError::new_err(format!(
+                "network['{label}']: unknown key '{key}' (allowed: {})",
+                allowed.join(", ")
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn parse_mounts(mounts: Option<&Bound<'_, PyList>>) -> PyResult<Vec<RealMountConfig>> {
@@ -2736,7 +2962,7 @@ impl PyBash {
             self.external_handler_reentry_depth.clone(),
         );
         if let Some(ref net) = self.network {
-            builder = builder.network(net.to_allowlist());
+            builder = net.apply(builder);
         }
         let files = clone_file_mounts(py, &self.files);
         let builder = apply_fs_config(builder, &files, &self.real_mounts)?;
@@ -2848,7 +3074,7 @@ impl PyBash {
             external_handler_reentry_depth.clone(),
         );
         if let Some(ref net) = network {
-            builder = builder.network(net.to_allowlist());
+            builder = net.apply(builder);
         }
         builder = apply_fs_config(builder, &files, &real_mounts)?;
         let builtin_engine = PyCallbackEngine::new(py)?;
@@ -3358,7 +3584,7 @@ impl BashTool {
         }
 
         if let Some(ref net) = self.network {
-            builder = builder.network(net.to_allowlist());
+            builder = net.apply(builder);
         }
         let files = clone_file_mounts(py, &self.files);
         let builder = apply_fs_config(builder, &files, &self.real_mounts)?;
@@ -3462,7 +3688,7 @@ impl BashTool {
         let custom_builtins = parse_custom_builtins(py, custom_builtins)?;
         let network = parse_network_config(network)?;
         if let Some(ref net) = network {
-            builder = builder.network(net.to_allowlist());
+            builder = net.apply(builder);
         }
         builder = apply_fs_config(builder, &files, &real_mounts)?;
         let builtin_engine = PyCallbackEngine::new(py)?;

--- a/crates/bashkit-python/tests/test_network_credentials.py
+++ b/crates/bashkit-python/tests/test_network_credentials.py
@@ -1,0 +1,401 @@
+"""Tests for ``credentials`` and ``credential_placeholders`` on ``network=``.
+
+Covers phase 2 of #1348: per-host credential injection (script unaware) and
+placeholder-mode injection (script sees an opaque env-var placeholder that
+the runtime replaces on the wire). Tests do not contact any public network;
+they exercise validation, env-var visibility, and config preservation across
+``reset()`` / ``from_snapshot()``.
+"""
+
+import pytest
+
+from bashkit import Bash, BashTool
+
+_PROBE = "curl -sS -o /dev/null --max-time 2 https://api.example.invalid/x; echo exit=$?"
+
+
+class TestCredentialValidation:
+    """The parser surfaces credential-config mistakes immediately."""
+
+    def test_credentials_must_be_list(self):
+        with pytest.raises(ValueError, match="credentials"):
+            Bash(network={"allow": ["https://x"], "credentials": {"pattern": "x"}})
+
+    def test_credentials_entry_must_be_dict(self):
+        with pytest.raises(ValueError, match="credentials"):
+            Bash(network={"allow": ["https://x"], "credentials": ["not-a-dict"]})
+
+    def test_credentials_missing_pattern(self):
+        with pytest.raises(ValueError, match="pattern"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [{"kind": "bearer", "token": "t"}],
+                }
+            )
+
+    def test_credentials_missing_kind(self):
+        with pytest.raises(ValueError, match="kind"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [{"pattern": "https://x", "token": "t"}],
+                }
+            )
+
+    def test_credentials_unknown_kind(self):
+        with pytest.raises(ValueError, match="kind"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [{"pattern": "https://x", "kind": "basic", "token": "t"}],
+                }
+            )
+
+    def test_bearer_missing_token(self):
+        with pytest.raises(ValueError, match="token"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [{"pattern": "https://x", "kind": "bearer"}],
+                }
+            )
+
+    def test_header_missing_name(self):
+        with pytest.raises(ValueError, match="name"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [{"pattern": "https://x", "kind": "header", "value": "v"}],
+                }
+            )
+
+    def test_header_empty_name(self):
+        with pytest.raises(ValueError, match="name"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [
+                        {
+                            "pattern": "https://x",
+                            "kind": "header",
+                            "name": "",
+                            "value": "v",
+                        }
+                    ],
+                }
+            )
+
+    def test_headers_must_be_list_of_pairs(self):
+        with pytest.raises(ValueError, match="headers"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [
+                        {
+                            "pattern": "https://x",
+                            "kind": "headers",
+                            "headers": "X-Api-Key:value",
+                        }
+                    ],
+                }
+            )
+
+    def test_headers_empty_list_rejected(self):
+        with pytest.raises(ValueError, match="at least one"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [{"pattern": "https://x", "kind": "headers", "headers": []}],
+                }
+            )
+
+    def test_credential_unknown_extra_key(self):
+        with pytest.raises(ValueError, match="unknown key"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credentials": [
+                        {
+                            "pattern": "https://x",
+                            "kind": "bearer",
+                            "token": "t",
+                            "extra": 1,
+                        }
+                    ],
+                }
+            )
+
+    def test_placeholder_missing_env(self):
+        with pytest.raises(ValueError, match="env"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credential_placeholders": [{"pattern": "https://x", "kind": "bearer", "token": "t"}],
+                }
+            )
+
+    def test_placeholder_empty_env(self):
+        with pytest.raises(ValueError, match="env"):
+            Bash(
+                network={
+                    "allow": ["https://x"],
+                    "credential_placeholders": [
+                        {
+                            "env": "",
+                            "pattern": "https://x",
+                            "kind": "bearer",
+                            "token": "t",
+                        }
+                    ],
+                }
+            )
+
+
+class TestCredentialsAccepted:
+    """Constructor accepts well-formed credentials without raising."""
+
+    def test_bearer_injection_accepted_on_bash(self):
+        Bash(
+            network={
+                "allow": ["https://api.github.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.github.com",
+                        "kind": "bearer",
+                        "token": "ghp_xxx",
+                    }
+                ],
+            }
+        )
+
+    def test_bearer_injection_accepted_on_bashtool(self):
+        BashTool(
+            network={
+                "allow": ["https://api.github.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.github.com",
+                        "kind": "bearer",
+                        "token": "ghp_xxx",
+                    }
+                ],
+            }
+        )
+
+    def test_header_injection_accepted(self):
+        Bash(
+            network={
+                "allow": ["https://api.example.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.example.com",
+                        "kind": "header",
+                        "name": "X-Api-Key",
+                        "value": "secret",
+                    }
+                ],
+            }
+        )
+
+    def test_headers_injection_accepted_with_tuples(self):
+        Bash(
+            network={
+                "allow": ["https://api.example.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.example.com",
+                        "kind": "headers",
+                        "headers": [("X-Api-Key", "k"), ("X-Api-Secret", "s")],
+                    }
+                ],
+            }
+        )
+
+    def test_headers_injection_accepted_with_lists(self):
+        Bash(
+            network={
+                "allow": ["https://api.example.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.example.com",
+                        "kind": "headers",
+                        "headers": [["X-Api-Key", "k"]],
+                    }
+                ],
+            }
+        )
+
+
+class TestCredentialPlaceholders:
+    """Placeholder mode exposes opaque env vars to scripts."""
+
+    def test_placeholder_env_var_is_set(self):
+        bash = Bash(
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            }
+        )
+        r = bash.execute_sync("echo $OPENAI_API_KEY")
+        assert r.exit_code == 0
+        out = r.stdout.strip()
+        # Env var must contain the runtime-generated placeholder, never the
+        # real secret. Format: `bk_placeholder_<32 hex chars>`.
+        assert out.startswith("bk_placeholder_")
+        assert "sk-real-key" not in r.stdout
+
+    def test_placeholder_does_not_leak_secret_via_env_dump(self):
+        bash = Bash(
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            }
+        )
+        r = bash.execute_sync("env")
+        assert "sk-real-key" not in r.stdout
+        assert "bk_placeholder_" in r.stdout
+
+    def test_placeholder_env_var_on_bashtool(self):
+        tool = BashTool(
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            }
+        )
+        r = tool.execute_sync("echo $OPENAI_API_KEY")
+        assert r.exit_code == 0
+        assert r.stdout.strip().startswith("bk_placeholder_")
+
+
+class TestCredentialsPreservedAcrossReset:
+    """``reset()`` rebuilds with the same credential surface."""
+
+    def test_reset_preserves_placeholder_env_var(self):
+        bash = Bash(
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            }
+        )
+        bash.reset()
+        # After reset the env var must still be a placeholder (the actual
+        # value is regenerated, but the variable must remain present).
+        r = bash.execute_sync("echo $OPENAI_API_KEY")
+        assert r.exit_code == 0
+        assert r.stdout.strip().startswith("bk_placeholder_")
+
+    def test_reset_preserves_injection_does_not_open_allowlist(self):
+        # Injection alone does not relax the allowlist — unlisted hosts
+        # must still be blocked even when credentials are configured.
+        bash = Bash(
+            network={
+                "allow": ["https://api.github.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.github.com",
+                        "kind": "bearer",
+                        "token": "ghp_xxx",
+                    }
+                ],
+            }
+        )
+        bash.reset()
+        r = bash.execute_sync(_PROBE)
+        assert "0" not in r.stdout.strip().split("=")[-1]
+
+
+class TestCredentialsPreservedAcrossSnapshot:
+    """``from_snapshot()`` accepts the same credential surface."""
+
+    def test_bash_from_snapshot_with_credentials(self):
+        src = Bash(
+            network={
+                "allow": ["https://api.github.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.github.com",
+                        "kind": "bearer",
+                        "token": "ghp_xxx",
+                    }
+                ],
+            }
+        )
+        data = src.snapshot()
+        restored = Bash.from_snapshot(
+            data,
+            network={
+                "allow": ["https://api.github.com"],
+                "credentials": [
+                    {
+                        "pattern": "https://api.github.com",
+                        "kind": "bearer",
+                        "token": "ghp_xxx",
+                    }
+                ],
+            },
+        )
+        # Sanity: still allowlisted, still default-secure for unlisted hosts.
+        r = restored.execute_sync(_PROBE)
+        assert "0" not in r.stdout.strip().split("=")[-1]
+
+    def test_bashtool_from_snapshot_with_placeholder(self):
+        src = BashTool(
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            }
+        )
+        data = src.snapshot()
+        restored = BashTool.from_snapshot(
+            data,
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            },
+        )
+        r = restored.execute_sync("echo $OPENAI_API_KEY")
+        assert r.exit_code == 0
+        assert r.stdout.strip().startswith("bk_placeholder_")

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -183,8 +183,41 @@ The `bashkit-python` crate compiles the core with `http_client`, so
 layer. Configuration is persisted on the wrapper struct so `reset()` and
 `from_snapshot(...)` rebuild with the same allowlist.
 
-Phase 1 (#1348) covers the allowlist surface only. Credential injection,
-request callbacks (`http_handler`, `before_http`, `after_http`), and
+Phase 2 (#1348) adds per-host credential injection through two optional
+keys on the same `network=` dict:
+
+- `credentials`: list of injection rules. Each rule has `pattern`, `kind`
+  (`"bearer"`, `"header"`, or `"headers"`), and the credential payload
+  (`token` for bearer, `name`/`value` for header, or a list of
+  `(name, value)` pairs for headers). The script never sees the secret —
+  the runtime adds the headers transparently after the allowlist check.
+- `credential_placeholders`: list of placeholder rules. Each rule adds an
+  `env` key (the env-var name visible to scripts) on top of the injection
+  fields. The runtime sets the env var to a randomly generated
+  `bk_placeholder_<hex>` token and replaces that token with the real
+  credential on the wire only for requests matching `pattern`.
+
+```python
+Bash(
+    network={
+        "allow": ["https://api.github.com", "https://api.openai.com/v1"],
+        "credentials": [
+            {"pattern": "https://api.github.com", "kind": "bearer",
+             "token": "ghp_xxx"},
+        ],
+        "credential_placeholders": [
+            {"env": "OPENAI_API_KEY", "pattern": "https://api.openai.com",
+             "kind": "bearer", "token": "sk-real-key"},
+        ],
+    },
+)
+```
+
+Credentials and placeholders are also preserved across `reset()` and
+`from_snapshot(...)`. Each rebuild generates a fresh placeholder string,
+so scripts must read placeholder env vars after every reset/restore.
+
+Request callbacks (`http_handler`, `before_http`, `after_http`) and
 bot-auth ship in follow-up phases.
 
 Snapshot/restore methods also exist on `Bash` and mirror the Node bindings:


### PR DESCRIPTION
## Summary

Phase 2 of #1348. Extends the existing Python `network=` kwarg with per-host credential injection that mirrors `BashBuilder::credential` and `BashBuilder::credential_placeholder` in the Rust core.

- `credentials`: list of `{pattern, kind, ...}` dicts. `kind="bearer"` (`token`), `"header"` (`name`, `value`), or `"headers"` (list of `(name, value)` pairs). Headers are added transparently after the allowlist check and overwrite any script-provided headers with the same name.
- `credential_placeholders`: same shape plus an `env` key. Sets the env var to a randomly generated `bk_placeholder_<hex>` token visible to scripts and replaces it with the real credential on the wire only for requests matching `pattern`.

Both lists are preserved across `reset()` and `from_snapshot(...)`. Each rebuild regenerates placeholder tokens, so scripts must read placeholder env vars after every reset/restore.

## Why

#1348 tracks full outbound HTTP parity for Python `Bash` / `BashTool`. Phase 1 (#1489) landed the allowlist surface. This PR closes the credential gap so Python users can call `curl`/`wget`/`http` with transparent per-host auth without ever exposing the real secret to the script.

## How

- Extend `PyNetworkConfig` with `credentials: Vec<PyCredentialInjection>` and `credential_placeholders: Vec<PyCredentialPlaceholder>` plus a small `PyCredentialSpec` enum mirroring the Rust `Credential` variants.
- Add `PyNetworkConfig::apply` that wires both lists onto the `BashBuilder` after `network()`.
- Replace the four `builder = builder.network(net.to_allowlist())` call sites with `builder = net.apply(builder)` so the construct/reset/snapshot paths all stay in sync.
- Validate every credential dict with clear `network['credentials[N]']`-style paths so typos surface immediately.
- Headers payload accepts both tuples and 2-element lists for JSON friendliness.

## Tests

`crates/bashkit-python/tests/test_network_credentials.py` (25 tests, all green):

- 13 negative tests: missing keys, wrong types, unknown `kind`, empty `name`/`env`, unknown extra keys, empty `headers`
- 5 positive acceptance tests across `Bash` and `BashTool` for bearer / header / headers (with both tuple and list pair forms)
- 3 placeholder visibility tests — env var format, env-dump leak resistance, `BashTool` symmetry
- 4 preservation tests across `reset()` and `from_snapshot()` for both modes

### Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p bashkit --features http_client --lib` (2217 pass)
- [x] `pytest crates/bashkit-python/tests/test_network_credentials.py crates/bashkit-python/tests/test_network_config.py` (40 pass)
- [x] `pytest crates/bashkit-python/tests/` (602 pass, 2 skipped — `test_filesystem_interop` and `test_python_security` skipped for env reasons unrelated to this change)
- [x] `ruff check && ruff format --check crates/bashkit-python` (clean)
- [x] Manual smoke test: env-var placeholder injection visible to script, secret never appears in `env` dump
- [x] Spec updated: `specs/python-package.md` documents the new keys
- [x] Type stubs and README updated

Part of #1348

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTyPhSz1aVzcotveBLkbb8)_