### PR TITLE
test(isolation): pin TM-ISO-021/022/024 cross-exec leak guards

### DIFF
--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -549,6 +549,73 @@ mod finding_shell_options_leak {
 }
 
 // =============================================================================
+// FINDING 7b: STATE ISOLATION — $? LEAKS INTO VFS SUBPROCESS
+// Threat: TM-ISO-024 (new)
+// Issue: Within one exec(), the parent's $? leaks into a VFS-script subprocess
+// and trips `set -e`.
+// =============================================================================
+
+mod finding_subprocess_exit_code_leak {
+    use super::*;
+
+    /// TM-ISO-024: $? must reset to 0 inside a VFS-script subprocess regardless
+    /// of the parent's last exit code. Otherwise a child running `set -e` aborts
+    /// on its first command for no reason.
+    #[tokio::test]
+    async fn parent_exit_code_does_not_leak_into_subprocess() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                cat > /tmp/child.sh <<'EOF'
+#!/bin/bash
+echo "child_dollar_q=$?"
+EOF
+                chmod +x /tmp/child.sh
+                false
+                /tmp/child.sh
+                "#,
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.stdout.contains("child_dollar_q=0"),
+            "parent's $?=1 leaked into VFS subprocess; got: {}",
+            result.stdout
+        );
+    }
+
+    /// TM-ISO-024: combined with `set -e`, a leaked parent exit code would abort
+    /// the child immediately. This pins that the child runs to completion.
+    #[tokio::test]
+    async fn set_e_in_subprocess_does_not_trip_on_parent_exit_code() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                cat > /tmp/child.sh <<'EOF'
+#!/bin/bash
+set -e
+echo "child_first_line"
+echo "child_second_line"
+EOF
+                chmod +x /tmp/child.sh
+                false
+                /tmp/child.sh
+                "#,
+            )
+            .await
+            .unwrap();
+        assert!(
+            result.stdout.contains("child_first_line")
+                && result.stdout.contains("child_second_line"),
+            "child aborted under set -e; got: {}",
+            result.stdout
+        );
+    }
+}
+
+// =============================================================================
 // FINDING 8: /dev/urandom RETURNS EMPTY WITH head -c
 // Threat: TM-INT-007 (new)
 // Issue: head -c N /dev/urandom returns empty output.

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -849,9 +849,10 @@ Only exact domain matches are allowed (TM-NET-017).
 | TM-ISO-004 | Cross-session env pollution via jq | `std::env::set_var()` in jq modifies process-wide env, visible to concurrent sessions | Custom `$__bashkit_env__` jaq context variable replaces `std::env` access | **FIXED** |
 | TM-ISO-005 | Session-level cumulative counter bypass | Repeated `exec()` calls each reset `ExecutionCounters`, giving unbounded aggregate resources | — | **OPEN** |
 | TM-ISO-006 | No per-instance variable/memory budget | Unbounded `HashMap` growth in variables, arrays, functions exhausts process memory | — | **OPEN** |
-| TM-ISO-021 | EXIT trap leaks across `exec()` calls | EXIT trap set in one `exec()` fires in subsequent `exec()` calls on same Bash instance | — | **OPEN** |
-| TM-ISO-022 | `$?` leaks across `exec()` calls | Exit code from one `exec()` visible as `$?` in next `exec()` instead of resetting to 0 | — | **OPEN** |
+| TM-ISO-021 | EXIT trap leaks across `exec()` calls | EXIT trap set in one `exec()` fires in subsequent `exec()` calls on same Bash instance | `reset_transient_state()` clears `traps` at the start of every `exec()` | **MITIGATED** |
+| TM-ISO-022 | `$?` leaks across `exec()` calls | Exit code from one `exec()` visible as `$?` in next `exec()` instead of resetting to 0 | `reset_transient_state()` zeroes `last_exit_code` at the start of every `exec()` | **MITIGATED** |
 | TM-ISO-023 | `set -e` leaks across `exec()` calls | `set` options (`-e`, `-x`, etc.) persist across `exec()` calls, causing unexpected abort behavior | `reset_transient_state()` clears `SET_OPTION_VARS` | **FIXED** |
+| TM-ISO-024 | `$?` leaks into VFS subprocess | Parent `last_exit_code` visible inside VFS script subprocess, causing false `set -e` failures | `execute_script_content()` sets `last_exit_code = 0`, clears `nounset_error`, and clears `traps` for the child | **MITIGATED** |
 
 **TM-ISO-004**: Fixed. The jq builtin now injects shell variables via a custom jaq context variable
 (`$__bashkit_env__`) and overrides the `env` filter to read from it instead of `std::env`.
@@ -1303,10 +1304,10 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | ~~TM-INJ-019~~ | ~~`unset` removes readonly variables~~ | ~~Integrity bypass — readonly protection defeated~~ | ~~Check readonly attribute in unset before removal~~ (**FIXED**) |
 | ~~TM-INJ-020~~ | ~~`declare` overwrites readonly variables~~ | ~~Integrity bypass — `declare X=new` overwrites `readonly X=old`~~ | ~~Check readonly attribute in declare assignment path~~ (**FIXED**) |
 | ~~TM-INJ-021~~ | ~~`export` overwrites readonly variables~~ | ~~Integrity bypass — `export X=new` overwrites `readonly X=old`~~ | ~~Check readonly attribute in export assignment path~~ (**FIXED**) |
-| TM-ISO-021 | EXIT trap leaks across `exec()` calls | Cross-invocation interference — trap from exec N fires in exec N+1 | Reset traps in `reset_for_execution()` |
-| TM-ISO-022 | `$?` leaks across `exec()` calls | State pollution — exit code from previous exec visible to next exec | Reset `last_exit_code` in `reset_for_execution()` |
+| ~~TM-ISO-021~~ | ~~EXIT trap leaks across `exec()` calls~~ | ~~Cross-invocation interference — trap from exec N fires in exec N+1~~ | ~~Reset traps in `reset_for_execution()`~~ — `reset_transient_state()` clears `traps` (**FIXED**) |
+| ~~TM-ISO-022~~ | ~~`$?` leaks across `exec()` calls~~ | ~~State pollution — exit code from previous exec visible to next exec~~ | ~~Reset `last_exit_code` in `reset_for_execution()`~~ — `reset_transient_state()` zeroes `last_exit_code` (**FIXED**) |
 | TM-ISO-023 | `set -e` leaks across `exec()` calls | Unexpected abort — `set` options from previous exec affect next exec | `SET_OPTION_VARS` cleared in `reset_transient_state()` (**FIXED**) |
-| TM-ISO-024 | `$?` leaks into VFS subprocess | Parent `last_exit_code` visible inside VFS script subprocess, causing false `set -e` failures | Reset `last_exit_code = 0` and `nounset_error = None` in `execute_script_content` subprocess isolation |
+| ~~TM-ISO-024~~ | ~~`$?` leaks into VFS subprocess~~ | ~~Parent `last_exit_code` visible inside VFS script subprocess, causing false `set -e` failures~~ | ~~Reset `last_exit_code = 0` and `nounset_error = None` in `execute_script_content` subprocess isolation~~ (**FIXED**) |
 | TM-INT-007 | `/dev/urandom` empty with `head -c` | Weak randomness — `head -c 16 /dev/urandom` returns empty string | Fix virtual device pipe handling in head builtin |
 | TM-DOS-044 | Nested `$()` stack overflow (regression) | Process crash (SIGABRT) at depth ~50 despite #492 fix | Interpreter execution path may need separate depth tracking from lexer fix |
 | TM-DOS-088 | Command substitution OOM via state cloning | OOM at depth N (memory ≈ N × state_size) | Dedicated `max_subst_depth` limit (default 32), separate from `max_function_depth` — **FIXED** via #1088 |


### PR DESCRIPTION
## Summary

Closes the documentation/test gap on three threat-model entries that
were already mitigated in code but still listed as `OPEN` in
`specs/threat-model.md`. TM-ISO-024 had no regression test at all.

Mitigates (now confirmed by tests):

- **TM-ISO-021** — EXIT trap leak across `exec()` calls: `reset_transient_state()`
  clears `traps` at the start of every `exec()`.
- **TM-ISO-022** — `$?` leak across `exec()` calls: same path zeroes
  `last_exit_code`.
- **TM-ISO-024** — `$?` leak into VFS subprocess:
  `execute_script_content()` sets `last_exit_code = 0` and clears
  `nounset_error` for the child.

## Why

The mitigations existed but TM-ISO-024 had no test, so a future refactor
of `execute_script_content` could regress the subprocess isolation
silently. This PR pins the behaviour and updates the spec so the
open-issue list is no longer misleading.

## How

- `crates/bashkit/tests/blackbox_security_tests.rs` — new module
  `finding_subprocess_exit_code_leak` with two tests:
  - `parent_exit_code_does_not_leak_into_subprocess` — sets parent
    `$?=1` via `false`, then runs a VFS script that prints `$?`,
    asserts the child sees `0`.
  - `set_e_in_subprocess_does_not_trip_on_parent_exit_code` — same
    setup but child runs `set -e`, asserts the child runs to
    completion instead of aborting on the leaked exit code.
- `specs/threat-model.md` — TM-ISO-021 / TM-ISO-022 / TM-ISO-024
  marked **MITIGATED** in §6 Multi-Tenant Isolation and **FIXED** in
  the 2026-03 Blackbox Security Testing table. Mitigation column now
  points at the actual reset-state call sites.

## Tests

\`\`\`
cargo test -p bashkit --test blackbox_security_tests
\`\`\`
84 pass (including 2 new TM-ISO-024 tests).

\`\`\`
cargo fmt --all --check                     # clean
cargo clippy -p bashkit --all-targets -- -D warnings  # clean
\`\`\`

## Test plan

- [x] EXIT trap from one exec() does not leak into the next (existing)
- [x] \$? from one exec() does not leak into the next (existing)
- [x] Parent's \$? does not leak into VFS subprocess (new)
- [x] Subprocess set -e is not tripped by leaked parent exit code (new)
- [x] Lib + lint clean