### PR TITLE
fix(printf): cap float exponent magnitude in format validation

### DIFF
--- a/crates/bashkit/src/builtins/printf.rs
+++ b/crates/bashkit/src/builtins/printf.rs
@@ -291,6 +291,7 @@ struct CapSpec {
     position: CapArgLocation,
     width: Option<CapValue>,
     precision: Option<CapValue>,
+    specifier: u8,
 }
 
 enum CapValue {
@@ -308,9 +309,43 @@ impl CapSpec {
             let precision = resolve_cap_value(precision, args, false);
             reject_over_cap("precision", precision)?;
         }
-        args.consume(self.position);
+        if is_float_specifier(self.specifier) {
+            let value = args.next_arg(self.position).unwrap_or_default();
+            reject_float_exponent_over_cap(value)?;
+        } else {
+            args.consume(self.position);
+        }
         Ok(())
     }
+}
+
+fn is_float_specifier(specifier: u8) -> bool {
+    matches!(
+        specifier,
+        b'f' | b'F' | b'e' | b'E' | b'g' | b'G' | b'a' | b'A'
+    )
+}
+
+fn reject_float_exponent_over_cap(value: &str) -> std::result::Result<(), String> {
+    let Some(exponent) = parse_float_exponent(value) else {
+        return Ok(());
+    };
+    let exponent = exponent.unsigned_abs();
+    if exponent > MAX_FORMAT_WIDTH as u64 {
+        return Err(format!(
+            "printf: format exponent {exponent} exceeds limit {MAX_FORMAT_WIDTH}\n"
+        ));
+    }
+    Ok(())
+}
+
+fn parse_float_exponent(value: &str) -> Option<i64> {
+    let bytes = value.as_bytes();
+    let marker = bytes
+        .iter()
+        .rposition(|b| matches!(b, b'e' | b'E' | b'p' | b'P'))?;
+    let exponent = value.get(marker + 1..)?;
+    Some(parse_leading_i64(exponent))
 }
 
 fn reject_over_cap(kind: &str, value: usize) -> std::result::Result<(), String> {
@@ -394,6 +429,7 @@ fn parse_cap_spec(format: &[u8], start: usize) -> Option<CapSpec> {
         position,
         width,
         precision,
+        specifier,
     })
 }
 
@@ -532,6 +568,12 @@ mod tests {
     fn rejects_nested_repeat_asterisk_width_over_cap() {
         let err = render_printf("%s %*s", &["ok".into(), "999999".into(), "x".into()]).unwrap_err();
         assert!(err.contains("width 999999 exceeds limit"));
+    }
+
+    #[test]
+    fn rejects_float_exponent_over_cap() {
+        let err = render_printf("%f", &["1e1000000000".into()]).unwrap_err();
+        assert!(err.contains("exponent 1000000000 exceeds limit"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- The generated uucore-backed `printf` path can parse floats into arbitrary-precision `BigDecimal` and then materialize a fixed-decimal `String`, letting tiny inputs like `1e1000000000` cause enormous allocations because preflight validation only checked width/precision.
- Prevent untrusted script input from forcing massive intermediate allocation before interpreter stdout truncation by failing early during format-cap validation.

### Description
- Extend `CapSpec` with a `specifier` field and detect float-style specifiers via `is_float_specifier` to run float-specific checks while keeping existing width/precision caps.
- Implement `reject_float_exponent_over_cap` which peeks the raw argument, uses `parse_float_exponent` + `parse_leading_i64` to extract an exponent, and rejects it if its magnitude exceeds `MAX_FORMAT_WIDTH`.
- For float specifiers the validator now checks exponent magnitude instead of blindly consuming the argument; non-float specs retain prior `args.consume` behaviour.
- Add unit test `rejects_float_exponent_over_cap` asserting `render_printf("%f", &["1e1000000000".into()])` fails quickly with a cap error.

### Testing
- Ran `cargo test -p bashkit rejects_float_exponent_over_cap -- --nocapture` and the new test passed (`ok`).
- The crate compiled and the affected unit tests executed with no failures observed for the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6c1ec410832bb09e04a8edeabe57)