### PR TITLE
chore(site): add homepage link headers

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "postbuild": "node scripts/verify-doc-routes.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs",
+    "postbuild": "node scripts/verify-doc-routes.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs",
     "preview": "wrangler dev",
     "deploy": "npm run build && wrangler deploy",
     "check": "astro check",

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,4 @@
+# Decision: bashkit.sh does not publish an HTTP API catalog today, so advertise
+# the existing machine-readable Agent Skills index and human service docs.
+/
+  Link: </.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json", </docs/>; rel="service-doc"; type="text/html"

--- a/site/scripts/verify-link-headers.mjs
+++ b/site/scripts/verify-link-headers.mjs
@@ -1,0 +1,74 @@
+// Decision: verify Cloudflare static asset headers from build output because
+// bashkit.sh is static and homepage discovery must survive deploy packaging.
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptDir, "..");
+const headersPath = path.join(siteRoot, "dist", "_headers");
+
+if (!existsSync(headersPath)) {
+  throw new Error(`Missing Cloudflare headers output: ${headersPath}`);
+}
+
+const blocks = parseHeaders(readFileSync(headersPath, "utf8"));
+const homeHeaders = blocks.get("/");
+
+if (!homeHeaders) {
+  throw new Error("_headers must define a homepage rule for /");
+}
+
+const linkHeaders = homeHeaders.get("link") ?? [];
+const linkValue = linkHeaders.join(", ");
+const expectedLinks = [
+  '</.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json"',
+  '</docs/>; rel="service-doc"; type="text/html"',
+];
+
+for (const expectedLink of expectedLinks) {
+  if (!linkValue.includes(expectedLink)) {
+    throw new Error(`Homepage Link header missing: ${expectedLink}`);
+  }
+}
+
+console.log("Verified homepage Link response headers.");
+
+function parseHeaders(source) {
+  const blocks = new Map();
+  let currentPattern = null;
+
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+
+    if (line.trim().length === 0 || line.trimStart().startsWith("#")) {
+      continue;
+    }
+
+    if (!/^\s/.test(line)) {
+      currentPattern = line.trim();
+      if (!blocks.has(currentPattern)) {
+        blocks.set(currentPattern, new Map());
+      }
+      continue;
+    }
+
+    if (!currentPattern) {
+      throw new Error(`Header declared before a path pattern: ${line}`);
+    }
+
+    const separator = line.indexOf(":");
+    if (separator < 0) {
+      throw new Error(`Header line must use "Name: value": ${line}`);
+    }
+
+    const name = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    const headers = blocks.get(currentPattern);
+    const values = headers.get(name) ?? [];
+    values.push(value);
+    headers.set(name, values);
+  }
+
+  return blocks;
+}


### PR DESCRIPTION
## What
Add Cloudflare homepage Link response headers for agent discovery and a post-build verifier for the generated `_headers` asset.

## Why
The homepage did not expose RFC 8288 Link headers, so agents had no response-header discovery path for the existing Agent Skills index or docs.

## How
- Add `site/public/_headers` with `service-desc` and `service-doc` Link values for `/`.
- Add `site/scripts/verify-link-headers.mjs` to validate the generated homepage header rule.
- Wire the verifier into the site `postbuild` script.

## Risk
- Low
- Misconfigured Cloudflare header syntax could omit homepage discovery headers; covered by build verification and local Wrangler preview smoke test.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verified:
- `npm run build`
- `npm run check`
- `just pre-pr`
- `wrangler dev` preview smoke test with `curl -I /` showing the Link header