### PR TITLE
docs(site): publish rustdoc guides

### DIFF
--- a/crates/bashkit/docs/clap-builtins.md
+++ b/crates/bashkit/docs/clap-builtins.md
@@ -133,6 +133,6 @@ async fn main() -> bashkit::Result<()> {
 
 ## See Also
 
-- [`crates/bashkit/examples/clap_builtin.rs`](../crates/bashkit/examples/clap_builtin.rs)
-- [`crates/bashkit/examples/clap_builtin_subcommands.rs`](../crates/bashkit/examples/clap_builtin_subcommands.rs)
-- [`crates/bashkit/docs/custom_builtins.md`](../crates/bashkit/docs/custom_builtins.md)
+- [`crates/bashkit/examples/clap_builtin.rs`](../examples/clap_builtin.rs)
+- [`crates/bashkit/examples/clap_builtin_subcommands.rs`](../examples/clap_builtin_subcommands.rs)
+- [`crates/bashkit/docs/custom_builtins.md`](./custom_builtins.md)

--- a/crates/bashkit/docs/custom_builtins.md
+++ b/crates/bashkit/docs/custom_builtins.md
@@ -7,7 +7,7 @@ virtual filesystem.
 
 **See also:**
 - [API Documentation](https://docs.rs/bashkit) - Full API reference
-- [Clap Builtins](../../../docs/clap-builtins.md) - Derive parser structs for custom builtin args
+- [Clap Builtins](./clap-builtins.md) - Derive parser structs for custom builtin args
 - [Hooks](./hooks.md) - Interceptor hooks for the execution pipeline
 - [Compatibility Reference](./compatibility.md) - Supported bash features
 - [Threat Model](./threat-model.md) - Security considerations

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,11 +2,124 @@ import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
 import sitemapEnhance from "./integrations/sitemap-enhance.mjs";
 
+// Decision: Rustdoc markdown is reused on the public site. Normalize rustdoc
+// fence attributes and local guide links at render time instead of duplicating
+// those guides under site-specific paths.
+const DOC_LINKS = new Map([
+  ["builtin_typescript.md", "/docs/builtin_typescript/"],
+  ["clap-builtins.md", "/docs/clap-builtins/"],
+  ["cli.md", "/docs/cli/"],
+  ["compatibility.md", "/docs/compatibility/"],
+  ["credential-injection.md", "/docs/credential-injection/"],
+  ["custom_builtins.md", "/docs/custom-builtins/"],
+  ["hooks.md", "/docs/hooks/"],
+  ["jq.md", "/docs/jq/"],
+  ["live_mounts.md", "/docs/live-mounts/"],
+  ["logging.md", "/docs/logging/"],
+  ["python.md", "/docs/python/"],
+  ["security.md", "/docs/security/"],
+  ["snapshotting.md", "/docs/snapshotting/"],
+  ["sqlite.md", "/docs/sqlite/"],
+  ["ssh.md", "/docs/ssh/"],
+  ["threat-model.md", "/docs/security/"],
+  ["typescript.md", "/docs/builtin_typescript/"],
+]);
+
+function normalizeGuideMarkdown() {
+  return (tree) => {
+    visit(tree, (node) => {
+      if (node.type === "code" && typeof node.lang === "string") {
+        node.lang = node.lang.split(",")[0];
+      }
+
+      if (node.type === "link" && typeof node.url === "string") {
+        const target = DOC_LINKS.get(node.url.split("/").pop());
+        if (target) {
+          node.url = target;
+          return;
+        }
+
+        const repoTarget = repoUrl(node.url);
+        if (repoTarget) {
+          node.url = repoTarget;
+        }
+      }
+    });
+  };
+}
+
+function repoUrl(url) {
+  if (
+    url.startsWith("http://") ||
+    url.startsWith("https://") ||
+    url.startsWith("/") ||
+    url.startsWith("#")
+  ) {
+    return null;
+  }
+
+  const cleanUrl = url.replace(/^\.\.\//g, "").replace(/^\.\//, "");
+
+  if (cleanUrl === "README.md" || cleanUrl === "SECURITY.md") {
+    return `https://github.com/everruns/bashkit/blob/main/${cleanUrl}`;
+  }
+
+  const specsIndex = cleanUrl.indexOf("specs/");
+  if (specsIndex >= 0) {
+    return `https://github.com/everruns/bashkit/blob/main/${cleanUrl.slice(specsIndex)}`;
+  }
+
+  const examplesIndex = cleanUrl.indexOf("examples/");
+  if (examplesIndex >= 0) {
+    return `https://github.com/everruns/bashkit/blob/main/crates/bashkit/${cleanUrl.slice(examplesIndex)}`;
+  }
+
+  return null;
+}
+
+function rewriteRenderedLinks() {
+  return (tree) => {
+    visit(tree, (node) => {
+      if (node.type !== "element" || node.tagName !== "a") {
+        return;
+      }
+
+      const href = node.properties?.href;
+      if (typeof href !== "string") {
+        return;
+      }
+
+      const docTarget = DOC_LINKS.get(href.split("/").pop());
+      if (docTarget) {
+        node.properties.href = docTarget;
+        return;
+      }
+
+      const repoTarget = repoUrl(href);
+      if (repoTarget) {
+        node.properties.href = repoTarget;
+      }
+    });
+  };
+}
+
+function visit(node, visitor) {
+  visitor(node);
+  if (!Array.isArray(node.children)) {
+    return;
+  }
+  for (const child of node.children) {
+    visit(child, visitor);
+  }
+}
+
 export default defineConfig({
   site: "https://bashkit.sh",
   output: "static",
   markdown: {
     shikiConfig: { theme: "github-light" },
+    remarkPlugins: [normalizeGuideMarkdown],
+    rehypePlugins: [rewriteRenderedLinks],
   },
   integrations: [sitemap(), sitemapEnhance()],
 });

--- a/site/package.json
+++ b/site/package.json
@@ -10,10 +10,11 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "postbuild": "node scripts/verify-sitemap.mjs",
+    "postbuild": "node scripts/verify-doc-routes.mjs && node scripts/verify-sitemap.mjs",
     "preview": "wrangler dev",
     "deploy": "npm run build && wrangler deploy",
-    "check": "astro check"
+    "check": "astro check",
+    "verify:docs": "node scripts/verify-doc-routes.mjs"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",

--- a/site/scripts/verify-doc-routes.mjs
+++ b/site/scripts/verify-doc-routes.mjs
@@ -1,0 +1,87 @@
+// Decision: route metadata is hand-curated, so verify it against markdown
+// sources to catch docs that exist on disk but are invisible on the site.
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(siteRoot, "..");
+const metaPath = path.join(siteRoot, "src/pages/docs/_meta.ts");
+const publicDocsDir = path.join(repoRoot, "docs");
+const rustDocsDir = path.join(repoRoot, "crates/bashkit/docs");
+
+const metaSource = readFileSync(metaPath, "utf8");
+const objectPattern = /\{\s*slug:\s*"([^"]+)"[\s\S]*?\}/g;
+
+const entries = [];
+const slugs = new Set();
+let match;
+
+while ((match = objectPattern.exec(metaSource)) !== null) {
+  const block = match[0];
+  const slug = match[1];
+  const collection = extractString(block, "collection") ?? "docs";
+  const sourceId = extractString(block, "sourceId") ?? slug;
+  const seoTitle = extractString(block, "seoTitle");
+  const seoDescription = extractString(block, "seoDescription");
+
+  if (slugs.has(slug)) {
+    throw new Error(`Duplicate docs slug in _meta.ts: ${slug}`);
+  }
+
+  if (!seoTitle) {
+    throw new Error(`/docs/${slug} is missing seoTitle`);
+  }
+
+  if (!seoDescription) {
+    throw new Error(`/docs/${slug} is missing seoDescription`);
+  }
+
+  if (seoTitle.length < 30 || seoTitle.length > 65) {
+    throw new Error(
+      `/docs/${slug} seoTitle should be 30-65 characters, got ${seoTitle.length}`,
+    );
+  }
+
+  if (seoDescription.length < 70 || seoDescription.length > 160) {
+    throw new Error(
+      `/docs/${slug} seoDescription should be 70-160 characters, got ${seoDescription.length}`,
+    );
+  }
+
+  slugs.add(slug);
+  entries.push({ slug, collection, sourceId });
+}
+
+const publicDocIds = readdirSync(publicDocsDir)
+  .filter((name) => name.endsWith(".md"))
+  .map((name) => name.replace(/\.md$/, ""));
+
+for (const id of publicDocIds) {
+  const hasRoute = entries.some(
+    (entry) => entry.collection === "docs" && entry.sourceId === id,
+  );
+
+  if (!hasRoute) {
+    throw new Error(`docs/${id}.md is missing from docs route metadata`);
+  }
+}
+
+for (const entry of entries) {
+  const sourceDir = entry.collection === "rustdocs" ? rustDocsDir : publicDocsDir;
+  const sourcePath = path.join(sourceDir, `${entry.sourceId}.md`);
+
+  if (!existsSync(sourcePath)) {
+    throw new Error(
+      `/docs/${entry.slug} points at missing ${entry.collection}/${entry.sourceId}.md`,
+    );
+  }
+}
+
+console.log(`Verified ${entries.length} docs route metadata entries.`);
+
+function extractString(block, key) {
+  const fieldPattern = new RegExp(`${key}:\\s*"([^"]+)"`);
+  return fieldPattern.exec(block)?.[1];
+}

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -1,5 +1,6 @@
-// Decision: render user-facing guides from the canonical ../docs/ tree via
-// Astro's glob loader so the site and the repo share a single source of truth.
+// Decision: render user-facing guides from their canonical markdown locations.
+// Public articles live in ../docs; Rust API/integration guides stay in
+// ../crates/bashkit/docs so rustdoc and the site share the same source files.
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 
@@ -7,4 +8,8 @@ const docs = defineCollection({
   loader: glob({ pattern: "*.md", base: "../docs" }),
 });
 
-export const collections = { docs };
+const rustdocs = defineCollection({
+  loader: glob({ pattern: "*.md", base: "../crates/bashkit/docs" }),
+});
+
+export const collections = { docs, rustdocs };

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -39,6 +39,7 @@ const pageUrl = Astro.site
     <meta name="twitter:description" content={description} />
 
     <script
+      is:inline
       type="application/ld+json"
       set:html={JSON.stringify({
         "@context": "https://schema.org",

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -15,11 +15,12 @@ const index = DOC_META.findIndex((doc) => doc.slug === slug);
 const prev = index > 0 ? DOC_META[index - 1] : null;
 const next = index >= 0 && index < DOC_META.length - 1 ? DOC_META[index + 1] : null;
 
-const editUrl = `https://github.com/everruns/bashkit/blob/main/docs/${slug}.md`;
+const editPath = meta?.editPath ?? `docs/${slug}.md`;
+const editUrl = `https://github.com/everruns/bashkit/blob/main/${editPath}`;
 ---
 
 <BaseLayout
-  title={`${title} — Bashkit docs`}
+  title={title}
   description={description ?? meta?.summary}
 >
   <article class="doc section">

--- a/site/src/pages/docs/[slug].astro
+++ b/site/src/pages/docs/[slug].astro
@@ -1,27 +1,47 @@
 ---
 import { getCollection, render } from "astro:content";
 import DocsLayout from "../../layouts/DocsLayout.astro";
-import { DOC_META_BY_SLUG } from "./_meta";
+import { DOC_META } from "./_meta";
 
 export async function getStaticPaths() {
-  const docs = await getCollection("docs");
-  return docs
-    .filter((entry) => DOC_META_BY_SLUG[entry.id])
-    .map((entry) => ({
-      params: { slug: entry.id },
-      props: { entry },
-    }));
+  const [docs, rustdocs] = await Promise.all([
+    getCollection("docs"),
+    getCollection("rustdocs"),
+  ]);
+  const entries = new Map<string, (typeof docs)[number] | (typeof rustdocs)[number]>();
+  for (const entry of docs) {
+    entries.set(`docs:${entry.id}`, entry);
+  }
+  for (const entry of rustdocs) {
+    entries.set(`rustdocs:${entry.id}`, entry);
+  }
+
+  return DOC_META.map((meta) => {
+    const collection = meta.collection ?? "docs";
+    const sourceId = meta.sourceId ?? meta.slug;
+    const entry = entries.get(`${collection}:${sourceId}`);
+
+    if (!entry) {
+      throw new Error(`/docs/${meta.slug} source not found: ${collection}/${sourceId}.md`);
+    }
+
+    return {
+      params: { slug: meta.slug },
+      props: { entry, meta },
+    };
+  });
 }
 
-const { entry } = Astro.props;
-const meta = DOC_META_BY_SLUG[entry.id];
+const { entry, meta } = Astro.props;
 const { Content, headings } = await render(entry);
 
 // Title: prefer an explicit H1 from markdown, fall back to curated metadata.
 const h1 = headings.find((heading) => heading.depth === 1);
 const title = h1?.text ?? meta.title;
+const seoTitle = meta.seoTitle ?? `${title} — Bashkit docs`;
+const seoDescription = meta.seoDescription ?? meta.summary;
 ---
 
-<DocsLayout slug={entry.id} title={title} description={meta.summary}>
+<DocsLayout slug={meta.slug} title={seoTitle} description={seoDescription}>
   <Content />
 </DocsLayout>

--- a/site/src/pages/docs/_meta.ts
+++ b/site/src/pages/docs/_meta.ts
@@ -7,6 +7,11 @@ export type DocMeta = {
   title: string;
   summary: string;
   section: string;
+  seoTitle?: string;
+  seoDescription?: string;
+  collection?: "docs" | "rustdocs";
+  sourceId?: string;
+  editPath?: string;
 };
 
 export const DOC_META: DocMeta[] = [
@@ -14,25 +19,160 @@ export const DOC_META: DocMeta[] = [
     slug: "cli",
     title: "CLI",
     summary: "Run scripts with bashkit-cli: flags, exit codes, opt-in runtimes.",
+    seoTitle: "bashkit-cli docs: run sandboxed shell scripts",
+    seoDescription:
+      "Learn bashkit-cli modes, install options, limits, host filesystem mounts, interactive shell usage, and sandboxed script examples.",
     section: "Getting started",
   },
   {
     slug: "security",
     title: "Security",
     summary: "Sandbox boundaries, threat model, and what scripts cannot do.",
+    seoTitle: "Bashkit security model and sandbox boundaries",
+    seoDescription:
+      "Review Bashkit's virtual filesystem, resource limits, network allowlists, POSIX security deviations, and threat model guidance.",
     section: "Operations",
+  },
+  {
+    slug: "compatibility",
+    title: "Compatibility",
+    summary: "Bash and builtin feature coverage, security exclusions, and known gaps.",
+    seoTitle: "Bashkit compatibility scorecard for bash and builtins",
+    seoDescription:
+      "Check Bashkit POSIX shell support, implemented builtins, syntax coverage, expansions, resource limits, and known compatibility gaps.",
+    section: "Reference",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/compatibility.md",
+  },
+  {
+    slug: "jq",
+    title: "jq builtin",
+    summary: "Supported jq flags, filters, variables, exit codes, and compatibility notes.",
+    seoTitle: "Bashkit jq builtin compatibility guide",
+    seoDescription:
+      "See which jq flags, filters, variables, exit statuses, errors, and compatibility gaps Bashkit supports through its embedded jq builtin.",
+    section: "Reference",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/jq.md",
   },
   {
     slug: "snapshotting",
     title: "Snapshotting",
     summary: "Serialize interpreter state and restore it for checkpoint/resume flows.",
+    seoTitle: "Bashkit snapshotting for checkpoint and resume workflows",
+    seoDescription:
+      "Use Bashkit snapshots to serialize and restore virtual shell state across Rust, Python, and Node.js checkpoint/resume workflows.",
     section: "Features",
   },
   {
     slug: "builtin_typescript",
     title: "TypeScript builtin",
     summary: "Embedded ZapCode TypeScript runtime shared with bash in-memory.",
+    seoTitle: "Bashkit TypeScript builtin with ZapCode runtime",
+    seoDescription:
+      "Run TypeScript inside Bashkit with ZapCode, VFS file sharing, pipelines, resource limits, and Node.js-compatible command aliases.",
     section: "Features",
+  },
+  {
+    slug: "python",
+    title: "Python builtin",
+    summary: "Embedded Monty Python runtime, VFS bridging, limits, and caveats.",
+    seoTitle: "Bashkit Python builtin with Monty runtime",
+    seoDescription:
+      "Run embedded Python in Bashkit with Monty, virtual filesystem bridging, pipelines, command substitution, resource limits, and safety caveats.",
+    section: "Runtimes",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/python.md",
+  },
+  {
+    slug: "sqlite",
+    title: "SQLite builtin",
+    summary: "Embedded Turso SQLite runtime, backends, output modes, and limits.",
+    seoTitle: "Bashkit SQLite builtin with Turso",
+    seoDescription:
+      "Use Bashkit's embedded SQLite builtin with Turso, VFS-backed databases, output modes, dot-commands, resource limits, and security notes.",
+    section: "Runtimes",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/sqlite.md",
+  },
+  {
+    slug: "ssh",
+    title: "SSH support",
+    summary: "Sandboxed ssh, scp, and sftp builtins with host allowlists.",
+    seoTitle: "Bashkit SSH, SCP, and SFTP builtin support",
+    seoDescription:
+      "Configure Bashkit ssh, scp, and sftp builtins with host allowlists, VFS-only keys, remote command execution, and transfer limits.",
+    section: "Runtimes",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/ssh.md",
+  },
+  {
+    slug: "custom-builtins",
+    title: "Custom builtins",
+    summary: "Implement Rust commands that run inside the Bashkit shell.",
+    seoTitle: "Build custom Bashkit builtins in Rust",
+    seoDescription:
+      "Create custom Bashkit commands in Rust with Builtin, BuiltinContext, virtual filesystem access, execution extensions, and tested examples.",
+    section: "Extending",
+    collection: "rustdocs",
+    sourceId: "custom_builtins",
+    editPath: "crates/bashkit/docs/custom_builtins.md",
+  },
+  {
+    slug: "clap-builtins",
+    title: "Clap builtins",
+    summary: "Use clap parser structs to build typed custom commands.",
+    seoTitle: "Build typed Bashkit builtins with clap",
+    seoDescription:
+      "Use ClapBuiltin and clap Parser derives to add typed Bashkit commands with help output, parse errors, subcommands, and pipeline stdin.",
+    section: "Extending",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/clap-builtins.md",
+  },
+  {
+    slug: "hooks",
+    title: "Hooks",
+    summary: "Observe, modify, or cancel execution, builtin, lifecycle, and HTTP events.",
+    seoTitle: "Bashkit hooks for execution, tools, and HTTP events",
+    seoDescription:
+      "Use Bashkit hooks to observe, rewrite, or cancel script execution, builtins, shell lifecycle events, and allowlisted HTTP requests.",
+    section: "Extending",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/hooks.md",
+  },
+  {
+    slug: "live-mounts",
+    title: "Live mounts",
+    summary: "Attach, detach, and hot-swap filesystems on a running interpreter.",
+    seoTitle: "Bashkit live mounts for virtual filesystems",
+    seoDescription:
+      "Attach, detach, and hot-swap Bashkit virtual filesystems on a running interpreter while preserving shell state and mounted data.",
+    section: "Extending",
+    collection: "rustdocs",
+    sourceId: "live_mounts",
+    editPath: "crates/bashkit/docs/live_mounts.md",
+  },
+  {
+    slug: "credential-injection",
+    title: "Credential injection",
+    summary: "Inject outbound HTTP credentials without exposing secrets to scripts.",
+    seoTitle: "Bashkit credential injection for sandboxed HTTP",
+    seoDescription:
+      "Inject bearer tokens and headers into Bashkit outbound HTTP requests without exposing real secrets to sandboxed shell scripts.",
+    section: "Operations",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/credential-injection.md",
+  },
+  {
+    slug: "logging",
+    title: "Logging",
+    summary: "Structured tracing setup, log targets, and redaction behavior.",
+    seoTitle: "Bashkit structured logging and tracing guide",
+    seoDescription:
+      "Enable Bashkit structured logging with tracing, configure log targets and levels, and redact sensitive script, URL, and environment data.",
+    section: "Operations",
+    collection: "rustdocs",
+    editPath: "crates/bashkit/docs/logging.md",
   },
 ];
 

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -2,7 +2,14 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { DOC_META } from "./_meta";
 
-const sectionOrder = ["Getting started", "Features", "Operations"];
+const sectionOrder = [
+  "Getting started",
+  "Reference",
+  "Features",
+  "Runtimes",
+  "Extending",
+  "Operations",
+];
 const bySection = sectionOrder
   .map((section) => ({
     section,


### PR DESCRIPTION
## What
Publish selected Rustdoc guide markdown on the public docs site with SEO-focused titles and meta descriptions.

## Why
Several useful guides existed only in crate rustdoc and were not discoverable from bashkit.sh or sitemap.xml.

## How
- Load public docs from both docs/ and crates/bashkit/docs/ collections.
- Add route metadata for Rustdoc-backed pages and SEO metadata for every docs route.
- Normalize Rustdoc code fences and local links during site rendering.
- Add docs route metadata validation and include it in postbuild before sitemap verification.

## Risk
- Low
- Static docs routing and metadata changes only; main risk is broken generated links or missing sitemap entries, covered by build checks.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verification:
- npm run verify:docs
- npm run check
- npm run build
- cargo doc -p bashkit --no-deps
- just pre-pr