### PR TITLE
fix(bindings): derive sqlite limits from host time and memory caps

### DIFF
--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -2409,6 +2409,20 @@ fn build_limits(state: &SharedState) -> ExecutionLimits {
     limits
 }
 
+fn derive_sqlite_limits(state: &SharedState) -> bashkit::SqliteLimits {
+    let mut limits = bashkit::SqliteLimits::default();
+    if let Some(ms) = state.timeout_ms {
+        limits = limits.max_duration(std::time::Duration::from_millis(u64::from(ms)));
+    }
+    if let Some(memory_mb) = state.max_memory {
+        let max_db_bytes = (memory_mb.max(0.0) * 1024.0 * 1024.0).floor() as usize;
+        if max_db_bytes > 0 {
+            limits = limits.max_db_bytes(max_db_bytes);
+        }
+    }
+    limits
+}
+
 fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, String>>) -> RustBash {
     let mut builder = RustBash::builder();
 
@@ -2473,7 +2487,7 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
     // Enable embedded SQLite (Turso). Passing `sqlite: true` from JS is the
     // explicit opt-in that must also flip the in-process SQLite env gate.
     if state.sqlite {
-        builder = builder.sqlite();
+        builder = builder.sqlite_with_limits(derive_sqlite_limits(state));
         builder = builder.env("BASHKIT_ALLOW_INPROCESS_SQLITE", "1");
     }
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2883,12 +2883,24 @@ fn apply_python_config(
 /// explicit opt-in for in-process SQLite execution, so we register the
 /// builtin and inject the runtime gate env var. The deny-list defaults
 /// (resource/FS-shaped PRAGMAs) come from `SqliteLimits::default()`.
-fn apply_sqlite_config(mut builder: bashkit::BashBuilder, sqlite: bool) -> bashkit::BashBuilder {
+fn apply_sqlite_config(
+    mut builder: bashkit::BashBuilder,
+    sqlite: bool,
+    timeout_seconds: Option<f64>,
+    max_memory: Option<u64>,
+) -> PyResult<bashkit::BashBuilder> {
     if sqlite {
-        builder = builder.sqlite();
+        let mut limits = bashkit::SqliteLimits::default();
+        if let Some(ts) = timeout_seconds {
+            limits = limits.max_duration(parse_timeout_seconds(ts)?);
+        }
+        if let Some(mm) = max_memory {
+            limits = limits.max_db_bytes(usize::try_from(mm).unwrap_or(usize::MAX));
+        }
+        builder = builder.sqlite_with_limits(limits);
         builder = builder.env("BASHKIT_ALLOW_INPROCESS_SQLITE", "1");
     }
-    builder
+    Ok(builder)
 }
 
 /// Core bash interpreter with virtual filesystem.
@@ -2979,7 +2991,7 @@ impl PyBash {
             handler_clone,
             self.external_handler_reentry_depth.clone(),
         );
-        builder = apply_sqlite_config(builder, self.sqlite);
+        builder = apply_sqlite_config(builder, self.sqlite, self.timeout_seconds, self.max_memory)?;
         if let Some(ref net) = self.network {
             builder = net.apply(builder);
         }
@@ -3094,7 +3106,7 @@ impl PyBash {
             handler_for_build,
             external_handler_reentry_depth.clone(),
         );
-        builder = apply_sqlite_config(builder, sqlite);
+        builder = apply_sqlite_config(builder, sqlite, timeout_seconds, max_memory)?;
         if let Some(ref net) = network {
             builder = net.apply(builder);
         }


### PR DESCRIPTION
### Motivation
- The Python/JS bindings enabled the in-process SQLite builtin with `SqliteLimits::default()`, which allowed large result materialisation and rendering to bypass host `ExecutionLimits` and risk in-process DoS. 
- The change aligns SQLite budgets with the binding-level resource knobs so opting-in from Python/JS cannot exceed caller time or memory caps.

### Description
- Python: `apply_sqlite_config` now accepts `timeout_seconds` and `max_memory`, maps them to `SqliteLimits::max_duration` / `max_db_bytes`, and uses `builder.sqlite_with_limits(...)` instead of `builder.sqlite()`; constructor and reset call sites updated to pass the host limits. 
- JavaScript: added `derive_sqlite_limits(state)` which maps `timeout_ms` and `max_memory` (MiB) into `SqliteLimits`, and switched the JS opt-in to `builder.sqlite_with_limits(derive_sqlite_limits(state))`. 
- Kept the explicit env gate behavior unchanged (`BASHKIT_ALLOW_INPROCESS_SQLITE=1`) and preserved existing deny-list defaults; changes restrict sqlite runtime budgets to host-specified limits. 

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo check -p bashkit-python -p bashkit-js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd27590ba0832ba8d7668e8cbdf3fa)