### PR TITLE
fix(coreutils-port): harden uu_app builder validation

### DIFF
--- a/crates/bashkit-coreutils-port/src/args.rs
+++ b/crates/bashkit-coreutils-port/src/args.rs
@@ -660,7 +660,9 @@ fn validate_uu_app_body(uu_app: &ItemFn) -> Result<()> {
         bail!("unsafe uu_app body: {}", validator.errors.join("; "));
     }
     if !chain_roots_at_command_new(command_expr) {
-        bail!("unsafe uu_app body: tail expression must be a clap Command::new(...) builder chain");
+        bail!(
+            "unsafe uu_app body: tail expression must be a clap::Command::new(...) builder chain"
+        );
     }
     Ok(())
 }
@@ -670,6 +672,29 @@ struct UuAppExprValidator {
 }
 
 impl<'ast> syn::visit::Visit<'ast> for UuAppExprValidator {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if is_disallowed_chain_method(&node.method.to_string()) {
+            self.errors.push(format!(
+                "method is not allowed in command builder: {}",
+                quote::quote!(#node)
+            ));
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_closure(&mut self, node: &'ast syn::ExprClosure) {
+        self.errors.push(format!(
+            "closure is not allowed in command builder: {}",
+            quote::quote!(#node)
+        ));
+    }
+
+    fn visit_expr_macro(&mut self, node: &'ast syn::ExprMacro) {
+        self.errors.push(format!(
+            "macro is not allowed in command builder: {}",
+            quote::quote!(#node)
+        ));
+    }
     fn visit_expr_block(&mut self, node: &'ast syn::ExprBlock) {
         self.errors.push(format!(
             "block expression is not allowed in command builder: {}",
@@ -736,13 +761,25 @@ fn path_ends_with_command_new(func: &Expr) -> bool {
         return false;
     };
     let segs = path_segments(&p.path);
-    let last_two: Vec<&str> = segs
-        .iter()
-        .rev()
-        .take(2)
-        .map(String::as_str)
-        .collect::<Vec<_>>();
-    matches!(last_two.as_slice(), ["new", "Command"])
+    matches!(segs.as_slice(), [single, new] if single == "Command" && new == "new")
+        || matches!(segs.as_slice(), [clap, command, new] if clap == "clap" && command == "Command" && new == "new")
+}
+
+fn is_disallowed_chain_method(method: &str) -> bool {
+    matches!(
+        method,
+        "spawn"
+            | "status"
+            | "output"
+            | "exec"
+            | "wait"
+            | "kill"
+            | "map"
+            | "and_then"
+            | "or_else"
+            | "unwrap"
+            | "expect"
+    )
 }
 
 fn find_fn<'a>(file: &'a syn::File, name: &str) -> Option<&'a ItemFn> {
@@ -1047,6 +1084,34 @@ pub fn uu_app() -> clap::Command {
         let body = run(&uutils, "cat", "poc").unwrap();
         assert!(body.contains("pub fn cat_command() -> clap::Command"));
         assert!(body.contains("Command::new(\"cat\")"));
+    }
+
+    #[test]
+    fn rejects_non_clap_command_root_chain() {
+        let (_tmp, uutils) = fixture(&[
+            (
+                "src/uu/cat/src/cat.rs",
+                r#"
+mod options {
+    pub static FILE: &str = "file";
+}
+
+pub fn uu_app() -> clap::Command {
+    std::process::Command::new("sh")
+        .arg("-c")
+        .arg("echo nope")
+        .status()
+        .map(|_| clap::Command::new("cat").arg(clap::Arg::new(options::FILE)))
+        .unwrap()
+}
+"#,
+            ),
+            ("src/uu/cat/locales/en-US.ftl", ""),
+        ]);
+
+        let err = run(&uutils, "cat", "poc").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unsafe uu_app"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The previous validator accepted single-expression `uu_app()` bodies that could execute side effects (e.g. `std::process::Command::new(...).status().map(...).unwrap()`), allowing generated Rust to run during CI or at runtime.
- Need a minimal, focused guard that ensures only safe clap builder expressions can be emitted and prevents side-effecting chains from passing validation.

### Description
- Tightened `validate_uu_app_body` in `crates/bashkit-coreutils-port/src/args.rs` to require a `clap::Command::new(...)`-style root expression and improved error message.
- Extended `UuAppExprValidator` with `visit_expr_method_call` to reject clearly unsafe chain methods and added visitors to reject closures and macros inside the builder expression.
- Added `is_disallowed_chain_method` helper to enumerate disallowed side-effecting methods (`status`, `spawn`, `output`, `map`, `unwrap`, etc.) and made `path_ends_with_command_new` accept only `Command::new` or `clap::Command::new` roots.
- Added regression test `rejects_non_clap_command_root_chain` to cover the single-expression `std::process::Command` bypass scenario.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p bashkit-coreutils-port` and all tests passed (17 passed, 0 failed), including the new regression test that rejects the bypass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4a708c60832b913dd8f8f8f61bc3)