### PR TITLE
feat(scripted-tool): add ToolDef extension

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -475,7 +475,8 @@ pub use trace::{
 pub use scripted_tool::{
     AsyncToolCallback, CallbackKind, DiscoverTool, DiscoveryMode, ScriptedCommandInvocation,
     ScriptedCommandKind, ScriptedExecutionTrace, ScriptedTool, ScriptedToolBuilder,
-    ScriptingToolSet, ScriptingToolSetBuilder, ToolArgs, ToolCallback, ToolDef,
+    ScriptingToolSet, ScriptingToolSetBuilder, ToolArgs, ToolCallback, ToolDef, ToolDefExtension,
+    ToolDefExtensionBuilder,
 };
 #[cfg(feature = "scripted_tool")]
 pub use tool_def::{AsyncToolExec, SyncToolExec, ToolImpl};

--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -1,429 +1,15 @@
-//! ScriptedTool execution: Tool impl, builtin adapter, documentation helpers.
+//! ScriptedTool execution: Tool impl and documentation helpers.
 
-use super::{
-    CallbackKind, ScriptedCommandInvocation, ScriptedCommandKind, ScriptedExecutionTrace,
-    ScriptedTool, ToolArgs,
-};
+use super::{ScriptedExecutionTrace, ScriptedTool, ToolDefExtension, extension::InvocationLog};
 use crate::Bash;
-use crate::builtins::{Builtin, Context};
-use crate::error::Result;
-use crate::interpreter::ExecResult;
 use crate::tool::{
     Tool, ToolError, ToolExecution, ToolOutputChunk, ToolRequest, ToolResponse, ToolStatus,
     VERSION, localized, tool_output_from_response, tool_request_from_value,
 };
-use crate::tool_def::{parse_flags, usage_from_schema};
+use crate::tool_def::usage_from_schema;
 use async_trait::async_trait;
 use schemars::schema_for;
 use std::sync::{Arc, Mutex};
-
-type InvocationLog = Arc<Mutex<Vec<ScriptedCommandInvocation>>>;
-
-fn push_invocation(
-    log: &InvocationLog,
-    name: &str,
-    kind: ScriptedCommandKind,
-    args: &[String],
-    exit_code: i32,
-) {
-    let mut invocations = log.lock().expect("scripted invocation log poisoned");
-    invocations.push(ScriptedCommandInvocation {
-        name: name.to_string(),
-        kind,
-        args: args.to_vec(),
-        exit_code,
-    });
-}
-
-// ============================================================================
-// ToolBuiltinAdapter — wraps ToolCallback as a Builtin
-// ============================================================================
-
-/// Adapts a [`CallbackKind`] into a [`Builtin`] so the interpreter can execute it.
-/// Parses `--key value` flags from `ctx.args` using the schema for type coercion.
-struct ToolBuiltinAdapter {
-    name: String,
-    description: String,
-    callback: CallbackKind,
-    schema: serde_json::Value,
-    log: InvocationLog,
-    sanitize_errors: bool,
-    dry_run: Option<CallbackKind>,
-}
-
-impl ToolBuiltinAdapter {
-    /// Generate help text from the tool's schema, identical to `help <tool>`.
-    fn help_text(&self) -> String {
-        let mut out = format!("{} - {}\n", self.name, self.description);
-        if let Some(usage) = usage_from_schema(&self.schema) {
-            out.push_str(&format!("Usage: {} {}\n", self.name, usage));
-        }
-        out
-    }
-}
-
-#[async_trait]
-impl Builtin for ToolBuiltinAdapter {
-    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        // Intercept --help before calling the callback — return the same
-        // quality output as `help <tool>` without invoking the callback.
-        // --help takes precedence over --dry-run.
-        if ctx.args.iter().any(|a| a == "--help") {
-            let result = ExecResult::ok(self.help_text());
-            push_invocation(
-                &self.log,
-                &self.name,
-                ScriptedCommandKind::Help,
-                ctx.args,
-                result.exit_code,
-            );
-            return Ok(result);
-        }
-
-        // Intercept --dry-run: validate args without executing the callback.
-        if ctx.args.iter().any(|a| a == "--dry-run") {
-            let stripped: Vec<String> = ctx
-                .args
-                .iter()
-                .filter(|a| a.as_str() != "--dry-run")
-                .cloned()
-                .collect();
-            let exit_result = match parse_flags(&stripped, &self.schema) {
-                Ok(params) => {
-                    if let Some(ref dr) = self.dry_run {
-                        // Custom dry-run handler
-                        let tool_args = ToolArgs {
-                            params,
-                            stdin: ctx.stdin.map(String::from),
-                        };
-                        let cb_result = match dr {
-                            CallbackKind::Sync(cb) => (cb)(&tool_args),
-                            CallbackKind::Async(cb) => (cb)(tool_args).await,
-                        };
-                        match cb_result {
-                            Ok(stdout) => ExecResult::ok(stdout),
-                            Err(msg) => {
-                                if self.sanitize_errors {
-                                    #[cfg(feature = "tracing")]
-                                    tracing::debug!(
-                                        tool = %self.name,
-                                        error = %msg,
-                                        "tool dry-run callback error (sanitized)"
-                                    );
-                                    ExecResult::err(format!("{}: callback failed\n", self.name), 1)
-                                } else {
-                                    ExecResult::err(msg, 1)
-                                }
-                            }
-                        }
-                    } else {
-                        // Default: return structured JSON validation result
-                        let obj = serde_json::json!({
-                            "dry_run": true,
-                            "valid": true,
-                            "tool": self.name,
-                            "params": params,
-                        });
-                        ExecResult::ok(format!(
-                            "{}\n",
-                            serde_json::to_string(&obj).unwrap_or_default()
-                        ))
-                    }
-                }
-                Err(err) => {
-                    let obj = serde_json::json!({
-                        "dry_run": true,
-                        "valid": false,
-                        "tool": self.name,
-                        "error": err,
-                    });
-                    let json = serde_json::to_string(&obj).unwrap_or_default();
-                    ExecResult::err(format!("{json}\n"), 1)
-                }
-            };
-            push_invocation(
-                &self.log,
-                &self.name,
-                ScriptedCommandKind::Tool,
-                ctx.args,
-                exit_result.exit_code,
-            );
-            return Ok(exit_result);
-        }
-
-        let exit_result = match parse_flags(ctx.args, &self.schema) {
-            Ok(params) => {
-                let tool_args = ToolArgs {
-                    params,
-                    stdin: ctx.stdin.map(String::from),
-                };
-
-                let cb_result = match &self.callback {
-                    CallbackKind::Sync(cb) => (cb)(&tool_args),
-                    CallbackKind::Async(cb) => (cb)(tool_args).await,
-                };
-
-                match cb_result {
-                    Ok(stdout) => ExecResult::ok(stdout),
-                    Err(msg) => {
-                        // THREAT[TM-INF-030]: Sanitize callback errors to prevent
-                        // leaking internal details (connection strings, file paths,
-                        // stack traces) in tool output visible to LLM agents.
-                        if self.sanitize_errors {
-                            #[cfg(feature = "tracing")]
-                            tracing::debug!(
-                                tool = %self.name,
-                                error = %msg,
-                                "tool callback error (sanitized)"
-                            );
-                            ExecResult::err(format!("{}: callback failed\n", self.name), 1)
-                        } else {
-                            ExecResult::err(msg, 1)
-                        }
-                    }
-                }
-            }
-            Err(msg) => ExecResult::err(msg, 2),
-        };
-
-        push_invocation(
-            &self.log,
-            &self.name,
-            ScriptedCommandKind::Tool,
-            ctx.args,
-            exit_result.exit_code,
-        );
-        Ok(exit_result)
-    }
-}
-
-// ============================================================================
-// HelpBuiltin — runtime schema introspection
-// ============================================================================
-
-/// Snapshot of a tool definition for the `help` and `discover` builtins.
-#[derive(Clone)]
-struct ToolDefSnapshot {
-    name: String,
-    description: String,
-    input_schema: serde_json::Value,
-    tags: Vec<String>,
-    category: Option<String>,
-}
-
-/// Built-in `help` command for runtime tool schema introspection.
-///
-/// Modes:
-/// - `help --list` — list all tool names + descriptions
-/// - `help <tool>` — human-readable usage
-/// - `help <tool> --json` — machine-readable JSON schema
-struct HelpBuiltin {
-    tools: Vec<ToolDefSnapshot>,
-    log: InvocationLog,
-}
-
-#[async_trait]
-impl Builtin for HelpBuiltin {
-    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        let args = ctx.args;
-
-        let result = if args.is_empty() || (args.len() == 1 && args[0] == "--list") {
-            // List all tools
-            let mut out = String::new();
-            for t in &self.tools {
-                out.push_str(&format!("{:<20} {}\n", t.name, t.description));
-            }
-            ExecResult::ok(out)
-        } else {
-            // Find the tool name (first non-flag arg)
-            let tool_name = args.iter().find(|a| !a.starts_with("--"));
-            let json_mode = args.iter().any(|a| a == "--json");
-
-            let Some(tool_name) = tool_name else {
-                let result =
-                    ExecResult::err("usage: help [--list] [<tool>] [--json]".to_string(), 1);
-                push_invocation(
-                    &self.log,
-                    "help",
-                    ScriptedCommandKind::Help,
-                    args,
-                    result.exit_code,
-                );
-                return Ok(result);
-            };
-
-            let Some(tool) = self.tools.iter().find(|t| t.name == *tool_name) else {
-                let result = ExecResult::err(format!("help: unknown tool: {tool_name}"), 1);
-                push_invocation(
-                    &self.log,
-                    "help",
-                    ScriptedCommandKind::Help,
-                    args,
-                    result.exit_code,
-                );
-                return Ok(result);
-            };
-
-            if json_mode {
-                // Machine-readable JSON output
-                let obj = serde_json::json!({
-                    "name": tool.name,
-                    "description": tool.description,
-                    "input_schema": tool.input_schema,
-                });
-                let json_str = serde_json::to_string_pretty(&obj).unwrap_or_default();
-                ExecResult::ok(format!("{json_str}\n"))
-            } else {
-                // Human-readable output
-                let mut out = format!("{} - {}\n", tool.name, tool.description);
-                if let Some(usage) = usage_from_schema(&tool.input_schema) {
-                    out.push_str(&format!("Usage: {} {}\n", tool.name, usage));
-                }
-                ExecResult::ok(out)
-            }
-        };
-
-        push_invocation(
-            &self.log,
-            "help",
-            ScriptedCommandKind::Help,
-            args,
-            result.exit_code,
-        );
-        Ok(result)
-    }
-}
-
-// ============================================================================
-// DiscoverBuiltin — progressive tool discovery
-// ============================================================================
-
-/// Built-in `discover` command for exploring large tool sets.
-struct DiscoverBuiltin {
-    tools: Vec<ToolDefSnapshot>,
-    log: InvocationLog,
-}
-
-impl DiscoverBuiltin {
-    fn filter_tools(&self, args: &[String]) -> Vec<&ToolDefSnapshot> {
-        if let Some(pos) = args.iter().position(|a| a == "--category") {
-            let cat = args.get(pos + 1).map(|s| s.as_str()).unwrap_or("");
-            return self
-                .tools
-                .iter()
-                .filter(|t| t.category.as_deref() == Some(cat))
-                .collect();
-        }
-
-        if let Some(pos) = args.iter().position(|a| a == "--tag") {
-            let tag = args.get(pos + 1).map(|s| s.as_str()).unwrap_or("");
-            return self
-                .tools
-                .iter()
-                .filter(|t| t.tags.iter().any(|tg| tg == tag))
-                .collect();
-        }
-
-        if let Some(pos) = args.iter().position(|a| a == "--search") {
-            let keyword = args
-                .get(pos + 1)
-                .map(|s| s.to_lowercase())
-                .unwrap_or_default();
-            return self
-                .tools
-                .iter()
-                .filter(|t| {
-                    t.name.to_lowercase().contains(&keyword)
-                        || t.description.to_lowercase().contains(&keyword)
-                })
-                .collect();
-        }
-
-        self.tools.iter().collect()
-    }
-}
-
-#[async_trait]
-impl Builtin for DiscoverBuiltin {
-    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        let args = ctx.args;
-
-        let result = if args.is_empty() {
-            ExecResult::err(
-                "usage: discover --categories | --category <name> | --tag <tag> | --search <keyword> [--json]".to_string(),
-                1,
-            )
-        } else {
-            let json_mode = args.iter().any(|a| a == "--json");
-
-            // --categories
-            if args.iter().any(|a| a == "--categories") {
-                let mut cats: std::collections::BTreeMap<String, usize> =
-                    std::collections::BTreeMap::new();
-                for t in &self.tools {
-                    if let Some(ref cat) = t.category {
-                        *cats.entry(cat.clone()).or_insert(0) += 1;
-                    }
-                }
-                if json_mode {
-                    let arr: Vec<serde_json::Value> = cats
-                        .iter()
-                        .map(|(name, count)| serde_json::json!({"category": name, "count": count}))
-                        .collect();
-                    let json_str =
-                        serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".to_string());
-                    ExecResult::ok(format!("{json_str}\n"))
-                } else {
-                    let mut out = String::new();
-                    for (name, count) in &cats {
-                        let plural = if *count == 1 { "tool" } else { "tools" };
-                        out.push_str(&format!("{name} ({count} {plural})\n"));
-                    }
-                    ExecResult::ok(out)
-                }
-            } else {
-                let filtered = self.filter_tools(args);
-
-                if json_mode {
-                    let arr: Vec<serde_json::Value> = filtered
-                        .iter()
-                        .map(|t| {
-                            let mut obj = serde_json::json!({
-                                "name": t.name,
-                                "description": t.description,
-                            });
-                            if !t.tags.is_empty() {
-                                obj["tags"] = serde_json::json!(t.tags);
-                            }
-                            if let Some(ref cat) = t.category {
-                                obj["category"] = serde_json::json!(cat);
-                            }
-                            obj
-                        })
-                        .collect();
-                    let json_str =
-                        serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".to_string());
-                    ExecResult::ok(format!("{json_str}\n"))
-                } else {
-                    let mut out = String::new();
-                    for t in &filtered {
-                        out.push_str(&format!("{:<20} {}\n", t.name, t.description));
-                    }
-                    ExecResult::ok(out)
-                }
-            }
-        };
-
-        push_invocation(
-            &self.log,
-            "discover",
-            ScriptedCommandKind::Discover,
-            args,
-            result.exit_code,
-        );
-        Ok(result)
-    }
-}
 
 // ============================================================================
 // ScriptedTool — internal helpers
@@ -440,45 +26,10 @@ impl ScriptedTool {
         for (key, value) in &self.env_vars {
             builder = builder.env(key, value);
         }
-        for tool in &self.tools {
-            let name = tool.def.name.clone();
-            let builtin: Box<dyn Builtin> = Box::new(ToolBuiltinAdapter {
-                name: name.clone(),
-                description: tool.def.description.clone(),
-                callback: tool.callback.clone(),
-                schema: tool.def.input_schema.clone(),
-                log: Arc::clone(&log),
-                sanitize_errors: self.sanitize_errors,
-                dry_run: tool.dry_run.clone(),
-            });
-            builder = builder.builtin(name, builtin);
-        }
-
-        // Register the help and discover builtins
-        let snapshots: Vec<ToolDefSnapshot> = self
-            .tools
-            .iter()
-            .map(|t| ToolDefSnapshot {
-                name: t.def.name.clone(),
-                description: t.def.description.clone(),
-                input_schema: t.def.input_schema.clone(),
-                tags: t.def.tags.clone(),
-                category: t.def.category.clone(),
-            })
-            .collect();
-        builder = builder.builtin(
-            "help".to_string(),
-            Box::new(HelpBuiltin {
-                tools: snapshots.clone(),
-                log: Arc::clone(&log),
-            }),
-        );
-        builder = builder.builtin(
-            "discover".to_string(),
-            Box::new(DiscoverBuiltin {
-                tools: snapshots,
-                log,
-            }),
+        builder = builder.extension(
+            ToolDefExtension::from_registered_tools(self.tools.clone())
+                .sanitize_errors(self.sanitize_errors)
+                .with_invocation_log(log),
         );
 
         builder.build()
@@ -696,7 +247,9 @@ impl Tool for ScriptedTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolArgs;
     use crate::ToolDef;
+    use crate::tool_def::parse_flags;
 
     #[test]
     fn test_parse_flags_key_value() {
@@ -800,7 +353,7 @@ mod tests {
                         "id": {"type": "integer"}
                     }
                 })),
-                |_args: &super::ToolArgs| Ok("{\"id\":1}\n".to_string()),
+                |_args: &ToolArgs| Ok("{\"id\":1}\n".to_string()),
             )
             .tool_fn(
                 ToolDef::new("list_orders", "List orders for user").with_schema(
@@ -812,7 +365,7 @@ mod tests {
                         }
                     }),
                 ),
-                |_args: &super::ToolArgs| Ok("[]\n".to_string()),
+                |_args: &ToolArgs| Ok("[]\n".to_string()),
             )
             .build()
     }
@@ -912,7 +465,7 @@ mod tests {
                     "type": "object",
                     "properties": { "id": {"type": "integer"} }
                 })),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .build();
         let sp = tool.system_prompt();
@@ -928,7 +481,7 @@ mod tests {
                     "type": "object",
                     "properties": { "id": {"type": "integer"} }
                 })),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .build();
         let sp = tool.system_prompt();
@@ -943,10 +496,9 @@ mod tests {
 
         let tool = ScriptedTool::builder("test")
             .short_description("test")
-            .tool_fn(
-                ToolDef::new("fail", "Always fails"),
-                |_args: &super::ToolArgs| Err("service error".to_string()),
-            )
+            .tool_fn(ToolDef::new("fail", "Always fails"), |_args: &ToolArgs| {
+                Err("service error".to_string())
+            })
             .build();
         let req = ToolRequest {
             commands: "fail".into(),
@@ -971,29 +523,29 @@ mod tests {
                 ToolDef::new("create_charge", "Create a payment charge")
                     .with_category("payments")
                     .with_tags(&["billing", "write"]),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .tool_fn(
                 ToolDef::new("refund", "Issue a refund")
                     .with_category("payments")
                     .with_tags(&["billing", "write"]),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .tool_fn(
                 ToolDef::new("get_user", "Fetch user by ID")
                     .with_category("users")
                     .with_tags(&["read"]),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .tool_fn(
                 ToolDef::new("delete_user", "Delete a user account")
                     .with_category("users")
                     .with_tags(&["admin", "write"]),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .tool_fn(
                 ToolDef::new("get_inventory", "Check inventory levels").with_category("inventory"),
-                |_args: &super::ToolArgs| Ok("ok\n".to_string()),
+                |_args: &ToolArgs| Ok("ok\n".to_string()),
             )
             .build()
     }
@@ -1152,12 +704,9 @@ mod tests {
     #[tokio::test]
     async fn test_callback_error_sanitized_by_default() {
         let tool = ScriptedTool::builder("api")
-            .tool_fn(
-                ToolDef::new("fail", "Always fails"),
-                |_args: &super::ToolArgs| {
-                    Err("connection failed: postgres://admin:secret@internal-db:5432/prod".into())
-                },
-            )
+            .tool_fn(ToolDef::new("fail", "Always fails"), |_args: &ToolArgs| {
+                Err("connection failed: postgres://admin:secret@internal-db:5432/prod".into())
+            })
             .build();
         let resp = tool
             .execute(ToolRequest {
@@ -1179,12 +728,9 @@ mod tests {
     async fn test_callback_error_unsanitized_when_disabled() {
         let tool = ScriptedTool::builder("api")
             .sanitize_errors(false)
-            .tool_fn(
-                ToolDef::new("fail", "Always fails"),
-                |_args: &super::ToolArgs| {
-                    Err("connection failed: postgres://admin:secret@internal-db:5432/prod".into())
-                },
-            )
+            .tool_fn(ToolDef::new("fail", "Always fails"), |_args: &ToolArgs| {
+                Err("connection failed: postgres://admin:secret@internal-db:5432/prod".into())
+            })
             .build();
         let resp = tool
             .execute(ToolRequest {

--- a/crates/bashkit/src/scripted_tool/extension.rs
+++ b/crates/bashkit/src/scripted_tool/extension.rs
@@ -1,0 +1,552 @@
+// ToolDefExtension centralizes ToolDef-backed builtins so plain Bash and
+// ScriptedTool share the same command, help, discover, dry-run, and trace behavior.
+
+use super::{
+    CallbackKind, RegisteredTool, ScriptedCommandInvocation, ScriptedCommandKind, ToolArgs,
+    ToolDef, ToolImpl,
+};
+use crate::builtins::{Builtin, Context, Extension};
+use crate::error::Result;
+use crate::interpreter::ExecResult;
+use crate::tool_def::{parse_flags, usage_from_schema};
+use async_trait::async_trait;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+pub(crate) type InvocationLog = Arc<Mutex<Vec<ScriptedCommandInvocation>>>;
+
+fn push_invocation(
+    log: &InvocationLog,
+    name: &str,
+    kind: ScriptedCommandKind,
+    args: &[String],
+    exit_code: i32,
+) {
+    let mut invocations = log.lock().expect("tool-def invocation log poisoned");
+    invocations.push(ScriptedCommandInvocation {
+        name: name.to_string(),
+        kind,
+        args: args.to_vec(),
+        exit_code,
+    });
+}
+
+/// Builder for [`ToolDefExtension`].
+pub struct ToolDefExtensionBuilder {
+    tools: Vec<RegisteredTool>,
+    sanitize_errors: bool,
+    invocation_log: InvocationLog,
+}
+
+impl Default for ToolDefExtensionBuilder {
+    fn default() -> Self {
+        Self {
+            tools: Vec::new(),
+            sanitize_errors: true,
+            invocation_log: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ToolDefExtensionBuilder {
+    /// Register a [`ToolImpl`] (definition + exec functions).
+    pub fn tool(mut self, tool: ToolImpl) -> Self {
+        self.tools.push(RegisteredTool::from_tool_impl(tool));
+        self
+    }
+
+    /// Register a tool with its definition and synchronous exec function.
+    pub fn tool_fn(
+        mut self,
+        def: ToolDef,
+        exec: impl Fn(&ToolArgs) -> std::result::Result<String, String> + Send + Sync + 'static,
+    ) -> Self {
+        self.tools.push(RegisteredTool {
+            def,
+            callback: CallbackKind::Sync(Arc::new(exec)),
+            dry_run: None,
+        });
+        self
+    }
+
+    /// Register a sync tool plus a custom `--dry-run` handler.
+    pub fn tool_with_dry_run(
+        mut self,
+        def: ToolDef,
+        exec: impl Fn(&ToolArgs) -> std::result::Result<String, String> + Send + Sync + 'static,
+        dry_run: impl Fn(&ToolArgs) -> std::result::Result<String, String> + Send + Sync + 'static,
+    ) -> Self {
+        self.tools.push(RegisteredTool {
+            def,
+            callback: CallbackKind::Sync(Arc::new(exec)),
+            dry_run: Some(CallbackKind::Sync(Arc::new(dry_run))),
+        });
+        self
+    }
+
+    /// Register a tool with its definition and async exec function.
+    pub fn async_tool_fn<F, Fut>(mut self, def: ToolDef, exec: F) -> Self
+    where
+        F: Fn(ToolArgs) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = std::result::Result<String, String>> + Send + 'static,
+    {
+        self.tools.push(RegisteredTool {
+            def,
+            callback: CallbackKind::Async(Arc::new(move |args| Box::pin(exec(args)))),
+            dry_run: None,
+        });
+        self
+    }
+
+    /// Replace callback errors with generic messages before exposing them to scripts.
+    pub fn sanitize_errors(mut self, sanitize: bool) -> Self {
+        self.sanitize_errors = sanitize;
+        self
+    }
+
+    /// Build the extension.
+    pub fn build(&self) -> ToolDefExtension {
+        ToolDefExtension {
+            tools: self.tools.clone(),
+            sanitize_errors: self.sanitize_errors,
+            invocation_log: Arc::clone(&self.invocation_log),
+        }
+    }
+}
+
+/// Bash extension that registers ToolDef-backed commands plus `help` and `discover`.
+#[derive(Clone)]
+pub struct ToolDefExtension {
+    tools: Vec<RegisteredTool>,
+    sanitize_errors: bool,
+    invocation_log: InvocationLog,
+}
+
+impl ToolDefExtension {
+    /// Create an empty builder.
+    pub fn builder() -> ToolDefExtensionBuilder {
+        ToolDefExtensionBuilder::default()
+    }
+
+    pub(crate) fn from_registered_tools(tools: Vec<RegisteredTool>) -> Self {
+        Self {
+            tools,
+            sanitize_errors: true,
+            invocation_log: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub(crate) fn with_invocation_log(mut self, log: InvocationLog) -> Self {
+        self.invocation_log = log;
+        self
+    }
+
+    /// Control whether callback errors are sanitized.
+    pub fn sanitize_errors(mut self, sanitize: bool) -> Self {
+        self.sanitize_errors = sanitize;
+        self
+    }
+
+    /// Return and clear accumulated command invocation trace entries.
+    pub fn take_invocations(&self) -> Vec<ScriptedCommandInvocation> {
+        let mut invocations = self
+            .invocation_log
+            .lock()
+            .expect("tool-def invocation log poisoned");
+        std::mem::take(&mut *invocations)
+    }
+
+    fn snapshots(&self) -> Vec<ToolDefSnapshot> {
+        self.tools
+            .iter()
+            .map(|t| ToolDefSnapshot {
+                name: t.def.name.clone(),
+                description: t.def.description.clone(),
+                input_schema: t.def.input_schema.clone(),
+                tags: t.def.tags.clone(),
+                category: t.def.category.clone(),
+            })
+            .collect()
+    }
+}
+
+impl Extension for ToolDefExtension {
+    fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)> {
+        let mut builtins: Vec<(String, Box<dyn Builtin>)> = Vec::new();
+        for tool in &self.tools {
+            let name = tool.def.name.clone();
+            builtins.push((
+                name.clone(),
+                Box::new(ToolBuiltinAdapter {
+                    name,
+                    description: tool.def.description.clone(),
+                    callback: tool.callback.clone(),
+                    schema: tool.def.input_schema.clone(),
+                    log: Arc::clone(&self.invocation_log),
+                    sanitize_errors: self.sanitize_errors,
+                    dry_run: tool.dry_run.clone(),
+                }),
+            ));
+        }
+
+        let snapshots = self.snapshots();
+        builtins.push((
+            "help".to_string(),
+            Box::new(HelpBuiltin {
+                tools: snapshots.clone(),
+                log: Arc::clone(&self.invocation_log),
+            }),
+        ));
+        builtins.push((
+            "discover".to_string(),
+            Box::new(DiscoverBuiltin {
+                tools: snapshots,
+                log: Arc::clone(&self.invocation_log),
+            }),
+        ));
+        builtins
+    }
+}
+
+/// Adapts a [`CallbackKind`] into a [`Builtin`] so the interpreter can execute it.
+struct ToolBuiltinAdapter {
+    name: String,
+    description: String,
+    callback: CallbackKind,
+    schema: serde_json::Value,
+    log: InvocationLog,
+    sanitize_errors: bool,
+    dry_run: Option<CallbackKind>,
+}
+
+impl ToolBuiltinAdapter {
+    fn help_text(&self) -> String {
+        let mut out = format!("{} - {}\n", self.name, self.description);
+        if let Some(usage) = usage_from_schema(&self.schema) {
+            out.push_str(&format!("Usage: {} {}\n", self.name, usage));
+        }
+        out
+    }
+}
+
+#[async_trait]
+impl Builtin for ToolBuiltinAdapter {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        if ctx.args.iter().any(|a| a == "--help") {
+            let result = ExecResult::ok(self.help_text());
+            push_invocation(
+                &self.log,
+                &self.name,
+                ScriptedCommandKind::Help,
+                ctx.args,
+                result.exit_code,
+            );
+            return Ok(result);
+        }
+
+        if ctx.args.iter().any(|a| a == "--dry-run") {
+            let stripped: Vec<String> = ctx
+                .args
+                .iter()
+                .filter(|a| a.as_str() != "--dry-run")
+                .cloned()
+                .collect();
+            let exit_result = match parse_flags(&stripped, &self.schema) {
+                Ok(params) => {
+                    if let Some(ref dr) = self.dry_run {
+                        let tool_args = ToolArgs {
+                            params,
+                            stdin: ctx.stdin.map(String::from),
+                        };
+                        let cb_result = match dr {
+                            CallbackKind::Sync(cb) => (cb)(&tool_args),
+                            CallbackKind::Async(cb) => (cb)(tool_args).await,
+                        };
+                        match cb_result {
+                            Ok(stdout) => ExecResult::ok(stdout),
+                            Err(_msg) if self.sanitize_errors => {
+                                #[cfg(feature = "tracing")]
+                                tracing::debug!(
+                                    tool = %self.name,
+                                    error = %_msg,
+                                    "tool dry-run callback error (sanitized)"
+                                );
+                                ExecResult::err(format!("{}: callback failed\n", self.name), 1)
+                            }
+                            Err(msg) => ExecResult::err(msg, 1),
+                        }
+                    } else {
+                        let obj = serde_json::json!({
+                            "dry_run": true,
+                            "valid": true,
+                            "tool": self.name,
+                            "params": params,
+                        });
+                        ExecResult::ok(format!(
+                            "{}\n",
+                            serde_json::to_string(&obj).unwrap_or_default()
+                        ))
+                    }
+                }
+                Err(err) => {
+                    let obj = serde_json::json!({
+                        "dry_run": true,
+                        "valid": false,
+                        "tool": self.name,
+                        "error": err,
+                    });
+                    let json = serde_json::to_string(&obj).unwrap_or_default();
+                    ExecResult::err(format!("{json}\n"), 1)
+                }
+            };
+            push_invocation(
+                &self.log,
+                &self.name,
+                ScriptedCommandKind::Tool,
+                ctx.args,
+                exit_result.exit_code,
+            );
+            return Ok(exit_result);
+        }
+
+        let exit_result = match parse_flags(ctx.args, &self.schema) {
+            Ok(params) => {
+                let tool_args = ToolArgs {
+                    params,
+                    stdin: ctx.stdin.map(String::from),
+                };
+                let cb_result = match &self.callback {
+                    CallbackKind::Sync(cb) => (cb)(&tool_args),
+                    CallbackKind::Async(cb) => (cb)(tool_args).await,
+                };
+                match cb_result {
+                    Ok(stdout) => ExecResult::ok(stdout),
+                    Err(_msg) if self.sanitize_errors => {
+                        #[cfg(feature = "tracing")]
+                        tracing::debug!(
+                            tool = %self.name,
+                            error = %_msg,
+                            "tool callback error (sanitized)"
+                        );
+                        ExecResult::err(format!("{}: callback failed\n", self.name), 1)
+                    }
+                    Err(msg) => ExecResult::err(msg, 1),
+                }
+            }
+            Err(msg) => ExecResult::err(msg, 2),
+        };
+
+        push_invocation(
+            &self.log,
+            &self.name,
+            ScriptedCommandKind::Tool,
+            ctx.args,
+            exit_result.exit_code,
+        );
+        Ok(exit_result)
+    }
+}
+
+#[derive(Clone)]
+struct ToolDefSnapshot {
+    name: String,
+    description: String,
+    input_schema: serde_json::Value,
+    tags: Vec<String>,
+    category: Option<String>,
+}
+
+struct HelpBuiltin {
+    tools: Vec<ToolDefSnapshot>,
+    log: InvocationLog,
+}
+
+#[async_trait]
+impl Builtin for HelpBuiltin {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        let args = ctx.args;
+        let result = if args.is_empty() || (args.len() == 1 && args[0] == "--list") {
+            let mut out = String::new();
+            for t in &self.tools {
+                out.push_str(&format!("{:<20} {}\n", t.name, t.description));
+            }
+            ExecResult::ok(out)
+        } else {
+            let tool_name = args.iter().find(|a| !a.starts_with("--"));
+            let json_mode = args.iter().any(|a| a == "--json");
+
+            let Some(tool_name) = tool_name else {
+                let result =
+                    ExecResult::err("usage: help [--list] [<tool>] [--json]".to_string(), 1);
+                push_invocation(
+                    &self.log,
+                    "help",
+                    ScriptedCommandKind::Help,
+                    args,
+                    result.exit_code,
+                );
+                return Ok(result);
+            };
+
+            let Some(tool) = self.tools.iter().find(|t| t.name == *tool_name) else {
+                let result = ExecResult::err(format!("help: unknown tool: {tool_name}"), 1);
+                push_invocation(
+                    &self.log,
+                    "help",
+                    ScriptedCommandKind::Help,
+                    args,
+                    result.exit_code,
+                );
+                return Ok(result);
+            };
+
+            if json_mode {
+                let obj = serde_json::json!({
+                    "name": tool.name,
+                    "description": tool.description,
+                    "input_schema": tool.input_schema,
+                });
+                let json_str = serde_json::to_string_pretty(&obj).unwrap_or_default();
+                ExecResult::ok(format!("{json_str}\n"))
+            } else {
+                let mut out = format!("{} - {}\n", tool.name, tool.description);
+                if let Some(usage) = usage_from_schema(&tool.input_schema) {
+                    out.push_str(&format!("Usage: {} {}\n", tool.name, usage));
+                }
+                ExecResult::ok(out)
+            }
+        };
+
+        push_invocation(
+            &self.log,
+            "help",
+            ScriptedCommandKind::Help,
+            args,
+            result.exit_code,
+        );
+        Ok(result)
+    }
+}
+
+struct DiscoverBuiltin {
+    tools: Vec<ToolDefSnapshot>,
+    log: InvocationLog,
+}
+
+impl DiscoverBuiltin {
+    fn filter_tools(&self, args: &[String]) -> Vec<&ToolDefSnapshot> {
+        if let Some(pos) = args.iter().position(|a| a == "--category") {
+            let cat = args.get(pos + 1).map(|s| s.as_str()).unwrap_or("");
+            return self
+                .tools
+                .iter()
+                .filter(|t| t.category.as_deref() == Some(cat))
+                .collect();
+        }
+
+        if let Some(pos) = args.iter().position(|a| a == "--tag") {
+            let tag = args.get(pos + 1).map(|s| s.as_str()).unwrap_or("");
+            return self
+                .tools
+                .iter()
+                .filter(|t| t.tags.iter().any(|tg| tg == tag))
+                .collect();
+        }
+
+        if let Some(pos) = args.iter().position(|a| a == "--search") {
+            let keyword = args
+                .get(pos + 1)
+                .map(|s| s.to_lowercase())
+                .unwrap_or_default();
+            return self
+                .tools
+                .iter()
+                .filter(|t| {
+                    t.name.to_lowercase().contains(&keyword)
+                        || t.description.to_lowercase().contains(&keyword)
+                })
+                .collect();
+        }
+
+        self.tools.iter().collect()
+    }
+}
+
+#[async_trait]
+impl Builtin for DiscoverBuiltin {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        let args = ctx.args;
+        let result = if args.is_empty() {
+            ExecResult::err(
+                "usage: discover --categories | --category <name> | --tag <tag> | --search <keyword> [--json]".to_string(),
+                1,
+            )
+        } else {
+            let json_mode = args.iter().any(|a| a == "--json");
+
+            if args.iter().any(|a| a == "--categories") {
+                let mut cats: std::collections::BTreeMap<String, usize> =
+                    std::collections::BTreeMap::new();
+                for t in &self.tools {
+                    if let Some(ref cat) = t.category {
+                        *cats.entry(cat.clone()).or_insert(0) += 1;
+                    }
+                }
+                if json_mode {
+                    let arr: Vec<serde_json::Value> = cats
+                        .iter()
+                        .map(|(name, count)| serde_json::json!({"category": name, "count": count}))
+                        .collect();
+                    let json_str =
+                        serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".to_string());
+                    ExecResult::ok(format!("{json_str}\n"))
+                } else {
+                    let mut out = String::new();
+                    for (name, count) in &cats {
+                        let plural = if *count == 1 { "tool" } else { "tools" };
+                        out.push_str(&format!("{name} ({count} {plural})\n"));
+                    }
+                    ExecResult::ok(out)
+                }
+            } else {
+                let filtered = self.filter_tools(args);
+                if json_mode {
+                    let arr: Vec<serde_json::Value> = filtered
+                        .iter()
+                        .map(|t| {
+                            let mut obj = serde_json::json!({
+                                "name": t.name,
+                                "description": t.description,
+                            });
+                            if !t.tags.is_empty() {
+                                obj["tags"] = serde_json::json!(t.tags);
+                            }
+                            if let Some(ref cat) = t.category {
+                                obj["category"] = serde_json::json!(cat);
+                            }
+                            obj
+                        })
+                        .collect();
+                    let json_str =
+                        serde_json::to_string_pretty(&arr).unwrap_or_else(|_| "[]".to_string());
+                    ExecResult::ok(format!("{json_str}\n"))
+                } else {
+                    let mut out = String::new();
+                    for t in &filtered {
+                        out.push_str(&format!("{:<20} {}\n", t.name, t.description));
+                    }
+                    ExecResult::ok(out)
+                }
+            }
+        };
+
+        push_invocation(
+            &self.log,
+            "discover",
+            ScriptedCommandKind::Discover,
+            args,
+            result.exit_code,
+        );
+        Ok(result)
+    }
+}

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -128,8 +128,10 @@
 //! the same `Arc<ToolCallback>` instances are reused across `execute()` calls.
 
 mod execute;
+mod extension;
 mod toolset;
 
+pub use extension::{ToolDefExtension, ToolDefExtensionBuilder};
 pub use toolset::{DiscoverTool, DiscoveryMode, ScriptingToolSet, ScriptingToolSetBuilder};
 
 // Re-export foundational types from tool_def (they used to live here).
@@ -1436,6 +1438,36 @@ mod tests {
         assert_eq!(resp.exit_code, 0);
         assert!(resp.stdout.contains("from_impl"));
         assert!(resp.stdout.contains("from_fn"));
+    }
+
+    #[tokio::test]
+    async fn test_tool_def_extension_registers_tools_help_and_discover_in_bash() {
+        let extension = ToolDefExtension::builder()
+            .tool_fn(
+                ToolDef::new("get_user", "Fetch user by ID")
+                    .with_schema(serde_json::json!({
+                        "type": "object",
+                        "properties": { "id": {"type": "integer"} }
+                    }))
+                    .with_category("users")
+                    .with_tags(&["read"]),
+                |args: &ToolArgs| {
+                    let id = args.param_i64("id").ok_or("missing --id")?;
+                    Ok(format!("{{\"id\":{id}}}\n"))
+                },
+            )
+            .build();
+
+        let mut bash = crate::Bash::builder().extension(extension).build();
+        let result = bash
+            .exec("discover --category users\nhelp get_user\nget_user --id 7")
+            .await
+            .expect("extension commands should execute");
+
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("get_user"));
+        assert!(result.stdout.contains("Usage: get_user --id <integer>"));
+        assert!(result.stdout.contains(r#""id":7"#));
     }
 
     // -- Issue #1278: --help flag tests --

--- a/specs/scripted-tool-orchestration.md
+++ b/specs/scripted-tool-orchestration.md
@@ -143,6 +143,32 @@ ScriptedTool::builder("api").tool(tool).build();
 Type aliases for backward compatibility: `ToolCallback = SyncToolExec`,
 `AsyncToolCallback = AsyncToolExec`.
 
+### ToolDefExtension — Bash extension for ToolDef-backed commands
+
+`ToolDefExtension` implements the shared `Extension` trait and registers a group
+of `ToolDef`/callback pairs into any `Bash` instance:
+
+```rust
+let extension = ToolDefExtension::builder()
+    .tool_fn(ToolDef::new("get_user", "Fetch user by ID"), |args| {
+        let id = args.param_i64("id").ok_or("missing --id")?;
+        Ok(format!("{{\"id\":{id}}}\n"))
+    })
+    .build();
+
+let mut bash = Bash::builder().extension(extension).build();
+```
+
+The extension contributes:
+
+- one builtin per registered tool
+- `help` for runtime schema/usage introspection
+- `discover` for category/tag/search discovery
+- `--help`, `--dry-run`, callback error sanitization, and invocation tracing behavior shared with `ScriptedTool`
+
+`ScriptedTool` builds its per-call logic-only shell by installing this extension,
+so plain `Bash` and `ScriptedTool` use one command adapter path.
+
 ### ContextVar propagation (Python)
 
 Python callbacks (both sync and async) automatically see `contextvars.ContextVar`
@@ -427,14 +453,16 @@ Builder API mirrors `ScriptedToolBuilder`: `.tool()`, `.env()`, `.limits()`,
 tool_def.rs          — ToolDef, ToolArgs, ToolImpl, SyncToolExec, AsyncToolExec, parse_flags
 scripted_tool/
 ├── mod.rs           — CallbackKind, ScriptedToolBuilder, ScriptedTool, re-exports from tool_def
-├── execute.rs       — Tool impl, ToolBuiltinAdapter, documentation helpers
+├── extension.rs     — ToolDefExtension, ToolBuiltinAdapter, help/discover builtins
+├── execute.rs       — Tool impl and documentation helpers
 └── toolset.rs       — ScriptingToolSet, ScriptingToolSetBuilder, DiscoveryMode
 ```
 
 Public exports from `lib.rs` (gated by `scripted_tool` feature):
 `ToolDef`, `ToolArgs`, `ToolImpl`, `SyncToolExec`, `AsyncToolExec`,
 `ToolCallback`, `AsyncToolCallback` (aliases), `ScriptedTool`, `ScriptedToolBuilder`,
-`ScriptingToolSet`, `ScriptingToolSetBuilder`, `DiscoverTool`, `DiscoveryMode`.
+`ToolDefExtension`, `ToolDefExtensionBuilder`, `ScriptingToolSet`,
+`ScriptingToolSetBuilder`, `DiscoverTool`, `DiscoveryMode`.
 
 ## Example
 


### PR DESCRIPTION
## What
- Add `ToolDefExtension` for registering `ToolDef`-backed builtins plus `help` and `discover` into `Bash`.
- Port `ScriptedTool` to install `ToolDefExtension` for its per-call logic shell.
- Document the shared extension in the scripted-tool orchestration spec.

## Why
Reuse scripted-tool command and discovery behavior from plain Bash without duplicating adapters, while preserving `ScriptedTool` behavior.

## How
- Extracted tool/help/discover builtin adapters into `scripted_tool::extension`.
- Added builder methods mirroring `ScriptedTool` registration paths.
- Kept trace, sanitization, and dry-run behavior shared through one adapter.
- Added a Bash-level regression test for tool execution, help, and discovery.

## Risk
- Medium
- Refactors scripted-tool command registration; regressions would affect tool execution/help/discover behavior.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered