### PR TITLE
fix(ci): green up failing main-branch tests and example

### DIFF
--- a/crates/bashkit/examples/agent_tool.rs
+++ b/crates/bashkit/examples/agent_tool.rs
@@ -262,6 +262,10 @@ impl Agent {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // reqwest is built with `rustls-no-provider`, so a CryptoProvider must be
+    // installed process-wide before `reqwest::Client::new()` is called.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     println!("=== Bashkit LLM Agent Example ===\n");
 
     let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_else(|_| {

--- a/crates/bashkit/src/builtins/jq/tests.rs
+++ b/crates/bashkit/src/builtins/jq/tests.rs
@@ -1111,7 +1111,11 @@ mod differential {
             .stderr(Stdio::piped())
             .spawn()
             .ok()?;
-        child.stdin.as_mut()?.write_all(input.as_bytes()).ok()?;
+        // Ignore write errors: jq may exit before reading stdin (e.g. on
+        // unknown flags), causing a broken pipe. Drop stdin to signal EOF.
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = stdin.write_all(input.as_bytes());
+        }
         let out = child.wait_with_output().ok()?;
         let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
         Some((stdout, out.status.code().unwrap_or(-1)))

--- a/crates/bashkit/src/builtins/sqlite/tests.rs
+++ b/crates/bashkit/src/builtins/sqlite/tests.rs
@@ -330,7 +330,7 @@ async fn persistence_round_trip_memory_backend() {
         &env,
     )
     .await;
-    assert_eq!(r1.exit_code, 0, "first invocation failed: {r1:?}");
+    assert_eq!(r1.exit_code, 0, "first invocation failed: {r1:?}"); // debug-ok: assert-failure message
     // The DB file must now exist on the VFS.
     assert!(fs.exists(Path::new("/tmp/db.sqlite")).await.unwrap());
     let r2 = run_persisting(
@@ -340,7 +340,7 @@ async fn persistence_round_trip_memory_backend() {
         &env,
     )
     .await;
-    assert_eq!(r2.exit_code, 0, "second invocation failed: {r2:?}");
+    assert_eq!(r2.exit_code, 0, "second invocation failed: {r2:?}"); // debug-ok: assert-failure message
     assert_eq!(r2.stdout.trim(), "1");
 }
 
@@ -358,7 +358,7 @@ async fn persistence_round_trip_vfs_backend() {
         &env,
     )
     .await;
-    assert_eq!(r1.exit_code, 0, "first invocation failed: {r1:?}");
+    assert_eq!(r1.exit_code, 0, "first invocation failed: {r1:?}"); // debug-ok: assert-failure message
     let r2 = run_persisting(
         &["/tmp/dbvfs.sqlite", "SELECT * FROM t"],
         SqliteBackend::Vfs,
@@ -611,7 +611,7 @@ async fn null_text_does_not_collide_with_real_text() {
     assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
     assert!(
         r.stdout.contains("(null)"),
-        "stdout missing null sentinel: {:?}",
+        "stdout missing null sentinel: {:?}", // debug-ok: assert-failure message
         r.stdout
     );
     // The empty-string row is rendered as a literal empty line (just `\n`).

--- a/crates/bashkit/src/builtins/ssh/config.rs
+++ b/crates/bashkit/src/builtins/ssh/config.rs
@@ -303,7 +303,7 @@ mod tests {
         let config = SshConfig::new()
             .default_password(&pass)
             .default_private_key(&key);
-        let debug = format!("{:?}", config);
+        let debug = format!("{:?}", config); // debug-ok: this test verifies Debug redaction
         // Verify sensitive values are not present in Debug output
         assert!(!debug.contains(&pass), "password leaked in Debug output");
         assert!(

--- a/crates/bashkit/src/builtins/ssh/handler.rs
+++ b/crates/bashkit/src/builtins/ssh/handler.rs
@@ -156,7 +156,7 @@ mod tests {
             private_key: Some("-----BEGIN OPENSSH PRIVATE KEY-----".to_string()),
             password: Some("super_secret".to_string()),
         };
-        let debug = format!("{:?}", target);
+        let debug = format!("{:?}", target); // debug-ok: this test verifies Debug redaction
         assert!(!debug.contains("super_secret"), "password leaked: {debug}");
         assert!(
             !debug.contains("BEGIN OPENSSH PRIVATE KEY"),


### PR DESCRIPTION
## Summary

CI on `main` was red across `Test`, `Coverage`, and `Examples`. Three independent root causes — fixed each:

1. **TM-INF-022 source guard (`no_debug_fmt_in_builtin_source`)** — six legitimate Debug uses in `ssh/{config,handler}.rs` and `sqlite/tests.rs` were missing the `// debug-ok: <reason>` marker that the static guard requires. Annotated each: the ssh tests assert that Debug *redacts* secrets (the Debug call IS the test), and the sqlite asserts dump the run result on assertion failure.
2. **`jq::tests::differential::diff_unknown_flag_exit_code`** — `run_real_jq` returned `None` when real jq exited before reading stdin (broken pipe on `--xyzzy`), and the test fell back to `exit=-1`, never matching bashkit's `2`. Drop stdin and ignore the write error so `wait_with_output` still produces the real exit code.
3. **`agent_tool` example panicked with "No provider set"** — reqwest is built with `rustls-no-provider`, so a `CryptoProvider` must be installed before `reqwest::Client::new()`. Install ring at the top of `main()`, mirroring what `network::client::install_default_crypto_provider` does for the library.

## Test plan

- [x] `cargo test -p bashkit --lib no_debug_fmt_in_builtin_source` (was red, now green)
- [x] `cargo test -p bashkit --lib differential::diff_unknown_flag_exit_code` (was red, now green)
- [x] `cargo test -p bashkit --lib ssh::config::tests::test_debug_redacts_credentials ssh::handler::tests::test_debug_redacts_credentials sqlite::tests::persistence_round_trip*` (still green after annotations)
- [x] `cargo build --example agent_tool --features http_client` (compiles)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`


---
_Generated by [Claude Code](https://claude.ai/code/session_014WYh23S4XHWgaHsfVdF7Bv)_