### PR TITLE
chore(ci): pin Rust toolchain, mirror RSA advisory, gate dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
 
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Security audit (cargo-audit)
         uses: rustsec/audit-check@v2.0.0
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: llvm-tools-preview
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: llvm-tools-preview
 
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-path: crates/bashkit-js/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: ${{ matrix.settings.target }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Verify version matches tag
         run: |
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Wait for crates.io index update
         run: sleep 30

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,7 +73,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 
@@ -114,7 +114,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - uses: Swatinem/rust-cache@v2
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,9 @@ just pre-pr       # Pre-PR checks
 
 ### Rust
 
-- Stable Rust, toolchain in `rust-toolchain.toml`
+- Stable Rust, version pinned in `rust-toolchain.toml` (bump deliberately;
+  match the new version in `dtolnay/rust-toolchain@<version>` refs across
+  `.github/workflows/*` so CI can't be broken by a same-day rustc release)
 - `cargo fmt` and `cargo clippy -- -D warnings`
 - License checks: `cargo deny check` (see `deny.toml`)
 

--- a/crates/bashkit/src/builtins/curl.rs
+++ b/crates/bashkit/src/builtins/curl.rs
@@ -708,6 +708,7 @@ fn resolve_redirect_url(base: &str, location: &str) -> String {
 }
 
 /// Check if two URLs have the same origin (scheme + host + port).
+#[cfg(feature = "http_client")]
 fn same_origin(a: &str, b: &str) -> bool {
     let (Ok(a_url), Ok(b_url)) = (url::Url::parse(a), url::Url::parse(b)) else {
         return false;
@@ -718,6 +719,7 @@ fn same_origin(a: &str, b: &str) -> bool {
 }
 
 /// Sensitive headers that must not be forwarded cross-origin on redirect.
+#[cfg(feature = "http_client")]
 const SENSITIVE_HEADERS: &[&str] = &["authorization", "cookie", "proxy-authorization"];
 
 #[cfg(feature = "http_client")]

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -400,6 +400,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod builtins;
+#[cfg(feature = "http_client")]
 mod credential;
 mod error;
 mod fs;
@@ -437,6 +438,7 @@ pub use async_trait::async_trait;
 pub use builtins::git::GitConfig;
 pub use builtins::ssh::{SshAllowlist, SshConfig, TrustedHostKey};
 pub use builtins::{Builtin, Context as BuiltinContext, ExecutionExtensions};
+#[cfg(feature = "http_client")]
 pub use credential::Credential;
 pub use error::{Error, Result};
 pub use fs::{
@@ -1278,6 +1280,7 @@ impl BashBuilder {
     }
 
     /// Restrict this shell to logic/data-flow commands and custom builtins.
+    #[cfg(feature = "scripted_tool")]
     pub(crate) fn logic_only(mut self) -> Self {
         self.shell_profile = interpreter::ShellProfile::LogicOnly;
         self

--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,12 @@ ignore = [
     # rand: unsoundness with custom logger using rand::rng() (RUSTSEC-2026-0097)
     # Transitive via russh, statrs, proptest, reqwest; we don't use custom loggers
     "RUSTSEC-2026-0097",
+    # rsa: Marvin Attack timing side-channel (RUSTSEC-2023-0071, GHSA-c25x-cm9x-cq9w)
+    # No patched version published upstream — RustCrypto/RSA#19. Pulled in
+    # transitively via russh's ssh-key dep. Mirrors the `ignore:` already set
+    # in .github/workflows/ci.yml for rustsec/audit-check, and is the same
+    # advisory surfaced as Dependabot moderate alert #27.
+    "RUSTSEC-2023-0071",
 ]
 
 [bans]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,5 @@
 [toolchain]
-channel = "stable"
+# Pinned to avoid same-day rustc releases breaking CI; bump deliberately
+# (also bump dtolnay/rust-toolchain@<version> refs in .github/workflows/*).
+channel = "1.94.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Punch-list cleanup from the Turso/SQLite review notes (items #9-11):

- **#10 — Pin Rust toolchain.** A same-day `rustc 1.95` release broke CI. `rust-toolchain.toml` now pins to `1.94.1` and every `dtolnay/rust-toolchain@stable` ref across `.github/workflows/*` is pinned to `@1.94.1`. Bumps are now deliberate. `@nightly` refs (fuzz, nightly workflow, ci `fuzz-check`) intentionally untouched.
- **#9 — Triage Dependabot moderate alert #27** (RUSTSEC-2023-0071, Marvin Attack on `rsa`, transitive via `russh` ssh-key). No upstream patch (RustCrypto/RSA#19). The advisory is already ignored by `rustsec/audit-check` in CI; mirrored into `deny.toml` so `cargo deny check` succeeds locally and the accepted risk is documented in one place. The Dependabot alert itself still needs a manual UI dismissal with reason "no patched version available".
- **#11 — Pre-existing clippy `dead_code` baseline.** Without `--all-features`, `cargo clippy` on `main` emitted warnings for items only used from feature-gated callsites (`builtins/curl.rs::same_origin`, `SENSITIVE_HEADERS`; the entire `credential` module + `pub use Credential`; `BashBuilder::logic_only`). Added matching `#[cfg(feature = "...")]` attributes so default-feature and single-feature builds are warning-free for contributors who don't pass `--all-features`.
- **Docs.** AGENTS.md now spells out that the toolchain pin in `rust-toolchain.toml` and the `dtolnay/rust-toolchain@<version>` workflow refs are bumped together.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy -p bashkit --all-targets` (default features)
- [x] `cargo clippy -p bashkit --all-targets --no-default-features`
- [x] `cargo clippy -p bashkit --all-targets --features http_client` (and `ssh`, `scripted_tool`, `sqlite` individually)
- [x] `cargo test --workspace --lib --bins --tests --features http_client,ssh,sqlite -- --skip ssh_supabase` — 86 test groups, 0 failures (`ssh_supabase_connects` skipped: needs live network to supabase.sh)
- [x] `rustup` confirms 1.94.1 is selected from the new `rust-toolchain.toml`

---
_Generated by [Claude Code](https://claude.ai/code/session_011f3oXjBiWyuJqPCiWL8Snj)_