### PR TITLE
fix(credential): generate placeholder tokens with the OS CSPRNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "futures-util",
+ "getrandom 0.3.4",
  "hmac 0.13.0",
  "insta",
  "jaq-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.10"
 zeroize = "1"
 
+# CSPRNG for placeholder token generation (security-grade randomness).
+# Used by the credential placeholder generator; getrandom is the lowest-level
+# CSPRNG primitive and is already transitively in the dep tree via reqwest/rustls.
+getrandom = "0.3"
+
 # CLI
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -68,6 +68,9 @@ ed25519-dalek = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 zeroize = { workspace = true, optional = true }
 
+# CSPRNG for credential placeholder generation
+getrandom = { workspace = true }
+
 # Checksums (for md5sum, sha1sum, sha256sum builtins)
 md-5 = { workspace = true }
 sha1 = { workspace = true }

--- a/crates/bashkit/src/credential.rs
+++ b/crates/bashkit/src/credential.rs
@@ -125,27 +125,32 @@ impl std::fmt::Debug for Credential {
 /// Placeholder prefix for generated placeholder tokens.
 const PLACEHOLDER_PREFIX: &str = "bk_placeholder_";
 
-/// Generate a random placeholder token.
+/// Generate a random placeholder token using a CSPRNG.
 ///
-/// Format: `bk_placeholder_<32 hex chars>` (128 bits of randomness).
+/// Format: `bk_placeholder_<32 hex chars>` (128 bits of OS randomness).
+///
+/// # Security
+///
+/// The placeholder acts like a bearer capability inside scripts: if a script
+/// sends the placeholder value to a URL matching a credential rule, BashKit
+/// injects the real credential-owned header. The token therefore must come
+/// from a security-grade RNG so it cannot be predicted, brute-forced, or
+/// reproduced from observed program state.
+///
+/// `getrandom::fill` reads from the OS CSPRNG (`getrandom(2)` / `arc4random_buf`
+/// / `BCryptGenRandom`). If the OS RNG is genuinely unavailable the function
+/// panics — there is no safe fallback for credential-shaped randomness, and
+/// silently weakening it (e.g. `RandomState`) was the bug this code replaces.
 fn generate_placeholder() -> String {
-    use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hasher};
-
-    // Use two RandomState hashers for 128 bits of randomness.
-    // This avoids pulling `rand` as a non-optional dependency.
-    let s1 = RandomState::new();
-    let s2 = RandomState::new();
-    let mut h1 = s1.build_hasher();
-    h1.write_u64(0);
-    let mut h2 = s2.build_hasher();
-    h2.write_u64(1);
-    format!(
-        "{}{:016x}{:016x}",
-        PLACEHOLDER_PREFIX,
-        h1.finish(),
-        h2.finish()
-    )
+    let mut bytes = [0u8; 16]; // 128 bits
+    getrandom::fill(&mut bytes).expect("OS CSPRNG must be available for credential placeholder");
+    let mut hex = String::with_capacity(PLACEHOLDER_PREFIX.len() + 32);
+    hex.push_str(PLACEHOLDER_PREFIX);
+    for byte in bytes {
+        use std::fmt::Write;
+        let _ = write!(hex, "{:02x}", byte);
+    }
+    hex
 }
 
 /// A rule mapping a URL pattern to a credential.
@@ -281,10 +286,50 @@ mod tests {
         let p2 = generate_placeholder();
         assert!(p1.starts_with(PLACEHOLDER_PREFIX));
         assert!(p2.starts_with(PLACEHOLDER_PREFIX));
-        // Should be different (128 bits of randomness)
+        // Should be different (128 bits of CSPRNG randomness)
         assert_ne!(p1, p2);
         // Fixed length: prefix (15) + 32 hex chars = 47
         assert_eq!(p1.len(), 47);
+    }
+
+    #[test]
+    fn test_placeholder_format_is_lowercase_hex() {
+        let p = generate_placeholder();
+        let hex_part = &p[PLACEHOLDER_PREFIX.len()..];
+        assert_eq!(hex_part.len(), 32);
+        for c in hex_part.chars() {
+            assert!(
+                c.is_ascii_hexdigit() && (!c.is_ascii_alphabetic() || c.is_ascii_lowercase()),
+                "placeholder must be lowercase hex, got: {p}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_placeholder_uniqueness_across_many_generations() {
+        // CSPRNG must produce 1024 distinct 128-bit tokens. RandomState's
+        // hasher used to share initialization across hashers within a thread,
+        // which made this regression surface; getrandom must not.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..1024 {
+            let p = generate_placeholder();
+            assert!(seen.insert(p), "placeholder collision detected");
+        }
+    }
+
+    #[test]
+    fn test_placeholder_does_not_leak_raw_credential() {
+        // Placeholder tokens must never embed any portion of a real secret.
+        // Build one alongside an injected credential and assert the secret
+        // bytes do not appear in the placeholder string.
+        let secret = "hunter2-very-long-secret-token-payload-XYZ";
+        let mut policy = CredentialPolicy::new();
+        let cred = Credential::bearer(secret);
+        let placeholder = policy.add_placeholder("https://api.example.com", cred);
+        assert!(!placeholder.contains(secret));
+        // Debug formatting of the placeholder must also not leak the secret.
+        let debug = format!("{:?}", placeholder);
+        assert!(!debug.contains(secret));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`generate_placeholder()` previously built tokens from two `hash_map::RandomState` hashers via `Hasher::finish()`. `RandomState` is a hash-map seed primitive — the standard library makes no guarantees about its predictability or that two independent `RandomState` instances produce independent values. The placeholder acts like a bearer capability inside scripts: if a script sends the placeholder value to a URL matching a credential rule, BashKit injects the real credential-owned header. The token therefore must come from a security-grade RNG.

This PR replaces the `RandomState`-based generator with `getrandom::fill`, which reads from the OS CSPRNG (`getrandom(2)` / `arc4random_buf` / `BCryptGenRandom`). The placeholder format and length stay identical (`bk_placeholder_<32 hex chars>` = 47 chars).

## Why

Closes #1550.

## How

- `getrandom = "0.3"` added to workspace + bashkit direct deps. It's already transitively in the dep tree via reqwest/rustls so the build cost is essentially zero.
- `generate_placeholder()` rewritten: `getrandom::fill(&mut [u8; 16])` then lowercase hex format. Panics if the OS RNG is genuinely unavailable — there is no safe fallback for credential-shaped randomness.
- Doc comment updated to describe the actual randomness source.

## Tests

New regression tests in `credential::tests`:

- `test_placeholder_format_is_lowercase_hex` — every hex char is `0-9a-f`.
- `test_placeholder_uniqueness_across_many_generations` — 1024 generations all distinct (regression for the `RandomState` cross-init shortcut).
- `test_placeholder_does_not_leak_raw_credential` — the placeholder string and its `Debug` form do not embed the secret bytes.

Existing `test_placeholder_generation` still passes. All 2261 lib tests pass. `cargo fmt --check` and `cargo clippy --all-targets --features http_client -- -D warnings` are green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUJR2V1kE75fLNdfWxD4iS)_