### PR TITLE
fix(bashkit-eval): install rustls provider for library providers

### DIFF
--- a/crates/bashkit-eval/src/provider/anthropic.rs
+++ b/crates/bashkit-eval/src/provider/anthropic.rs
@@ -5,7 +5,10 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
-use super::{ContentBlock, Message, Provider, ProviderResponse, Role, ToolDefinition};
+use super::{
+    ContentBlock, Message, Provider, ProviderResponse, Role, ToolDefinition,
+    ensure_rustls_crypto_provider,
+};
 
 pub struct AnthropicProvider {
     client: reqwest::Client,
@@ -15,6 +18,7 @@ pub struct AnthropicProvider {
 
 impl AnthropicProvider {
     pub fn new(model: &str) -> Result<Self> {
+        ensure_rustls_crypto_provider()?;
         let api_key =
             std::env::var("ANTHROPIC_API_KEY").context("ANTHROPIC_API_KEY env var not set")?;
         Ok(Self {

--- a/crates/bashkit-eval/src/provider/mod.rs
+++ b/crates/bashkit-eval/src/provider/mod.rs
@@ -9,9 +9,26 @@ pub mod openai_responses;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use std::sync::OnceLock;
+
 pub use anthropic::AnthropicProvider;
 pub use openai::OpenAiProvider;
 pub use openai_responses::OpenAiResponsesProvider;
+
+pub fn ensure_rustls_crypto_provider() -> anyhow::Result<()> {
+    static INSTALL_RESULT: OnceLock<anyhow::Result<()>> = OnceLock::new();
+
+    let install_result = INSTALL_RESULT.get_or_init(|| {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .map_err(|_| anyhow::anyhow!("failed to install rustls ring crypto provider"))
+    });
+
+    install_result
+        .as_ref()
+        .map(|_| ())
+        .map_err(|e| anyhow::anyhow!("rustls crypto provider unavailable: {e}"))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/bashkit-eval/src/provider/openai.rs
+++ b/crates/bashkit-eval/src/provider/openai.rs
@@ -5,7 +5,10 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
-use super::{ContentBlock, Message, Provider, ProviderResponse, Role, ToolDefinition};
+use super::{
+    ContentBlock, Message, Provider, ProviderResponse, Role, ToolDefinition,
+    ensure_rustls_crypto_provider,
+};
 
 pub struct OpenAiProvider {
     client: reqwest::Client,
@@ -15,6 +18,7 @@ pub struct OpenAiProvider {
 
 impl OpenAiProvider {
     pub fn new(model: &str) -> Result<Self> {
+        ensure_rustls_crypto_provider()?;
         let api_key = std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY env var not set")?;
         Ok(Self {
             client: reqwest::Client::new(),

--- a/crates/bashkit-eval/src/provider/openai_responses.rs
+++ b/crates/bashkit-eval/src/provider/openai_responses.rs
@@ -7,7 +7,10 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
-use super::{ContentBlock, Message, Provider, ProviderResponse, Role, ToolDefinition};
+use super::{
+    ContentBlock, Message, Provider, ProviderResponse, Role, ToolDefinition,
+    ensure_rustls_crypto_provider,
+};
 
 pub struct OpenAiResponsesProvider {
     client: reqwest::Client,
@@ -17,6 +20,7 @@ pub struct OpenAiResponsesProvider {
 
 impl OpenAiResponsesProvider {
     pub fn new(model: &str) -> Result<Self> {
+        ensure_rustls_crypto_provider()?;
         let api_key = std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY env var not set")?;
         Ok(Self {
             client: reqwest::Client::new(),


### PR DESCRIPTION
### Motivation
- `reqwest` is built with `rustls-no-provider`, so library consumers of `bashkit-eval` could construct providers and then fail/panic on the first HTTPS request when no process-wide rustls `CryptoProvider` is installed.
- The binary `main()` already installed the `ring` provider, but public library constructors bypassed that initialization.

### Description
- Add `ensure_rustls_crypto_provider()` in `crates/bashkit-eval/src/provider/mod.rs` which installs the `rustls::crypto::ring` provider exactly once via `OnceLock`.
- Call `ensure_rustls_crypto_provider()?` from each public provider constructor (`OpenAiProvider::new`, `AnthropicProvider::new`, `OpenAiResponsesProvider::new`) before creating `reqwest::Client` so library users get the same initialization as the binary.
- Changes are minimal and keep existing binary initialization intact while covering the library path.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test -p bashkit-eval` and all unit tests passed (9 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2758e124832bb8ffdc8043d82eb9)