### PR TITLE
fix(export): sync successful exports when readonly args fail

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4833,11 +4833,18 @@ impl Interpreter {
 
             self.apply_builtin_side_effects(&result);
 
-            // Sync exported variables into env so subprocess isolation can see them
-            if name == "export" && result.exit_code == 0 {
+            // Sync successful export operands into env so subprocess isolation can see them.
+            // Keep syncing even if export returned nonzero for other args (bash-compatible).
+            if name == "export" {
                 for arg in args {
                     if let Some(eq_pos) = arg.find('=') {
                         let var_name = &arg[..eq_pos];
+                        if self
+                            .variables
+                            .contains_key(&format!("_READONLY_{}", var_name))
+                        {
+                            continue;
+                        }
                         if let Some(value) = self.variables.get(var_name) {
                             self.env.insert(var_name.to_string(), value.clone());
                         }

--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -455,6 +455,25 @@ mod finding_readonly_bypass {
         assert!(result.stdout.contains("exit=1"));
     }
 
+    /// export must still sync successful operands into env after a readonly error.
+    #[tokio::test]
+    async fn export_continues_after_readonly_error_and_exports_good_args() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                readonly LOCKED=original
+                export LOCKED=skip GOOD=ok
+                echo "exit=$?"
+                printenv GOOD
+                "#,
+            )
+            .await
+            .unwrap();
+        assert!(result.stdout.contains("exit=1"));
+        assert!(result.stdout.contains("ok"));
+    }
+
     /// Non-finding: readonly via local in function is bash-compatible shadowing.
     #[tokio::test]
     async fn local_shadows_readonly_in_function() {


### PR DESCRIPTION
### Motivation
- Recent readonly-error handling caused `export` to return nonzero for an operand and the interpreter to skip syncing *all* exported operands into `self.env`, so otherwise-valid NAME=VALUE operands in the same command were not visible to `printenv`/`export -p` despite being set in shell variables.

### Description
- Update interpreter post-processing in `crates/bashkit/src/interpreter/mod.rs` to always perform export env sync for `export` and to skip only operands that are readonly by checking the `_READONLY_<NAME>` marker instead of gating on `result.exit_code == 0`.
- Add a targeted regression test `export_continues_after_readonly_error_and_exports_good_args` in `crates/bashkit/tests/blackbox_security_tests.rs` that asserts `export LOCKED=skip GOOD=ok` exits `1` and that `GOOD` is visible via `printenv`.
- Preserve the readonly error reporting in the `export` builtin implementation; this change only adjusts the interpreter-side env synchronization so Bash-compatible semantics are maintained.

### Testing
- Ran `cargo test -p bashkit --test blackbox_security_tests finding_readonly_bypass::export_continues_after_readonly_error_and_exports_good_args` and the test passed (`ok`).
- The regression test verifies both the nonzero exit on readonly failure and that successful operands are exported to `self.env` and visible to `printenv`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd275a53d8832bb40ac6712272e875)