### PR TITLE
fix(sqlite): invalidate cached engine when VFS file changes

### DIFF
--- a/crates/bashkit/src/builtins/sqlite/mod.rs
+++ b/crates/bashkit/src/builtins/sqlite/mod.rs
@@ -407,12 +407,28 @@ impl Builtin for Sqlite {
                 let handle = self.cache_handle(&key);
                 let mut guard = handle.lock().await;
 
-                if guard.is_none() {
+                // Security: if the VFS file was removed/replaced between calls,
+                // invalidate cached state and re-open from current bytes.
+                let mut reopen = guard.is_none();
+                if !reopen
+                    && let Some(engine) = guard.as_ref()
+                    && let Some(snapshot) = engine.snapshot_bytes()
+                {
+                    match ctx.fs.read_file(path).await {
+                        Ok(current) => {
+                            if current != snapshot {
+                                reopen = true;
+                            }
+                        }
+                        Err(_) => {
+                            reopen = true;
+                        }
+                    }
+                }
+                if reopen {
                     match open_file_engine(backend, path, &ctx.fs, &self.limits).await {
                         Ok(e) => *guard = Some(e),
-                        Err(msg) => {
-                            return Ok(ExecResult::err(format!("sqlite: {msg}\n"), 1));
-                        }
+                        Err(msg) => return Ok(ExecResult::err(format!("sqlite: {msg}\n"), 1)),
                     }
                 }
                 let engine = guard.as_ref().expect("engine populated above");

--- a/crates/bashkit/tests/sqlite_integration_tests.rs
+++ b/crates/bashkit/tests/sqlite_integration_tests.rs
@@ -320,6 +320,50 @@ async fn snapshot_and_restore_round_trips_sqlite_state() {
 }
 
 #[tokio::test]
+async fn cached_engine_respects_deleted_db_between_exec_calls() {
+    let mut bash = make_bash();
+    let setup = bash
+        .exec(r#"sqlite /tmp/deleted.sqlite 'CREATE TABLE t(v); INSERT INTO t VALUES ("secret")'"#)
+        .await
+        .unwrap();
+    assert_eq!(setup.exit_code, 0, "stderr: {}", setup.stderr);
+
+    let rm = bash.exec(r#"rm -f /tmp/deleted.sqlite"#).await.unwrap();
+    assert_eq!(rm.exit_code, 0, "stderr: {}", rm.stderr);
+
+    let query = bash
+        .exec(r#"sqlite /tmp/deleted.sqlite 'SELECT count(*) FROM sqlite_master'"#)
+        .await
+        .unwrap();
+    assert_ne!(query.exit_code, 0, "stdout: {}", query.stdout);
+}
+
+#[tokio::test]
+async fn cached_engine_respects_replaced_db_between_exec_calls() {
+    let mut bash = make_bash();
+    let setup = bash
+        .exec(r#"sqlite /tmp/replaced.sqlite 'CREATE TABLE t(v); INSERT INTO t VALUES ("old")'"#)
+        .await
+        .unwrap();
+    assert_eq!(setup.exit_code, 0, "stderr: {}", setup.stderr);
+
+    let overwrite = bash
+        .exec(
+            r#"sqlite /tmp/new.sqlite 'CREATE TABLE t(v); INSERT INTO t VALUES ("new")'; cp /tmp/new.sqlite /tmp/replaced.sqlite"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(overwrite.exit_code, 0, "stderr: {}", overwrite.stderr);
+
+    let query = bash
+        .exec(r#"sqlite /tmp/replaced.sqlite 'SELECT v FROM t'"#)
+        .await
+        .unwrap();
+    assert_eq!(query.exit_code, 0, "stderr: {}", query.stderr);
+    assert_eq!(query.stdout.trim(), "new");
+}
+
+#[tokio::test]
 async fn invalid_sql_exit_code_one() {
     let mut bash = make_bash();
     let r = bash


### PR DESCRIPTION
### Motivation
- The session-scoped SQLite engine cache reused engines keyed only by backend+path, allowing stale in-memory DB state to be read and flushed back after the VFS file was deleted or replaced.
- This could resurrect deleted data or overwrite a replacement file inside a Bash session, causing confidentiality/integrity issues within the VFS sandbox.

### Description
- Before reusing a cached file-backed engine, compare the engine's `snapshot_bytes()` with the current `ctx.fs.read_file(path)` and force a reopen when the bytes differ or the read fails. (change in `crates/bashkit/src/builtins/sqlite/mod.rs` around the file-target path handling)
- Preserve existing semantics for `:memory:` targets (still ephemeral per-invocation). (no behavioural change to memory backend)
- Add two integration tests that cover deletion and replacement between `exec()` calls to guard against stale-cache resurrection and overwrite regressions. (added tests in `crates/bashkit/tests/sqlite_integration_tests.rs`)

### Testing
- Ran the new integration tests filter with `cargo test --features sqlite -p bashkit --test sqlite_integration_tests -- cached_engine_respects_`, and both tests passed (2 passed, 0 failed).
- An earlier test run exposed an error which led to tightening the deleted-DB expectation; after the code change and test update the targeted integration tests passed.
- Build/test compilation completed locally for the modified test target during verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd27589a20832b85cb275df802a278)