### PR TITLE
feat(sqlite): session-scoped engine cache for transactions across exec()

### DIFF
--- a/crates/bashkit/src/builtins/sqlite/mod.rs
+++ b/crates/bashkit/src/builtins/sqlite/mod.rs
@@ -97,7 +97,7 @@ const DEFAULT_PRAGMA_DENY: &[&str] = &[
 ];
 
 /// Choice of `IO` backend.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum SqliteBackend {
     /// Phase 1: load whole DB file into turso's `MemoryIO`, run, flush back.
     /// Default — most predictable and exposes the smallest surface of the
@@ -239,22 +239,58 @@ fn sqlite_inprocess_enabled(ctx: &Context<'_>) -> bool {
 }
 
 /// The `sqlite` / `sqlite3` builtin command.
+///
+/// Holds a session-scoped cache of file-backed engines so that consecutive
+/// `bash.exec("sqlite DB ...")` calls reuse the same connection. This lets
+/// transactions span shell commands (e.g. `BEGIN` in one call, `COMMIT` in
+/// the next) and avoids reloading the DB file from the VFS for every
+/// invocation.
+///
+/// `:memory:` databases bypass the cache — they are intentionally
+/// ephemeral so users get a fresh slate on every invocation.
 pub struct Sqlite {
     /// Resource and backend configuration.
     pub limits: SqliteLimits,
+    /// Per-database cached engine handles. Key: `(backend, canonical-ish path)`.
+    /// Value: an `Arc<TokioMutex<Option<SqliteEngine>>>` so concurrent calls
+    /// to the same path serialise without losing the cached connection.
+    engine_cache: EngineCache,
 }
+
+type CacheKey = (SqliteBackend, std::path::PathBuf);
+type EngineHandle = Arc<tokio::sync::Mutex<Option<engine::SqliteEngine>>>;
+type EngineCache = Arc<std::sync::Mutex<std::collections::HashMap<CacheKey, EngineHandle>>>;
 
 impl Sqlite {
     /// Construct with default limits and the Memory backend.
     pub fn new() -> Self {
         Self {
             limits: SqliteLimits::default(),
+            engine_cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
     /// Construct with custom limits.
     pub fn with_limits(limits: SqliteLimits) -> Self {
-        Self { limits }
+        Self {
+            limits,
+            engine_cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        }
+    }
+
+    /// Look up (or insert) the per-database engine handle. The outer
+    /// `std::sync::Mutex` is held only briefly for HashMap access; the
+    /// inner `tokio::sync::Mutex` is what serialises concurrent `sqlite`
+    /// calls against the same database.
+    fn cache_handle(&self, key: &CacheKey) -> EngineHandle {
+        let mut cache = self
+            .engine_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cache
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None)))
+            .clone()
     }
 }
 
@@ -317,19 +353,10 @@ impl Builtin for Sqlite {
         // Resolve effective backend (CLI flag overrides builder default).
         let backend = parsed.backend.unwrap_or(self.limits.backend);
 
-        // Open the engine, optionally seeded from VFS.
-        let engine = match open_engine(&db_target, backend, &ctx.fs, &self.limits).await {
-            Ok(e) => e,
-            Err(msg) => return Ok(ExecResult::err(format!("sqlite: {msg}\n"), 1)),
-        };
-
         // Initial output options come from the CLI flags; dot-commands may
         // mutate them as we go.
         let mut opts = parsed.output;
 
-        // Run statements + dot-commands in order. We collect output into a
-        // single buffer; errors short-circuit further execution but still
-        // attempt a flush of any successful writes.
         let mut stdout = String::new();
         let mut stderr = String::new();
         let mut exit_code = 0i32;
@@ -345,33 +372,78 @@ impl Builtin for Sqlite {
             ));
         }
         let deadline = engine::Deadline::new(self.limits.max_duration);
-        let exec_outcome = run_statements(
-            &engine,
-            stmts,
-            &ctx.fs,
-            ctx.cwd,
-            &mut opts,
-            &mut stdout,
-            &self.limits,
-            deadline,
-            0,
-        )
-        .await;
-        if let Err(e) = exec_outcome {
-            stderr.push_str(&format!("sqlite: {e}\n"));
-            exit_code = 1;
-        }
 
-        // Flush + persist.
+        // For `:memory:`, don't cache — every invocation gets a fresh
+        // ephemeral engine. For file-backed targets we lock a per-key
+        // handle so consecutive calls reuse the same connection
+        // (transactions can span shell commands).
         match &db_target {
-            DbTarget::Memory => {}
-            DbTarget::File { path } => match backend {
-                SqliteBackend::Memory => {
-                    if let Some(bytes) = engine.snapshot_bytes() {
-                        // Even on error, try to persist anything that was
-                        // flushed by turso so the caller doesn't lose work
-                        // from earlier statements in the batch.
-                        if let Err(e) = ctx.fs.write_file(path, &bytes).await {
+            DbTarget::Memory => {
+                let engine = match SqliteEngine::open_pure_memory() {
+                    Ok(e) => e,
+                    Err(msg) => {
+                        return Ok(ExecResult::err(format!("sqlite: {msg}\n"), 1));
+                    }
+                };
+                let outcome = run_statements(
+                    &engine,
+                    stmts,
+                    &ctx.fs,
+                    ctx.cwd,
+                    &mut opts,
+                    &mut stdout,
+                    &self.limits,
+                    deadline,
+                    0,
+                )
+                .await;
+                if let Err(e) = outcome {
+                    stderr.push_str(&format!("sqlite: {e}\n"));
+                    exit_code = 1;
+                }
+            }
+            DbTarget::File { path } => {
+                let key: CacheKey = (backend, path.clone());
+                let handle = self.cache_handle(&key);
+                let mut guard = handle.lock().await;
+
+                if guard.is_none() {
+                    match open_file_engine(backend, path, &ctx.fs, &self.limits).await {
+                        Ok(e) => *guard = Some(e),
+                        Err(msg) => {
+                            return Ok(ExecResult::err(format!("sqlite: {msg}\n"), 1));
+                        }
+                    }
+                }
+                let engine = guard.as_ref().expect("engine populated above");
+
+                let outcome = run_statements(
+                    engine,
+                    stmts,
+                    &ctx.fs,
+                    ctx.cwd,
+                    &mut opts,
+                    &mut stdout,
+                    &self.limits,
+                    deadline,
+                    0,
+                )
+                .await;
+                if let Err(e) = outcome {
+                    stderr.push_str(&format!("sqlite: {e}\n"));
+                    exit_code = 1;
+                }
+
+                // Persist to the VFS so snapshots taken between exec()
+                // calls always pick up the latest committed state. We
+                // keep the engine in the cache regardless; the next call
+                // will reuse it (and any in-flight transaction will
+                // continue to see uncommitted state).
+                match backend {
+                    SqliteBackend::Memory => {
+                        if let Some(bytes) = engine.snapshot_bytes()
+                            && let Err(e) = ctx.fs.write_file(path, &bytes).await
+                        {
                             stderr.push_str(&format!(
                                 "sqlite: persist failed: {}: {e}\n",
                                 path.display()
@@ -379,14 +451,14 @@ impl Builtin for Sqlite {
                             exit_code = exit_code.max(1);
                         }
                     }
-                }
-                SqliteBackend::Vfs => {
-                    if let Err(e) = engine.flush_dirty().await {
-                        stderr.push_str(&format!("sqlite: flush failed: {e}\n"));
-                        exit_code = exit_code.max(1);
+                    SqliteBackend::Vfs => {
+                        if let Err(e) = engine.flush_dirty().await {
+                            stderr.push_str(&format!("sqlite: flush failed: {e}\n"));
+                            exit_code = exit_code.max(1);
+                        }
                     }
                 }
-            },
+            }
         }
 
         let mut result = ExecResult {
@@ -559,38 +631,39 @@ fn decode_escapes(s: &str) -> String {
     out
 }
 
-async fn open_engine(
-    target: &DbTarget,
+/// Open a fresh engine for a *file-backed* database, reading the current
+/// VFS bytes for the Memory backend or constructing a `BashkitVfsIO` for
+/// the VFS backend. Called only on cache miss; once cached, the engine
+/// is reused across invocations.
+async fn open_file_engine(
     backend: SqliteBackend,
+    path: &Path,
     fs: &Arc<dyn FileSystem>,
     limits: &SqliteLimits,
 ) -> std::result::Result<SqliteEngine, String> {
-    match target {
-        DbTarget::Memory => SqliteEngine::open_pure_memory(),
-        DbTarget::File { path } => match backend {
-            SqliteBackend::Memory => {
-                let initial = match fs.read_file(path).await {
-                    Ok(bytes) => {
-                        if bytes.len() > limits.max_db_bytes {
-                            return Err(format!(
-                                "database file too large ({} bytes; limit {})",
-                                bytes.len(),
-                                limits.max_db_bytes
-                            ));
-                        }
-                        Some(bytes)
+    match backend {
+        SqliteBackend::Memory => {
+            let initial = match fs.read_file(path).await {
+                Ok(bytes) => {
+                    if bytes.len() > limits.max_db_bytes {
+                        return Err(format!(
+                            "database file too large ({} bytes; limit {})",
+                            bytes.len(),
+                            limits.max_db_bytes
+                        ));
                     }
-                    Err(_) => None,
-                };
-                SqliteEngine::open_memory(initial.as_deref())
-            }
-            SqliteBackend::Vfs => {
-                let handle = vfs_io::current_handle_or_default();
-                let io = vfs_io::BashkitVfsIO::new(fs.clone(), handle);
-                let path_str = path.to_string_lossy().into_owned();
-                SqliteEngine::open_vfs(io, &path_str)
-            }
-        },
+                    Some(bytes)
+                }
+                Err(_) => None,
+            };
+            SqliteEngine::open_memory(initial.as_deref())
+        }
+        SqliteBackend::Vfs => {
+            let handle = vfs_io::current_handle_or_default();
+            let io = vfs_io::BashkitVfsIO::new(fs.clone(), handle);
+            let path_str = path.to_string_lossy().into_owned();
+            SqliteEngine::open_vfs(io, &path_str)
+        }
     }
 }
 

--- a/crates/bashkit/tests/sqlite_integration_tests.rs
+++ b/crates/bashkit/tests/sqlite_integration_tests.rs
@@ -222,6 +222,104 @@ async fn dot_dump_round_trips_via_dot_read() {
 }
 
 #[tokio::test]
+async fn cached_engine_keeps_in_flight_transaction_across_exec_calls() {
+    // Without the engine cache, every `sqlite` invocation opens a fresh
+    // connection from the VFS bytes — so a `BEGIN` in one call would be
+    // dropped before the next call's `COMMIT` could see it. With the
+    // cache, the connection persists for the lifetime of the `Bash`
+    // instance, and transactions span shell commands.
+    let mut bash = make_bash();
+    let r = bash
+        .exec(
+            r#"sqlite /tmp/tx.sqlite 'CREATE TABLE t(a INTEGER); BEGIN; INSERT INTO t VALUES (1)'"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
+
+    // Mid-transaction: the row is visible to the same connection but not
+    // yet committed. A follow-up call on the SAME `Bash` reuses the same
+    // engine, so it sees the uncommitted row.
+    let mid = bash
+        .exec(r#"sqlite /tmp/tx.sqlite 'SELECT count(*) FROM t'"#)
+        .await
+        .unwrap();
+    assert_eq!(mid.exit_code, 0, "stderr: {}", mid.stderr);
+    assert_eq!(mid.stdout.trim(), "1");
+
+    // Commit and verify with a final query.
+    let commit = bash
+        .exec(r#"sqlite /tmp/tx.sqlite 'COMMIT; SELECT count(*) FROM t'"#)
+        .await
+        .unwrap();
+    assert_eq!(commit.exit_code, 0, "stderr: {}", commit.stderr);
+    assert_eq!(commit.stdout.trim(), "1");
+}
+
+#[tokio::test]
+async fn cached_engine_isolated_per_database_path() {
+    // Two different DB paths must not collide in the cache. Schema
+    // changes to `/tmp/a.sqlite` are invisible from `/tmp/b.sqlite`.
+    let mut bash = make_bash();
+    bash.exec(r#"sqlite /tmp/a.sqlite 'CREATE TABLE only_in_a(x)'"#)
+        .await
+        .unwrap();
+    let r = bash
+        .exec(r#"sqlite /tmp/b.sqlite '.tables'"#)
+        .await
+        .unwrap();
+    assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
+    assert!(
+        !r.stdout.contains("only_in_a"),
+        "schema leaked across cache keys: {:?}",
+        r.stdout
+    );
+}
+
+#[tokio::test]
+async fn memory_target_does_not_persist_across_exec_calls() {
+    // `:memory:` databases are deliberately ephemeral — the cache only
+    // holds file-backed engines. A schema created in one call must NOT
+    // be visible to the next.
+    let mut bash = make_bash();
+    bash.exec(r#"sqlite :memory: 'CREATE TABLE ephemeral(x)'"#)
+        .await
+        .unwrap();
+    let r = bash.exec(r#"sqlite :memory: '.tables'"#).await.unwrap();
+    assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
+    assert!(
+        !r.stdout.contains("ephemeral"),
+        ":memory: leaked schema between invocations: {:?}",
+        r.stdout
+    );
+}
+
+#[tokio::test]
+async fn snapshot_and_restore_round_trips_sqlite_state() {
+    // Prove the snapshot/restore story end-to-end: write a row in one
+    // Bash, snapshot, drop it, restore in a fresh Bash, and read the
+    // row back. The flush at command boundary keeps the on-disk image
+    // current, so the snapshot picks up everything.
+    let mut bash = make_bash();
+    bash.exec(r#"sqlite /tmp/snap.sqlite 'CREATE TABLE t(v); INSERT INTO t VALUES ("preserved")'"#)
+        .await
+        .unwrap();
+    let snap = bash.snapshot().expect("snapshot");
+
+    // Brand new Bash, restored from the snapshot. The engine cache is
+    // empty, so the first `sqlite` call re-opens from the VFS — and
+    // sees the row because the previous Bash flushed before snapshot.
+    let mut restored = make_bash();
+    restored.restore_snapshot(&snap).expect("restore");
+    let r = restored
+        .exec(r#"sqlite /tmp/snap.sqlite 'SELECT v FROM t'"#)
+        .await
+        .unwrap();
+    assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout.trim(), "preserved");
+}
+
+#[tokio::test]
 async fn invalid_sql_exit_code_one() {
     let mut bash = make_bash();
     let r = bash

--- a/specs/sqlite-builtin.md
+++ b/specs/sqlite-builtin.md
@@ -127,6 +127,42 @@ mixed mid-statement with `;`.
 `.read` is bounded by `MAX_DOT_READ_DEPTH` (16) to prevent stack overflow
 on self-referential scripts. Tested via `tm_sql_008`.
 
+### Session-scoped engine cache
+
+The `Sqlite` builtin holds an `Arc<Mutex<HashMap<(backend, path),
+Arc<TokioMutex<Option<SqliteEngine>>>>>>` keyed by
+`(SqliteBackend, PathBuf)`. The first `sqlite DB ...` call against a
+file-backed path opens the engine and stores it in the cache; every
+subsequent call locks the per-key `TokioMutex` and reuses the same
+connection. Concurrent calls to the same DB serialise through that
+mutex; calls against different DBs (or different backends) run
+independently.
+
+Consequences worth knowing:
+
+- **Transactions span shell commands.** `BEGIN` in one
+  `bash.exec("sqlite DB ...")` and `COMMIT` in the next now work — the
+  connection lives between calls. Tested by
+  `cached_engine_keeps_in_flight_transaction_across_exec_calls`.
+- **`:memory:` is intentionally NOT cached.** Each invocation against
+  `:memory:` opens a fresh ephemeral engine. Use a VFS path if you
+  want persistence within a single `Bash` lifecycle. Tested by
+  `memory_target_does_not_persist_across_exec_calls`.
+- **Per-call flush is preserved.** After every successful or failing
+  call, the builtin still snapshots/flushes to the VFS. Snapshots
+  taken between exec calls always pick up the latest committed state.
+  Tested by `snapshot_and_restore_round_trips_sqlite_state`.
+- **Lifecycle.** The cache is dropped when the owning `Bash` (which
+  owns the `Sqlite` trait object) drops, taking the engines with it.
+  Each `Bash::builder().sqlite()` produces its own cache, so two
+  parallel `Bash` instances do not cross-contaminate.
+
+Snapshot integration is automatic: because we always flush after every
+exec, the on-disk image (within the VFS) is current at every point a
+caller could legitimately call `bash.snapshot()`. Restore creates a
+fresh `Bash` with an empty cache; the first `sqlite` call re-opens
+the engine from the restored VFS bytes.
+
 ### SQL policy: ATTACH / DETACH and PRAGMA deny list
 
 Before each statement reaches turso, `check_sql_policy()` inspects the


### PR DESCRIPTION
## Summary

PR D — final entry in the post-launch follow-up plan. Adds a session-scoped engine cache to the `sqlite` builtin so connections persist across `bash.exec()` calls. The headline win: `BEGIN` in one call, `COMMIT` in the next, now actually works.

## Why

Before this PR, every `sqlite DB ...` invocation opened a fresh engine from the VFS bytes, ran the SQL, and closed. That meant transactions, prepared statements, and any in-memory state died at command boundary — useless for the most common reason humans use SQLite in scripts.

## How

`Sqlite` gains:

```rust
type CacheKey = (SqliteBackend, PathBuf);
type EngineHandle = Arc<TokioMutex<Option<SqliteEngine>>>;
type EngineCache = Arc<Mutex<HashMap<CacheKey, EngineHandle>>>;
```

- The outer `std::sync::Mutex` is held only briefly for HashMap access.
- The inner `tokio::sync::Mutex` serialises concurrent `sqlite` calls against the same database without losing the cached connection.
- `:memory:` bypasses the cache entirely — each invocation is a fresh ephemeral engine. Pin a VFS path if you want persistence.
- The cache is dropped when the owning `Bash` drops, taking the engines with it. Two parallel `Bash` instances do not cross-contaminate.

The per-call flush is preserved: after every call we snapshot/flush to the VFS, so the on-disk image is current at every point a caller could legitimately call `bash.snapshot()`.

## Snapshot/restore

Automatic — because flush happens after every exec, the VFS file is up-to-date at snapshot time. Restore creates a fresh `Bash` with an empty cache; the first `sqlite` call re-opens the engine from the restored VFS bytes. Verified end-to-end by `snapshot_and_restore_round_trips_sqlite_state`.

## Tests

Four new integration tests:

| Test | Asserts |
|---|---|
| `cached_engine_keeps_in_flight_transaction_across_exec_calls` | `BEGIN` in one call survives until `COMMIT` in the next |
| `cached_engine_isolated_per_database_path` | Two DB paths don't collide in the cache |
| `memory_target_does_not_persist_across_exec_calls` | `:memory:` stays ephemeral by design |
| `snapshot_and_restore_round_trips_sqlite_state` | `Bash::snapshot()` between exec calls captures committed state |

All previously-green tests still pass: **2275 lib + 18 integration + 11 security + 8 compat + 19 differential + 4 fuzz + 95 CLI**.

## Spec

`specs/sqlite-builtin.md` has a new "Session-scoped engine cache" section documenting cache shape, lifecycle, transaction semantics, and the `:memory:` carve-out.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --features sqlite -p bashkit --lib` → 2275 passed
- [x] `cargo test --features sqlite -p bashkit --test sqlite_*` → 60 passed (incl. 4 new)
- [x] `cargo vet --locked` succeeds
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_018ERUz5RrSCoZ5Hjku3URK2)_