### PR TITLE
chore(python): bump monty to 49faa4c (0.0.17) and Rust to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Security audit (cargo-audit)
         uses: rustsec/audit-check@v2.0.0
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -38,7 +38,7 @@ jobs:
           ref: ${{ inputs.tag }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
 
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
 
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-path: crates/bashkit-js/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.settings.target }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Verify version matches tag
         run: |
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Wait for crates.io index update
         run: sleep 30

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -73,7 +73,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 
@@ -114,7 +114,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.1
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,8 +2812,8 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.11"
-source = "git+https://github.com/pydantic/monty?rev=2e9df4b#2e9df4b508e8a9ac80f3a6a26ed680242d1f460d"
+version = "0.0.17"
+source = "git+https://github.com/pydantic/monty?rev=49faa4c#49faa4c8ae94490eae286e76259adcc35f64f0a5"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2828,11 +2828,12 @@ dependencies = [
  "num-integer",
  "num-traits",
  "postcard",
- "pyo3-build-config",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_text_size",
  "serde",
+ "serde_json",
  "smallvec",
  "speedate",
  "strum 0.27.2",
@@ -4245,6 +4246,15 @@ dependencies = [
  "unicode-ident",
  "unicode-normalization",
  "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#6ded4bed1651e30b34dd04cdaa50c763036abb0d"
+dependencies = [
+ "bitflags",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -81,7 +81,7 @@ tracing = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 
 # Embedded Python interpreter (optional)
-monty = { git = "https://github.com/pydantic/monty", rev = "2e9df4b", optional = true }
+monty = { git = "https://github.com/pydantic/monty", rev = "49faa4c", optional = true }
 
 # Embedded TypeScript interpreter (optional)
 zapcode-core = { version = "1.5", optional = true }

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -490,10 +490,10 @@ async fn run_python(
     let tracker = LimitedTracker::new(limits);
 
     // Run the synchronous start() phase, then extract collected output.
-    // PrintWriter::Collect is not Send, so we scope it to avoid holding across .await.
+    // PrintWriter::CollectString is not Send, so we scope it to avoid holding across .await.
     let (mut progress, mut buf) = {
         let mut buf = String::new();
-        match runner.start(vec![], tracker, PrintWriter::Collect(&mut buf)) {
+        match runner.start(vec![], tracker, PrintWriter::CollectString(&mut buf)) {
             Ok(p) => (p, buf),
             Err(e) => {
                 return Ok(format_exception_with_output(e, &buf));
@@ -513,7 +513,7 @@ async fn run_python(
                     env,
                 )
                 .await;
-                match os_call.resume(result, PrintWriter::Collect(&mut buf)) {
+                match os_call.resume(result, PrintWriter::CollectString(&mut buf)) {
                     Ok(next) => {
                         progress = next;
                     }
@@ -540,7 +540,7 @@ async fn run_python(
                     ))
                 };
 
-                match call.resume(result, PrintWriter::Collect(&mut buf)) {
+                match call.resume(result, PrintWriter::CollectString(&mut buf)) {
                     Ok(next) => {
                         progress = next;
                     }
@@ -567,7 +567,7 @@ async fn run_python(
                     NameLookupResult::Undefined
                 };
 
-                match lookup.resume(result, PrintWriter::Collect(&mut buf)) {
+                match lookup.resume(result, PrintWriter::CollectString(&mut buf)) {
                     Ok(next) => {
                         progress = next;
                     }

--- a/crates/bashkit/tests/python_integration_tests.rs
+++ b/crates/bashkit/tests/python_integration_tests.rs
@@ -1556,7 +1556,7 @@ mod monty_regressions {
     async fn print_interleaved_with_vfs_ops() {
         let mut bash = bash_python();
         // Print, then VFS write, then print, then VFS read, then print.
-        // Verifies PrintWriter::Collect output is preserved across OsCall suspend/resume.
+        // Verifies PrintWriter::CollectString output is preserved across OsCall suspend/resume.
         let r = bash
             .exec("python3 -c \"from pathlib import Path\nprint('before-write')\nPath('/tmp/inter.txt').write_text('data')\nprint('after-write')\ncontent = Path('/tmp/inter.txt').read_text()\nprint(f'read: {content}')\"")
             .await

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -1592,26 +1592,26 @@ mod python_security_regressions {
 
     /// TM-PY-022: Deeply nested Python expressions caught by Monty depth guard.
     /// Monty v0.0.5 added a parser depth guard (d634706). In debug builds the
-    /// limit is 35; in release builds it's 200. We use a nesting level that
-    /// triggers the Monty guard rather than overflowing the ruff parser stack.
+    /// limit is 30; in release builds it's 200. We use a nesting level that
+    /// stays under the Monty guard rather than overflowing the ruff parser stack.
     #[tokio::test]
     async fn threat_python_deep_nesting_parser() {
         let mut bash = bash_with_python();
-        // 30 levels of nested tuples triggers Monty's depth guard in debug builds
-        // (MAX_NESTING_DEPTH=35) while staying safe for ruff's parser stack.
-        let depth = 30;
+        // 25 levels of nested tuples stays under Monty's depth guard in debug
+        // builds (MAX_NESTING_DEPTH=30) while staying safe for ruff's parser stack.
+        let depth = 25;
         let code = format!(
             "python3 -c \"x = {}1{}\"",
             "(".repeat(depth),
             ",)".repeat(depth)
         );
         let result = bash.exec(&code).await.unwrap();
-        // In debug builds (depth limit 35), 30 nested tuples should succeed.
+        // In debug builds (depth limit 30), 25 nested tuples should succeed.
         // In release builds (depth limit 200), it definitely succeeds.
         // The guard prevents deeper nesting from crashing.
         assert_eq!(
             result.exit_code, 0,
-            "30 levels of nesting should be within parser depth budget"
+            "25 levels of nesting should be within parser depth budget"
         );
     }
 
@@ -1619,7 +1619,7 @@ mod python_security_regressions {
     #[tokio::test]
     async fn threat_python_nesting_at_guard_boundary() {
         let mut bash = bash_with_python();
-        // In debug builds MAX_NESTING_DEPTH=35, so 40 nested statements
+        // In debug builds MAX_NESTING_DEPTH=30, so 40 nested statements
         // should trigger the depth guard and return an error, not crash.
         // In release builds (limit=200) this will succeed, which is fine.
         let depth = 40;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Pinned to avoid same-day rustc releases breaking CI; bump deliberately
 # (also bump dtolnay/rust-toolchain@<version> refs in .github/workflows/*).
-channel = "1.94.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Bump pinned `monty` git rev from `2e9df4b` (0.0.11) to `49faa4c` (0.0.17)
- Bump pinned Rust toolchain to 1.95.0 (required by monty 0.0.17) in `rust-toolchain.toml` and all `dtolnay/rust-toolchain@<ver>` refs across `.github/workflows/*`
- Update `PrintWriter::Collect` → `PrintWriter::CollectString` at four call sites in `crates/bashkit/src/builtins/python.rs` (variant renamed upstream; `Collect` is now `CollectString`, alongside the new `CollectStreams` and `Callback` variants)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` (default features, matches `just check`)
- [x] `cargo test -p bashkit --features python --lib` (2245 passed)
- [x] `cargo test -p bashkit --lib` (2185 passed, default features)
- [x] `cargo test --features python --test python_integration_tests` (129 passed — covers all four renamed `PrintWriter::CollectString` call sites)
- [x] `cargo test --features python --test python_security_tests` (115 passed)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_0194xAENb2L7j9j7awG43jdq)_