### PR TITLE
fix(python): preserve credential placeholder env on snapshot restore

### DIFF
--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1185,20 +1185,50 @@ fn snapshot_live_bash(
     })
 }
 
-fn restore_live_bash(
+fn restore_live_bash_with_env_overrides(
     py: Python<'_>,
     rt: &Arc<Runtime>,
     inner: &Arc<Mutex<Bash>>,
     data: Vec<u8>,
+    env_overrides: &[(String, String)],
 ) -> PyResult<()> {
     let rt = rt.clone();
     let inner = inner.clone();
+    let env_overrides = env_overrides.to_vec();
     py.detach(|| {
         rt.block_on(async move {
             let mut bash = inner.lock().await;
-            bash.restore_snapshot(&data).map_err(raise_snapshot_error)
+            bash.restore_snapshot(&data).map_err(raise_snapshot_error)?;
+            if env_overrides.is_empty() {
+                return Ok(());
+            }
+            let mut state = bash.shell_state();
+            for (key, value) in env_overrides {
+                state.env.insert(key, value);
+            }
+            bash.restore_shell_state(&state);
+            Ok(())
         })
     })
+}
+
+fn placeholder_env_overrides(
+    state: &ShellState,
+    network_config: &Option<PyNetworkConfig>,
+) -> Vec<(String, String)> {
+    let Some(config) = network_config else {
+        return Vec::new();
+    };
+    config
+        .credential_placeholders
+        .iter()
+        .filter_map(|ph| {
+            state
+                .env
+                .get(&ph.env)
+                .map(|value| (ph.env.clone(), value.clone()))
+        })
+        .collect()
 }
 
 static MAPPING_PROXY_TYPE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
@@ -3327,7 +3357,9 @@ impl PyBash {
     /// Restore interpreter state from bytes previously produced by `snapshot()`.
     fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
         self.reject_external_handler_reentry()?;
-        restore_live_bash(py, &self.rt, &self.inner, data)
+        let state = capture_shell_state(py, &self.rt, &self.inner)?;
+        let env_overrides = placeholder_env_overrides(&state, &self.network);
+        restore_live_bash_with_env_overrides(py, &self.rt, &self.inner, data, &env_overrides)
     }
 
     /// Create a new Bash instance from a snapshot and optional constructor kwargs.
@@ -3913,7 +3945,9 @@ impl BashTool {
 
     /// Restore interpreter state from bytes previously produced by `snapshot()`.
     fn restore_snapshot(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<()> {
-        restore_live_bash(py, &self.rt, &self.inner, data)
+        let state = capture_shell_state(py, &self.rt, &self.inner)?;
+        let env_overrides = placeholder_env_overrides(&state, &self.network);
+        restore_live_bash_with_env_overrides(py, &self.rt, &self.inner, data, &env_overrides)
     }
 
     /// Create a new BashTool instance from a snapshot and optional constructor kwargs.

--- a/crates/bashkit-python/tests/test_network_credentials.py
+++ b/crates/bashkit-python/tests/test_network_credentials.py
@@ -399,3 +399,24 @@ class TestCredentialsPreservedAcrossSnapshot:
         r = restored.execute_sync("echo $OPENAI_API_KEY")
         assert r.exit_code == 0
         assert r.stdout.strip().startswith("bk_placeholder_")
+
+    def test_bashtool_from_snapshot_reapplies_placeholder_env_after_restore(self):
+        src = BashTool()
+        data = src.snapshot()
+        restored = BashTool.from_snapshot(
+            data,
+            network={
+                "allow": ["https://api.openai.com"],
+                "credential_placeholders": [
+                    {
+                        "env": "OPENAI_API_KEY",
+                        "pattern": "https://api.openai.com",
+                        "kind": "bearer",
+                        "token": "sk-real-key",
+                    }
+                ],
+            },
+        )
+        r = restored.execute_sync("echo $OPENAI_API_KEY")
+        assert r.exit_code == 0
+        assert r.stdout.strip().startswith("bk_placeholder_")


### PR DESCRIPTION
### Motivation
- Snapshot restore was overwriting freshly generated credential-placeholder env vars installed by `credential_placeholder(...)`, causing script-visible placeholders to be stale or absent while HTTP hooks expected newly generated tokens.
- This broke authenticated requests after `from_snapshot()`/`restore_snapshot()` flows without exposing the real credential, so restored instances could silently fail network auth.

### Description
- Capture live placeholder env values before restoring snapshot and re-apply them after the snapshot state is loaded by adding `restore_live_bash_with_env_overrides` and `placeholder_env_overrides` helper functions in `crates/bashkit-python/src/lib.rs`.
- Update `PyBash::restore_snapshot` and `BashTool::restore_snapshot` to collect placeholder env overrides and call the new restore helper so placeholders remain aligned with active HTTP credential hooks.
- Add a regression test `test_bashtool_from_snapshot_reapplies_placeholder_env_after_restore` in `crates/bashkit-python/tests/test_network_credentials.py` to assert that a placeholder env is present after `BashTool.from_snapshot()` when the source snapshot lacks placeholder env state.

### Testing
- Ran `cargo fmt --all`, which completed successfully.
- Ran `python -m pytest crates/bashkit-python/tests/test_network_credentials.py -k from_snapshot` which failed in this environment with `ModuleNotFoundError: No module named 'bashkit'` during test collection so the Python-level test could not be executed here.
- Invoked `cargo test -p bashkit-python --no-run` which began dependency resolution and compilation but could not complete within the validation window (network/dependency fetch in progress), so no final pass/fail was recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd275ab78c832bac2d6b9675c959d2)