### PR TITLE
chore(deps): bump turso_core 0.5.3 → 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,15 +615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
-dependencies = [
- "chrono",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1546,6 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.4",
  "siphasher",
 ]
 
@@ -3391,10 +3381,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pbkdf2"
@@ -5604,9 +5594,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso_core"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac73a12b91b569f4671d63d65912876c11e6312597c996dac40494f9f9b39"
+checksum = "584dcc247f472c45d4f369daf590487a609c16a7f8848f2fb2902d3d3f055d31"
 dependencies = [
  "aegis",
  "aes 0.8.4",
@@ -5616,9 +5606,9 @@ dependencies = [
  "bigdecimal",
  "bitflags",
  "branches",
- "built",
  "bumpalo",
  "bytemuck",
+ "cfg_aliases",
  "cfg_block",
  "chrono",
  "crc32c",
@@ -5637,7 +5627,7 @@ dependencies = [
  "num-traits",
  "pack1",
  "parking_lot",
- "paste",
+ "pastey",
  "polling",
  "rand 0.9.4",
  "rapidhash",
@@ -5668,20 +5658,20 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd7410a02a3a4cebd48a5bc0db74940d1157dc9c05ad42d48ee5156dd31edd1"
+checksum = "870a80e0516ec000ee51aed89664d41e258e31c1b4a639f86e0ce7c2dd3bbc18"
 dependencies = [
  "chrono",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "turso_macros",
 ]
 
 [[package]]
 name = "turso_macros"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c846c30c3cb085884a8bbaba7760bdcc406ff2176cbde1e51d41b6057171fd4"
+checksum = "97578dbe06dd73634457b38b3546b868b4886aebefa57570b11a899679355761"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5690,9 +5680,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8402ba98c236e3e6d6ed6a43557a9a0b3a682f86a37fcafe02b659b9e6c06b82"
+checksum = "aa8dd793f7e9c467568275b0acddfd527ec19b7d1057bed41364b4c77b1111b3"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ russh-keys = "0.49"
 
 # Embedded SQLite engine (Turso, pure Rust). Upstream is BETA — gated behind
 # the `sqlite` feature and disabled by default; see specs/sqlite-builtin.md.
-turso_core = "0.5"
+turso_core = "0.6"
 
 # Serial test execution
 serial_test = "3"

--- a/crates/bashkit/tests/sqlite_differential_tests.rs
+++ b/crates/bashkit/tests/sqlite_differential_tests.rs
@@ -293,7 +293,7 @@ async fn join_inner() {
 // Documented divergences — features the differential suite *expects* to
 // disagree on. Convert to `assert_matches` once Turso closes the gap.
 //
-// Recursive CTEs: turso 0.5.3 returns
+// Recursive CTEs: turso 0.6.0 returns
 //   "Parse error: Recursive CTEs are not yet supported"
 // while real sqlite3 emits 1..N. Track upstream:
 //   https://github.com/tursodatabase/turso (search "WITH RECURSIVE").

--- a/specs/sqlite-builtin.md
+++ b/specs/sqlite-builtin.md
@@ -246,7 +246,7 @@ Coverage lives in four layers (all cited tests are real):
   COALESCE, subqueries, INNER JOIN, NULL handling, and PRAGMA round
   trips. Skips gracefully when `sqlite3` isn't on `$PATH`; CI
   explicitly installs it. One additional case (`recursive_cte_unsupported_in_turso`)
-  pins a *known* divergence: Turso 0.5.3 rejects recursive CTEs while
+  pins a *known* divergence: Turso 0.6.0 rejects recursive CTEs while
   real sqlite3 accepts them — convert to `assert_matches` once Turso
   closes the gap.
 - **Fuzz / property** — `crates/bashkit/tests/sqlite_fuzz_tests.rs`.

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -219,10 +219,6 @@ criteria = "safe-to-deploy"
 version = "1.12.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.built]]
-version = "0.7.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.bumpalo]]
 version = "3.20.2"
 criteria = "safe-to-deploy"
@@ -1335,8 +1331,8 @@ criteria = "safe-to-deploy"
 version = "0.5.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.paste]]
-version = "1.0.15"
+[[exemptions.pastey]]
+version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.pbkdf2]]
@@ -2128,19 +2124,19 @@ version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_core]]
-version = "0.5.3"
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_ext]]
-version = "0.5.3"
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_macros]]
-version = "0.5.3"
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_parser]]
-version = "0.5.3"
+version = "0.6.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.twox-hash]]


### PR DESCRIPTION
## Summary

Bump `turso_core` (and `turso_ext`/`turso_macros`/`turso_parser`) from
**0.5.3 → 0.6.0** — latest stable release on crates.io. Skipped the
0.7.0-pre.1 pre-release to stay on GA versions.

## What changes

- `Cargo.toml`: `turso_core = "0.5"` → `"0.6"`
- `Cargo.lock`: 4× `turso_*` bumps; `built 0.7.5` removed (no longer
  pulled transitively); `paste 1.0.15` → `pastey 0.2.2` (turso switched
  proc-macro helper).
- `supply-chain/config.toml`: matching exemption updates (drop `built`,
  rename `paste`→`pastey`, bump turso entries).
- Refresh "Turso 0.5.3" version breadcrumbs in `specs/sqlite-builtin.md`
  and the `recursive_cte_unsupported_in_turso` divergence note.

No source-code changes — the API surface we depend on (`Database`,
`Connection`, `Value`, `IO`, `File`, `OpenFlags`, `StepResult`,
`Buffer`, `Completion`, `CheckpointMode`, `LimboError`,
`FileSyncType`) is unchanged.

## Verification

- `cargo build -p bashkit --features sqlite` — green
- `cargo clippy --all-targets --features sqlite -- -D warnings` — green
- `cargo fmt --check` — green
- `cargo test -p bashkit --features sqlite --lib builtins::sqlite` —
  **100 passed**
- `cargo test -p bashkit --features sqlite --test sqlite_differential_tests` —
  **19 passed** (incl. the `recursive_cte_unsupported_in_turso`
  divergence pin — turso 0.6.0 still rejects `WITH RECURSIVE`)

## Related — #1634

This bump does **not** close [#1634](https://github.com/everruns/bashkit/issues/1634)
(RustCrypto stack split). Turso 0.6.0 still depends on `aes-gcm 0.10.3`,
which keeps `aes 0.8`, `cipher 0.4`, `ctr 0.9`, `crypto-common 0.1`,
and `cpufeatures 0.2` in the tree alongside the workspace's 0.11
cohort. The split remains blocked on either an `aes-gcm 0.11` release
upstream or turso replacing `aes-gcm`. #1634 stays open.

## Test plan

- [x] sqlite lib + differential tests pass with turso 0.6.0
- [x] supply-chain exemptions match the new lockfile
- [x] no new workspace-duplicate crates introduced by this bump
