### PR TITLE
feat(scripted-tool): run scripts in logic-only code mode

### DIFF
--- a/crates/bashkit/src/fs/mod.rs
+++ b/crates/bashkit/src/fs/mod.rs
@@ -423,6 +423,80 @@ pub use traits::{DirEntry, FileSystem, FileSystemExt, FileType, Metadata, fs_err
 use crate::error::Result;
 use std::io::{Error as IoError, ErrorKind};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// Filesystem implementation for logic-only shells.
+///
+/// Important decision: ScriptedTool code mode still needs an `Arc<dyn FileSystem>`
+/// because the interpreter and builtin context require one, but every real
+/// operation is rejected so scripts cannot use VFS as storage or input.
+pub(crate) struct DisabledFs;
+
+fn disabled_fs_error() -> crate::Error {
+    IoError::new(ErrorKind::PermissionDenied, "filesystem access disabled").into()
+}
+
+#[async_trait::async_trait]
+impl FileSystemExt for DisabledFs {}
+
+#[async_trait::async_trait]
+impl FileSystem for DisabledFs {
+    async fn read_file(&self, _path: &Path) -> Result<Vec<u8>> {
+        Err(disabled_fs_error())
+    }
+
+    async fn write_file(&self, _path: &Path, _content: &[u8]) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn append_file(&self, _path: &Path, _content: &[u8]) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn mkdir(&self, _path: &Path, _recursive: bool) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn remove(&self, _path: &Path, _recursive: bool) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn stat(&self, _path: &Path) -> Result<Metadata> {
+        Err(disabled_fs_error())
+    }
+
+    async fn read_dir(&self, _path: &Path) -> Result<Vec<DirEntry>> {
+        Err(disabled_fs_error())
+    }
+
+    async fn exists(&self, _path: &Path) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn rename(&self, _from: &Path, _to: &Path) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn copy(&self, _from: &Path, _to: &Path) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn symlink(&self, _target: &Path, _link: &Path) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn read_link(&self, _path: &Path) -> Result<PathBuf> {
+        Err(disabled_fs_error())
+    }
+
+    async fn chmod(&self, _path: &Path, _mode: u32) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+
+    async fn set_modified_time(&self, _path: &Path, _time: SystemTime) -> Result<()> {
+        Err(disabled_fs_error())
+    }
+}
 
 /// Normalize a virtual filesystem path by resolving `.` and `..` components.
 ///

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -57,6 +57,134 @@ pub struct HistoryEntry {
     pub duration_ms: u64,
 }
 
+/// Runtime command surface for an interpreter instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum ShellProfile {
+    /// Full Bashkit shell with VFS-backed commands.
+    #[default]
+    Full,
+    /// Logic-only shell for ScriptedTool code mode: no filesystem primitives.
+    LogicOnly,
+}
+
+impl ShellProfile {
+    pub(crate) fn is_logic_only(self) -> bool {
+        self == Self::LogicOnly
+    }
+}
+
+fn logic_only_builtin_allowed(name: &str) -> bool {
+    matches!(
+        name,
+        // Core shell/data flow
+        "echo"
+            | "true"
+            | "false"
+            | "exit"
+            | "break"
+            | "continue"
+            | "return"
+            | "test"
+            | "["
+            | "printf"
+            | "export"
+            | "read"
+            | "set"
+            | "unset"
+            | "shift"
+            | "local"
+            | ":"
+            | "readonly"
+            | "times"
+            | "eval"
+            // Text and data transforms that work from stdin
+            | "grep"
+            | "sed"
+            | "awk"
+            | "head"
+            | "tail"
+            | "sort"
+            | "uniq"
+            | "cut"
+            | "tr"
+            | "wc"
+            | "nl"
+            | "paste"
+            | "column"
+            | "comm"
+            | "strings"
+            | "tac"
+            | "rev"
+            | "fold"
+            | "expand"
+            | "unexpand"
+            | "join"
+            | "split"
+            | "jq"
+            | "seq"
+            | "expr"
+            | "bc"
+            | "numfmt"
+            // Shell state, introspection, and structured transforms
+            | "env"
+            | "printenv"
+            | "type"
+            | "which"
+            | "hash"
+            | "alias"
+            | "unalias"
+            | "trap"
+            | "caller"
+            | "mapfile"
+            | "readarray"
+            | "shopt"
+            | "clear"
+            | "envsubst"
+            | "assert"
+            | "log"
+            | "retry"
+            | "semver"
+            | "verify"
+            | "compgen"
+            | "csv"
+            | "help"
+            | "iconv"
+            | "json"
+            | "parallel"
+            | "template"
+            | "tomlq"
+            | "yaml"
+            | "timeout"
+            | "xargs"
+            | "wait"
+    )
+}
+
+fn word_literal_text(word: &Word) -> Option<&str> {
+    if word.parts.len() == 1
+        && let WordPart::Literal(s) = &word.parts[0]
+    {
+        return Some(s);
+    }
+    None
+}
+
+fn word_has_process_substitution(word: &Word) -> bool {
+    word.parts
+        .iter()
+        .any(|part| matches!(part, WordPart::ProcessSubstitution { .. }))
+}
+
+fn word_is_literal_dev_null(word: &Word) -> bool {
+    word_literal_text(word) == Some(DEV_NULL)
+}
+
+fn redirect_target_label(word: &Word) -> String {
+    word_literal_text(word)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| word.to_string())
+}
+
 fn compat_bash_versinfo_array() -> HashMap<usize, String> {
     COMPAT_BASH_VERSINFO
         .iter()
@@ -727,6 +855,9 @@ pub struct Interpreter {
     /// Uses `AtomicU32` for interior mutability so $RANDOM can advance state
     /// in `expand_variable(&self, ...)` while remaining `Send + Sync`.
     random_state: AtomicU32,
+    /// Runtime command surface. ScriptedTool uses LogicOnly to prevent scripts
+    /// from reaching VFS-backed commands while preserving shell logic.
+    shell_profile: ShellProfile,
 }
 
 impl Interpreter {
@@ -747,7 +878,7 @@ impl Interpreter {
 
     /// Create a new interpreter with the given filesystem.
     pub fn new(fs: Arc<dyn FileSystem>) -> Self {
-        Self::with_config(fs, None, None, None, HashMap::new())
+        Self::with_config(fs, None, None, None, HashMap::new(), ShellProfile::Full)
     }
 
     /// Create a new interpreter with custom username, hostname, and builtins.
@@ -764,6 +895,7 @@ impl Interpreter {
         hostname: Option<String>,
         fixed_epoch: Option<i64>,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
+        shell_profile: ShellProfile,
     ) -> Self {
         // Macro to reduce boilerplate for simple zero-arg builtin registration.
         // Custom-construction builtins (date, source, hostname, etc.) are registered below.
@@ -987,6 +1119,10 @@ impl Interpreter {
             builtins.insert("sftp".to_string(), Box::new(builtins::Sftp));
         }
 
+        if shell_profile.is_logic_only() {
+            builtins.retain(|name, _| logic_only_builtin_allowed(name));
+        }
+
         // Merge custom builtins (override defaults if same name)
         for (name, builtin) in custom_builtins {
             builtins.insert(name, builtin);
@@ -1065,6 +1201,7 @@ impl Interpreter {
             deferred_proc_subs: Vec::new(),
             proc_sub_paths: HashSet::new(),
             random_state: AtomicU32::new(random_seed),
+            shell_profile,
         }
     }
 
@@ -1809,6 +1946,10 @@ impl Interpreter {
                 Command::Pipeline(pipeline) => self.execute_pipeline(pipeline).await,
                 Command::List(list) => self.execute_list(list).await,
                 Command::Compound(compound, redirects) => {
+                    if let Some(stderr) = self.logic_only_redirect_error(redirects) {
+                        return Ok(ExecResult::err(stderr, 1));
+                    }
+
                     // Process input redirections before executing compound
                     let stdin = self.process_input_redirections(None, redirects).await?;
                     let prev_pipeline_stdin = if stdin.is_some() {
@@ -4379,6 +4520,10 @@ impl Interpreter {
                 });
             }
 
+            if let Some(stderr) = self.logic_only_redirect_error(&command.redirects) {
+                return Ok(ExecResult::err(stderr, 1));
+            }
+
             // Handle input redirections first
             let stdin = self
                 .process_input_redirections(stdin, &command.redirects)
@@ -4728,6 +4873,15 @@ impl Interpreter {
         stdin: Option<String>,
         redirects: &[Redirect],
     ) -> Option<Result<ExecResult>> {
+        if self.shell_profile.is_logic_only()
+            && matches!(name, "exec" | "bash" | "sh" | "source" | ".")
+        {
+            return Some(Ok(ExecResult::err(
+                format!("bash: {}: command not found", name),
+                127,
+            )));
+        }
+
         match name {
             "exec" => Some(self.execute_exec_builtin(args, redirects).await),
             "local" => Some(self.execute_local_builtin(args, redirects).await),
@@ -4778,15 +4932,22 @@ impl Interpreter {
 
             // Script execution by path
             if name.contains('/') {
+                if self.shell_profile.is_logic_only() {
+                    return Ok(ExecResult::err(
+                        format!("bash: {}: command not found", name),
+                        127,
+                    ));
+                }
                 return self
                     .try_execute_script_by_path(name, &args, stdin, &command.redirects)
                     .await;
             }
 
             // $PATH search
-            if let Some(result) = self
-                .try_execute_script_via_path_search(name, &args, stdin, &command.redirects)
-                .await?
+            if !self.shell_profile.is_logic_only()
+                && let Some(result) = self
+                    .try_execute_script_via_path_search(name, &args, stdin, &command.redirects)
+                    .await?
             {
                 return Ok(result);
             }
@@ -4869,6 +5030,10 @@ impl Interpreter {
     /// Resolve a command name to its full path via PATH search on VFS.
     /// Returns the resolved path string if found, None otherwise.
     async fn resolve_command_path(&self, name: &str) -> Option<String> {
+        if self.shell_profile.is_logic_only() {
+            return None;
+        }
+
         let path_var = self
             .variables
             .get("PATH")
@@ -6443,11 +6608,24 @@ impl Interpreter {
         for redirect in redirects {
             match redirect.kind {
                 RedirectKind::Input => {
+                    if self.shell_profile.is_logic_only()
+                        && !word_is_literal_dev_null(&redirect.target)
+                    {
+                        return Err(crate::error::Error::Execution(format!(
+                            "bash: {}: filesystem redirection disabled",
+                            redirect_target_label(&redirect.target)
+                        )));
+                    }
                     let target_path = self.expand_word(&redirect.target).await?;
                     let path = self.resolve_path(&target_path);
                     // Handle /dev/null at interpreter level - cannot be bypassed
                     if is_dev_null(&path) {
                         stdin = Some(String::new()); // EOF
+                    } else if self.shell_profile.is_logic_only() {
+                        return Err(crate::error::Error::Execution(format!(
+                            "bash: {}: filesystem redirection disabled",
+                            target_path
+                        )));
                     } else {
                         let content = self.fs.read_file(&path).await?;
                         stdin = Some(bytes_to_latin1_string(&content));
@@ -6752,6 +6930,13 @@ impl Interpreter {
         mut result: ExecResult,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
+        if let Some(stderr) = self.logic_only_redirect_error(redirects) {
+            result.stdout = String::new();
+            result.stderr = stderr;
+            result.exit_code = 1;
+            return Ok(result);
+        }
+
         // Skip the fd-table path when there are no DupOutput redirects mixed
         // with file redirects — the simple single-pass logic is sufficient and
         // avoids any behavioural delta for the common case.
@@ -6927,6 +7112,34 @@ impl Interpreter {
         }
 
         Ok(result)
+    }
+
+    fn logic_only_redirect_error(&self, redirects: &[Redirect]) -> Option<String> {
+        if !self.shell_profile.is_logic_only() {
+            return None;
+        }
+
+        for redirect in redirects {
+            if word_has_process_substitution(&redirect.target) {
+                return Some("bash: process substitution disabled in logic-only shell".to_string());
+            }
+
+            if matches!(
+                redirect.kind,
+                RedirectKind::Output
+                    | RedirectKind::Clobber
+                    | RedirectKind::Append
+                    | RedirectKind::Input
+                    | RedirectKind::OutputBoth
+            ) && !word_is_literal_dev_null(&redirect.target)
+            {
+                return Some(format!(
+                    "bash: {}: filesystem redirection disabled\n",
+                    redirect_target_label(&redirect.target)
+                ));
+            }
+        }
+        None
     }
 
     /// Apply redirections using an fd-table model for correct left-to-right
@@ -7190,6 +7403,12 @@ impl Interpreter {
         commands: &[Command],
         is_input: bool,
     ) -> Result<String> {
+        if self.shell_profile.is_logic_only() {
+            return Err(crate::error::Error::Execution(
+                "bash: process substitution disabled in logic-only shell".to_string(),
+            ));
+        }
+
         let path_str = format!(
             "/dev/fd/proc_sub_{}",
             PROC_SUB_COUNTER.fetch_add(1, Ordering::Relaxed)

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1191,6 +1191,7 @@ pub struct BashBuilder {
     hostname: Option<String>,
     /// Fixed epoch for virtualizing the `date` builtin (TM-INF-018)
     fixed_epoch: Option<i64>,
+    shell_profile: interpreter::ShellProfile,
     custom_builtins: HashMap<String, Box<dyn Builtin>>,
     /// Files to mount in the virtual filesystem
     mounted_files: Vec<MountedFile>,
@@ -1264,6 +1265,12 @@ impl BashBuilder {
     /// Set execution limits.
     pub fn limits(mut self, limits: ExecutionLimits) -> Self {
         self.limits = limits;
+        self
+    }
+
+    /// Restrict this shell to logic/data-flow commands and custom builtins.
+    pub(crate) fn logic_only(mut self) -> Self {
+        self.shell_profile = interpreter::ShellProfile::LogicOnly;
         self
     }
 
@@ -2303,7 +2310,11 @@ impl BashBuilder {
     /// # }
     /// ```
     pub fn build(self) -> Bash {
-        let base_fs = self.fs.unwrap_or_else(|| Arc::new(InMemoryFs::new()));
+        let base_fs: Arc<dyn FileSystem> = if self.shell_profile.is_logic_only() {
+            Arc::new(fs::DisabledFs)
+        } else {
+            self.fs.unwrap_or_else(|| Arc::new(InMemoryFs::new()))
+        };
 
         // Layer 1: Apply real filesystem mounts (if any)
         #[cfg(feature = "realfs")]
@@ -2342,6 +2353,7 @@ impl BashBuilder {
             self.hostname,
             self.fixed_epoch,
             self.cwd,
+            self.shell_profile,
             self.limits,
             self.session_limits,
             self.memory_limits,
@@ -2539,6 +2551,7 @@ impl BashBuilder {
         hostname: Option<String>,
         fixed_epoch: Option<i64>,
         cwd: Option<PathBuf>,
+        shell_profile: interpreter::ShellProfile,
         limits: ExecutionLimits,
         session_limits: SessionLimits,
         memory_limits: MemoryLimits,
@@ -2571,6 +2584,7 @@ impl BashBuilder {
             hostname,
             fixed_epoch,
             custom_builtins,
+            shell_profile,
         );
 
         // Set environment variables (also override shell variable defaults)

--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -432,7 +432,7 @@ impl Builtin for DiscoverBuiltin {
 impl ScriptedTool {
     /// Create a fresh Bash instance with all tool builtins registered.
     fn create_bash(&self, log: InvocationLog) -> Bash {
-        let mut builder = Bash::builder();
+        let mut builder = Bash::builder().logic_only();
 
         if let Some(ref limits) = self.limits {
             builder = builder.limits(limits.clone());
@@ -501,7 +501,7 @@ impl ScriptedTool {
         }
 
         doc.push_str(
-            "\n## Result\n\n| Field | Type | Description |\n|------|------|-------------|\n| `stdout` | string | Combined standard output |\n| `stderr` | string | Tool or bash errors |\n| `exit_code` | integer | Shell exit code |\n| `error` | string | Error category when execution fails |\n\n## Examples\n\n```json\n{\"commands\":\"get_user --id 42\"}\n```\n\n```json\n{\"commands\":\"user=$(get_user --id 42)\\necho \\\"$user\\\" | jq -r '.name'\"}\n```\n\n## Notes\n\n- Pass arguments as `--key value` or `--key=value`.\n- Standard bash builtins like `echo`, `jq`, `grep`, `sed`, and `awk` are available.\n- Use `help <tool> --json` inside the tool for runtime schema inspection.\n",
+            "\n## Result\n\n| Field | Type | Description |\n|------|------|-------------|\n| `stdout` | string | Combined standard output |\n| `stderr` | string | Tool or bash errors |\n| `exit_code` | integer | Shell exit code |\n| `error` | string | Error category when execution fails |\n\n## Examples\n\n```json\n{\"commands\":\"get_user --id 42\"}\n```\n\n```json\n{\"commands\":\"user=$(get_user --id 42)\\necho \\\"$user\\\" | jq -r '.name'\"}\n```\n\n## Notes\n\n- Pass arguments as `--key value` or `--key=value`.\n- Shell logic, variables, loops, conditionals, pipes, heredocs, here-strings, and stdin-based transforms are available.\n- Filesystem primitives are unavailable: file commands, path script execution, file redirection, and process substitution are rejected.\n- Use `help <tool> --json` inside the tool for runtime schema inspection.\n",
         );
 
         doc
@@ -539,8 +539,8 @@ impl ScriptedTool {
         ));
         parts.push(localized(
             self.locale.as_str(),
-            "Pass args as --key value or --key=value. Use help/discover builtins for runtime details.",
-            "Передавайте аргументи як --key value або --key=value. Використовуйте help/discover для деталей.",
+            "Pass args as --key value or --key=value. Shell logic and stdin pipelines are available; filesystem primitives are unavailable. Use help/discover builtins for runtime details.",
+            "Передавайте аргументи як --key value або --key=value. Доступні логіка shell і stdin-конвеєри; файлові примітиви недоступні. Використовуйте help/discover для деталей.",
         ).to_string());
 
         parts.join(" ")

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -840,6 +840,153 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_scripted_tool_rejects_filesystem_command() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "mkdir -p /tmp/work".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_eq!(resp.exit_code, 127);
+        assert!(resp.stderr.contains("command not found"), "{}", resp.stderr);
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_rejects_file_redirection() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "echo data > /tmp/out".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_ne!(resp.exit_code, 0);
+        assert!(
+            resp.stderr.contains("filesystem redirection disabled"),
+            "{}",
+            resp.stderr
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_rejects_file_redirection_before_callback() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let tool_calls = Arc::clone(&calls);
+        let tool = ScriptedTool::builder("test_api")
+            .tool_fn(
+                ToolDef::new("side_effect", "Count calls"),
+                move |_args: &ToolArgs| {
+                    tool_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok("called\n".to_string())
+                },
+            )
+            .build();
+
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "side_effect > /tmp/out".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_ne!(resp.exit_code, 0);
+        assert!(
+            resp.stderr.contains("filesystem redirection disabled"),
+            "{}",
+            resp.stderr
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_allows_dev_null_redirection() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "echo hidden > /dev/null; echo visible".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "visible");
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_rejects_input_redirection() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "from_stdin < /tmp/in".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_ne!(resp.exit_code, 0);
+        assert!(
+            resp.stderr.contains("filesystem redirection disabled"),
+            "{}",
+            resp.stderr
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_rejects_path_operands_for_dual_use_tools() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "grep Alice /tmp/users.json".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_ne!(resp.exit_code, 0);
+        let combined = format!("{}{}", resp.stdout, resp.stderr);
+        assert!(
+            combined.contains("filesystem access disabled"),
+            "{}",
+            combined
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_rejects_script_path_execution() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "/tmp/script.sh".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_eq!(resp.exit_code, 127);
+        assert!(resp.stderr.contains("command not found"), "{}", resp.stderr);
+    }
+
+    #[tokio::test]
+    async fn test_scripted_tool_rejects_process_substitution() {
+        let tool = build_test_tool();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "from_stdin < <(echo data)".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_ne!(resp.exit_code, 0);
+        assert!(
+            resp.stderr.contains("process substitution disabled"),
+            "{}",
+            resp.stderr
+        );
+    }
+
+    #[tokio::test]
     async fn test_execute_with_env() {
         let tool = ScriptedTool::builder("env_test")
             .env("API_BASE", "https://api.example.com")

--- a/specs/scripted-tool-orchestration.md
+++ b/specs/scripted-tool-orchestration.md
@@ -8,6 +8,10 @@ Implemented
 
 Compose tool definitions (`ToolDef`) + execution callbacks into a single `ScriptedTool` that accepts bash scripts. Each sub-tool becomes a builtin command, letting LLMs orchestrate N tools in one call using pipes, variables, loops, and conditionals.
 
+`ScriptedTool` always runs in code/logic mode. The bash language is used for
+control flow and data transformation, not as a VFS shell: filesystem primitives,
+path script execution, file redirection, and process substitution are unavailable.
+
 `ScriptedToolBuilder` and `ScriptingToolSetBuilder` also implement the shared
 toolkit-library contract from [the tool contract](./tool-contract.md):
 locale-aware metadata, `build_service()`, `build_tool_definition()`,
@@ -21,6 +25,11 @@ locale-aware metadata, `build_service()`, `build_tool_definition()`,
 ## Motivation
 
 When an LLM has access to many tools (get_user, list_orders, get_inventory, etc.), each tool call is a separate round-trip. A data-gathering task that needs 5 tools requires 5+ turns. With `ScriptedTool`, the LLM writes a single bash script that calls all tools, pipes results through `jq`, and returns composed output — reducing latency and token cost.
+
+The intended use is "code mode": logic, conditionals, loops, pipes, and data
+transformations represented as bash. It is not intended for project/file
+manipulation; use `Bash` / `BashTool` when a virtual filesystem is part of the
+task.
 
 ## Design
 
@@ -216,12 +225,32 @@ from `ctx.args` using the tool's schema for type coercion, then calls the callba
 
 Implements the `Tool` trait. On each `execute()`:
 
-1. Creates a fresh `Bash` instance.
+1. Creates a fresh logic-only `Bash` instance.
 2. Registers each callback as a builtin via `Arc::clone`.
 3. Runs the user-provided script.
 4. Returns `ToolResponse { stdout, stderr, exit_code }`.
 
 Reusable — multiple `execute()` calls share the same `Arc<ToolCallback>` instances.
+
+The logic-only shell keeps bash syntax and stdin/stdout data-flow features:
+
+- variables, arrays, functions, arithmetic, command substitution
+- `if`/`case`/`for`/`while`
+- pipelines, heredocs, here-strings
+- callback commands plus `help` and `discover`
+- stdin-oriented transforms such as `jq`, `grep`, `sed`, `awk`, `sort`, `cut`,
+  `tr`, `wc`, `head`, `tail`, `seq`, and `expr`
+
+The following filesystem surfaces are rejected:
+
+- file commands such as `cat`, `ls`, `find`, `mkdir`, `rm`, `cp`, `mv`, `touch`,
+  `chmod`, `ln`, `stat`, `source`, and `.`
+- path execution such as `/tmp/script.sh` or `$PATH` script lookup
+- file input/output redirection (`< file`, `> file`, `>> file`, `&> file`), except
+  `/dev/null`
+- process substitution (`<(...)`, `>(...)`)
+- file operands to dual-use tools; the internal filesystem rejects all real
+  operations with `filesystem access disabled`
 
 ### Built-in `help` command
 
@@ -287,6 +316,7 @@ Output: {stdout, stderr, exit_code}
 - Pass arguments as `--key value` or `--key=value` flags
 - Pipe tool output through `jq` for JSON processing
 - Use variables to pass data between tool calls
+- Do not use filesystem commands or file redirection
 ```
 
 ### Shared context across callbacks
@@ -438,5 +468,8 @@ Inherits all bashkit sandbox guarantees:
 - Virtual filesystem (no host access)
 - Resource limits (max commands, loop iterations, function depth)
 - No network access unless explicitly configured
+
+`ScriptedTool` further uses a disabled filesystem backend and a reduced builtin
+surface so scripts cannot use VFS storage or path-based script execution.
 
 Sub-tool callback implementations control their own security boundaries.


### PR DESCRIPTION
## What
ScriptedTool now always runs bash scripts in a logic-only code mode. The shell keeps variables, conditionals, loops, pipes, heredocs, here-strings, and stdin-based transforms while blocking filesystem primitives.

## Why
ScriptedTool is intended to orchestrate ToolDef callbacks and data transformations, not expose a VFS shell. This reduces the command surface for LLM-written script logic.

## How
- Added a LogicOnly shell profile with a reduced builtin allowlist.
- Added a disabled filesystem backend for ScriptedTool shells.
- Rejected file commands, path script execution, file redirection, and process substitution while preserving /dev/null.
- Updated docs and added regression coverage, including blocked-redirection-before-callback execution.

## Risk
- Medium
- Existing ScriptedTool scripts that used VFS commands or file redirection will now fail by design. BashTool/full Bash remains the filesystem mode.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered