### PR TITLE
fix(js): require branded token for filesystem external imports

### DIFF
--- a/crates/bashkit-js/__test__/vfs.spec.ts
+++ b/crates/bashkit-js/__test__/vfs.spec.ts
@@ -165,7 +165,7 @@ test("filesystem external roundtrip mounts into bash", (t) => {
 
 test("filesystem external import rejects plain objects", (t) => {
   t.throws(() => FileSystem.fromExternal({}), {
-    message: /native External/,
+    message: /requires a token created by FileSystem\.toExternal\(\)/,
   });
 });
 

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -409,6 +409,30 @@ function toNativeSnapshotOptions(
   };
 }
 
+const fileSystemExternalTokens = new WeakSet<object>();
+
+interface FileSystemExternalToken {
+  readonly __bashkitFsExternalBrand: true;
+  readonly external: unknown;
+}
+
+function createFileSystemExternalToken(external: unknown): FileSystemExternalToken {
+  const token = Object.freeze({
+    __bashkitFsExternalBrand: true as const,
+    external,
+  });
+  fileSystemExternalTokens.add(token);
+  return token;
+}
+
+function isFileSystemExternalToken(value: unknown): value is FileSystemExternalToken {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    fileSystemExternalTokens.has(value as object)
+  );
+}
+
 function isFileSystemLike(value: unknown): value is { toExternal(): unknown } {
   return (
     typeof (value as { toExternal?: unknown } | null)?.toExternal === "function"
@@ -446,7 +470,7 @@ export interface FileSystemRealOptions {
 
 export class FileSystem {
   private native: any;
-  private external?: unknown;
+  private external?: FileSystemExternalToken;
 
   constructor() {
     this.native = nativeCreateFileSystem();
@@ -473,13 +497,20 @@ export class FileSystem {
   }
 
   static fromExternal(external: unknown): FileSystem {
-    const fs = FileSystem.fromNative(nativeImportFileSystem(external));
+    if (!isFileSystemExternalToken(external)) {
+      throw new TypeError(
+        "FileSystem.fromExternal requires a token created by FileSystem.toExternal()",
+      );
+    }
+    const fs = FileSystem.fromNative(nativeImportFileSystem(external.external));
     fs.external = external;
     return fs;
   }
 
   toExternal(): unknown {
-    this.external ??= nativeFileSystemToExternal(this.native);
+    this.external ??= createFileSystemExternalToken(
+      nativeFileSystemToExternal(this.native),
+    );
     return this.external;
   }
 
@@ -863,7 +894,9 @@ export class Bash {
     writable?: boolean,
   ): void {
     if (isFileSystemLike(vfsPathOrFs)) {
-      this.native.mountFileSystem(hostPathOrVfsPath, vfsPathOrFs.toExternal());
+      const token = vfsPathOrFs.toExternal();
+      const external = isFileSystemExternalToken(token) ? token.external : token;
+      this.native.mountFileSystem(hostPathOrVfsPath, external);
       return;
     }
     this.native.mount(hostPathOrVfsPath, vfsPathOrFs, writable);
@@ -1200,7 +1233,9 @@ export class BashTool {
     writable?: boolean,
   ): void {
     if (isFileSystemLike(vfsPathOrFs)) {
-      this.native.mountFileSystem(hostPathOrVfsPath, vfsPathOrFs.toExternal());
+      const token = vfsPathOrFs.toExternal();
+      const external = isFileSystemExternalToken(token) ? token.external : token;
+      this.native.mountFileSystem(hostPathOrVfsPath, external);
       return;
     }
     this.native.mount(hostPathOrVfsPath, vfsPathOrFs, writable);


### PR DESCRIPTION
### Motivation
- The Node `External` import path accepted arbitrary N-API `External` values and then interpreted their raw pointer as a bashkit filesystem ABI handle, allowing non-bashkit externals to reach unsafe native import code. 
- This can lead to invalid memory reads, vtable dereferences, or invocation of attacker-controlled callbacks when an External from another native addon is misinterpreted.
- Mitigate at the JS boundary by ensuring only tokens minted by this module's export path are forwarded to native import.

### Description
- Add an in-process branded token wrapper implemented with a module-local `WeakSet` and `FileSystemExternalToken` interface to mark provenance in `crates/bashkit-js/wrapper.ts`.
- Implement `createFileSystemExternalToken` and `isFileSystemExternalToken` and use them so `FileSystem.toExternal()` returns a branded frozen token and `FileSystem.fromExternal()` rejects any value not created by `toExternal()`.
- Change `FileSystem.external` cached type to the branded token and unwrap the native external only after JS-level validation.
- Update the JS test expectation in `crates/bashkit-js/__test__/vfs.spec.ts` to assert the new explicit provenance error message.

### Testing
- Attempted `cargo check -p bashkit-js`, but the invocation failed in this environment while fetching/compiling unrelated dependencies; the change is TypeScript-only and does not touch the native import path.
- Ran the JS test command for the updated spec, but `ava` is not installed in this environment so the test run could not be executed here.
- Changes were committed locally with message `fix(js): require branded token for filesystem external imports`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2758b468832b8b53720e60619f6a)