### PR TITLE
fix(sqlite): harden pragma policy and db caps

### DIFF
--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -580,6 +580,43 @@ Monty runs directly in the host process. Resource limits (memory, allocations,
 time, recursion) are enforced by Monty's own runtime. All VFS operations are
 bridged through the host process — Python code never touches the real filesystem.
 
+### SQLite Security (TM-SQL-*)
+
+The `sqlite`/`sqlite3` builtins embed Turso's pure-Rust SQLite-compatible engine.
+This is experimental and **opt-in for now**. Library callers must enable the
+`sqlite` feature, register the builtin with `.sqlite()` or `.sqlite_with_limits(...)`,
+and set `BASHKIT_ALLOW_INPROCESS_SQLITE=1` before SQL executes. Without the
+runtime opt-in, registered commands fail closed with a disabled error.
+
+SQLite database files live in Bashkit's virtual filesystem, or in `:memory:`.
+The default backend loads and flushes database bytes through the VFS at command
+boundaries; the VFS backend implements Turso's IO trait over `Arc<dyn FileSystem>`.
+Both paths are tested so SQL cannot intentionally read host files.
+
+| Threat | Attack Example | Mitigation | Status |
+|--------|---------------|------------|--------|
+| BETA engine execution (TM-SQL-001) | `sqlite :memory: 'SELECT 1'` without opt-in | Feature + builder registration + runtime opt-in gate | MITIGATED |
+| Host FS escape (TM-SQL-002) | Open `/etc/passwd` as a database | All paths resolve through Bashkit VFS | MITIGATED |
+| Large SQL input (TM-SQL-003) | Multi-MB SQL script | `max_script_bytes` | MITIGATED |
+| Huge result set (TM-SQL-004) | Query returns millions of rows | `max_rows_per_query` | MITIGATED |
+| Huge DB file (TM-SQL-005) | Load or grow oversized `.sqlite` file | `max_db_bytes` on both backends | MITIGATED |
+| Wall-clock burn (TM-SQL-005a) | Expensive query/CTE | Per-step deadline + interrupt | MITIGATED |
+| Statement flood (TM-SQL-005b) | Millions of `;` statements | `max_statements` | MITIGATED |
+| Binary truncation (TM-SQL-006) | BLOB contains NUL bytes | `Vec<u8>` values, tested round-trip | MITIGATED |
+| CSV injection/escape failure (TM-SQL-007) | Blob/text contains separator | RFC-4180 quoting | MITIGATED |
+| Recursive `.read` (TM-SQL-008) | Script `.read`s itself | `MAX_DOT_READ_DEPTH` | MITIGATED |
+| Cross-database access (TM-SQL-009) | `ATTACH DATABASE '/tmp/x'` | `ATTACH`/`DETACH` rejected by policy | MITIGATED |
+| Dangerous PRAGMAs (TM-SQL-010) | `PRAGMA main."cache_size"=...` | Default `pragma_deny` list, including quoted/schema-qualified names | MITIGATED |
+| Host path errors (TM-SQL-011) | Upstream error includes `/rustc/...` | Sanitizer strips host path annotations | MITIGATED |
+
+Black-box coverage drives `Bash::exec` through
+`tests/sqlite_integration_tests.rs` and `tests/sqlite_security_tests.rs`.
+White-box coverage in `builtins/sqlite/tests.rs` exercises parser, policy,
+formatter, sanitizer, backend, and dot-command internals directly.
+Exploratory probing found and fixed two policy/limit gaps: quoted
+schema-qualified PRAGMAs bypassed the deny list, and VFS-backed databases did
+not honor custom `max_db_bytes` while growing.
+
 ### Git Security (TM-GIT-*)
 
 Optional virtual git operations via the `git` feature. All operations are confined
@@ -744,6 +781,7 @@ All threats use stable IDs in the format `TM-<CATEGORY>-<NUMBER>`:
 | TM-LOG | Logging Security |
 | TM-GIT | Git Security |
 | TM-PY | Python/Monty Security |
+| TM-SQL | SQLite Security |
 | TM-UNI | Unicode Security |
 
 Full threat analysis: [`specs/threat-model.md`][spec]

--- a/crates/bashkit/src/builtins/sqlite/mod.rs
+++ b/crates/bashkit/src/builtins/sqlite/mod.rs
@@ -436,19 +436,28 @@ impl Builtin for Sqlite {
 
                 // Persist to the VFS so snapshots taken between exec()
                 // calls always pick up the latest committed state. We
-                // keep the engine in the cache regardless; the next call
-                // will reuse it (and any in-flight transaction will
-                // continue to see uncommitted state).
+                // keep the engine in the cache unless the snapshot exceeds
+                // the configured cap; an oversized cached image would keep
+                // memory pressure alive across later shell commands.
+                let mut drop_cached_engine = false;
                 match backend {
                     SqliteBackend::Memory => {
-                        if let Some(bytes) = engine.snapshot_bytes()
-                            && let Err(e) = ctx.fs.write_file(path, &bytes).await
-                        {
-                            stderr.push_str(&format!(
-                                "sqlite: persist failed: {}: {e}\n",
-                                path.display()
-                            ));
-                            exit_code = exit_code.max(1);
+                        if let Some(bytes) = engine.snapshot_bytes() {
+                            if bytes.len() > self.limits.max_db_bytes {
+                                stderr.push_str(&format!(
+                                    "sqlite: database file too large after execution ({} bytes; limit {})\n",
+                                    bytes.len(),
+                                    self.limits.max_db_bytes
+                                ));
+                                exit_code = exit_code.max(1);
+                                drop_cached_engine = true;
+                            } else if let Err(e) = ctx.fs.write_file(path, &bytes).await {
+                                stderr.push_str(&format!(
+                                    "sqlite: persist failed: {}: {e}\n",
+                                    path.display()
+                                ));
+                                exit_code = exit_code.max(1);
+                            }
                         }
                     }
                     SqliteBackend::Vfs => {
@@ -457,6 +466,9 @@ impl Builtin for Sqlite {
                             exit_code = exit_code.max(1);
                         }
                     }
+                }
+                if drop_cached_engine {
+                    *guard = None;
                 }
             }
         }
@@ -660,7 +672,7 @@ async fn open_file_engine(
         }
         SqliteBackend::Vfs => {
             let handle = vfs_io::current_handle_or_default();
-            let io = vfs_io::BashkitVfsIO::new(fs.clone(), handle);
+            let io = vfs_io::BashkitVfsIO::new_with_cap(fs.clone(), handle, limits.max_db_bytes);
             let path_str = path.to_string_lossy().into_owned();
             SqliteEngine::open_vfs(io, &path_str)
         }

--- a/crates/bashkit/src/builtins/sqlite/parser.rs
+++ b/crates/bashkit/src/builtins/sqlite/parser.rs
@@ -191,35 +191,105 @@ pub(super) fn pragma_name(sql: &str) -> Option<String> {
     if s.len() < 7 || !s[..6].eq_ignore_ascii_case("pragma") {
         return None;
     }
-    let after = &s[6..];
-    if !after.starts_with(|c: char| c.is_ascii_whitespace()) {
+    let bytes = s.as_bytes();
+    if !starts_sql_separator(bytes, 6) {
         return None;
     }
     // Skip whitespace + optional `main.`/`temp.` schema prefix. We compare
     // the *last* identifier — `PRAGMA main.cache_size = 0` should still be
     // matched as `cache_size`.
-    let after = after.trim_start();
-    let bytes = after.as_bytes();
-    let mut start = 0usize;
-    let mut end = 0usize;
-    while end < bytes.len() {
-        let b = bytes[end];
-        if b.is_ascii_alphanumeric() || b == b'_' {
-            end += 1;
-            continue;
-        }
-        if b == b'.' && end > start {
-            // Schema-qualified PRAGMA — restart name tracking after the dot.
-            end += 1;
-            start = end;
+    let mut i = skip_sql_noise(bytes, 6);
+    let (name, next) = parse_identifier(s, i)?;
+    let mut last = name.to_ascii_lowercase();
+    i = skip_sql_noise(bytes, next);
+    loop {
+        if bytes.get(i) == Some(&b'.') {
+            i = skip_sql_noise(bytes, i + 1);
+            let (name, next) = parse_identifier(s, i)?;
+            last = name.to_ascii_lowercase();
+            i = skip_sql_noise(bytes, next);
             continue;
         }
         break;
     }
-    if end == start {
+    Some(last)
+}
+
+fn starts_sql_separator(bytes: &[u8], i: usize) -> bool {
+    bytes.get(i).is_some_and(|b| b.is_ascii_whitespace())
+        || (bytes.get(i) == Some(&b'/') && bytes.get(i + 1) == Some(&b'*'))
+        || (bytes.get(i) == Some(&b'-') && bytes.get(i + 1) == Some(&b'-'))
+}
+
+fn skip_sql_noise(bytes: &[u8], mut i: usize) -> usize {
+    loop {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+            continue;
+        }
+        return i;
+    }
+}
+
+fn parse_identifier(s: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = s.as_bytes();
+    match bytes.get(start).copied()? {
+        b'"' | b'`' => parse_quoted_identifier(s, start),
+        b'[' => parse_bracket_identifier(s, start),
+        b if b.is_ascii_alphanumeric() || b == b'_' => {
+            let mut end = start + 1;
+            while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'_') {
+                end += 1;
+            }
+            Some((s[start..end].to_string(), end))
+        }
+        _ => None,
+    }
+}
+
+fn parse_quoted_identifier(s: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = s.as_bytes();
+    let quote = bytes[start];
+    let mut out = String::new();
+    let mut i = start + 1;
+    while i < bytes.len() {
+        if bytes[i] == quote {
+            if quote == b'"' && bytes.get(i + 1) == Some(&quote) {
+                out.push('"');
+                i += 2;
+                continue;
+            }
+            return Some((out, i + 1));
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    None
+}
+
+fn parse_bracket_identifier(s: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = s.as_bytes();
+    let mut end = start + 1;
+    while end < bytes.len() && bytes[end] != b']' {
+        end += 1;
+    }
+    if end >= bytes.len() {
         return None;
     }
-    Some(after[start..end].to_ascii_lowercase())
+    Some((s[start + 1..end].to_string(), end + 1))
 }
 
 fn split_args(s: &str) -> Vec<String> {
@@ -420,9 +490,29 @@ mod tests {
     }
 
     #[test]
+    fn pragma_name_handles_quoted_schema_qualified_names() {
+        assert_eq!(
+            pragma_name("PRAGMA main.\"cache_size\" = -1024"),
+            Some("cache_size".into())
+        );
+        assert_eq!(
+            pragma_name("PRAGMA temp.[cache_size]"),
+            Some("cache_size".into())
+        );
+        assert_eq!(
+            pragma_name("PRAGMA main.`cache_size`"),
+            Some("cache_size".into())
+        );
+    }
+
+    #[test]
     fn pragma_name_skips_comments() {
         assert_eq!(
             pragma_name("-- hi\n  /* */ PRAGMA cache_size"),
+            Some("cache_size".into())
+        );
+        assert_eq!(
+            pragma_name("PRAGMA/**/cache_size"),
             Some("cache_size".into())
         );
     }

--- a/crates/bashkit/src/builtins/sqlite/tests.rs
+++ b/crates/bashkit/src/builtins/sqlite/tests.rs
@@ -569,9 +569,16 @@ async fn pragma_cache_size_blocked_by_default() {
 async fn pragma_schema_qualified_match() {
     // Schema-qualified PRAGMAs (e.g. `main.cache_size`) must still hit the
     // deny list — otherwise the policy is trivial to bypass.
-    let r = run(&[":memory:", "PRAGMA main.cache_size = 100"], None).await;
-    assert_eq!(r.exit_code, 1);
-    assert!(r.stderr.contains("PRAGMA cache_size is denied"));
+    for sql in [
+        "PRAGMA main.cache_size = 100",
+        "PRAGMA main.\"cache_size\" = 100",
+        "PRAGMA temp.[cache_size]",
+        "PRAGMA main.`cache_size`",
+    ] {
+        let r = run(&[":memory:", sql], None).await;
+        assert_eq!(r.exit_code, 1, "{sql} stderr: {}", r.stderr);
+        assert!(r.stderr.contains("PRAGMA cache_size is denied"));
+    }
 }
 
 #[tokio::test]
@@ -669,6 +676,34 @@ async fn db_file_too_large_rejected() {
     let r = Sqlite::with_limits(limits).execute(ctx).await.unwrap();
     assert_eq!(r.exit_code, 1);
     assert!(r.stderr.contains("too large"));
+}
+
+#[tokio::test]
+async fn db_growth_beyond_max_rejected_on_both_backends() {
+    for backend in [SqliteBackend::Memory, SqliteBackend::Vfs] {
+        let backend_name = match backend {
+            SqliteBackend::Memory => "memory",
+            SqliteBackend::Vfs => "vfs",
+        };
+        let env = opt_in_env();
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let owned: Vec<String> = [
+            "/tmp/tiny.sqlite".to_string(),
+            "CREATE TABLE t(a); INSERT INTO t VALUES (1)".to_string(),
+        ]
+        .to_vec();
+        let mut variables = HashMap::new();
+        let mut cwd = PathBuf::from("/home/user");
+        let ctx = Context::new_for_test(&owned, &env, &mut variables, &mut cwd, fs, None);
+        let limits = SqliteLimits::default().max_db_bytes(128).backend(backend);
+        let r = Sqlite::with_limits(limits).execute(ctx).await.unwrap();
+        assert_eq!(r.exit_code, 1, "{backend_name} stdout: {}", r.stdout);
+        assert!(
+            r.stderr.contains("too large") || r.stderr.contains("exceeds 128 bytes cap"),
+            "{backend_name} stderr: {}",
+            r.stderr
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/bashkit/src/builtins/sqlite/vfs_io.rs
+++ b/crates/bashkit/src/builtins/sqlite/vfs_io.rs
@@ -39,15 +39,24 @@ pub(super) struct VfsFile {
     path: PathBuf,
     bytes: Mutex<Vec<u8>>,
     dirty: AtomicBool,
+    max_file_bytes: usize,
 }
 
 impl VfsFile {
-    fn new(path: PathBuf, bytes: Vec<u8>) -> Self {
+    fn new(path: PathBuf, bytes: Vec<u8>, max_file_bytes: usize) -> Self {
         Self {
             path,
             bytes: Mutex::new(bytes),
             dirty: AtomicBool::new(false),
+            max_file_bytes,
         }
+    }
+
+    fn cap_error(&self) -> turso_core::LimboError {
+        turso_core::LimboError::InternalError(format!(
+            "sqlite: VFS file exceeds {} bytes cap",
+            self.max_file_bytes
+        ))
     }
 }
 
@@ -95,8 +104,13 @@ impl File for VfsFile {
         c: Completion,
     ) -> turso_core::Result<Completion> {
         let mut buf = lock_bytes(&self.bytes);
-        let pos_usize = pos as usize;
-        let needed = pos_usize + buffer.len();
+        let pos_usize = usize::try_from(pos).map_err(|_| self.cap_error())?;
+        let needed = pos_usize
+            .checked_add(buffer.len())
+            .ok_or_else(|| self.cap_error())?;
+        if needed > self.max_file_bytes {
+            return Err(self.cap_error());
+        }
         if needed > buf.len() {
             buf.resize(needed, 0);
         }
@@ -121,8 +135,12 @@ impl File for VfsFile {
     }
 
     fn truncate(&self, len: u64, c: Completion) -> turso_core::Result<Completion> {
+        let len_usize = usize::try_from(len).map_err(|_| self.cap_error())?;
+        if len_usize > self.max_file_bytes {
+            return Err(self.cap_error());
+        }
         let mut buf = lock_bytes(&self.bytes);
-        buf.resize(len as usize, 0);
+        buf.resize(len_usize, 0);
         self.dirty.store(true, Ordering::Release);
         c.complete(0);
         Ok(c)
@@ -144,23 +162,9 @@ pub(super) struct BashkitVfsIO {
 }
 
 impl BashkitVfsIO {
-    pub(super) fn new(fs: Arc<dyn FileSystem>, handle: Handle) -> Arc<Self> {
-        Arc::new(Self {
-            fs,
-            open_files: Mutex::new(HashMap::new()),
-            handle,
-            max_file_bytes: 256 * 1024 * 1024,
-        })
-    }
-
-    /// Test/admin hook to override the file-size cap.
-    ///
-    /// Currently unused outside of the public crate API but retained as a
-    /// test seam: integration tests that want to exercise the VFS-cap path
-    /// without going through the full builtin can construct an IO with a
-    /// tighter limit here.
-    #[cfg(test)]
-    #[allow(dead_code)]
+    /// Override the file-size cap. The builtin passes
+    /// `SqliteLimits::max_db_bytes` here so both VFS reads and writes share
+    /// the same per-database cap.
     pub(super) fn new_with_cap(
         fs: Arc<dyn FileSystem>,
         handle: Handle,
@@ -256,7 +260,7 @@ impl IO for BashkitVfsIO {
                 Vec::new()
             }
         };
-        let file = Arc::new(VfsFile::new(pb, bytes));
+        let file = Arc::new(VfsFile::new(pb, bytes, cap));
         self.open_files_lock()
             .insert(path.to_string(), file.clone());
         Ok(file as Arc<dyn File>)

--- a/specs/sqlite-builtin.md
+++ b/specs/sqlite-builtin.md
@@ -204,30 +204,30 @@ leading SQL keyword via the parser's lightweight tokeniser
 | TM-SQL-002    | Sandbox escape via host filesystem                  | All paths resolve through `Arc<dyn FileSystem>`; Phase 2 IO is bound to that FS only |
 | TM-SQL-003    | DoS via large SQL input                              | `SqliteLimits::max_script_bytes` (4 MiB default)                        |
 | TM-SQL-004    | DoS via huge result set                              | `SqliteLimits::max_rows_per_query` (1M default)                         |
-| TM-SQL-005    | DoS via huge DB file                                 | `SqliteLimits::max_db_bytes` (256 MiB default) at load time             |
+| TM-SQL-005    | DoS via huge DB file                                 | `SqliteLimits::max_db_bytes` (256 MiB default) at load time and while growing DBs |
 | TM-SQL-005a   | DoS via wall-clock burn (regex-style queries, CTEs)  | `SqliteLimits::max_duration` enforced via per-step deadline + `Statement::interrupt()` |
 | TM-SQL-005b   | DoS via statement-flood (millions of `;`)            | `SqliteLimits::max_statements` checked after splitting                  |
 | TM-SQL-006    | Binary corruption / truncation in BLOB round-trip    | Backed by `Vec<u8>`; tested via `tm_sql_006`                            |
 | TM-SQL-007    | CSV escape failure with separator-bearing blobs      | Per-RFC-4180 quoting; tested via `tm_sql_007`                           |
 | TM-SQL-008    | Stack overflow via recursive `.read`                 | `MAX_DOT_READ_DEPTH` cap; tested via `tm_sql_008`                       |
 | TM-SQL-009    | Cross-database access via `ATTACH`/`DETACH`          | Policy rejects both keywords (case-insensitive, comment-aware); tested via `tm_sql_009` |
-| TM-SQL-010    | DoS / fingerprinting via dangerous PRAGMAs           | `SqliteLimits::pragma_deny` defaults block `cache_size`, `mmap_size`, `page_size`, `max_page_count`, `temp_store_directory`, `data_store_directory`, `compile_options`, `locking_mode`, `shared_cache`; tested via `tm_sql_010` |
+| TM-SQL-010    | DoS / fingerprinting via dangerous PRAGMAs           | `SqliteLimits::pragma_deny` defaults block `cache_size`, `mmap_size`, `page_size`, `max_page_count`, `temp_store_directory`, `data_store_directory`, `compile_options`, `locking_mode`, `shared_cache`; parser handles comments plus quoted/schema-qualified names |
 | TM-SQL-011    | Information leakage via host-side error strings      | `sanitize()` strips ` at /…:N:M` annotations from turso errors          |
 
 ## Test Plan
 
 Coverage lives in four layers (all cited tests are real):
 
-- **Unit** — `crates/bashkit/src/builtins/sqlite/{tests.rs,…}`. 74 cases
-  covering positive flow, every flag, every dot-command, every output
-  mode, opt-in gate, recursion cap, oversize input, and proptest harness
-  for the SQL splitter.
+- **Unit** — `crates/bashkit/src/builtins/sqlite/{tests.rs,…}`. Covers
+  positive flow, every flag, every dot-command, every output mode, opt-in
+  gate, recursion cap, oversize input, parser/policy/sanitizer internals,
+  and the proptest harness for the SQL splitter.
 - **Integration** — `crates/bashkit/tests/sqlite_integration_tests.rs`.
   14 cases driving `Bash::exec` end-to-end (pipelines, redirection, env
   expansion, `.read` of a heredoc-built VFS file, `.dump`/`.read` round
   trip, both backends).
-- **Security** — `crates/bashkit/tests/sqlite_security_tests.rs`. 9 cases,
-  one per TM row above.
+- **Security** — `crates/bashkit/tests/sqlite_security_tests.rs`. Black-box
+  threat-model regression tests for the TM-SQL rows above.
 - **Compatibility** — `crates/bashkit/tests/sqlite_compat_tests.rs`. 8
   parity checks against the sqlite3 shell (separator, CSV escaping,
   `.tables` ordering, `.dump` brackets, PRAGMA round-trip, ORDER/LIMIT,

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -35,6 +35,7 @@ All threats use a stable ID format: `TM-<CATEGORY>-<NUMBER>`
 | TM-CRY | Cryptographic Material Security | Private key handling, zeroization, key lifetime minimization |
 | TM-PY | Python Security | Embedded Python sandbox escape, VFS isolation, resource limits |
 | TM-TS | TypeScript Security | Embedded TypeScript sandbox escape, VFS isolation, resource limits |
+| TM-SQL | SQLite Security | Embedded SQLite sandbox escape, VFS isolation, resource limits |
 | TM-UNI | Unicode Security | Byte-boundary panics, invisible chars, homoglyphs, normalization |
 
 ### Adding New Threats
@@ -1365,6 +1366,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Log injection prevention | TM-LOG-005, TM-LOG-006 | `logging.rs` | Yes |
 | Log value truncation | TM-LOG-007, TM-LOG-008 | `logging.rs` | Yes |
 | Python resource limits | TM-PY-001 to TM-PY-003 | `builtins/python.rs` | Yes |
+| SQLite opt-in and limits | TM-SQL-001 to TM-SQL-011 | `builtins/sqlite/` | Yes |
 | Path char validation (bidi) | TM-DOS-015, TM-UNI-003, TM-UNI-011 | `fs/limits.rs` | Partial (bidi yes, zero-width/tags no) |
 | Builtin panic catching | TM-INT-001, TM-UNI-001, TM-UNI-002, TM-UNI-015, TM-UNI-016, TM-UNI-017 | `interpreter/mod.rs` | Yes (catch_unwind) |
 
@@ -1815,6 +1817,63 @@ ZapCode blocks these at the language level (not just runtime):
 This means `console.log()` output produced *after* a VFS call (external
 function) is not captured. Use the return-value pattern instead — the last
 expression's value is printed. This is a `zapcode-core` API limitation.
+
+---
+
+## SQLite Security (TM-SQL)
+
+> **Experimental and opt-in for now.** The `sqlite`/`sqlite3` builtins embed
+> Turso's pure-Rust SQLite-compatible engine. Library callers must compile
+> the `sqlite` feature, register the builtin with `.sqlite()` or
+> `.sqlite_with_limits(...)`, and set `BASHKIT_ALLOW_INPROCESS_SQLITE=1`
+> before SQL executes. Without the runtime opt-in, registered commands fail
+> closed with a disabled error.
+
+Bashkit runs SQLite in-process against databases stored in the virtual
+filesystem or `:memory:`. The default backend loads and flushes whole database
+files through the VFS; the VFS backend implements Turso's `IO` trait over
+`Arc<dyn FileSystem>`. Neither backend intentionally touches the host
+filesystem.
+
+### Threats
+
+| ID | Threat | Severity | Mitigation | Test |
+|----|--------|----------|------------|------|
+| TM-SQL-001 | Code execution via BETA upstream | Critical | Cargo feature + builder registration + runtime opt-in gate | `tm_sql_001_default_disabled_without_opt_in` |
+| TM-SQL-002 | Sandbox escape via host filesystem | Critical | DB files, `.read`, and VFS backend paths resolve through `Arc<dyn FileSystem>` | `tm_sql_002_paths_resolve_only_to_vfs`, `tm_sql_002b_vfs_backend_isolated_to_bash_fs` |
+| TM-SQL-003 | DoS via large SQL input | High | `SqliteLimits::max_script_bytes` | `tm_sql_003_oversize_script_rejected` |
+| TM-SQL-004 | DoS via huge result set | High | `SqliteLimits::max_rows_per_query` | `tm_sql_004_oversize_result_set_aborts` |
+| TM-SQL-005 | DoS via huge DB file | High | `SqliteLimits::max_db_bytes` on load and while growing DBs on both backends | `tm_sql_005_oversize_db_file_rejected`, `db_growth_beyond_max_rejected_on_both_backends` |
+| TM-SQL-005a | DoS via wall-clock burn | High | Per-step deadline and `Statement::interrupt()` | `deadline_already_expired_aborts_with_timeout` |
+| TM-SQL-005b | DoS via statement flood | Medium | `SqliteLimits::max_statements` after splitting | `too_many_statements_rejected` |
+| TM-SQL-006 | Binary truncation in BLOB round-trip | Medium | Values backed by `Vec<u8>` | `tm_sql_006_null_bytes_in_text_safely_round_trip` |
+| TM-SQL-007 | CSV escape failure with separator-bearing blobs | Medium | RFC-4180 quoting | `tm_sql_007_blob_with_separator_quoted_in_csv` |
+| TM-SQL-008 | Stack overflow via recursive `.read` | High | `MAX_DOT_READ_DEPTH` hard cap | `tm_sql_008_recursive_dot_read_eventually_terminates` |
+| TM-SQL-009 | Cross-database access via `ATTACH`/`DETACH` | High | Case/comment-aware policy rejection | `tm_sql_009_attach_detach_rejected`, `attach_blocked_even_with_leading_comment` |
+| TM-SQL-010 | DoS or fingerprinting via dangerous PRAGMAs | High | `SqliteLimits::pragma_deny` default deny list; policy parser handles comments plus quoted/schema-qualified names | `tm_sql_010_pragma_deny_blocks_resource_knobs`, `pragma_schema_qualified_match` |
+| TM-SQL-011 | Host-side error string disclosure | Medium | `sanitize()` strips host path annotations from Turso errors | Manual exploratory review |
+
+### Test Shape
+
+SQLite coverage intentionally mixes black-box and white-box checks:
+
+- **Black-box**: `tests/sqlite_integration_tests.rs` and
+  `tests/sqlite_security_tests.rs` drive `Bash::exec`, shell parsing,
+  redirection, pipelines, the `sqlite3` alias, opt-in failure, VFS
+  persistence, and policy errors through the public API.
+- **White-box**: `builtins/sqlite/tests.rs` exercises parser splitting,
+  SQL policy sniffing, sanitizer behavior, backend equivalence, formatter
+  modes, resource limits, and dot-command recursion directly inside the
+  module.
+- **Differential/fuzz**: `tests/sqlite_differential_tests.rs`,
+  `tests/sqlite_compat_tests.rs`, and `tests/sqlite_fuzz_tests.rs` compare
+  against host `sqlite3` where available and assert no-panic/no-leak
+  invariants for generated inputs.
+
+Exploratory probing found and fixed two gaps in this section: quoted
+schema-qualified PRAGMAs such as `PRAGMA main."cache_size"` bypassed the deny
+list, and the VFS backend used the default 256 MiB cap instead of the caller's
+custom `max_db_bytes` while allowing growth past the cap.
 
 ---
 


### PR DESCRIPTION
## What
Harden the experimental SQLite builtin after exploratory black-box and white-box testing.

## Why
Exploratory probes found two issues:
- quoted/schema-qualified PRAGMAs like `PRAGMA main."cache_size"` bypassed the deny list
- VFS-backed SQLite databases did not consistently honor custom `max_db_bytes` while growing

SQLite remains opt-in for now.

## How
- Extend PRAGMA policy parsing to handle SQL comments and quoted/bracket/backtick identifiers.
- Enforce `max_db_bytes` during VFS writes/truncates and before memory-backend persistence.
- Drop oversized cached memory engines instead of retaining an over-cap image.
- Update internal and public threat models plus SQLite spec notes.

## Risk
- Medium
- SQLite execution and cached file-backed database persistence can break if Turso emits unexpected IO growth patterns or if callers relied on previously uncapped oversized DB writes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verification:
- `cargo test --features sqlite -p bashkit --lib sqlite`
- `cargo test --features sqlite -p bashkit --test sqlite_security_tests --test sqlite_integration_tests --test sqlite_compat_tests --test sqlite_differential_tests --test sqlite_fuzz_tests`
- `just pre-pr`
- CLI smoke: `cargo run -q -p bashkit-cli -- -c "sqlite :memory: 'PRAGMA main.\"cache_size\"'"`
