### PR TITLE
fix(network): normalize IPv4-mapped IPv6 in is_private_ip to block SSRF

### DIFF
--- a/crates/bashkit/src/network/allowlist.rs
+++ b/crates/bashkit/src/network/allowlist.rs
@@ -23,28 +23,51 @@ use url::Url;
 /// Check if an IP address is in a private/reserved range.
 ///
 /// Blocks: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
-/// 169.254.0.0/16, 0.0.0.0, ::1, fd00::/8, fe80::/10, ::
+/// 169.254.0.0/16, 100.64.0.0/10, 0.0.0.0, ::1, fd00::/8, fe80::/10, ::
 ///
-/// # Security (TM-NET-002, TM-NET-004)
+/// IPv4-mapped IPv6 addresses (`::ffff:0:0/96`) are normalized to their
+/// embedded IPv4 form and classified using the v4 rules. This is critical:
+/// without it, an attacker who controls DNS for an allowlisted hostname
+/// can return an AAAA record pointing at e.g. `::ffff:127.0.0.1` or
+/// `::ffff:169.254.169.254` and bypass the v4 private-range checks.
+///
+/// # Security (TM-NET-002, TM-NET-004, TM-NET-008)
 ///
 /// Used to prevent SSRF attacks where an allowed hostname resolves
 /// to an internal/cloud metadata IP address.
 pub fn is_private_ip(ip: &IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()                    // 127.0.0.0/8
-                || v4.is_private()              // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-                || v4.is_link_local()           // 169.254.0.0/16
-                || v4.is_unspecified()          // 0.0.0.0
-                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 (CGNAT)
-        }
+        IpAddr::V4(v4) => is_private_ipv4(v4),
         IpAddr::V6(v6) => {
+            // SECURITY (TM-NET-008, #1569): IPv4-mapped IPv6 addresses
+            // (`::ffff:a.b.c.d`) and IPv4-compatible addresses
+            // (`::a.b.c.d`, deprecated but still resolvable) re-enter the
+            // address space as v4 at the kernel/socket layer. Reject them
+            // by their v4 classification before applying v6-only rules.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_private_ipv4(&v4);
+            }
+            if let Some(v4) = v6.to_ipv4()
+                && v6.segments()[..6].iter().all(|s| *s == 0)
+                && v6.segments()[6] != 0
+            {
+                // ::a.b.c.d (IPv4-compatible) — apply v4 rules.
+                return is_private_ipv4(&v4);
+            }
             v6.is_loopback()                    // ::1
                 || v6.is_unspecified()          // ::
                 || (v6.segments()[0] & 0xfe00) == 0xfc00 // fd00::/8 (unique local)
                 || (v6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
         }
     }
+}
+
+fn is_private_ipv4(v4: &std::net::Ipv4Addr) -> bool {
+    v4.is_loopback()                    // 127.0.0.0/8
+        || v4.is_private()              // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+        || v4.is_link_local()           // 169.254.0.0/16
+        || v4.is_unspecified()          // 0.0.0.0
+        || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 (CGNAT)
 }
 
 /// Redact credentials from a URL for safe inclusion in error messages.
@@ -554,6 +577,60 @@ mod tests {
         assert!(!is_private_ip(
             &"2001:db8::1".parse::<std::net::IpAddr>().unwrap()
         ));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_mapped_v6_loopback() {
+        // Regression for #1569 (TM-NET-008): IPv4-mapped IPv6 addresses
+        // must be normalized and classified by the embedded v4 address.
+        // Without normalization, an AAAA record returning `::ffff:127.0.0.1`
+        // would bypass the v4 loopback check and reach localhost.
+        assert!(is_private_ip(&"::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:127.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_mapped_v6_rfc1918() {
+        // Regression for #1569: AAAA → ::ffff:10.0.0.1 / ::ffff:192.168.x.y
+        // must trip the v4 private-range check.
+        assert!(is_private_ip(&"::ffff:10.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:172.16.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:192.168.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_mapped_v6_metadata() {
+        // Regression for #1569: ::ffff:169.254.169.254 (AWS metadata) is
+        // the highest-impact bypass and must classify as private.
+        assert!(is_private_ip(&"::ffff:169.254.169.254".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:169.254.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_mapped_v6_cgnat() {
+        // CGNAT range coverage carries through normalization too.
+        assert!(is_private_ip(&"::ffff:100.64.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:100.127.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_mapped_v6_unspecified() {
+        assert!(is_private_ip(&"::ffff:0.0.0.0".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_mapped_v6_public_still_public() {
+        // Public IPv4 wrapped as v4-mapped v6 must still be public.
+        assert!(!is_private_ip(&"::ffff:8.8.8.8".parse().unwrap()));
+        assert!(!is_private_ip(&"::ffff:1.1.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_is_private_ip_v4_compatible_v6_loopback() {
+        // IPv4-compatible IPv6 (`::a.b.c.d`, deprecated but still parsable)
+        // also needs v4 classification.
+        assert!(is_private_ip(&"::127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"::169.254.169.254".parse().unwrap()));
     }
 
     #[test]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -676,6 +676,7 @@ allowlist.allow("https://api.example.com");
 | TM-NET-019 | Query param injection | `http GET url q=='foo&admin=true'` injects extra params | URL-encode via `url::form_urlencoded` | **MITIGATED** |
 | TM-NET-020 | Form body injection | `http --form POST url user='x&role=admin'` injects extra fields | URL-encode via `url::form_urlencoded` | **MITIGATED** |
 | TM-NET-021 | Bot identity spoofing | Forge requests as a trusted bot | Ed25519 request signing (bot-auth feature, `specs/request-signing.md`) | **MITIGATED** (opt-in) |
+| TM-NET-022 | IPv4-mapped IPv6 SSRF bypass | AAAA record returns `::ffff:127.0.0.1`, `::ffff:10.0.0.1`, `::ffff:169.254.169.254`, etc. — embedded v4 address would re-enter the v4 address space at the kernel/socket layer, but the v6 branch of `is_private_ip` only inspected `is_loopback`/`is_unspecified`/`fd00::/8`/`fe80::/10`, treating everything else as public | `is_private_ip` normalizes IPv4-mapped (`::ffff:0:0/96`) and IPv4-compatible (`::a.b.c.d`) v6 forms back to v4 via `Ipv6Addr::to_ipv4_mapped()` and applies the v4 classifier (`is_private_ipv4`). Tested via `test_is_private_ip_v4_mapped_v6_*` cases for loopback, RFC1918, AWS metadata (169.254.169.254), CGNAT, unspecified, public, and IPv4-compatible. Mitigation reaches both the v6 connect-time `PrivateIpFilteringResolver` and the URL/precheck path. | **FIXED** (#1569) |
 
 **Current Risk**: LOW - Multiple mitigations in place
 


### PR DESCRIPTION
Closes #1569.

## Summary

The v6 branch of `is_private_ip` only checked `is_loopback` /
`is_unspecified` / `fd00::/8` / `fe80::/10`. IPv4-mapped IPv6
addresses (`::ffff:a.b.c.d`) and IPv4-compatible v6 (`::a.b.c.d`,
deprecated but still parsable) fell through as "public", even though
the embedded v4 address re-enters the v4 address space at the
kernel/socket layer.

An attacker controlling DNS for an allowlisted hostname can return AAAA
records like:

- `::ffff:127.0.0.1` → loopback
- `::ffff:169.254.169.254` → AWS metadata
- `::ffff:10.0.0.1` / `::ffff:192.168.1.1` → RFC1918

The allowlist check passes, the connection lands on internal services,
and SSRF mitigations (`PrivateIpFilteringResolver`, the precheck, and
the URL match check) all silently allowed it.

## Fix

In the v6 branch of `is_private_ip`, first try `v6.to_ipv4_mapped()` and
a check for IPv4-compatible `::a.b.c.d`, then apply the v4 classifier
(`is_private_ipv4`) to the embedded address. Factor the v4 rules into
`is_private_ipv4` so both branches share identical logic.

The fix benefits all four call sites that consume `is_private_ip`:
`PrivateIpFilteringResolver` (connect-time), the URL precheck, the
filter on resolved socket addresses, and the URL/IP match in
`NetworkAllowlist`.

## Tests

- `test_is_private_ip_v4_mapped_v6_loopback` — `::ffff:127.0.0.1`
- `test_is_private_ip_v4_mapped_v6_rfc1918` — `::ffff:{10.x, 172.x, 192.168.x}`
- `test_is_private_ip_v4_mapped_v6_metadata` — `::ffff:169.254.169.254` (AWS)
- `test_is_private_ip_v4_mapped_v6_cgnat` — `100.64.0.0/10`
- `test_is_private_ip_v4_mapped_v6_unspecified` — `::ffff:0.0.0.0`
- `test_is_private_ip_v4_mapped_v6_public_still_public` — `::ffff:8.8.8.8`
- `test_is_private_ip_v4_compatible_v6_loopback` — `::127.0.0.1`

All 29 `network::allowlist` tests pass.

## Spec

- `specs/threat-model.md`: new row `TM-NET-022` covering this threat
  and its mitigation.

## Test plan

- [x] `cargo test -p bashkit --lib network`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p bashkit --all-targets -- -D warnings`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYBPd2MxpEcWxD51YLWFDh)_