### PR TITLE
fix(date): force UTC formatting under virtual clock modes

### DIFF
--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -328,8 +328,8 @@ fn expand_nanoseconds(format: &str, nanos: u32) -> String {
 }
 
 /// Format an RFC 2822 date string from a UTC datetime.
-fn format_rfc2822(dt: &DateTime<Utc>, utc: bool) -> String {
-    if utc {
+fn format_rfc2822(dt: &DateTime<Utc>, force_utc: bool) -> String {
+    if force_utc {
         dt.format("%a, %d %b %Y %H:%M:%S +0000").to_string()
     } else {
         let local_dt: DateTime<Local> = (*dt).into();
@@ -338,10 +338,10 @@ fn format_rfc2822(dt: &DateTime<Utc>, utc: bool) -> String {
 }
 
 /// Format an ISO 8601 date string.
-fn format_iso8601(dt: &DateTime<Utc>, utc: bool, precision: &str) -> String {
+fn format_iso8601(dt: &DateTime<Utc>, force_utc: bool, precision: &str) -> String {
     match precision {
         "hours" => {
-            if utc {
+            if force_utc {
                 dt.format("%Y-%m-%dT%H+00:00").to_string()
             } else {
                 let local_dt: DateTime<Local> = (*dt).into();
@@ -349,7 +349,7 @@ fn format_iso8601(dt: &DateTime<Utc>, utc: bool, precision: &str) -> String {
             }
         }
         "minutes" => {
-            if utc {
+            if force_utc {
                 dt.format("%Y-%m-%dT%H:%M+00:00").to_string()
             } else {
                 let local_dt: DateTime<Local> = (*dt).into();
@@ -357,7 +357,7 @@ fn format_iso8601(dt: &DateTime<Utc>, utc: bool, precision: &str) -> String {
             }
         }
         "seconds" | "s" => {
-            if utc {
+            if force_utc {
                 dt.format("%Y-%m-%dT%H:%M:%S+00:00").to_string()
             } else {
                 let local_dt: DateTime<Local> = (*dt).into();
@@ -460,15 +460,18 @@ impl Builtin for Date {
             dt_utc = now;
         };
 
+        let virtualized_clock = self.fixed_epoch.is_some() || self.offset_seconds != 0;
+        let force_utc = utc || epoch_input || virtualized_clock;
+
         // Handle -R (RFC 2822) output
         if rfc2822 {
-            let output = format_rfc2822(&dt_utc, utc);
+            let output = format_rfc2822(&dt_utc, force_utc);
             return Ok(ExecResult::ok(format!("{}\n", output)));
         }
 
         // Handle -I (ISO 8601) output
         if let Some(ref precision) = iso8601 {
-            let output = format_iso8601(&dt_utc, utc, precision);
+            let output = format_iso8601(&dt_utc, force_utc, precision);
             return Ok(ExecResult::ok(format!("{}\n", output)));
         }
 
@@ -501,7 +504,7 @@ impl Builtin for Date {
 
         // Format the date, handling potential errors gracefully.
         let mut output = String::new();
-        let format_result = if utc || epoch_input {
+        let format_result = if force_utc {
             write!(output, "{}", dt_utc.format(&format))
         } else {
             let local_dt: DateTime<Local> = dt_utc.into();

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -3810,6 +3810,24 @@ mod tm_inf_018_date {
         );
     }
 
+
+    /// TM-INF-018: virtual clock modes must not leak host timezone via custom formats.
+    #[tokio::test]
+    async fn fixed_epoch_forces_utc_for_timezone_formats() {
+        let mut bash = Bash::builder().fixed_epoch(1_700_000_000).build();
+        let r = bash.exec("date +%z").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "+0000");
+    }
+
+    /// TM-INF-018: epoch_offset mode must not leak host timezone via RFC 2822 output.
+    #[tokio::test]
+    async fn epoch_offset_forces_utc_for_rfc2822() {
+        let mut bash = Bash::builder().epoch_offset(86_400).build();
+        let r = bash.exec("date -R").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert!(r.stdout.trim_end().ends_with(" +0000"));
+    }
     /// TM-INF-018: `fixed_epoch` and `epoch_offset` are mutually
     /// exclusive — last builder call wins. fixed_epoch followed by
     /// epoch_offset should disable fixed_epoch.

--- a/crates/bashkit/tests/threat_model_tests.rs
+++ b/crates/bashkit/tests/threat_model_tests.rs
@@ -3810,7 +3810,6 @@ mod tm_inf_018_date {
         );
     }
 
-
     /// TM-INF-018: virtual clock modes must not leak host timezone via custom formats.
     #[tokio::test]
     async fn fixed_epoch_forces_utc_for_timezone_formats() {


### PR DESCRIPTION
### Motivation
- Virtual-clock modes (`fixed_epoch` / `epoch_offset`) were intended to blind absolute wall-clock information for TM-INF-018, but final formatting still used the host `Local` timezone when `-u` was not supplied, permitting timezone fingerprinting.
- Ensure the TM-INF-018 mitigation actually prevents host timezone leaks while preserving existing behavior for normal (non-virtual) clocks.

### Description
- Compute a `virtualized_clock` flag and a `force_utc` value in `Date::execute` that is true when `-u`, epoch input, or a virtual clock mode is active.
- Change RFC 2822 and ISO-8601 formatting helpers to accept a `force_utc` parameter and use it to avoid converting the virtual UTC timestamp through `chrono::Local`.
- Use `force_utc` for the `-R`, `-I*`, and `+FORMAT` (default/custom) output paths so timezone-bearing formats (`%z`, `%Z`, `-R`, `-Iseconds`) emit UTC when the clock is virtualized.
- Add targeted TM-INF-018 regression tests in `tests/threat_model_tests.rs` that assert `fixed_epoch` returns `+0000` for `date +%z` and `epoch_offset` ends RFC 2822 output with `+0000`.

### Testing
- Ran `cargo test --test threat_model_tests tm_inf_018_date`, which executed the relevant tests and reported all tests passed (`6 passed`).
- The change compiles as part of the test run (full test binary build completed during testing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a653da79c832b8f442928e24f961c)