### PR TITLE
feat(examples): improve docs agent search

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -489,6 +489,7 @@ tool = create_bash_tool(
     ],
     allowed_mount_paths=["/path/to/docs"],
     readonly_filesystem=True,
+    max_output_length=12_000,
 )
 ```
 

--- a/crates/bashkit-python/bashkit/langchain.py
+++ b/crates/bashkit-python/bashkit/langchain.py
@@ -213,6 +213,7 @@ def create_bash_tool(
     mounts: list[dict[str, Any]] | None = None,
     allowed_mount_paths: list[str] | None = None,
     readonly_filesystem: bool = False,
+    max_output_length: int = 100_000,
 ) -> BashkitTool:
     """Create a LangChain-compatible Bashkit tool.
 
@@ -232,6 +233,8 @@ def create_bash_tool(
             paths under a user home directory.
         readonly_filesystem: Deny all filesystem mutations after configured
             files and mounts are applied.
+        max_output_length: Maximum number of characters returned to the
+            LangChain agent from one bash tool call before truncation.
 
     Returns:
         BashkitTool instance for use with LangChain agents
@@ -259,6 +262,7 @@ def create_bash_tool(
         mounts=mounts,
         allowed_mount_paths=allowed_mount_paths,
         readonly_filesystem=readonly_filesystem,
+        max_output_length=max_output_length,
     )
 
 

--- a/crates/bashkit-python/tests/test_ai_adapters.py
+++ b/crates/bashkit-python/tests/test_ai_adapters.py
@@ -311,6 +311,18 @@ def test_langchain_create_bash_tool_accepts_files():
         assert "[Exit code:" in tool.invoke({"commands": "printf nope > /tmp/nope.txt"})
 
 
+def test_langchain_create_bash_tool_caps_output_length():
+    """create_bash_tool forwards max_output_length into BashkitTool."""
+    from bashkit.langchain import LANGCHAIN_AVAILABLE
+
+    if LANGCHAIN_AVAILABLE:
+        from bashkit.langchain import create_bash_tool
+
+        tool = create_bash_tool(max_output_length=12)
+        output = tool.invoke({"commands": "printf abcdefghijklmnopqrstuvwxyz"})
+        assert output == "abcdefghijkl\n[truncated]"
+
+
 def test_pydantic_ai_create_bash_tool_accepts_timeout():
     """create_bash_tool in pydantic_ai accepts timeout_seconds."""
     from bashkit.pydantic_ai import PYDANTIC_AI_AVAILABLE

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,10 +59,10 @@ uv run examples/deepagent_coding_agent.py
 ### docs-grep-agent/
 
 Minimal LangChain/LangGraph console agent for Bashkit docs Q&A. It exposes
-Bashkit's built-in bash tool to the model, which writes grep scripts against
-real docs and a curated examples view mounted read-only under `/docs`. The
-whole session filesystem is read-only, so copy/write attempts into `/tmp` fail
-too.
+Bashkit's built-in bash tool to the model, which writes compact `rg`, `grep`,
+and `sed` search scripts against real docs and a curated examples view mounted
+read-only under `/docs`. The whole session filesystem is read-only, so
+copy/write attempts into `/tmp` fail too.
 
 ```bash
 cd examples/docs-grep-agent

--- a/examples/docs-grep-agent/README.md
+++ b/examples/docs-grep-agent/README.md
@@ -1,4 +1,4 @@
-# Bashkit Docs Grep Agent
+# Bashkit Docs Search Agent
 
 Minimal console app for a public Bashkit docs chat.
 
@@ -8,8 +8,10 @@ itself, and the script runs inside a bashkit interpreter with real docs mounted
 read-only at `/docs/public` and `/docs/rustdoc`, plus a curated `/docs/examples`
 view that excludes local generated artifacts. The full bashkit filesystem is
 also read-only, so commands cannot copy docs into `/tmp` or create scratch
-files. By default the console only streams the final answer. Pass
-`--show-tools` to also print each bash script as a one-liner to stderr.
+files. Tool output is capped before it reaches the model, and the prompt steers
+the agent toward compact search pipelines. By default the console only streams
+the final answer. Pass `--show-tools` to also print each bash script as a
+one-liner to stderr.
 
 ## Run
 
@@ -34,6 +36,19 @@ uv run docs-grep-agent --show-tools "how do read-only mounts work?"
 
 Default model is `gpt-5.5-low`, parsed as `model=gpt-5.5` with low reasoning
 effort. Override with `--model` or `BASHKIT_DOCS_MODEL`.
+
+## Search Strategy
+
+The agent uses Bashkit's builtin shell tools directly:
+
+- `rg -i -n PATTERN ... | head -20` for broad discovery.
+- `grep -R -i -n -C 1 -m 3 -- PATTERN ...` for contextual evidence snippets.
+- `sed -n 'START,ENDp' FILE` after a relevant file and line range are known.
+- `find` only for targeted filename discovery.
+
+Bashkit `rg` is a compact ripgrep-style builtin, not full ripgrep. It is useful
+for first-pass searches, while `grep` is still better when context flags or
+include/exclude filters matter.
 
 ## Smoke Test
 

--- a/examples/docs-grep-agent/docs_grep_agent/app.py
+++ b/examples/docs-grep-agent/docs_grep_agent/app.py
@@ -36,7 +36,14 @@ Rules:
 - Use one multi-command bash script, or make multiple bash tool calls when separate searches are useful.
 - Only inspect files under /docs/public, /docs/rustdoc, and /docs/examples.
 - Generated local artifacts such as .venv, .ruff_cache, and __pycache__ are intentionally not mounted.
-- Prefer grep commands over broad file dumps.
+- Keep tool output compact. Bound every broad search with `head`, `-m`, `-l`, or a narrow `sed -n` range, and aim to keep total tool output under 12000 characters.
+- Search progressively:
+  1. Use `rg -i -n PATTERN PATH... | head -20` for broad discovery.
+  2. Use `grep -R -i -n -C 1 -m 3 -- PATTERN PATH...` when you need context around matches.
+  3. Use `sed -n 'START,ENDp' FILE` after finding the best file and line range.
+- Use `grep` instead of `rg` when you need context flags (`-A`, `-B`, `-C`) or include/exclude filters. Bashkit `rg` is intentionally simpler than full ripgrep.
+- Use `-F` with `rg` or `grep` for exact strings.
+- For multi-topic questions, print short section labels and run one compact search per topic.
 - Do not act as a filesystem browser. If the user asks to list, tree, enumerate, dump, or browse directories/files, do not return raw listings. Say that the agent answers Bashkit docs questions and mention the mounted entrypoint categories instead.
 - Use ls/find only as an internal discovery step for a specific Bashkit docs question, not as the final answer.
 - Use only facts present in bash tool output.
@@ -44,7 +51,7 @@ Rules:
 - Bashkit find supports common simple predicates but not every GNU find expression; prefer separate `find ... -name PATTERN` calls over `-o`.
 - If a successful command produces no output, say that it produced no output instead of returning an empty answer.
 - Keep answers concise and practical.
-- For CLI or code questions, grep for the relevant docs and include a runnable example when the output contains one.
+- For CLI or code questions, search the relevant docs and examples, then include a runnable example when the output contains one.
 - If the bash output does not answer the question, say the docs snippets do not show it.
 """
 
@@ -103,6 +110,7 @@ def create_docs_bash_tool(root: Path):
         files=build_example_files(root),
         allowed_mount_paths=[str(host_path) for host_path, _ in docs_mounts],
         readonly_filesystem=True,
+        max_output_length=MAX_CONTEXT_CHARS,
     )
 
 
@@ -189,10 +197,15 @@ async def answer(
 def self_test(root: Path) -> None:
     bash_tool = create_docs_bash_tool(root)
     what = bash_tool.invoke(
-        {"commands": "grep -R -i -n -C 1 -m 3 -- 'bashkit' /docs/public /docs/rustdoc"}
+        {"commands": "rg -i -n 'bashkit' /docs/public /docs/rustdoc | head -10"}
     )
     cli = bash_tool.invoke(
         {"commands": "grep -R -i -n -C 1 -m 3 -- 'cli' /docs/public"}
+    )
+    bounded = bash_tool.invoke(
+        {
+            "commands": "yes bashkit | head -20000",
+        }
     )
     readonly = bash_tool.invoke({"commands": "printf nope > /docs/public/nope.txt"})
     copy = bash_tool.invoke({"commands": "cp /docs/public/cli.md /tmp/cli-copy.md"})
@@ -211,6 +224,8 @@ def self_test(root: Path) -> None:
 
     assert "sandboxed" in what.lower() or "bashkit" in what.lower()
     assert "bashkit-cli" in cli.lower()
+    assert len(bounded) <= MAX_CONTEXT_CHARS + len("\n[truncated]")
+    assert bounded.endswith("[truncated]")
     assert "[Exit code:" in readonly
     assert "[Exit code:" in copy
     assert "/docs/examples/" in examples
@@ -220,7 +235,7 @@ def self_test(root: Path) -> None:
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Answer Bashkit docs questions with a LangGraph + bashkit grep agent."
+        description="Answer Bashkit docs questions with a LangGraph + bashkit search agent."
     )
     parser.add_argument(
         "question", nargs="*", help="Question to answer. Omit for interactive mode."
@@ -237,7 +252,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--show-tools",
         action="store_true",
-        help="Print one-line grep commands to stderr.",
+        help="Print one-line bash search scripts to stderr.",
     )
     parser.add_argument(
         "--no-spinner",

--- a/examples/docs-grep-agent/pyproject.toml
+++ b/examples/docs-grep-agent/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bashkit-docs-grep-agent"
 version = "0.1.0"
-description = "Minimal LangGraph console agent for answering Bashkit docs questions with read-only bashkit grep."
+description = "Minimal LangGraph console agent for answering Bashkit docs questions with read-only bashkit search."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## What
Improve the docs agent retrieval strategy so it uses compact search pipelines instead of being grep-only. The agent prompt now guides broad discovery with `rg`, contextual evidence with `grep -C`, and focused excerpts with `sed`.

Expose `max_output_length` through the LangChain `create_bash_tool()` factory and set the docs agent output cap to 12k characters so noisy tool calls cannot flood model context.

## Why
The docs chat should find relevant Bashkit documentation faster and keep the agent context small enough for public-chat style use.

## How
- Update the docs agent system prompt with progressive search guidance.
- Cap docs agent bash tool output at `MAX_CONTEXT_CHARS`.
- Add a LangChain adapter test for `max_output_length`.
- Update README/example wording from grep-only to search pipelines.

## Risk
- Low
- The LangChain factory gains a new optional argument and the example prompt changes retrieval behavior. Existing defaults are preserved.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered