### PR TITLE
fix(sqlite): reject VACUUM to block VFS escape via VACUUM INTO

### DIFF
--- a/crates/bashkit/src/builtins/sqlite/mod.rs
+++ b/crates/bashkit/src/builtins/sqlite/mod.rs
@@ -307,7 +307,7 @@ impl Builtin for Sqlite {
             "sqlite/sqlite3: Embedded SQLite-compatible engine (Turso, BETA). \
              Usage: sqlite DB SQL... | sqlite DB <script | sqlite -separator , -header DB SELECT. \
              Dot-commands: .tables .schema .dump .headers .mode .separator .nullvalue .read .help. \
-             Supports :memory:. No ATTACH/DETACH. \
+             Supports :memory:. No ATTACH/DETACH/VACUUM. \
              Set BASHKIT_ALLOW_INPROCESS_SQLITE=1 to enable.",
         )
     }
@@ -771,6 +771,11 @@ async fn run_statements(
 ///   access would let scripts read/write VFS paths the operator did not
 ///   stage, and turso's ATTACH path interacts with the registry in ways
 ///   the `:memory:bashkit-N` isolation does not cover.
+/// * `VACUUM` (with or without `INTO`) is unconditionally rejected.
+///   `VACUUM INTO` opens the destination via turso's `PlatformIO`, which
+///   writes to the host filesystem and bypasses both `MemoryIO` and
+///   `BashkitVfsIO`. Plain `VACUUM` is denied for symmetry — there is no
+///   sandbox-safe way to express it today.
 /// * `PRAGMA <name>` is rejected when `<name>` (case-insensitive) is in
 ///   `limits.pragma_deny`. Defaults are listed in [`DEFAULT_PRAGMA_DENY`].
 fn check_sql_policy(sql: &str, limits: &SqliteLimits) -> std::result::Result<(), String> {
@@ -778,6 +783,11 @@ fn check_sql_policy(sql: &str, limits: &SqliteLimits) -> std::result::Result<(),
         Some("ATTACH") | Some("DETACH") => {
             return Err("ATTACH/DETACH is not supported in the bashkit sandbox; \
                  cross-database access bypasses VFS isolation"
+                .to_string());
+        }
+        Some("VACUUM") => {
+            return Err("VACUUM is not supported in the bashkit sandbox; \
+                 VACUUM INTO would write to the host filesystem outside the VFS"
                 .to_string());
         }
         _ => {}

--- a/crates/bashkit/src/builtins/sqlite/tests.rs
+++ b/crates/bashkit/src/builtins/sqlite/tests.rs
@@ -543,6 +543,34 @@ async fn attach_blocked_even_with_leading_comment() {
 }
 
 #[tokio::test]
+async fn vacuum_into_blocked() {
+    // Regression for #1572: `VACUUM INTO` lets turso open the destination
+    // file via PlatformIO, escaping the VFS sandbox to write host paths.
+    let r = run(&[":memory:", "VACUUM INTO '/tmp/escape.db'"], None).await;
+    assert_eq!(r.exit_code, 1, "stderr: {}", r.stderr);
+    assert!(
+        r.stderr.contains("VACUUM is not supported"),
+        "stderr was: {}",
+        r.stderr
+    );
+}
+
+#[tokio::test]
+async fn vacuum_plain_blocked() {
+    let r = run(&[":memory:", "VACUUM"], None).await;
+    assert_eq!(r.exit_code, 1, "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("VACUUM is not supported"));
+}
+
+#[tokio::test]
+async fn vacuum_blocked_with_leading_comment() {
+    // The keyword-sniffer must skip leading comments before deciding.
+    let r = run(&[":memory:", "/* hi */ VACUUM INTO '/tmp/escape.db'"], None).await;
+    assert_eq!(r.exit_code, 1, "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("VACUUM is not supported"));
+}
+
+#[tokio::test]
 async fn pragma_user_version_still_works() {
     // user_version isn't on the deny list — it must round-trip cleanly.
     let r = run(

--- a/specs/sqlite-builtin.md
+++ b/specs/sqlite-builtin.md
@@ -163,7 +163,7 @@ caller could legitimately call `bash.snapshot()`. Restore creates a
 fresh `Bash` with an empty cache; the first `sqlite` call re-opens
 the engine from the restored VFS bytes.
 
-### SQL policy: ATTACH / DETACH and PRAGMA deny list
+### SQL policy: ATTACH / DETACH / VACUUM and PRAGMA deny list
 
 Before each statement reaches turso, `check_sql_policy()` inspects the
 leading SQL keyword via the parser's lightweight tokeniser
@@ -174,6 +174,12 @@ leading SQL keyword via the parser's lightweight tokeniser
   the operator never staged for read/write, and on the VFS backend it
   would also build new `MemoryIO`/`VfsIO` state outside our
   `:memory:bashkit-N` registry isolation.
+- `VACUUM` (with or without `INTO`) is unconditionally rejected. In
+  turso's current implementation, `VACUUM INTO` opens the destination
+  file via `PlatformIO`, which writes to the host filesystem rather than
+  the configured `MemoryIO`/`BashkitVfsIO`, escaping the sandbox. Plain
+  `VACUUM` is denied for symmetry — there is no sandbox-safe way to
+  express it today.
 - `PRAGMA <name>` is checked against `SqliteLimits::pragma_deny` (case-
   insensitive, schema-prefix-aware so `PRAGMA main.cache_size` is also
   matched). Defaults block resource/FS-shaped knobs:
@@ -213,6 +219,7 @@ leading SQL keyword via the parser's lightweight tokeniser
 | TM-SQL-009    | Cross-database access via `ATTACH`/`DETACH`          | Policy rejects both keywords (case-insensitive, comment-aware); tested via `tm_sql_009` |
 | TM-SQL-010    | DoS / fingerprinting via dangerous PRAGMAs           | `SqliteLimits::pragma_deny` defaults block `cache_size`, `mmap_size`, `page_size`, `max_page_count`, `temp_store_directory`, `data_store_directory`, `compile_options`, `locking_mode`, `shared_cache`; parser handles comments plus quoted/schema-qualified names |
 | TM-SQL-011    | Information leakage via host-side error strings      | `sanitize()` strips ` at /…:N:M` annotations from turso errors          |
+| TM-SQL-012    | Sandbox escape via `VACUUM INTO` writing host files  | Policy rejects `VACUUM` (with/without `INTO`) at the keyword sniffer; tested via `vacuum_into_blocked`/`vacuum_plain_blocked`/`vacuum_blocked_with_leading_comment` |
 
 ## Test Plan
 


### PR DESCRIPTION
Closes #1572.

## Summary

`VACUUM INTO` opens its destination through turso's `PlatformIO`, which writes
to the host filesystem instead of the configured `MemoryIO` / `BashkitVfsIO`
backend. A sandboxed script can therefore create a SQLite database file at any
host path writable by the process, bypassing bashkit's VFS boundary.

## Fix

Reject `VACUUM` (with or without `INTO`) at the keyword sniffer in
`check_sql_policy`, alongside the existing `ATTACH`/`DETACH` block. Plain
`VACUUM` is denied for symmetry — there is no sandbox-safe way to express it
today.

## Tests

- `vacuum_into_blocked` — `VACUUM INTO '/tmp/escape.db'` returns exit code 1 and
  the policy error.
- `vacuum_plain_blocked` — bare `VACUUM` is also rejected.
- `vacuum_blocked_with_leading_comment` — block-comment-prefixed VACUUM still
  hits the policy (exercises the comment-skipping logic in `leading_keyword`).

All 98 sqlite-feature unit tests pass.

## Spec

- `specs/sqlite-builtin.md` § "SQL policy" updated to document the VACUUM
  block.
- New row `TM-SQL-012` added to the threat-model table.

## Test plan

- [x] `cargo test -p bashkit --lib --features sqlite builtins::sqlite` (98/98)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p bashkit --features sqlite --all-targets -- -D warnings`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYBPd2MxpEcWxD51YLWFDh)_