### PR TITLE
fix(deps): bump postcss to 8.5.13 in browser example

### DIFF
--- a/examples/browser/package-lock.json
+++ b/examples/browser/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../../crates/bashkit-js": {
       "name": "@everruns/bashkit",
-      "version": "0.1.20",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #27 — moderate-severity advisory [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (PostCSS XSS via unescaped `</style>` in CSS stringify output) flagged on `examples/browser/package-lock.json`.

## Why

`postcss` is pulled in transitively by `vite` (devDependency of the browser example). The vulnerable range is `<8.5.10`; bumping to `8.5.13` clears the audit.

## How

`npm audit fix --package-lock-only` inside `examples/browser/`. No source changes, no app behavior change. The lockfile also picks up the current `@everruns/bashkit` workspace version (`0.3.0`) for the linked local package.

## Test plan

- [x] `npm audit` — `found 0 vulnerabilities`
- [x] postcss resolves to `8.5.13` in the lockfile

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bg1bgH3QhBgUJtfUSsX5xw)_