### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-06
+
+### Highlights
+
+- **Coreutils argument surface via codegen** — New POC pipeline ports uutils' `uu_app()` clap definitions into bashkit so builtins share the real coreutils argument shape; `cat`, `tac`, `truncate`, `shuf`, and `readlink` now flow through this surface, with a coreutils differential testing harness to catch parity drift. The codegen pipeline reads a single pinned uutils revision so generated builtins, the differential harness, and CI all agree on the upstream source of truth ([#1529](https://github.com/everruns/bashkit/pull/1529), [#1535](https://github.com/everruns/bashkit/pull/1535), [#1536](https://github.com/everruns/bashkit/pull/1536), [#1537](https://github.com/everruns/bashkit/pull/1537), [#1538](https://github.com/everruns/bashkit/pull/1538), [#1542](https://github.com/everruns/bashkit/pull/1542)).
+- **Site updates** — Bashkit agent skill is now published on the site, alongside rustdoc guides and content signal declarations for discoverability.
+
+### What's Changed
+
+* refactor(builtins): migrate readlink to codegen-ported argument surface ([#1542](https://github.com/everruns/bashkit/pull/1542)) by @chaliy
+* chore(site): publish bashkit agent skill ([#1541](https://github.com/everruns/bashkit/pull/1541)) by @chaliy
+* chore(site): declare content signals by @chaliy
+* docs(site): publish rustdoc guides by @chaliy
+* feat(builtins): add shuf via codegen with helper-fn inlining ([#1538](https://github.com/everruns/bashkit/pull/1538)) by @chaliy
+* chore(builtins): pin uutils revision as single source of truth ([#1537](https://github.com/everruns/bashkit/pull/1537)) by @chaliy
+* feat(builtins): add truncate via codegen-ported argument surface ([#1536](https://github.com/everruns/bashkit/pull/1536)) by @chaliy
+* test(builtins): add coreutils differential testing harness ([#1535](https://github.com/everruns/bashkit/pull/1535)) by @chaliy
+* feat(builtins): port uutils argument surfaces via codegen (POC: cat, tac) ([#1529](https://github.com/everruns/bashkit/pull/1529)) by @chaliy
+* feat(tool_def): accept --flag key=value... syntax for object/array flags ([#1528](https://github.com/everruns/bashkit/pull/1528)) by @chaliy
+* fix(tool_def): coerce stringified JSON for array/object flag schemas ([#1527](https://github.com/everruns/bashkit/pull/1527)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.4.1...v0.5.0
+
 ## [0.4.1] - 2026-05-04
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.4.1", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.5.0", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -21,12 +21,14 @@ Bashkit follows [Semantic Versioning](https://semver.org/):
 ### Overview
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  Human asks     │     │  Agent creates  │     │  GitHub         │     │  crates.io      │
-│  "release v0.2" │────>│  release PR     │────>│  Release        │────>│  Publish        │
-│                 │     │                 │     │  (automatic)    │     │  (automatic)    │
-└─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘
+┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
+│ Human    │   │ Agent    │   │ Agent    │   │ Human    │   │ CI       │   │ Agent    │
+│ asks     │──>│ prepares │──>│ verifies │──>│ merges   │──>│ tags +   │──>│ monitors │
+│ release  │   │ PR       │   │ publish  │   │ PR       │   │ publishes│   │ registries│
+└──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘
 ```
+
+The flow is: **prepare → verify-can-publish → merge → monitor-published**. Skipping the verify step risks tagging a release that fails to publish to crates.io / PyPI / npm (as v0.4.0 did, requiring the v0.4.1 hotfix); skipping the monitor step risks declaring "shipped" while one or more registries silently failed.
 
 ### Human Steps
 
@@ -35,9 +37,11 @@ Bashkit follows [Semantic Versioning](https://semver.org/):
    - "Prepare a patch release"
    - "Release the current changes as v0.2.0"
 
-2. **Review the PR** created by the agent
+2. **Review the PR** created by the agent — including the agent's publish-readiness report (see Agent step 5)
 
 3. **Merge to main** - CI handles GitHub Release and crates.io publish
+
+4. **Ask the agent to monitor publishing** (or let it auto-monitor if subscribed to PR activity) — the agent watches the publish workflows and registries, and reports back when all targets show the new version.
 
 ### Agent Steps (automated)
 
@@ -53,21 +57,38 @@ When asked to create a release, the agent:
    - List PRs in descending order with GitHub-style links and contributors
    - End with `**Full Changelog**: URL`
 
-3. **Update Cargo.toml**
-   - Set `version = "X.Y.Z"` in workspace
+3. **Update version across all manifests** (must all match the workspace version):
+   - `Cargo.toml` workspace `version`
+   - `crates/bashkit-cli/Cargo.toml` path-dep version pin on `bashkit`
+   - `crates/bashkit-js/package.json` `version`
+   - `crates/bashkit-js/package-lock.json` top-level `version` and `packages.""` `version`
+   - `Cargo.lock` (regenerate via `cargo update -p bashkit -p bashkit-cli ...`)
 
-4. **Run verification**
+4. **Run local verification**
    - `cargo fmt --check`
-   - `cargo clippy`
+   - `cargo clippy --all-targets --all-features -- -D warnings`
    - `cargo test`
 
-5. **Commit and push**
+5. **Verify publish-readiness** (catches what local tests don't — the `cargo publish` packaging step, missing files, version drift across registries):
+   - **crates.io**: `cargo publish --dry-run -p bashkit` and `cargo publish --dry-run -p bashkit-cli` — must succeed. This is what caught the v0.4.0 → v0.4.1 incident: the rustdoc guide lived outside the crate dir, so `cargo publish` couldn't find it. Local `cargo build` did not catch it.
+   - **PyPI / npm**: confirm the build pipelines that feed those registries still build (e.g. `maturin build --release` smoke for Python, `napi build` smoke for JS) when the changes touch packaging.
+   - **Version sync check**: confirm all manifests from step 3 read the same `X.Y.Z`, and that the new version is greater than the latest published version on every registry (`cargo search bashkit`, `pip index versions bashkit`, `npm view @everruns/bashkit version`).
+   - If any check fails, fix the root cause and re-run before opening the PR — do **not** merge a release PR with a known-broken publish path.
+
+6. **Commit and push**
    - Commit message: `chore(release): prepare vX.Y.Z`
    - Push to feature branch
 
-6. **Create PR**
+7. **Create PR**
    - Title: `chore(release): prepare vX.Y.Z`
    - Include changelog excerpt in description
+   - Include a **publish-readiness report** summarizing step 5 results (which dry-runs ran, registry version checks)
+
+8. **Monitor post-merge publishing** (after the human merges the PR):
+   - Watch `release.yml` complete and confirm the GitHub Release + tag `vX.Y.Z` were created.
+   - Watch `publish.yml`, `publish-python.yml`, `publish-js.yml`, and `cli-binaries.yml` to completion; surface any failure immediately.
+   - Run the post-release verification commands (see "Post-Release Verification" below) and report which registries show the new version.
+   - Only declare the release "shipped" when **all four** targets (crates.io, PyPI, npm, Homebrew) report the new version. If one fails, open a hotfix PR rather than leaving the release half-shipped.
 
 ### CI Automation
 
@@ -89,6 +110,24 @@ The agent verifies before creating a release PR:
 - [ ] `cargo clippy` - no warnings
 - [ ] `cargo test` - all tests pass
 - [ ] CHANGELOG.md has entries for changes since last release
+- [ ] Version is consistent across `Cargo.toml`, `crates/bashkit-cli/Cargo.toml`, `crates/bashkit-js/package.json`, `package-lock.json`, and `Cargo.lock`
+- [ ] `cargo publish --dry-run -p bashkit` succeeds
+- [ ] `cargo publish --dry-run -p bashkit-cli` succeeds
+- [ ] New version > latest published version on each registry (crates.io, PyPI, npm)
+
+## Post-Merge Monitoring
+
+After the release PR merges, the agent watches each publish target until it reports the new version (or fails):
+
+| Target      | Workflow                | How to confirm                                            |
+|-------------|-------------------------|-----------------------------------------------------------|
+| GitHub Release | `release.yml`        | `gh release view vX.Y.Z`                                  |
+| crates.io   | `publish.yml`           | `cargo search bashkit` shows `X.Y.Z`                      |
+| PyPI        | `publish-python.yml`    | `pip index versions bashkit` includes `X.Y.Z`             |
+| npm         | `publish-js.yml`        | `npm view @everruns/bashkit version` returns `X.Y.Z`      |
+| Homebrew    | `cli-binaries.yml`      | `everruns/homebrew-tap` formula bumped to `X.Y.Z`         |
+
+If a workflow fails, the agent inspects logs (`gh run view <run-id> --log-failed`), identifies root cause, and either re-runs the workflow (transient) or opens a hotfix PR (code/packaging bug — see v0.4.0 → v0.4.1 for a worked example).
 
 ## Changelog Format
 


### PR DESCRIPTION
Minor release `0.4.1` → `0.5.0`. Two new builtins (`shuf`, `truncate`), a coreutils-codegen pipeline that ports uutils' `uu_app()` clap definitions for `cat`/`tac`/`truncate`/`shuf`/`readlink`, and `tool_def` flag-syntax improvements.

## Highlights

- **Coreutils argument surface via codegen** — Ports uutils' `uu_app()` clap definitions into bashkit so builtins share the real coreutils argument shape; `cat`, `tac`, `truncate`, `shuf`, and `readlink` now flow through this surface, with a coreutils differential testing harness to catch parity drift. Pipeline reads a single pinned uutils revision so generated builtins, the differential harness, and CI all agree on the upstream source of truth (#1529, #1535, #1536, #1537, #1538, #1542).
- **Site updates** — Bashkit agent skill is now published on the site, alongside rustdoc guides and content signal declarations for discoverability.

## What's Changed

* refactor(builtins): migrate readlink to codegen-ported argument surface (#1542)
* chore(site): publish bashkit agent skill (#1541)
* chore(site): declare content signals
* docs(site): publish rustdoc guides
* feat(builtins): add shuf via codegen with helper-fn inlining (#1538)
* chore(builtins): pin uutils revision as single source of truth (#1537)
* feat(builtins): add truncate via codegen-ported argument surface (#1536)
* test(builtins): add coreutils differential testing harness (#1535)
* feat(builtins): port uutils argument surfaces via codegen (POC: cat, tac) (#1529)
* feat(tool_def): accept --flag key=value... syntax for object/array flags (#1528)
* fix(tool_def): coerce stringified JSON for array/object flag schemas (#1527)

## Publish-readiness report

Per the updated `specs/release-process.md`:

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo build` clean
- [x] Versions synced across `Cargo.toml`, `crates/bashkit-cli/Cargo.toml`, `crates/bashkit-js/package.json`, `package-lock.json`, `Cargo.lock`
- [x] `cargo publish --dry-run -p bashkit --allow-dirty` (after CI's monty-strip): **success**
- [x] `cargo publish --dry-run -p bashkit-cli`: blocked only on ordering (`bashkit 0.5.0` not yet on crates.io) — resolves at real publish time when `publish-bashkit` runs first per `publish.yml`'s `needs:` chain.
- [x] New `0.5.0` > latest published versions on crates.io / PyPI / npm (`0.4.1`).

## Companion change

This branch also includes `chore(specs): document publish verification and post-merge monitoring`, codifying the verify-before-tag and watch-after-merge flow that this release follows.

On merge, `release.yml` will create the GitHub Release `v0.5.0` and dispatch publish workflows for crates.io, PyPI, npm, and Homebrew.

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.4.1...v0.5.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvuLdA8pMAmP4woG2HqxKw)_