### PR TITLE
feat(extension): add builtin extension abstraction

### DIFF
--- a/crates/bashkit/docs/custom_builtins.md
+++ b/crates/bashkit/docs/custom_builtins.md
@@ -114,6 +114,39 @@ let result = bash
 assert_eq!(result.stdout, "req-123\n");
 ```
 
+## Extensions
+
+Use an `Extension` when one capability contributes multiple builtins.
+
+```rust,ignore
+use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, Extension, async_trait};
+
+struct Hello;
+
+#[async_trait]
+impl Builtin for Hello {
+    async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        Ok(ExecResult::ok("hello\n".to_string()))
+    }
+}
+
+struct MyExtension;
+
+impl Extension for MyExtension {
+    fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+        vec![("hello".to_string(), Box::new(Hello))]
+    }
+}
+
+let mut bash = Bash::builder().extension(MyExtension).build();
+let result = bash.exec("hello").await?;
+assert_eq!(result.stdout, "hello\n");
+```
+
+The same extension can be added to `BashTool::builder().extension(...)`.
+`TypeScriptExtension` uses this model to register the embedded
+TypeScript/JavaScript builtins.
+
 ### Arguments
 
 Arguments are passed as a slice of strings, excluding the command name itself:

--- a/crates/bashkit/docs/typescript.md
+++ b/crates/bashkit/docs/typescript.md
@@ -32,6 +32,16 @@ assert_eq!(result.stdout, "hello from ZapCode\n");
 # }
 ```
 
+You can also register the same builtins through the extension model:
+
+```rust
+use bashkit::{Bash, TypeScriptExtension};
+
+let bash = Bash::builder()
+    .extension(TypeScriptExtension::default())
+    .build();
+```
+
 ## Usage Patterns
 
 ### Inline Code

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -223,7 +223,7 @@ pub use python::{Python, PythonExternalFnHandler, PythonExternalFns, PythonLimit
 
 #[cfg(feature = "typescript")]
 pub use typescript::{
-    TypeScript, TypeScriptConfig, TypeScriptExternalFnHandler, TypeScriptExternalFns,
+    TypeScriptConfig, TypeScriptExtension, TypeScriptExternalFnHandler, TypeScriptExternalFns,
     TypeScriptLimits,
 };
 
@@ -300,6 +300,19 @@ pub(crate) use crate::interpreter::ShellRef;
 
 // Re-export for use by builtins
 pub use crate::interpreter::BuiltinSideEffect;
+
+/// A bundle of shell capabilities registered together.
+///
+/// Extensions are intended for embedders that want to contribute a family of
+/// builtins as one unit. Builders expand extensions into normal builtin
+/// registrations so command dispatch remains unchanged.
+pub trait Extension: Send + Sync {
+    /// Return builtin commands contributed by this extension.
+    ///
+    /// Later registrations with the same name replace earlier registrations,
+    /// matching [`BashBuilder::builtin`](crate::BashBuilder::builtin).
+    fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)>;
+}
 
 /// Typed, per-execution data exposed to builtin implementations.
 ///

--- a/crates/bashkit/src/builtins/typescript.rs
+++ b/crates/bashkit/src/builtins/typescript.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use zapcode_core::{ResourceLimits, RunResult, Value, VmState, ZapcodeRun};
 
-use super::{Builtin, Context, resolve_path};
+use super::{Builtin, Context, Extension, resolve_path};
 use crate::error::Result;
 use crate::fs::FileSystem;
 use crate::interpreter::ExecResult;
@@ -246,6 +246,94 @@ impl TypeScriptConfig {
     pub fn unsupported_mode_hint(mut self, enable: bool) -> Self {
         self.enable_unsupported_mode_hint = enable;
         self
+    }
+}
+
+/// Extension that registers embedded TypeScript/JavaScript builtins.
+///
+/// Registers `ts` and `typescript`, plus `node`, `deno`, and `bun` when
+/// [`TypeScriptConfig::compat_aliases`] is enabled.
+#[derive(Debug, Clone, Default)]
+pub struct TypeScriptExtension {
+    config: TypeScriptConfig,
+    external_fns: Option<TypeScriptExternalFns>,
+}
+
+impl TypeScriptExtension {
+    /// Create a TypeScript extension with default configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a TypeScript extension with custom configuration.
+    pub fn with_config(config: TypeScriptConfig) -> Self {
+        Self {
+            config,
+            external_fns: None,
+        }
+    }
+
+    /// Create a TypeScript extension with custom resource limits.
+    pub fn with_limits(limits: TypeScriptLimits) -> Self {
+        Self::with_config(TypeScriptConfig::default().limits(limits))
+    }
+
+    /// Create a TypeScript extension with external function handlers.
+    pub fn with_external_handler(
+        limits: TypeScriptLimits,
+        external_fns: Vec<String>,
+        handler: TypeScriptExternalFnHandler,
+    ) -> Self {
+        Self {
+            config: TypeScriptConfig::default().limits(limits),
+            external_fns: Some(TypeScriptExternalFns {
+                names: external_fns,
+                handler,
+            }),
+        }
+    }
+
+    fn make_builtin(&self, cmd_name: &str) -> TypeScript {
+        let builtin = TypeScript::from_config(&self.config, cmd_name);
+        if let Some(external_fns) = &self.external_fns {
+            builtin.with_external_handler(external_fns.names.clone(), external_fns.handler.clone())
+        } else {
+            builtin
+        }
+    }
+}
+
+impl Extension for TypeScriptExtension {
+    fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+        let mut builtins: Vec<(String, Box<dyn Builtin>)> = vec![
+            (
+                "ts".to_string(),
+                Box::new(self.make_builtin("ts")) as Box<dyn Builtin>,
+            ),
+            (
+                "typescript".to_string(),
+                Box::new(self.make_builtin("typescript")) as Box<dyn Builtin>,
+            ),
+        ];
+
+        if self.config.enable_compat_aliases {
+            builtins.extend([
+                (
+                    "node".to_string(),
+                    Box::new(self.make_builtin("node")) as Box<dyn Builtin>,
+                ),
+                (
+                    "deno".to_string(),
+                    Box::new(self.make_builtin("deno")) as Box<dyn Builtin>,
+                ),
+                (
+                    "bun".to_string(),
+                    Box::new(self.make_builtin("bun")) as Box<dyn Builtin>,
+                ),
+            ]);
+        }
+
+        builtins
     }
 }
 

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -439,7 +439,7 @@ pub use builtins::git::GitConfig;
 pub use builtins::ssh::{SshAllowlist, SshConfig, TrustedHostKey};
 #[cfg(feature = "clap-builtins")]
 pub use builtins::{BashkitContext, ClapBuiltin};
-pub use builtins::{Builtin, Context as BuiltinContext, ExecutionExtensions};
+pub use builtins::{Builtin, Context as BuiltinContext, ExecutionExtensions, Extension};
 #[cfg(feature = "clap-builtins")]
 pub use clap;
 #[cfg(feature = "http_client")]
@@ -509,7 +509,8 @@ pub use monty::{ExcType, ExtFunctionResult, MontyException, MontyObject};
 
 #[cfg(feature = "typescript")]
 pub use builtins::{
-    TypeScriptConfig, TypeScriptExternalFnHandler, TypeScriptExternalFns, TypeScriptLimits,
+    TypeScriptConfig, TypeScriptExtension, TypeScriptExternalFnHandler, TypeScriptExternalFns,
+    TypeScriptLimits,
 };
 // Re-export zapcode-core types needed by external handler consumers.
 #[cfg(feature = "typescript")]
@@ -1801,33 +1802,7 @@ impl BashBuilder {
     /// ```
     #[cfg(feature = "typescript")]
     pub fn typescript_with_config(self, config: builtins::TypeScriptConfig) -> Self {
-        let mut builder = self
-            .builtin(
-                "ts",
-                Box::new(builtins::TypeScript::from_config(&config, "ts")),
-            )
-            .builtin(
-                "typescript",
-                Box::new(builtins::TypeScript::from_config(&config, "typescript")),
-            );
-
-        if config.enable_compat_aliases {
-            builder = builder
-                .builtin(
-                    "node",
-                    Box::new(builtins::TypeScript::from_config(&config, "node")),
-                )
-                .builtin(
-                    "deno",
-                    Box::new(builtins::TypeScript::from_config(&config, "deno")),
-                )
-                .builtin(
-                    "bun",
-                    Box::new(builtins::TypeScript::from_config(&config, "bun")),
-                );
-        }
-
-        builder
+        self.extension(builtins::TypeScriptExtension::with_config(config))
     }
 
     /// Enable embedded TypeScript with external function handlers.
@@ -1840,18 +1815,11 @@ impl BashBuilder {
         external_fns: Vec<String>,
         handler: builtins::TypeScriptExternalFnHandler,
     ) -> Self {
-        let config = builtins::TypeScriptConfig::default().limits(limits);
-
-        let make = |cmd_name: &str| {
-            builtins::TypeScript::from_config(&config, cmd_name)
-                .with_external_handler(external_fns.clone(), handler.clone())
-        };
-
-        self.builtin("ts", Box::new(make("ts")))
-            .builtin("typescript", Box::new(make("typescript")))
-            .builtin("node", Box::new(make("node")))
-            .builtin("deno", Box::new(make("deno")))
-            .builtin("bun", Box::new(make("bun")))
+        self.extension(builtins::TypeScriptExtension::with_external_handler(
+            limits,
+            external_fns,
+            handler,
+        ))
     }
 
     /// Register a custom builtin command.
@@ -1892,6 +1860,47 @@ impl BashBuilder {
     /// ```
     pub fn builtin(mut self, name: impl Into<String>, builtin: Box<dyn Builtin>) -> Self {
         self.custom_builtins.insert(name.into(), builtin);
+        self
+    }
+
+    /// Register a capability extension.
+    ///
+    /// Extensions contribute a related set of builtins as one unit. Commands
+    /// registered by an extension follow the same override rules as
+    /// [`BashBuilder::builtin`]: later registrations replace earlier ones with
+    /// the same name.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use bashkit::{Bash, Builtin, BuiltinContext, ExecResult, Extension, async_trait};
+    ///
+    /// struct Hello;
+    ///
+    /// #[async_trait]
+    /// impl Builtin for Hello {
+    ///     async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+    ///         Ok(ExecResult::ok("hello\n".to_string()))
+    ///     }
+    /// }
+    ///
+    /// struct HelloExtension;
+    ///
+    /// impl Extension for HelloExtension {
+    ///     fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+    ///         vec![("hello".to_string(), Box::new(Hello))]
+    ///     }
+    /// }
+    ///
+    /// let bash = Bash::builder().extension(HelloExtension).build();
+    /// ```
+    pub fn extension<E>(mut self, extension: E) -> Self
+    where
+        E: builtins::Extension,
+    {
+        for (name, builtin) in extension.builtins() {
+            self.custom_builtins.insert(name, builtin);
+        }
         self
     }
 
@@ -4349,7 +4358,7 @@ fn
     mod custom_builtins {
         use super::*;
         use crate::builtins::{Builtin, Context};
-        use crate::{ExecResult, ExecutionExtensions};
+        use crate::{ExecResult, ExecutionExtensions, Extension};
         use async_trait::async_trait;
 
         /// A simple custom builtin that outputs a static string
@@ -4518,6 +4527,28 @@ fn
 
             let result = bash.exec("echo foo | upper").await.unwrap();
             assert_eq!(result.stdout, "FOO\n");
+        }
+
+        struct GreetingExtension;
+
+        impl Extension for GreetingExtension {
+            fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+                vec![
+                    ("hello-ext".to_string(), Box::new(Hello)),
+                    ("greet-ext".to_string(), Box::new(Greet)),
+                ]
+            }
+        }
+
+        #[tokio::test]
+        async fn test_extension_registers_multiple_builtins() {
+            let mut bash = Bash::builder().extension(GreetingExtension).build();
+
+            let result = bash.exec("hello-ext").await.unwrap();
+            assert_eq!(result.stdout, "Hello from custom builtin!\n");
+
+            let result = bash.exec("greet-ext Extension").await.unwrap();
+            assert_eq!(result.stdout, "Hello, Extension!\n");
         }
 
         /// A custom builtin with internal state

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -60,13 +60,14 @@
 //! # });
 //! ```
 
-use crate::builtins::Builtin;
+use crate::builtins::{Builtin, Extension};
 use crate::error::Error;
 use crate::{Bash, ExecResult, ExecutionLimits, OutputCallback};
 use async_trait::async_trait;
 use futures_core::Stream;
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -534,6 +535,22 @@ impl BashToolBuilder {
         self
     }
 
+    /// Register a capability extension.
+    ///
+    /// Extensions contribute a related set of builtins as one unit. They will
+    /// be documented in the tool's `help()` output like custom builtins. Later
+    /// registrations with the same name replace earlier registrations during
+    /// shell creation.
+    pub fn extension<E>(mut self, extension: E) -> Self
+    where
+        E: Extension,
+    {
+        for (name, builtin) in extension.builtins() {
+            self.builtins.push((name, Arc::from(builtin)));
+        }
+        self
+    }
+
     /// Enable embedded Python (`python`/`python3` builtins) via Monty interpreter
     /// with default resource limits.
     ///
@@ -556,9 +573,55 @@ impl BashToolBuilder {
             .builtin("python3", Box::new(Python::with_limits(limits)))
     }
 
+    /// Enable embedded TypeScript/JavaScript execution via ZapCode with defaults.
+    ///
+    /// Requires the `typescript` feature flag.
+    #[cfg(feature = "typescript")]
+    pub fn typescript(self) -> Self {
+        self.typescript_with_config(crate::builtins::TypeScriptConfig::default())
+    }
+
+    /// Enable embedded TypeScript with custom resource limits.
+    #[cfg(feature = "typescript")]
+    pub fn typescript_with_limits(self, limits: crate::builtins::TypeScriptLimits) -> Self {
+        self.extension(crate::builtins::TypeScriptExtension::with_limits(limits))
+    }
+
+    /// Enable embedded TypeScript with full configuration control.
+    #[cfg(feature = "typescript")]
+    pub fn typescript_with_config(self, config: crate::builtins::TypeScriptConfig) -> Self {
+        self.extension(crate::builtins::TypeScriptExtension::with_config(config))
+    }
+
+    /// Enable embedded TypeScript with external function handlers.
+    #[cfg(feature = "typescript")]
+    pub fn typescript_with_external_handler(
+        self,
+        limits: crate::builtins::TypeScriptLimits,
+        external_fns: Vec<String>,
+        handler: crate::builtins::TypeScriptExternalFnHandler,
+    ) -> Self {
+        self.extension(crate::builtins::TypeScriptExtension::with_external_handler(
+            limits,
+            external_fns,
+            handler,
+        ))
+    }
+
     /// Build the BashTool
     pub fn build(&self) -> BashTool {
-        let builtin_names: Vec<String> = self.builtins.iter().map(|(n, _)| n.clone()).collect();
+        let mut seen_builtin_names = HashSet::new();
+        let builtin_names: Vec<String> = self
+            .builtins
+            .iter()
+            .filter_map(|(name, _)| {
+                if seen_builtin_names.insert(name) {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         // Collect LLM hints from builtins, deduplicated
         let mut builtin_hints: Vec<String> = self
@@ -1505,6 +1568,91 @@ mod tests {
             sysprompt.contains("mycommand: Processes CSV"),
             "system_prompt should contain the hint"
         );
+    }
+
+    #[tokio::test]
+    async fn test_extension_builtins_in_tool() {
+        use crate::builtins::{Builtin, Extension};
+        use crate::error::Result;
+        use crate::interpreter::ExecResult;
+
+        struct ToolHello;
+
+        #[async_trait]
+        impl Builtin for ToolHello {
+            async fn execute(&self, _ctx: crate::builtins::Context<'_>) -> Result<ExecResult> {
+                Ok(ExecResult::ok("hello from tool extension\n".to_string()))
+            }
+        }
+
+        struct ToolExtension;
+
+        impl Extension for ToolExtension {
+            fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+                vec![(
+                    "tool-hello".to_string(),
+                    Box::new(ToolHello) as Box<dyn Builtin>,
+                )]
+            }
+        }
+
+        let tool = BashTool::builder().extension(ToolExtension).build();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "tool-hello".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout, "hello from tool extension\n");
+        assert!(tool.help().contains("tool-hello"));
+    }
+
+    #[tokio::test]
+    async fn test_tool_extension_duplicate_names_document_once() {
+        use crate::builtins::{Builtin, Extension};
+        use crate::error::Result;
+        use crate::interpreter::ExecResult;
+
+        struct First;
+        struct Second;
+
+        #[async_trait]
+        impl Builtin for First {
+            async fn execute(&self, _ctx: crate::builtins::Context<'_>) -> Result<ExecResult> {
+                Ok(ExecResult::ok("first\n".to_string()))
+            }
+        }
+
+        #[async_trait]
+        impl Builtin for Second {
+            async fn execute(&self, _ctx: crate::builtins::Context<'_>) -> Result<ExecResult> {
+                Ok(ExecResult::ok("second\n".to_string()))
+            }
+        }
+
+        struct OverrideExtension;
+
+        impl Extension for OverrideExtension {
+            fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+                vec![("dup".to_string(), Box::new(Second) as Box<dyn Builtin>)]
+            }
+        }
+
+        let tool = BashTool::builder()
+            .builtin("dup", Box::new(First))
+            .extension(OverrideExtension)
+            .build();
+        let resp = tool
+            .execute(ToolRequest {
+                commands: "dup".to_string(),
+                timeout_ms: None,
+            })
+            .await;
+
+        assert_eq!(resp.stdout, "second\n");
+        assert_eq!(tool.help().matches("`dup`").count(), 1);
     }
 
     #[test]

--- a/crates/bashkit/tests/typescript_security_tests.rs
+++ b/crates/bashkit/tests/typescript_security_tests.rs
@@ -500,7 +500,7 @@ mod whitebox_bash_integration {
 // =============================================================================
 
 mod optin_verification {
-    use bashkit::Bash;
+    use bashkit::{Bash, TypeScriptExtension};
 
     /// TypeScript commands are NOT registered by default
     #[tokio::test]
@@ -547,6 +547,21 @@ mod optin_verification {
         let r = bash.exec("ts -c \"console.log('hi')\"").await.unwrap();
         assert_eq!(r.exit_code, 0, "ts should work after opt-in");
         assert_eq!(r.stdout.trim(), "hi");
+    }
+
+    /// TypeScript can be registered as an extension.
+    #[tokio::test]
+    async fn typescript_extension_registers_aliases() {
+        let mut bash = Bash::builder()
+            .extension(TypeScriptExtension::default())
+            .build();
+
+        let r = bash
+            .exec("typescript -c \"console.log('ok')\"")
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "ok");
     }
 
     /// All aliases available after .typescript()

--- a/docs/builtin_typescript.md
+++ b/docs/builtin_typescript.md
@@ -27,6 +27,16 @@ let r = bash.exec("ts -c \"console.log('hello')\"").await?;
 assert_eq!(r.stdout, "hello\n");
 ```
 
+Or register the TypeScript extension explicitly:
+
+```rust
+use bashkit::{Bash, TypeScriptExtension};
+
+let mut bash = Bash::builder()
+    .extension(TypeScriptExtension::default())
+    .build();
+```
+
 ## Command aliases
 
 Five commands are registered, all running the same ZapCode interpreter:

--- a/specs/builtins.md
+++ b/specs/builtins.md
@@ -104,6 +104,34 @@ impl ClapBuiltin for Greet {
 }
 ```
 
+### Extension Trait
+
+Extensions bundle a related set of builtins so embedders can add one capability
+to `BashBuilder` or `BashToolBuilder` instead of registering each command
+manually.
+
+```rust
+pub trait Extension: Send + Sync {
+    fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)>;
+}
+```
+
+Rules:
+
+- `BashBuilder::extension(ext)` expands each returned builtin into the builder's
+  custom builtin map
+- `BashToolBuilder::extension(ext)` expands each returned builtin into the
+  tool's custom builtin list
+- For `BashBuilder`, later registrations with the same command name override
+  earlier registrations, matching `BashBuilder::builtin`
+- Extensions must construct fresh builtin values or use shared ownership
+  internally; builders may call `builtins()` when configuring reusable tools
+
+Current extension:
+
+- `TypeScriptExtension` registers `ts`/`typescript` and, when enabled by
+  `TypeScriptConfig`, `node`/`deno`/`bun`
+
 ### Execution Extensions
 
 `Bash::exec_with_extensions()` and `Bash::exec_streaming_with_extensions()`

--- a/specs/zapcode-runtime.md
+++ b/specs/zapcode-runtime.md
@@ -45,6 +45,17 @@ let bash = Bash::builder()
     .build();
 ```
 
+The same builtins are provided by `TypeScriptExtension`, which can be added to
+either `BashBuilder` or `BashToolBuilder`:
+
+```rust
+use bashkit::{Bash, TypeScriptExtension};
+
+let bash = Bash::builder()
+    .extension(TypeScriptExtension::default())
+    .build();
+```
+
 The `typescript` feature flag enables compilation; `.typescript()` on the builder
 enables registration. This matches the `python` pattern
 (`Bash::builder().python().build()`).


### PR DESCRIPTION
## What
Adds a public `Extension` trait for grouping contributed builtins, plus builder APIs on `BashBuilder` and `BashToolBuilder` for installing extensions.

## Why
External integrations need a compact abstraction for registering related builtins without introducing a separate registry object. TypeScript is the first built-in example of that model.

## How
- Adds `Extension::builtins()` returning `(name, builtin)` pairs.
- Adds `.extension(...)` to `BashBuilder` and `BashToolBuilder`.
- Reworks TypeScript registration through `TypeScriptExtension` while keeping the existing TypeScript convenience builders.
- Deduplicates tool help text for duplicate extension names while preserving override behavior.
- Updates specs, rustdoc guides, and TypeScript docs with Extension examples.

## Risk
- Low
- Public builder API expands, and custom/extension builtin override order is intentionally preserved.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verification:
- `just pre-pr`
- `cargo clippy -p bashkit --all-targets --features typescript -- -D warnings`
- `cargo test -p bashkit --doc --features http_client,typescript`
- `cargo test -p bashkit --test typescript_security_tests --features typescript optin_verification`
