### PR TITLE
fix(scripts): follow redirects and bump just to 1.50.0 in init-cloud-env

### DIFF
--- a/scripts/init-cloud-env.sh
+++ b/scripts/init-cloud-env.sh
@@ -59,19 +59,20 @@ install_just() {
 
     ARCH=$(uname -m)
     case "$ARCH" in
-        x86_64)  JUST_ARCH="x86_64"; JUST_SHA256="181b91d0ceebe8a57723fb648ed2ce1a44d849438ce2e658339df4f8db5f1263" ;;
-        aarch64) JUST_ARCH="aarch64"; JUST_SHA256="d065d0df1a1f99529869fba8a5b3e0a25c1795b9007099b00dfabe29c7c1f7b6" ;;
+        x86_64)  JUST_ARCH="x86_64"; JUST_SHA256="27e011cd6328fadd632e59233d2cf5f18460b8a8c4269acd324c1a8669f34db0" ;;
+        aarch64) JUST_ARCH="aarch64"; JUST_SHA256="3beb4967ce05883cf09ac12d6d128166eb4c6d0b03eff74b61018a6880655d7d" ;;
         *)       error "Unsupported architecture: $ARCH" ;;
     esac
 
-    JUST_VERSION="1.40.0"
+    JUST_VERSION="1.50.0"
     JUST_TARBALL="just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz"
     JUST_URL="https://github.com/casey/just/releases/download/${JUST_VERSION}/${JUST_TARBALL}"
 
     TEMP_DIR=$(mktemp -d)
     trap "rm -rf $TEMP_DIR" EXIT
 
-    curl --proto '=https' --tlsv1.2 -sSf --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 "$JUST_URL" -o "$TEMP_DIR/$JUST_TARBALL"
+    # -L required: GitHub releases redirect to S3; without it curl writes an empty body.
+    curl --proto '=https' --tlsv1.2 -fsSL --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 "$JUST_URL" -o "$TEMP_DIR/$JUST_TARBALL"
     verify_sha256 "$TEMP_DIR/$JUST_TARBALL" "$JUST_SHA256"
     tar -xzf "$TEMP_DIR/$JUST_TARBALL" -C "$TEMP_DIR"
     cp "$TEMP_DIR/just" "$INSTALL_DIR/just"


### PR DESCRIPTION
## What

- Add `-L` to the `curl` invocation that downloads `just` (now uses the same `-fsSL` flags as the `gh` and `doppler` installers).
- Bump pinned `just` from 1.40.0 → 1.50.0 with refreshed SHA-256 checksums for x86_64 and aarch64 musl tarballs.

## Why

Cloud env setup was failing with:

```
[ERROR] Checksum mismatch for just-1.40.0-x86_64-unknown-linux-musl.tar.gz: expected 181b91d0ceebe8…
[ERROR] One or more tool installs failed
```

Root cause: GitHub release URLs 302-redirect to S3. The `install_just` curl call was missing `-L`, so curl wrote an empty body and exited 0. `verify_sha256` then compared `e3b0c44…` (sha of empty) against the (correct) pinned hash and bailed. The other installers already used `-fsSL`.

## How verified

- Reproduced the empty-download with the old `-sSf` flags.
- Re-downloaded with `-fsSL`: matched the pinned 1.40.0 hash.
- Bumped to 1.50.0 and ran the script end-to-end locally — `just`, `gh`, and `doppler` all installed cleanly, doppler/gh auth wired up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fid8F4RX5ivdppRLocePby)_