### PR TITLE
fix(fuzz): drop arithmetic_fuzz inputs that contain banned debug shapes

### DIFF
--- a/crates/bashkit/fuzz/fuzz_targets/arithmetic_fuzz.rs
+++ b/crates/bashkit/fuzz/fuzz_targets/arithmetic_fuzz.rs
@@ -38,6 +38,21 @@ fuzz_target!(|data: &[u8]| {
             return;
         }
 
+        // Reject inputs that themselves contain banned substrings — this
+        // target inlines `input` into `echo $((input))`. With unbalanced
+        // parens the arithmetic expansion can close early and the
+        // remainder is parsed as commands; bash then echoes the unknown
+        // command verbatim ("bash: /.rustup/toolchains/gww: No such file
+        // or directory"). That is real-shell stderr, not a TM-INF-022
+        // leak. Filtering at the fuzz-input layer keeps the harness's
+        // leak detector strict for real internals while avoiding false
+        // positives. (Mirrors glob_fuzz.)
+        for pat in bashkit::testing::UNIVERSAL_BANNED {
+            if input.contains(pat) {
+                return;
+            }
+        }
+
         // Wrap input in arithmetic expansion context
         let script = format!("echo $(({}))", input);
 


### PR DESCRIPTION
## Summary

The nightly fuzz job on main is red. `arithmetic_fuzz` inlines fuzz input directly into `echo \$(({input}))`. With unbalanced parens the arithmetic expansion closes early and the remainder is parsed as commands; bash then echoes the unknown command verbatim (`bash: /.rustup/toolchains/gww: No such file or directory`). That is real-shell stderr, not a TM-INF-022 leak.

Last run: input bytes contained `/.rustup/toolchains/` literally and the fuzz harness's leak detector tripped on the banned host-path shape — but no internal Debug formatter ran.

Fix: at the fuzz-input layer, drop inputs that already contain any `UNIVERSAL_BANNED` substring. Mirrors #1621 for `glob_fuzz`.

## Test plan

- [x] `cargo check` on the fuzz crate compiles cleanly
- [ ] Manually dispatch `Fuzz Testing` on this branch and confirm `arithmetic_fuzz` job is green