### PR TITLE
chore(site): declare content signals

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "postbuild": "node scripts/verify-doc-routes.mjs && node scripts/verify-sitemap.mjs",
+    "postbuild": "node scripts/verify-doc-routes.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs",
     "preview": "wrangler dev",
     "deploy": "npm run build && wrangler deploy",
     "check": "astro check",

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+# Content Signals: allow search indexing; disallow AI training and AI-input/RAG use.
+Content-Signal: ai-train=no, search=yes, ai-input=no
 
 Sitemap: https://bashkit.sh/sitemap.xml

--- a/site/scripts/verify-robots.mjs
+++ b/site/scripts/verify-robots.mjs
@@ -1,0 +1,48 @@
+// Decision: verify Content Signals in generated robots.txt so AI usage
+// preferences stay declared for bashkit.sh after future site edits.
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptDir, "..");
+const robotsPath = path.join(siteRoot, "dist", "robots.txt");
+
+if (!existsSync(robotsPath)) {
+  throw new Error(`Missing robots output: ${robotsPath}`);
+}
+
+const robots = readFileSync(robotsPath, "utf8");
+const signalLine = robots
+  .split(/\r?\n/)
+  .find((line) => line.trim().toLowerCase().startsWith("content-signal:"));
+
+if (!signalLine) {
+  throw new Error("robots.txt does not include a Content-Signal directive");
+}
+
+const preferences = new Map(
+  signalLine
+    .slice(signalLine.indexOf(":") + 1)
+    .split(",")
+    .map((entry) => entry.trim().split("="))
+    .filter(([key, value]) => key && value),
+);
+
+const expectedPreferences = new Map([
+  ["ai-train", "no"],
+  ["search", "yes"],
+  ["ai-input", "no"],
+]);
+
+for (const [key, expectedValue] of expectedPreferences) {
+  const actualValue = preferences.get(key);
+
+  if (actualValue !== expectedValue) {
+    throw new Error(
+      `robots.txt Content-Signal must include ${key}=${expectedValue}`,
+    );
+  }
+}
+
+console.log("Verified robots.txt Content Signals.");


### PR DESCRIPTION
## What
Add Content Signals to `site/public/robots.txt` declaring `ai-train=no`, `search=yes`, and `ai-input=no` for bashkit.sh. Add a generated robots.txt postbuild check so the directive is preserved.

## Why
Agent readiness scan reported no Content Signals in robots.txt.

## How
- Added the `Content-Signal` directive under the existing `User-agent: *` block
- Added `site/scripts/verify-robots.mjs` to validate generated `dist/robots.txt`
- Wired the new verifier into the site postbuild step after sitemap verification

## Risk
- Low
- Static site robots.txt only; main risk is malformed robots output, covered by the postbuild verifier.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verified:
- `npm run build`
- `npm run check`
- `just test`
- `just pre-pr`