### PR TITLE
fix(export): continue after invalid identifier to avoid stale env sync

### DIFF
--- a/crates/bashkit/src/builtins/export.rs
+++ b/crates/bashkit/src/builtins/export.rs
@@ -37,10 +37,9 @@ impl Builtin for Export {
                 let value = &arg[eq_pos + 1..];
                 // Validate variable name
                 if !is_valid_var_name(name) {
-                    return Ok(ExecResult::err(
-                        format!("export: `{}': not a valid identifier\n", arg),
-                        1,
-                    ));
+                    stderr.push_str(&format!("export: `{arg}': not a valid identifier\n"));
+                    exit_code = 1;
+                    continue;
                 }
                 // THREAT[TM-INJ-015]: Block internal variable prefix injection via export
                 if is_internal_variable(name) {

--- a/crates/bashkit/tests/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/blackbox_security_tests.rs
@@ -474,6 +474,27 @@ mod finding_readonly_bypass {
         assert!(result.stdout.contains("ok"));
     }
 
+    /// export with invalid identifier must continue processing later valid operands.
+    #[tokio::test]
+    async fn export_continues_after_invalid_identifier_and_exports_good_args() {
+        let mut bash = tight_bash();
+        let result = bash
+            .exec(
+                r#"
+                GOOD=old
+                export 1BAD=x GOOD=new
+                echo "exit=$?"
+                echo "var=$GOOD"
+                printenv GOOD
+                "#,
+            )
+            .await
+            .unwrap();
+        assert!(result.stdout.contains("exit=1"));
+        assert!(result.stdout.contains("var=new"));
+        assert!(result.stdout.contains("new"));
+    }
+
     /// Non-finding: readonly via local in function is bash-compatible shadowing.
     #[tokio::test]
     async fn local_shadows_readonly_in_function() {


### PR DESCRIPTION
### Motivation
- Interpreter post-processing always syncs export operands into `env`, but the `export` builtin previously returned immediately on invalid identifiers causing later valid NAME=VALUE operands to be skipped and stale values to be exported. 
- Align `export` behavior with Bash semantics and preserve readonly handling by making per-operand failures non-fatal to further argument processing.

### Description
- Change `crates/bashkit/src/builtins/export.rs` to stop returning early on invalid identifiers and instead append an error to `stderr`, set `exit_code = 1`, and `continue` processing remaining args. 
- Preserve existing readonly-error reporting and behavior (still sets `exit_code = 1` and continues). 
- Add a regression test `export_continues_after_invalid_identifier_and_exports_good_args` in `crates/bashkit/tests/blackbox_security_tests.rs` that exercises `GOOD=old; export 1BAD=x GOOD=new` and asserts the command exits nonzero while `GOOD` is updated and exported.

### Testing
- Ran the targeted test with `cargo test -p bashkit --test blackbox_security_tests finding_readonly_bypass::export_continues_after_invalid_identifier_and_exports_good_args` and it passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1b28c4cc832bb5ad5e9f43b5bb23)