### PR TITLE
fix(ln): surface remove failure under -f instead of falling through to symlink

### DIFF
--- a/crates/bashkit/src/builtins/fileops.rs
+++ b/crates/bashkit/src/builtins/fileops.rs
@@ -696,8 +696,16 @@ impl Builtin for Ln {
         // If link already exists
         if ctx.fs.exists(&link_path).await.unwrap_or(false) {
             if force {
-                // Remove existing
-                let _ = ctx.fs.remove(&link_path, false).await;
+                // Surface remove failures (e.g. non-empty directory) instead
+                // of falling through and overwriting via symlink, which on
+                // the in-memory VFS would orphan children and corrupt state
+                // (issue #1577).
+                if let Err(e) = ctx.fs.remove(&link_path, false).await {
+                    return Ok(ExecResult::err(
+                        format!("ln: cannot remove '{}': {}\n", link_name, e),
+                        1,
+                    ));
+                }
             } else {
                 return Ok(ExecResult::err(
                     format!(
@@ -1283,6 +1291,57 @@ mod tests {
 
         let meta = fs.stat(&cwd.join("script.sh")).await.unwrap();
         assert_eq!(meta.mode, 0o755);
+    }
+
+    /// Regression: issue #1577. `ln -f` over a non-empty directory must
+    /// surface the underlying remove failure instead of silently
+    /// proceeding to symlink creation, which on the in-memory VFS would
+    /// orphan the directory's children.
+    #[tokio::test]
+    async fn test_ln_force_over_non_empty_dir_fails() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        // Set up: target file + non-empty destination directory.
+        fs.write_file(&cwd.join("target.txt"), b"content")
+            .await
+            .unwrap();
+        fs.mkdir(&cwd.join("destdir"), false).await.unwrap();
+        fs.write_file(&cwd.join("destdir/child.txt"), b"x")
+            .await
+            .unwrap();
+
+        let args = vec![
+            "-sf".to_string(),
+            "target.txt".to_string(),
+            "destdir".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Ln.execute(ctx).await.unwrap();
+        assert_ne!(
+            result.exit_code, 0,
+            "ln -sf must fail when destination is a non-empty directory"
+        );
+        // Child must still exist; ln must not have proceeded to symlink.
+        assert!(
+            fs.exists(&cwd.join("destdir/child.txt")).await.unwrap(),
+            "child file must not be orphaned"
+        );
     }
 
     #[test]

--- a/crates/bashkit/tests/spec_cases/bash/ln.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/ln.test.sh
@@ -46,3 +46,15 @@ echo "ok"
 ### expect
 ok
 ### end
+
+### ln_force_dir_dest_fails
+### exit_code:1
+### bash_diff: Bashkit VFS rejects ln -sf over a non-empty directory; real ln also fails here.
+# Regression: issue #1577. ln -f must not silently overwrite a non-empty
+# directory with a symlink — that would orphan its children in the VFS.
+echo content > /tmp/force_dir_target.txt
+mkdir -p /tmp/force_dir_dest
+echo child > /tmp/force_dir_dest/child.txt
+ln -sf /tmp/force_dir_target.txt /tmp/force_dir_dest
+### expect
+### end


### PR DESCRIPTION
Closes #1577.

## Summary

`ln -f` previously swallowed the result of `ctx.fs.remove(...)` and called `ctx.fs.symlink(...)` unconditionally. When the destination is a non-empty directory, `remove(..., false)` fails, but the symlink insert on the in-memory VFS overwrites the directory entry while leaving its children orphaned in the `entries` map — a corruption of filesystem state.

## Fix

- Propagate the `remove` error and return exit 1 with a real-shell-style `ln: cannot remove '<name>': <reason>` message.
- Add unit-level regression test `test_ln_force_over_non_empty_dir_fails` (verifies non-zero exit + child file still present).
- Add a spec case `ln_force_dir_dest_fails` covering the same scenario from the user-facing CLI.

## Notes

The issue also suggests "make VFS `symlink` reject existing paths defensively". That change has broader implications for other callers (overlay, mountable, cp -R) and warrants its own PR — punting for now.

## Test plan

- [x] `cargo test -p bashkit --lib builtins::fileops::tests::test_ln_force_over_non_empty_dir_fails`
- [x] `cargo test -p bashkit --test spec_tests bash_spec` (passes; new ln_force_dir_dest_fails case included)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`


---
_Generated by [Claude Code](https://claude.ai/code/session_014PHDfbiFnvaBHeiDbARpRB)_