### PR TITLE
test(brace-expansion): pin TM-DOS-041/042 caps with regression tests

### DIFF
--- a/crates/bashkit/tests/security_audit_pocs.rs
+++ b/crates/bashkit/tests/security_audit_pocs.rs
@@ -522,6 +522,52 @@ mod brace_expansion_dos {
         let result = bash.exec("echo {1..3}").await.unwrap();
         assert_eq!(result.stdout.trim(), "1 2 3");
     }
+
+    /// TM-DOS-041: Reverse range `{N..1}` with N over the static cap is rejected.
+    #[tokio::test]
+    async fn security_audit_brace_expansion_reverse_capped() {
+        let mut bash = Bash::new();
+        let result = bash.exec("echo {1000000..1}").await;
+        assert!(
+            result.is_err(),
+            "Reverse brace expansion with 1M elements must be rejected"
+        );
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("brace range too large"),
+            "Expected static budget rejection on reverse range"
+        );
+    }
+
+    /// TM-DOS-042: Combinatorial blowup `{1..100}{1..100}{1..100}` (= 1M) cannot
+    /// allocate more than the runtime cap of 100k strings. Each individual range
+    /// passes the static check, so this exercises the runtime cap in
+    /// `expand_braces_capped`.
+    #[tokio::test]
+    async fn security_audit_brace_expansion_combinatorial_capped() {
+        let limits = ExecutionLimits::new()
+            .max_commands(10)
+            .timeout(Duration::from_secs(15));
+        let mut bash = Bash::builder().limits(limits).build();
+
+        // Pipe through `wc -w` so we don't materialise the whole expansion in stdout.
+        let result = bash
+            .exec("echo {1..100}{1..100}{1..100} | wc -w")
+            .await
+            .expect("combinatorial expansion must not panic or OOM");
+        let count: usize = result.stdout.trim().parse().unwrap_or(usize::MAX);
+
+        // Hard upper bound: runtime cap is 100k, plus one literal "tail" string
+        // that the loop emits when count >= max.
+        assert!(
+            count <= 200_000,
+            "combinatorial expansion produced {count} words, expected <= 200000",
+        );
+        // And it must produce *something* — sanity check that the call ran.
+        assert!(count > 0, "combinatorial expansion returned no output");
+    }
 }
 
 // =============================================================================

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1221,7 +1221,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Threat ID | Vulnerability | Impact | Recommendation |
 |-----------|---------------|--------|----------------|
 | TM-DOS-031 | ExtGlob exponential blowup | CPU exhaustion / stack overflow | Add fuel counter to glob_match_impl |
-| TM-DOS-041 | Brace expansion unbounded range | OOM DoS | Cap range size in try_expand_range() |
+| ~~TM-DOS-041~~ | ~~Brace expansion unbounded range~~ | ~~OOM DoS~~ | ~~Cap range size in try_expand_range()~~ (**FIXED**) |
 | TM-DOS-032 | Tokio runtime per sync call (Python) | OS thread/fd exhaustion | Shared runtime |
 | TM-PY-023 | Shell injection in deepagents.py | Command injection within VFS | Use shlex.quote() or direct API |
 | TM-PY-024 | Heredoc content injection in write() | Command injection within VFS | Random delimiter or direct API |
@@ -1279,8 +1279,8 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-INJ-016 | `_ARRAY_READ_` prefix not in `is_internal_variable()` | Arbitrary array creation/overwrite via marker injection | Add `_ARRAY_READ_` prefix to `is_internal_variable()` at `interpreter/mod.rs:7634` |
 | TM-INF-017 | `set` and `declare -p` leak internal markers | Internal state disclosure (_NAMEREF_, _READONLY_, _UPPER_, _LOWER_) | Filter `is_internal_variable()` names from output |
 | TM-INF-018 | `date` builtin returns real host time | Timezone fingerprinting, timing correlation | Configurable time source (fixed or offset) |
-| TM-DOS-041 | Brace expansion `{N..M}` unbounded range | OOM via `{1..999999999}` allocating billions of strings | Cap range size (e.g., 10,000 elements) in `try_expand_range()` at `interpreter/mod.rs:8049` |
-| TM-DOS-042 | Brace expansion combinatorial explosion | OOM via `{1..100}{1..100}{1..100}` = 1M strings | Cap total expansion count in `expand_braces()` at `interpreter/mod.rs:7967` |
+| ~~TM-DOS-041~~ | ~~Brace expansion `{N..M}` unbounded range~~ | ~~OOM via `{1..999999999}` allocating billions of strings~~ | Static parser-time check (`MAX_STATIC_BRACE_RANGE = 100_000` in `parser/budget.rs`) rejects oversized literal ranges with `BraceRangeTooLarge`; runtime fallback in `try_expand_range` (`MAX_BRACE_RANGE = 10_000`) treats remaining oversized ranges as literals (**FIXED**) |
+| ~~TM-DOS-042~~ | ~~Brace expansion combinatorial explosion~~ | ~~OOM via `{1..100}{1..100}{1..100}` = 1M strings~~ | `expand_braces` caps total emitted strings at `MAX_BRACE_EXPANSION_TOTAL = 100_000` and bails out of the recursion when the budget is hit (**FIXED**) |
 | TM-DOS-043 | Arithmetic overflow in `execute_arithmetic_with_side_effects` | Panic (DoS) in debug mode via `((x+=1))` with x=i64::MAX | Use `wrapping_add/sub/mul` at `interpreter/mod.rs:1563-1565` |
 | TM-DOS-044 | Lexer `read_command_subst_into` stack overflow | Process crash (SIGABRT) via ~50 nested `$()` in double-quotes | Add depth parameter to `read_command_subst_into()` at `parser/lexer.rs:1109` |
 | TM-DOS-045 | OverlayFs `symlink()` bypasses all limits | Unlimited symlink creation despite `max_file_count` | Add `check_write_limits()` + `validate_path()` to `fs/overlay.rs:683` |
@@ -1403,7 +1403,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Internal prefix injection via builtins | TM-INJ-012 to TM-INJ-015 | Add `is_internal_variable()` check to `declare`, `readonly`, `local`, `export` | **NEEDED** |
 | Missing `_ARRAY_READ_` in prefix guard | TM-INJ-016 | Add prefix to `is_internal_variable()` | **NEEDED** |
 | Internal marker info leak | TM-INF-017 | Filter internal vars from `set` and `declare -p` output | **NEEDED** |
-| Brace expansion DoS | TM-DOS-041, TM-DOS-042 | Cap range size and total expansion count | **NEEDED** |
+| Brace expansion DoS | TM-DOS-041, TM-DOS-042 | Cap range size and total expansion count | **MITIGATED** |
 | Arithmetic overflow in compound assignment | TM-DOS-043 | Use `wrapping_*` ops in `execute_arithmetic_with_side_effects` | **NEEDED** |
 | Lexer stack overflow | TM-DOS-044 | Depth tracking in `read_command_subst_into` | **NEEDED** |
 | Cmd subst OOM via state cloning | TM-DOS-088 | `max_subst_depth` limit in `ExecutionLimits` | **DONE** |


### PR DESCRIPTION
## Summary

Closes the documentation/test gap on two threat-model entries that were
already mitigated in code but still listed as `OPEN` in
`specs/threat-model.md`. TM-DOS-042 had no regression test at all.

Mitigates (now confirmed by tests):
- **TM-DOS-041** — `{1..999999999}` static check rejects oversized literal
  ranges via `MAX_STATIC_BRACE_RANGE = 100_000` in `parser/budget.rs`,
  with runtime fallback `MAX_BRACE_RANGE = 10_000` in
  `try_expand_range()`.
- **TM-DOS-042** — `{1..100}{1..100}{1..100}` (= 1M without the cap)
  runtime cap `MAX_BRACE_EXPANSION_TOTAL = 100_000` in
  ``expand_braces_capped`` keeps allocation bounded.

## Why

The mitigations existed but had no green-binding test for combinatorial
blowup, so a future refactor could regress the cap silently. This PR
pins both behaviours and updates the spec so the open-issue list isn't
misleading.

## How

- `crates/bashkit/tests/security_audit_pocs.rs`:
  - `security_audit_brace_expansion_reverse_capped` — covers `{N..1}`
    so the forward-only test isn't the sole guard.
  - `security_audit_brace_expansion_combinatorial_capped` — pipes
    through `wc -w` to avoid materialising the whole expansion in
    stdout, asserts output stays under 200k words.
- `specs/threat-model.md` — TM-DOS-041 / TM-DOS-042 marked **FIXED** in
  the Open (High) and Open (2026-03 Deep Audit) tables; the Security
  Controls Matrix row for ${"Brace expansion DoS"} flips from NEEDED to
  MITIGATED. Spec now points at the actual constants and call sites.

## Tests

\`\`\`
cargo test -p bashkit --test security_audit_pocs brace_expansion_dos
\`\`\`
3 passed (existing TM-DOS-041 test plus the two new ones).

\`\`\`
cargo test -p bashkit --lib  # 2207 passed
cargo fmt --all --check       # clean
cargo clippy -p bashkit --all-targets -- -D warnings  # clean
\`\`\`

## Test plan

- [x] Forward range over static cap rejected
- [x] Reverse range over static cap rejected (new)
- [x] Combinatorial blowup capped at runtime (new)
- [x] Lib + lint clean