### PR TITLE
feat(builtins): support clap-backed custom builtins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
         run: |
           cargo run --example basic
           cargo run --example custom_fs
+          cargo run --example clap_builtin
+          cargo run --example clap_builtin_subcommands
           cargo run --example resource_limits
           cargo run --example text_processing
           cargo run --example live_mounts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "clap",
  "criterion",
  "ed25519-dalek 2.2.0",
  "fail",

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -77,6 +77,9 @@ hmac = "0.13"
 # Logging/tracing (optional)
 tracing = { workspace = true, optional = true }
 
+# CLI-style argument parsing for custom builtins.
+clap = { workspace = true, optional = true }
+
 # Embedded Python interpreter (optional)
 monty = { git = "https://github.com/pydantic/monty", rev = "2e9df4b", optional = true }
 
@@ -88,7 +91,9 @@ zapcode-core = { version = "1.5", optional = true }
 turso_core = { workspace = true, optional = true }
 
 [features]
-default = []
+default = ["clap-builtins"]
+# Enable `ClapBuiltin` for custom builtins with `#[derive(clap::Parser)]`.
+clap-builtins = ["dep:clap"]
 # Enable jq builtin via embedded jaq interpreter
 # Usage: cargo build --features jq
 jq = ["dep:jaq-core", "dep:jaq-std", "dep:jaq-json"]

--- a/crates/bashkit/docs/custom_builtins.md
+++ b/crates/bashkit/docs/custom_builtins.md
@@ -7,6 +7,7 @@ virtual filesystem.
 
 **See also:**
 - [API Documentation](https://docs.rs/bashkit) - Full API reference
+- [Clap Builtins](../../../docs/clap-builtins.md) - Derive parser structs for custom builtin args
 - [Hooks](./hooks.md) - Interceptor hooks for the execution pipeline
 - [Compatibility Reference](./compatibility.md) - Supported bash features
 - [Threat Model](./threat-model.md) - Security considerations
@@ -121,6 +122,11 @@ Arguments are passed as a slice of strings, excluding the command name itself:
 // For "mycommand arg1 arg2", ctx.args = ["arg1", "arg2"]
 let first_arg = ctx.args.first().map(|s| s.as_str()).unwrap_or("default");
 ```
+
+For custom builtins with richer flags, options, or subcommands, enable the
+default `clap-builtins` feature and implement `ClapBuiltin` with a
+`#[derive(clap::Parser)]` argument type. See the `clap_builtins_guide` rustdoc
+module for tested examples.
 
 ### Environment Variables
 

--- a/crates/bashkit/examples/clap_builtin.rs
+++ b/crates/bashkit/examples/clap_builtin.rs
@@ -1,0 +1,54 @@
+//! Clap-backed custom builtin example.
+//!
+//! Run with: cargo run --example clap_builtin
+
+use async_trait::async_trait;
+use bashkit::clap::Parser;
+use bashkit::{Bash, BashkitContext, ClapBuiltin};
+
+#[derive(Parser)]
+#[command(name = "greet", about = "Print a greeting")]
+struct GreetArgs {
+    #[arg(short, long, default_value = "World")]
+    name: String,
+
+    #[arg(short, long)]
+    shout: bool,
+}
+
+struct Greet;
+
+#[async_trait]
+impl ClapBuiltin for Greet {
+    type Args = GreetArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        let greeting = format!("Hello, {}!", args.name);
+        let greeting = if args.shout {
+            greeting.to_uppercase()
+        } else {
+            greeting
+        };
+        ctx.write_stdout(format!("{greeting}\n"));
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut bash = Bash::builder().builtin("greet", Box::new(Greet)).build();
+
+    let result = bash.exec("greet --name Alice --shout").await?;
+    assert_eq!(result.stdout, "HELLO, ALICE!\n");
+    print!("{}", result.stdout);
+
+    let help = bash.exec("greet --help").await?;
+    assert_eq!(help.exit_code, 0);
+    assert!(help.stdout.contains("Usage: greet"));
+
+    Ok(())
+}

--- a/crates/bashkit/examples/clap_builtin_subcommands.rs
+++ b/crates/bashkit/examples/clap_builtin_subcommands.rs
@@ -1,0 +1,63 @@
+//! Clap-backed custom builtin with subcommands.
+//!
+//! Run with: cargo run --example clap_builtin_subcommands
+
+use async_trait::async_trait;
+use bashkit::clap::{Parser, Subcommand};
+use bashkit::{Bash, BashkitContext, ClapBuiltin};
+
+#[derive(Parser)]
+#[command(name = "kv", about = "Small key-value command")]
+struct KvArgs {
+    #[command(subcommand)]
+    command: KvCommand,
+}
+
+#[derive(Subcommand)]
+enum KvCommand {
+    Get { key: String },
+    Set { key: String, value: String },
+}
+
+struct Kv;
+
+#[async_trait]
+impl ClapBuiltin for Kv {
+    type Args = KvArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        match args.command {
+            KvCommand::Get { key } => {
+                let value = ctx
+                    .variables()
+                    .get(&format!("KV_{key}"))
+                    .cloned()
+                    .unwrap_or_default();
+                ctx.write_stdout(format!("{value}\n"));
+            }
+            KvCommand::Set { key, value } => {
+                ctx.variables().insert(format!("KV_{key}"), value);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut bash = Bash::builder().builtin("kv", Box::new(Kv)).build();
+
+    let result = bash.exec("kv set color blue && kv get color").await?;
+    assert_eq!(result.stdout, "blue\n");
+    print!("{}", result.stdout);
+
+    let bad = bash.exec("kv delete color").await?;
+    assert_eq!(bad.exit_code, 2);
+    assert!(bad.stderr.contains("unrecognized subcommand"));
+
+    Ok(())
+}

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -233,6 +233,8 @@ pub(crate) use sqlite::SqliteInprocessOptIn;
 pub use sqlite::{Sqlite, SqliteBackend, SqliteLimits};
 
 use async_trait::async_trait;
+#[cfg(feature = "clap-builtins")]
+use clap::{CommandFactory, FromArgMatches};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -656,6 +658,230 @@ pub trait Builtin: Send + Sync {
     fn llm_hint(&self) -> Option<&'static str> {
         None
     }
+}
+
+/// Trait for custom builtins that parse arguments with [`clap`].
+///
+/// Implement this trait when a builtin has enough flags/options that deriving a
+/// `clap::Parser` struct is clearer than manually inspecting [`Context::args`].
+///
+/// Enabled by the default `clap-builtins` crate feature.
+///
+/// # Example
+///
+/// ```rust
+/// use bashkit::{Bash, BashkitContext, ClapBuiltin, async_trait};
+/// use bashkit::clap::Parser;
+///
+/// #[derive(Parser)]
+/// #[command(name = "greet")]
+/// struct GreetArgs {
+///     #[arg(short, long, default_value = "World")]
+///     name: String,
+/// }
+///
+/// struct Greet;
+///
+/// #[async_trait]
+/// impl ClapBuiltin for Greet {
+///     type Args = GreetArgs;
+///
+///     async fn execute_clap(
+///         &self,
+///         args: Self::Args,
+///         ctx: &mut BashkitContext<'_>,
+///     ) -> bashkit::Result<()> {
+///         ctx.write_stdout(format!("Hello, {}!\n", args.name));
+///         Ok(())
+///     }
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// let mut bash = Bash::builder()
+///     .builtin("greet", Box::new(Greet))
+///     .build();
+/// let result = bash.exec("greet --name Alice").await?;
+/// assert_eq!(result.stdout, "Hello, Alice!\n");
+/// # Ok(())
+/// # }
+/// ```
+#[async_trait]
+#[cfg(feature = "clap-builtins")]
+pub trait ClapBuiltin: Send + Sync {
+    /// Clap parser type for this builtin's arguments.
+    type Args: clap::Parser + Send + 'static;
+
+    /// Execute the builtin with already-parsed clap arguments.
+    async fn execute_clap(&self, args: Self::Args, ctx: &mut BashkitContext<'_>) -> Result<()>;
+
+    /// Optional short hint for LLM system prompts.
+    fn llm_hint(&self) -> Option<&'static str> {
+        None
+    }
+}
+
+/// Mutable execution context for [`ClapBuiltin`] implementations.
+///
+/// This context keeps clap-backed builtins close to normal CLI code: handlers
+/// write to stdout/stderr, set an exit code when needed, and return
+/// `bashkit::Result<()>` for fatal host-side errors.
+#[cfg(feature = "clap-builtins")]
+pub struct BashkitContext<'a> {
+    inner: Context<'a>,
+
+    /// Captured stdout for this builtin invocation.
+    pub stdout: String,
+
+    /// Captured stderr for this builtin invocation.
+    pub stderr: String,
+
+    /// Exit code for this builtin invocation.
+    pub exit_code: i32,
+}
+
+#[cfg(feature = "clap-builtins")]
+impl<'a> BashkitContext<'a> {
+    fn new(inner: Context<'a>) -> Self {
+        Self {
+            inner,
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: 0,
+        }
+    }
+
+    fn into_exec_result(self) -> ExecResult {
+        ExecResult {
+            stdout: self.stdout,
+            stderr: self.stderr,
+            exit_code: self.exit_code,
+            ..Default::default()
+        }
+    }
+
+    /// Original shell words passed to the builtin, after shell expansion.
+    pub fn raw_args(&self) -> &[String] {
+        self.inner.args
+    }
+
+    /// Environment variables visible to this builtin.
+    pub fn env(&self) -> &HashMap<String, String> {
+        self.inner.env
+    }
+
+    /// Mutable shell variables.
+    pub fn variables(&mut self) -> &mut HashMap<String, String> {
+        self.inner.variables
+    }
+
+    /// Current working directory.
+    pub fn cwd(&self) -> &Path {
+        self.inner.cwd
+    }
+
+    /// Mutable current working directory.
+    pub fn cwd_mut(&mut self) -> &mut PathBuf {
+        self.inner.cwd
+    }
+
+    /// Virtual filesystem for this shell.
+    pub fn fs(&self) -> Arc<dyn FileSystem> {
+        Arc::clone(&self.inner.fs)
+    }
+
+    /// Pipeline stdin, if the builtin is invoked after a pipe.
+    pub fn stdin(&self) -> Option<&str> {
+        self.inner.stdin
+    }
+
+    /// Look up a typed per-execution extension, if present.
+    pub fn execution_extension<T>(&self) -> Option<&T>
+    where
+        T: Send + Sync + 'static,
+    {
+        self.inner.execution_extension::<T>()
+    }
+
+    /// Append text to stdout.
+    pub fn write_stdout(&mut self, output: impl AsRef<str>) {
+        self.stdout.push_str(output.as_ref());
+    }
+
+    /// Append text to stderr.
+    pub fn write_stderr(&mut self, output: impl AsRef<str>) {
+        self.stderr.push_str(output.as_ref());
+    }
+
+    /// Set the command exit code.
+    pub fn set_exit_code(&mut self, exit_code: i32) {
+        self.exit_code = exit_code;
+    }
+
+    /// Append stderr text and set a failing exit code.
+    pub fn fail(&mut self, stderr: impl AsRef<str>, exit_code: i32) {
+        self.write_stderr(stderr);
+        self.set_exit_code(exit_code);
+    }
+}
+
+#[async_trait]
+#[cfg(feature = "clap-builtins")]
+impl<T> Builtin for T
+where
+    T: ClapBuiltin,
+{
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        let mut command = <T::Args as CommandFactory>::command().color(clap::ColorChoice::Never);
+        let command_name = command.get_name().to_string();
+        let argv = std::iter::once(command_name).chain(ctx.args.iter().cloned());
+
+        let mut matches = match command.try_get_matches_from_mut(argv) {
+            Ok(matches) => matches,
+            Err(error) => return Ok(clap_error_to_exec_result(error)),
+        };
+        let args = match <T::Args as FromArgMatches>::from_arg_matches_mut(&mut matches) {
+            Ok(args) => args,
+            Err(error) => return Ok(clap_error_to_exec_result(error)),
+        };
+
+        let mut ctx = BashkitContext::new(ctx);
+        self.execute_clap(args, &mut ctx).await?;
+        Ok(ctx.into_exec_result())
+    }
+
+    fn llm_hint(&self) -> Option<&'static str> {
+        ClapBuiltin::llm_hint(self)
+    }
+}
+
+#[cfg(feature = "clap-builtins")]
+fn clap_error_to_exec_result(error: clap::Error) -> ExecResult {
+    let text = error.to_string();
+    if matches!(
+        error.kind(),
+        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+    ) {
+        return ExecResult::ok(text);
+    }
+
+    ExecResult::err(cap_diagnostic(text, 1024), error.exit_code())
+}
+
+#[cfg(feature = "clap-builtins")]
+fn cap_diagnostic(mut text: String, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text;
+    }
+
+    let cut = text
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .take_while(|idx| *idx <= max_bytes)
+        .last()
+        .unwrap_or(0);
+    text.truncate(cut);
+    text
 }
 
 #[async_trait]

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -437,7 +437,11 @@ pub mod trace;
 pub use async_trait::async_trait;
 pub use builtins::git::GitConfig;
 pub use builtins::ssh::{SshAllowlist, SshConfig, TrustedHostKey};
+#[cfg(feature = "clap-builtins")]
+pub use builtins::{BashkitContext, ClapBuiltin};
 pub use builtins::{Builtin, Context as BuiltinContext, ExecutionExtensions};
+#[cfg(feature = "clap-builtins")]
+pub use clap;
 #[cfg(feature = "http_client")]
 pub use credential::Credential;
 pub use error::{Error, Result};
@@ -2769,6 +2773,20 @@ pub mod credential_injection_guide {}
 /// **Related:** [`BashBuilder::builtin`], [`compatibility_scorecard`]
 #[doc = include_str!("../docs/custom_builtins.md")]
 pub mod custom_builtins_guide {}
+
+/// Public guide for clap-backed custom builtins.
+///
+/// This guide covers:
+/// - Enabling or disabling the default `clap-builtins` feature
+/// - Implementing [`ClapBuiltin`] with `#[derive(clap::Parser)]`
+/// - Writing stdout/stderr through [`BashkitContext`]
+/// - Help, version, and parse-error behavior
+/// - Subcommands and pipeline stdin
+///
+/// **Related:** [`ClapBuiltin`], [`BashkitContext`], [`BashBuilder::builtin`], [`custom_builtins_guide`]
+#[cfg(feature = "clap-builtins")]
+#[doc = include_str!("../../../docs/clap-builtins.md")]
+pub mod clap_builtins_guide {}
 
 /// Bash compatibility scorecard.
 ///

--- a/crates/bashkit/tests/custom_builtins_tests.rs
+++ b/crates/bashkit/tests/custom_builtins_tests.rs
@@ -4,6 +4,11 @@
 
 use async_trait::async_trait;
 use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, FileSystem, InMemoryFs};
+#[cfg(feature = "clap-builtins")]
+use bashkit::{
+    BashkitContext, ClapBuiltin,
+    clap::{Parser, Subcommand},
+};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -96,6 +101,83 @@ impl Builtin for EnvDumper {
     }
 }
 
+#[cfg(feature = "clap-builtins")]
+#[derive(Parser)]
+#[command(name = "hello-clap", about = "greet someone")]
+struct HelloClapArgs {
+    #[arg(short, long, default_value = "World")]
+    name: String,
+
+    #[arg(short, long)]
+    shout: bool,
+}
+
+#[cfg(feature = "clap-builtins")]
+struct HelloClap;
+
+#[async_trait]
+#[cfg(feature = "clap-builtins")]
+impl ClapBuiltin for HelloClap {
+    type Args = HelloClapArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        let greeting = format!("Hello, {}!", args.name);
+        let greeting = if args.shout {
+            greeting.to_uppercase()
+        } else {
+            greeting
+        };
+        ctx.write_stdout(format!("{greeting}\n"));
+        Ok(())
+    }
+}
+
+#[cfg(feature = "clap-builtins")]
+#[derive(Parser)]
+#[command(name = "math-clap")]
+struct MathClapArgs {
+    #[command(subcommand)]
+    command: MathClapCommand,
+}
+
+#[cfg(feature = "clap-builtins")]
+#[derive(Subcommand)]
+enum MathClapCommand {
+    Add { left: i64, right: i64 },
+    Fail { message: String },
+    StdinLen,
+}
+
+#[cfg(feature = "clap-builtins")]
+struct MathClap;
+
+#[async_trait]
+#[cfg(feature = "clap-builtins")]
+impl ClapBuiltin for MathClap {
+    type Args = MathClapArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        let value = match args.command {
+            MathClapCommand::Add { left, right } => left + right,
+            MathClapCommand::Fail { message } => {
+                ctx.fail(format!("math-clap: {message}\n"), 7);
+                return Ok(());
+            }
+            MathClapCommand::StdinLen => ctx.stdin().unwrap_or("").len() as i64,
+        };
+        ctx.write_stdout(format!("{value}\n"));
+        Ok(())
+    }
+}
+
 // =============================================================================
 // Basic functionality tests
 // =============================================================================
@@ -129,6 +211,57 @@ async fn test_custom_builtin_no_args() {
 
     let result = bash.exec("prefix").await.unwrap();
     assert_eq!(result.stdout, ">>> \n");
+}
+
+#[tokio::test]
+#[cfg(feature = "clap-builtins")]
+async fn test_custom_builtin_clap_parser() {
+    let mut bash = Bash::builder()
+        .builtin("hello-clap", Box::new(HelloClap))
+        .build();
+
+    let result = bash.exec("hello-clap --name Alice --shout").await.unwrap();
+    assert_eq!(result.stdout, "HELLO, ALICE!\n");
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+#[cfg(feature = "clap-builtins")]
+async fn test_custom_builtin_clap_help_and_errors() {
+    let mut bash = Bash::builder()
+        .builtin("hello-clap", Box::new(HelloClap))
+        .build();
+
+    let help = bash.exec("hello-clap --help").await.unwrap();
+    assert_eq!(help.exit_code, 0);
+    assert!(help.stdout.contains("Usage: hello-clap"));
+    assert!(help.stderr.is_empty());
+
+    let error = bash.exec("hello-clap --unknown").await.unwrap();
+    assert_eq!(error.exit_code, 2);
+    assert!(error.stderr.contains("unexpected argument"));
+    assert!(error.stdout.is_empty());
+}
+
+#[tokio::test]
+#[cfg(feature = "clap-builtins")]
+async fn test_custom_builtin_clap_subcommands_and_stdin() {
+    let mut bash = Bash::builder()
+        .builtin("math-clap", Box::new(MathClap))
+        .build();
+
+    let add = bash.exec("math-clap add 20 22").await.unwrap();
+    assert_eq!(add.stdout, "42\n");
+    assert_eq!(add.exit_code, 0);
+
+    let stdin_len = bash.exec("printf abc | math-clap stdin-len").await.unwrap();
+    assert_eq!(stdin_len.stdout, "3\n");
+    assert_eq!(stdin_len.exit_code, 0);
+
+    let fail = bash.exec("math-clap fail nope").await.unwrap();
+    assert_eq!(fail.stdout, "");
+    assert_eq!(fail.stderr, "math-clap: nope\n");
+    assert_eq!(fail.exit_code, 7);
 }
 
 // =============================================================================

--- a/docs/clap-builtins.md
+++ b/docs/clap-builtins.md
@@ -1,0 +1,151 @@
+# Clap Builtins
+
+`ClapBuiltin` lets Rust applications define custom Bashkit commands with
+`#[derive(clap::Parser)]` argument structs. Handlers receive a
+`BashkitContext` that captures stdout, stderr, and exit code for the virtual
+shell. The feature is enabled by default through `clap-builtins`.
+
+Disable it for a smaller library dependency surface:
+
+```toml
+[dependencies]
+bashkit = { version = "0.3", default-features = false }
+```
+
+Enable it explicitly when default features are off:
+
+```toml
+[dependencies]
+bashkit = { version = "0.3", default-features = false, features = ["clap-builtins"] }
+```
+
+## Basic Usage
+
+```rust
+use bashkit::clap::Parser;
+use bashkit::{Bash, BashkitContext, ClapBuiltin, async_trait};
+
+#[derive(Parser)]
+#[command(name = "greet", about = "Print a greeting")]
+struct GreetArgs {
+    #[arg(short, long, default_value = "World")]
+    name: String,
+
+    #[arg(short, long)]
+    shout: bool,
+}
+
+struct Greet;
+
+#[async_trait]
+impl ClapBuiltin for Greet {
+    type Args = GreetArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        let greeting = format!("Hello, {}!", args.name);
+        let greeting = if args.shout {
+            greeting.to_uppercase()
+        } else {
+            greeting
+        };
+        ctx.write_stdout(format!("{greeting}\n"));
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> bashkit::Result<()> {
+    let mut bash = Bash::builder().builtin("greet", Box::new(Greet)).build();
+
+    let result = bash.exec("greet --name Alice --shout").await?;
+    assert_eq!(result.stdout, "HELLO, ALICE!\n");
+
+    let help = bash.exec("greet --help").await?;
+    assert_eq!(help.exit_code, 0);
+    assert!(help.stdout.contains("Usage: greet"));
+    assert!(help.stderr.is_empty());
+
+    let error = bash.exec("greet --unknown").await?;
+    assert_eq!(error.exit_code, 2);
+    assert!(error.stderr.contains("unexpected argument"));
+    Ok(())
+}
+```
+
+## Subcommands
+
+Use normal clap subcommands for nested command surfaces.
+
+```rust
+use bashkit::clap::{Parser, Subcommand};
+use bashkit::{Bash, BashkitContext, ClapBuiltin, async_trait};
+
+#[derive(Parser)]
+#[command(name = "math")]
+struct MathArgs {
+    #[command(subcommand)]
+    command: MathCommand,
+}
+
+#[derive(Subcommand)]
+enum MathCommand {
+    Add { left: i64, right: i64 },
+    StdinLen,
+}
+
+struct Math;
+
+#[async_trait]
+impl ClapBuiltin for Math {
+    type Args = MathArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        let value = match args.command {
+            MathCommand::Add { left, right } => left + right,
+            MathCommand::StdinLen => ctx.stdin().unwrap_or("").len() as i64,
+        };
+        ctx.write_stdout(format!("{value}\n"));
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> bashkit::Result<()> {
+    let mut bash = Bash::builder().builtin("math", Box::new(Math)).build();
+
+    let sum = bash.exec("math add 20 22").await?;
+    assert_eq!(sum.stdout, "42\n");
+
+    let stdin_len = bash.exec("printf abc | math stdin-len").await?;
+    assert_eq!(stdin_len.stdout, "3\n");
+    Ok(())
+}
+```
+
+## Behavior
+
+- The clap parser receives only the command arguments, not the shell command
+  name from the script.
+- `BashkitContext::write_stdout()` and `write_stderr()` append virtual command
+  output; direct `println!`/`eprintln!` writes to the host process instead.
+- Set non-zero command status with `ctx.set_exit_code(code)` or
+  `ctx.fail(message, code)`.
+- `--help` and `--version` return exit code `0` with clap output on stdout.
+- Parse failures return clap's exit code, usually `2`, with diagnostics on
+  stderr.
+- Diagnostics are capped at 1 KB so custom builtins keep Bashkit's builtin
+  error-output safety guarantees.
+
+## See Also
+
+- [`crates/bashkit/examples/clap_builtin.rs`](../crates/bashkit/examples/clap_builtin.rs)
+- [`crates/bashkit/examples/clap_builtin_subcommands.rs`](../crates/bashkit/examples/clap_builtin_subcommands.rs)
+- [`crates/bashkit/docs/custom_builtins.md`](../crates/bashkit/docs/custom_builtins.md)

--- a/specs/builtins.md
+++ b/specs/builtins.md
@@ -61,6 +61,49 @@ impl Context<'_> {
 }
 ```
 
+### Clap-Backed Custom Builtins
+
+Custom Rust builtins can implement `ClapBuiltin` instead of `Builtin` when
+their arguments are better represented as a `#[derive(clap::Parser)]` struct.
+This API is enabled by the default `clap-builtins` crate feature; consumers
+that need a smaller dependency surface can disable it with
+`default-features = false`.
+The feature is part of the library default feature set, so normal
+`bashkit = "..."` usage can derive clap-backed builtins without extra feature
+configuration.
+Bashkit parses `Context::args` through clap, passes parsed args plus a mutable
+`BashkitContext` to the handler, maps `--help` and `--version` to successful
+stdout results, and maps clap parse failures to stderr with clap's exit code.
+Parse diagnostics are capped to 1 KB to preserve TM-INF-022 stderr constraints.
+
+```rust
+use bashkit::{BashkitContext, ClapBuiltin, async_trait};
+use bashkit::clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "greet")]
+struct GreetArgs {
+    #[arg(short, long, default_value = "World")]
+    name: String,
+}
+
+struct Greet;
+
+#[async_trait]
+impl ClapBuiltin for Greet {
+    type Args = GreetArgs;
+
+    async fn execute_clap(
+        &self,
+        args: Self::Args,
+        ctx: &mut BashkitContext<'_>,
+    ) -> bashkit::Result<()> {
+        ctx.write_stdout(format!("Hello, {}!\n", args.name));
+        Ok(())
+    }
+}
+```
+
 ### Execution Extensions
 
 `Bash::exec_with_extensions()` and `Bash::exec_streaming_with_extensions()`


### PR DESCRIPTION
## What
Adds a default-on `clap-builtins` feature for defining custom Bashkit builtins with `#[derive(clap::Parser)]`, plus `BashkitContext` for virtual stdout/stderr/exit-code output.

## Why
Custom builtins with richer options/subcommands should be able to use clap without manually constructing `ExecResult`.

## How
- Adds feature-gated `ClapBuiltin` and `BashkitContext`
- Re-exports `bashkit::clap` behind the default feature
- Adds integration tests, examples, rustdoc-tested public docs, and spec updates
- Adds CI example runs

## Risk
- Low
- New API is default-on but optional; consumers can disable with `default-features = false`

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
