### PR TITLE
fix(js): correct sqlite maxMemory unit handling

### DIFF
--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -2414,8 +2414,8 @@ fn derive_sqlite_limits(state: &SharedState) -> bashkit::SqliteLimits {
     if let Some(ms) = state.timeout_ms {
         limits = limits.max_duration(std::time::Duration::from_millis(u64::from(ms)));
     }
-    if let Some(memory_mb) = state.max_memory {
-        let max_db_bytes = (memory_mb.max(0.0) * 1024.0 * 1024.0).floor() as usize;
+    if let Some(memory_bytes) = state.max_memory {
+        let max_db_bytes = memory_bytes.max(0.0).floor() as usize;
         if max_db_bytes > 0 {
             limits = limits.max_db_bytes(max_db_bytes);
         }


### PR DESCRIPTION
### Motivation
- Fix a unit-mismatch bug where the JS `maxMemory` (documented and used as bytes) was treated as MiB when deriving `SqliteLimits`, inflating `max_db_bytes` and weakening host memory controls.

### Description
- In `derive_sqlite_limits` use `state.max_memory` as bytes by renaming the local to `memory_bytes` and removing the `* 1024 * 1024` multiplication so `max_db_bytes` is computed as `memory_bytes.max(0.0).floor() as usize`.

### Testing
- Ran `cargo fmt --all` which completed successfully and `cargo check -p bashkit-js` which finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe18fca5d4832bb359504d3db6ee4a)