### PR TITLE
chore(release): prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-04
+
+### Highlights
+
+- **Builtin extension abstraction** — New public `Extension` trait groups related builtins for one-call registration on `BashBuilder`/`BashToolBuilder`. TypeScript registration now flows through `TypeScriptExtension`, and `ScriptedTool` reuses a shared `ToolDefExtension` for its per-call logic shell ([#1515](https://github.com/everruns/bashkit/pull/1515), [#1518](https://github.com/everruns/bashkit/pull/1518)).
+- **Clap-backed custom builtins** — Custom builtins can now be defined declaratively against a `clap` parser, replacing hand-rolled arg parsing for new integrations ([#1514](https://github.com/everruns/bashkit/pull/1514)).
+- **SQLite session engine cache** — The `sqlite` builtin keeps a session-scoped engine alive across `exec()` calls, so transactions and prepared state survive multiple shell invocations within one session ([#1513](https://github.com/everruns/bashkit/pull/1513)).
+- **SQLite hardening follow-up** — PRAGMA policy parsing now handles SQL comments and quoted/bracket/backtick identifiers (closing a `PRAGMA main."cache_size"` bypass), and `max_db_bytes` is enforced consistently across VFS writes/truncates and memory-backend persistence ([#1521](https://github.com/everruns/bashkit/pull/1521)).
+- **Python + toolchain bumps** — Embedded Python (`monty`) bumped to `0.0.17` and Rust toolchain bumped to `1.95.0` across `rust-toolchain.toml` and matching CI workflow refs ([#1520](https://github.com/everruns/bashkit/pull/1520)).
+
+### What's Changed
+
+* bench(sqlite): add Criterion benchmark for sqlite builtin ([#1523](https://github.com/everruns/bashkit/pull/1523)) by @chaliy
+* chore(python): bump monty to 49faa4c (0.0.17) and Rust to 1.95.0 ([#1520](https://github.com/everruns/bashkit/pull/1520)) by @chaliy
+* fix(deps): bump postcss to 8.5.13 in browser example ([#1522](https://github.com/everruns/bashkit/pull/1522)) by @chaliy
+* fix(sqlite): harden pragma policy and db caps ([#1521](https://github.com/everruns/bashkit/pull/1521)) by @chaliy
+* test(ssh): retry live supabase smoke ([#1519](https://github.com/everruns/bashkit/pull/1519)) by @chaliy
+* feat(scripted-tool): add ToolDef extension ([#1518](https://github.com/everruns/bashkit/pull/1518)) by @chaliy
+* feat(sqlite): session-scoped engine cache for transactions across exec() ([#1513](https://github.com/everruns/bashkit/pull/1513)) by @chaliy
+* feat(extension): add builtin extension abstraction ([#1515](https://github.com/everruns/bashkit/pull/1515)) by @chaliy
+* feat(builtins): support clap-backed custom builtins ([#1514](https://github.com/everruns/bashkit/pull/1514)) by @chaliy
+* test(sqlite): add differential tests vs host sqlite3 binary ([#1511](https://github.com/everruns/bashkit/pull/1511)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.3.0...v0.4.0
+
 ## [0.3.0] - 2026-05-02
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.3.0", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.4.0", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",


### PR DESCRIPTION
Minor release bumping `0.3.0` → `0.4.0`.

## Highlights

- **Builtin extension abstraction** — New public `Extension` trait groups related builtins for one-call registration on `BashBuilder`/`BashToolBuilder`. TypeScript registration now flows through `TypeScriptExtension`, and `ScriptedTool` reuses a shared `ToolDefExtension` for its per-call logic shell (#1515, #1518).
- **Clap-backed custom builtins** — Custom builtins can now be defined declaratively against a `clap` parser, replacing hand-rolled arg parsing for new integrations (#1514).
- **SQLite session engine cache** — The `sqlite` builtin keeps a session-scoped engine alive across `exec()` calls, so transactions and prepared state survive multiple shell invocations within one session (#1513).
- **SQLite hardening follow-up** — PRAGMA policy parsing now handles SQL comments and quoted/bracket/backtick identifiers (closing a `PRAGMA main."cache_size"` bypass), and `max_db_bytes` is enforced consistently across VFS writes/truncates and memory-backend persistence (#1521).
- **Python + toolchain bumps** — Embedded Python (`monty`) bumped to `0.0.17` and Rust toolchain bumped to `1.95.0` across `rust-toolchain.toml` and matching CI workflow refs (#1520).

## Files

- `Cargo.toml`, `crates/bashkit-cli/Cargo.toml`, `Cargo.lock` → `0.4.0`
- `crates/bashkit-js/package.json`, `crates/bashkit-js/package-lock.json` → `0.4.0`
- `CHANGELOG.md` — new `[0.4.0] - 2026-05-04` section

On merge, `release.yml` will create the GitHub Release and dispatch the publish workflows for crates.io, PyPI, npm, and Homebrew.

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.3.0...v0.4.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTiBUK5YiumTRtqjogv9A5)_