### PR TITLE
fix(tool_def): reject bare array flags without values

### DIFF
--- a/crates/bashkit/src/tool_def.rs
+++ b/crates/bashkit/src/tool_def.rs
@@ -431,7 +431,7 @@ fn consume_array_value(
     flag_name: &str,
 ) -> std::result::Result<ArrayInput, String> {
     if *i >= args.len() || args[*i].starts_with("--") {
-        return Ok(ArrayInput::Items(Vec::new()));
+        return Err(format!("--{flag_name}: missing value"));
     }
     let next = &args[*i];
     let trimmed = next.trim_start();
@@ -912,6 +912,35 @@ mod tests {
         let args = vec!["--tags".to_string(), "abc".to_string()];
         let result = parse_flags(&args, &schema).unwrap();
         assert_eq!(result["tags"], serde_json::json!(["abc"]));
+    }
+
+    #[test]
+    fn test_parse_flags_array_missing_value_is_error() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"tags": {"type": "array", "items": {"type": "string"}}}
+        });
+        let args = vec!["--tags".to_string()];
+        let err = parse_flags(&args, &schema).unwrap_err();
+        assert_eq!(err, "--tags: missing value");
+    }
+
+    #[test]
+    fn test_parse_flags_array_missing_value_before_next_flag_is_error() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "name": {"type": "string"}
+            }
+        });
+        let args = vec![
+            "--tags".to_string(),
+            "--name".to_string(),
+            "alice".to_string(),
+        ];
+        let err = parse_flags(&args, &schema).unwrap_err();
+        assert_eq!(err, "--tags: missing value");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Bare array-typed flags (`--tags`) were parsed as present empty arrays (`[]`) when no value followed, which can let callbacks treat an omitted value as a valid empty array and bypass presence/type checks.
- The parser needs to preserve the prior malformed-invocation semantics and surface an error for missing array values to avoid trusting absent data.

### Description

- Change `consume_array_value` in `crates/bashkit/src/tool_def.rs` to return `Err(format!("--{flag_name}: missing value"))` when the flag has no following token or the next token is another `--flag`, instead of returning an empty `ArrayInput::Items(Vec::new())`.
- Add two regression tests in the same file: `test_parse_flags_array_missing_value_is_error` and `test_parse_flags_array_missing_value_before_next_flag_is_error` which assert the parser errors with `"--tags: missing value"` for both end-of-args and next-flag cases.
- Preserve existing parsing behavior for JSON arrays, object-pair groups, and comma-split scalar arrays (only the bare/missing-value case is made an error).

### Testing

- Ran `cargo test -p bashkit parse_flags_array_missing_value` and the new tests passed.
- Ran the package test suite (`cargo test -p bashkit`) as part of validation; the test run completed and the new tests and existing filtered tests did not fail. 
- Added unit tests are in `crates/bashkit/src/tool_def.rs` and cover the two missing-value scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2758c4ac832bb135fca574452da3)