### PR TITLE
fix(bashkit-eval): make rustls provider init idempotent

### DIFF
--- a/crates/bashkit-eval/src/provider/mod.rs
+++ b/crates/bashkit-eval/src/provider/mod.rs
@@ -18,13 +18,16 @@ pub use openai_responses::OpenAiResponsesProvider;
 pub fn ensure_rustls_crypto_provider() -> anyhow::Result<()> {
     static INSTALL_RESULT: OnceLock<anyhow::Result<()>> = OnceLock::new();
 
-    let install_result = INSTALL_RESULT.get_or_init(|| {
-        match rustls::crypto::ring::default_provider().install_default() {
-            Ok(()) => Ok(()),
-            Err(_) if rustls::crypto::CryptoProvider::get_default().is_some() => Ok(()),
-            Err(_) => Err(anyhow::anyhow!("failed to install rustls ring crypto provider")),
-        }
-    });
+    let install_result =
+        INSTALL_RESULT.get_or_init(|| {
+            match rustls::crypto::ring::default_provider().install_default() {
+                Ok(()) => Ok(()),
+                Err(_) if rustls::crypto::CryptoProvider::get_default().is_some() => Ok(()),
+                Err(_) => Err(anyhow::anyhow!(
+                    "failed to install rustls ring crypto provider"
+                )),
+            }
+        });
 
     install_result
         .as_ref()

--- a/crates/bashkit-eval/src/provider/mod.rs
+++ b/crates/bashkit-eval/src/provider/mod.rs
@@ -19,15 +19,29 @@ pub fn ensure_rustls_crypto_provider() -> anyhow::Result<()> {
     static INSTALL_RESULT: OnceLock<anyhow::Result<()>> = OnceLock::new();
 
     let install_result = INSTALL_RESULT.get_or_init(|| {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .map_err(|_| anyhow::anyhow!("failed to install rustls ring crypto provider"))
+        match rustls::crypto::ring::default_provider().install_default() {
+            Ok(()) => Ok(()),
+            Err(_) if rustls::crypto::CryptoProvider::get_default().is_some() => Ok(()),
+            Err(_) => Err(anyhow::anyhow!("failed to install rustls ring crypto provider")),
+        }
     });
 
     install_result
         .as_ref()
         .map(|_| ())
         .map_err(|e| anyhow::anyhow!("rustls crypto provider unavailable: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_rustls_crypto_provider;
+
+    #[test]
+    fn ensure_rustls_provider_succeeds_when_already_installed() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let result = ensure_rustls_crypto_provider();
+        assert!(result.is_ok());
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
### Motivation
- `ensure_rustls_crypto_provider()` previously cached any `install_default()` error in a `OnceLock`, which breaks callers when a rustls provider was already installed (benign second-install case).

### Description
- Update `ensure_rustls_crypto_provider()` to treat `install_default()` failing as success when `CryptoProvider::get_default()` is already `Some`, preserving idempotence while keeping `OnceLock` memoization.
- Preserve original failure semantics for real install errors.
- Add a unit test `ensure_rustls_provider_succeeds_when_already_installed` that pre-installs the ring provider and asserts the helper returns `Ok(())`.

### Testing
- Ran `cargo test -p bashkit-eval provider::tests::ensure_rustls_provider_succeeds_when_already_installed` and the test passed. 
- Built and ran the `bashkit-eval` package tests as part of the run; targeted regression test succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1b270e20832b8efe978a19063002)