### PR TITLE
fix(interop): mark filesystem import unsafe and own the foreign vtable

### DIFF
--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -360,7 +360,9 @@ fn file_system_external_handle(external: Unknown<'_>) -> napi::Result<BashkitFsA
 
 fn import_external_file_system(external: Unknown<'_>) -> napi::Result<Arc<dyn BashFileSystem>> {
     let handle = file_system_external_handle(external)?;
-    import_filesystem(&handle).map_err(|e| napi::Error::from_reason(e.to_string()))
+    // SAFETY: `external` was created by export_external_file_system; the
+    // ABI handle inside it is valid as long as the external value lives.
+    unsafe { import_filesystem(&handle) }.map_err(|e| napi::Error::from_reason(e.to_string()))
 }
 
 impl NativeFileSystemState {

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1354,7 +1354,9 @@ impl PyFileSystem {
             .map_err(|_| PyTypeError::new_err("capsule must be a PyCapsule"))?;
         let ptr = capsule.pointer_checked(Some(FILESYSTEM_CAPSULE_NAME))?;
         let exported = unsafe { &*ptr.as_ptr().cast::<BashkitFsAbiOwnedHandleV1>() };
-        let fs = import_owned_filesystem(exported)
+        // SAFETY: capsule was created by export_filesystem; the embedded
+        // ABI handle is valid as long as the capsule is alive.
+        let fs = unsafe { import_owned_filesystem(exported) }
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         let rt = make_runtime()?;
         Ok(Self::from_static(fs, rt))

--- a/crates/bashkit/src/interop/fs.rs
+++ b/crates/bashkit/src/interop/fs.rs
@@ -268,14 +268,40 @@ pub fn export_filesystem(fs: Arc<dyn FileSystem>) -> io::Result<BashkitFsAbiOwne
     })
 }
 
-pub fn import_filesystem(handle: &BashkitFsAbiHandleV1) -> io::Result<Arc<dyn FileSystem>> {
-    Ok(Arc::new(ImportedFileSystem::from_handle(handle)?) as Arc<dyn FileSystem>)
+/// Import a filesystem from a raw FFI handle.
+///
+/// # Safety
+///
+/// `handle.instance` must be a live pointer, valid for the lifetime of the
+/// returned `Arc`, and `handle.vtable` must point to a valid
+/// `BashkitFsAbiVTableV1` whose function pointers stay callable for that
+/// lifetime. The caller is responsible for ensuring all of `instance`,
+/// `vtable`, `retain`, and `release` form a coherent ABI v1 contract.
+///
+/// Bashkit retains an extra reference via `handle.retain` and releases it
+/// in `Drop`. The vtable is copied into owned state so its memory does
+/// not need to outlive this call.
+///
+/// Issue #1579: this API is unsafe because it dereferences raw FFI
+/// pointers.
+pub unsafe fn import_filesystem(handle: &BashkitFsAbiHandleV1) -> io::Result<Arc<dyn FileSystem>> {
+    let imported = unsafe { ImportedFileSystem::from_handle(handle)? };
+    Ok(Arc::new(imported) as Arc<dyn FileSystem>)
 }
 
-pub fn import_owned_filesystem(
+/// Import a filesystem from a bashkit-owned handle.
+///
+/// # Safety
+///
+/// Although [`BashkitFsAbiOwnedHandleV1`] is created by [`export_filesystem`]
+/// and therefore points at a valid bashkit-managed instance, dereferencing
+/// raw vtable function pointers from a foreign producer is still unsafe in
+/// the general case. Callers must uphold the same invariants as
+/// [`import_filesystem`].
+pub unsafe fn import_owned_filesystem(
     handle: &BashkitFsAbiOwnedHandleV1,
 ) -> io::Result<Arc<dyn FileSystem>> {
-    import_filesystem(handle.as_handle())
+    unsafe { import_filesystem(handle.as_handle()) }
 }
 
 fn missing_abi_field(name: &str) -> IoError {
@@ -335,20 +361,40 @@ fn validate_handle(handle: &BashkitFsAbiHandleV1) -> io::Result<&BashkitFsAbiVTa
 
 pub struct ImportedFileSystem {
     handle: BashkitFsAbiHandleV1,
+    /// Owned copy of the foreign vtable. Issue #1579: storing the
+    /// dereferenced vtable means we never re-deref the raw `vtable`
+    /// pointer after construction, eliminating use-after-free and
+    /// concurrent-mutation hazards across the FFI boundary.
+    vtable: BashkitFsAbiVTableV1,
 }
 
 impl ImportedFileSystem {
-    pub fn from_handle(handle: &BashkitFsAbiHandleV1) -> io::Result<Self> {
-        validate_handle(handle)?;
+    /// Build an `ImportedFileSystem` from a raw FFI handle.
+    ///
+    /// # Safety
+    ///
+    /// See [`import_filesystem`]. The caller must guarantee
+    /// `handle.instance` and `handle.vtable` point at live, valid memory
+    /// for the duration of the call. The vtable contents are copied into
+    /// owned state, so the vtable pointer itself does not need to outlive
+    /// this constructor.
+    pub unsafe fn from_handle(handle: &BashkitFsAbiHandleV1) -> io::Result<Self> {
+        // SAFETY: caller-established invariants on `handle.vtable` allow
+        // the deref inside `validate_handle`.
+        let vtable_ref = validate_handle(handle)?;
+        let vtable_owned = *vtable_ref;
         let retain = handle.retain.expect("filesystem ABI handle was validated");
         unsafe {
             retain(handle.instance);
         }
-        Ok(Self { handle: *handle })
+        Ok(Self {
+            handle: *handle,
+            vtable: vtable_owned,
+        })
     }
 
     fn vtable(&self) -> &BashkitFsAbiVTableV1 {
-        unsafe { &*self.handle.vtable }
+        &self.vtable
     }
 
     fn call(
@@ -1211,7 +1257,9 @@ mod tests {
         });
 
         let exported = export_filesystem(source).unwrap();
-        let imported = import_owned_filesystem(&exported).unwrap();
+        // SAFETY: `exported` is bashkit-owned and lives until the end of
+        // this scope, so its instance and vtable are valid here.
+        let imported = unsafe { import_owned_filesystem(&exported) }.unwrap();
 
         let bytes = rt
             .block_on(async { imported.read_file(Path::new("/org/repo/README.md")).await })
@@ -1229,7 +1277,9 @@ mod tests {
             release: Some(release_export_state),
             vtable: ptr::null(),
         };
-        let err = match ImportedFileSystem::from_handle(&handle) {
+        // SAFETY: the handle is intentionally invalid; from_handle must
+        // reject it before any deref happens.
+        let err = match unsafe { ImportedFileSystem::from_handle(&handle) } {
             Ok(_) => panic!("expected ABI version check to fail"),
             Err(err) => err,
         };
@@ -1243,7 +1293,9 @@ mod tests {
 
         let mut handle = *exported.as_handle();
         handle.retain = None;
-        let err = match ImportedFileSystem::from_handle(&handle) {
+        // SAFETY: handle is bashkit-owned; from_handle must reject the
+        // missing retain entry before dereferencing it.
+        let err = match unsafe { ImportedFileSystem::from_handle(&handle) } {
             Ok(_) => panic!("expected null retain check to fail"),
             Err(err) => err,
         };
@@ -1253,11 +1305,51 @@ mod tests {
         vtable.read_file = None;
         let mut handle = *exported.as_handle();
         handle.vtable = &vtable;
-        let err = match ImportedFileSystem::from_handle(&handle) {
+        // SAFETY: same — vtable is locally owned, handle is bashkit-owned.
+        let err = match unsafe { ImportedFileSystem::from_handle(&handle) } {
             Ok(_) => panic!("expected null vtable entry check to fail"),
             Err(err) => err,
         };
         assert_eq!(err.kind(), ErrorKind::InvalidData);
+    }
+
+    /// Regression: issue #1579. After `from_handle` returns, the foreign
+    /// vtable memory must no longer be consulted: bashkit copies it into
+    /// owned state. We mutate the source vtable in place after import and
+    /// verify subsequent operations still behave per the captured contract.
+    #[test]
+    fn imported_filesystem_uses_owned_vtable_copy() {
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        let source: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        rt.block_on(async {
+            source
+                .write_file(Path::new("/file.txt"), b"copy-vtable")
+                .await
+                .unwrap();
+        });
+        let exported = export_filesystem(source).unwrap();
+
+        // Build an importable handle using a *local, mutable* vtable so we
+        // can null it out after import. The static EXPORT_VTABLE can't be
+        // mutated, but we can copy it.
+        let mut local_vtable = EXPORT_VTABLE;
+        let mut handle = *exported.as_handle();
+        handle.vtable = &local_vtable;
+
+        // SAFETY: instance is bashkit-owned; local_vtable is on stack and
+        // outlives import_filesystem's deref.
+        let imported = unsafe { import_filesystem(&handle) }.unwrap();
+
+        // After import, smash the source vtable. If bashkit re-derefs the
+        // raw pointer on each call, this would either crash or read None
+        // entries; with an owned copy it's a no-op.
+        local_vtable.read_file = None;
+        assert!(local_vtable.read_file.is_none());
+
+        let bytes = rt
+            .block_on(async { imported.read_file(Path::new("/file.txt")).await })
+            .expect("read_file must use the owned vtable copy, not the smashed source");
+        assert_eq!(bytes, b"copy-vtable");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1579.

## Summary

`import_filesystem`, `import_owned_filesystem`, and `ImportedFileSystem::from_handle` were safe public APIs that accepted a `BashkitFsAbiHandleV1` carrying raw `instance` and `vtable` pointers. They dereferenced `handle.vtable` on validation, called `retain` on `handle.instance`, dereferenced the raw vtable again on every operation, and marked the wrapper `Send`/`Sync`. A malformed, stale, or non-thread-safe foreign handle could therefore crash or corrupt the host process via fully safe Rust code paths (capsule/external import, native extension imports, etc.).

## Fix

- Mark all three entry points `unsafe fn`; their docs spell out the invariants the caller must uphold (`instance` and `vtable` valid for the duration of the call, retain/release form a coherent contract).
- Snapshot the vtable into `ImportedFileSystem` at construction time and access only the owned copy thereafter, so the foreign vtable pointer can be freed or mutated after import without affecting us.
- Update the Python (PyCapsule) and Node (External) bindings to wrap their existing raw-deref + import call in `unsafe { ... }` with a `SAFETY:` note tying the contract to the exporting capsule/external.

## Tests

- New `imported_filesystem_uses_owned_vtable_copy`: imports a filesystem, mutates the source vtable in place after import, and verifies the imported FS still works because it holds an owned copy.
- Updated `rejects_unknown_abi_version`, `rejects_null_abi_callbacks_before_retain`, `export_import_roundtrip` to wrap the now-unsafe `from_handle` / `import_owned_filesystem` calls in `unsafe { … }` with safety notes.

## Test plan

- [x] `cargo test -p bashkit --lib --features interop interop::fs` (5/5 passing including the new test)
- [x] `cargo check --workspace --all-features` (bashkit, bashkit-python, bashkit-node, bashkit-cli all build)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p bashkit --features interop --all-targets -- -D warnings`

Note: `threat_jq_moderate_nesting_works` fails on this branch but also fails on `main` — pre-existing flake unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_014PHDfbiFnvaBHeiDbARpRB)_