### PR TITLE
feat(js): add customBuiltins to Bash and BashTool

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -328,6 +328,57 @@ Custom builtins survive `reset()`. They are host-side config, so
 `fromSnapshot()` and `restoreSnapshot()` do not preserve them —
 pass `customBuiltins` again when restoring.
 
+### Async Callbacks
+
+Callbacks can be async — return a `Promise<string>`:
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash({
+  customBuiltins: {
+    fetch: async (ctx) => {
+      // Simulate async work (fetch, DB query, etc.)
+      await new Promise((r) => setTimeout(r, 10));
+      return `result for ${ctx.argv[0]}\n`;
+    },
+    double: async (ctx) => `${Number(ctx.stdin.trim()) * 2}\n`,
+  },
+});
+
+// Pipe through async builtin
+const r1 = await bash.execute("echo 21 | double");
+console.log(r1.stdout); // 42
+
+// Chain sync + async builtins
+const r2 = await bash.execute(
+  "echo hello | tr a-z A-Z | double",
+);
+console.log(r2.stdout); // HELLO HELLO
+```
+
+Custom builtins support both sync and async callbacks. The adapter uses
+a two-phase dispatch: JS calls the callback, awaits the Promise if
+needed, then sends the result back via `respondToBuiltin`.
+
+### Error Handling
+
+Both sync and async callbacks that throw are caught and reported via
+stderr with exit code 1:
+
+```typescript
+const bash = new Bash({
+  customBuiltins: {
+    fail: async (ctx) => {
+      throw new Error(`unknown id: ${ctx.argv[0]}`);
+    },
+  },
+});
+const r = await bash.execute("fail 42");
+console.log(r.exitCode); // 1
+console.log(r.stderr);   // unknown id: 42
+```
+
 ## Snapshot / Restore
 
 State snapshots are available on both `Bash` and `BashTool` instances:
@@ -472,7 +523,9 @@ import {
 
 ### BuiltinCallback
 
-`(ctx: BuiltinContext) => string` — must return the stdout result.
+`(ctx: BuiltinContext) => string | Promise<string>` — must return the stdout
+result. Async callbacks (returning a Promise) are supported — the adapter
+awaits the Promise before sending the result back to the interpreter.
 
 ### ExecuteOptions
 

--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -285,6 +285,49 @@ const result = tool.executeSync("get_user --id 1 | jq -r '.name'");
 console.log(result.stdout); // Alice
 ```
 
+## Custom Builtins on Bash / BashTool
+
+Register JS callbacks as persistent bash builtins that share the `Bash` or
+`BashTool` instance's virtual filesystem. Files survive across `execute()`
+calls, enabling piped command chains and multi-step workflows.
+
+Custom builtins follow the Rust builtin semantics with a shell-first context
+object (`argv`, `stdin`, `env`, `cwd`).
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
+// Option A: constructor-time registration
+const bash = new Bash({
+  customBuiltins: {
+    "get-order": (ctx) =>
+      JSON.stringify({ id: ctx.argv[0], status: "shipped" }) + "\n",
+  },
+});
+
+// Option B: post-construction registration
+bash.addBuiltin("greet", (ctx) =>
+  `hello ${ctx.argv[0] ?? "world"}\n`,
+);
+
+// Tool output → VFS file (persists)
+await bash.execute("mkdir -p /scratch");
+await bash.execute("get-order 42 > /scratch/order.json");
+
+// Separate call — file is still there
+const result = await bash.execute("cat /scratch/order.json");
+console.log(result.stdout);
+// {"id":"42","status":"shipped"}
+```
+
+**Important**: Custom builtins use async callbacks under the hood.
+Use `execute()` (async) — `executeSync()` will deadlock if your script
+invokes any custom builtin, just like `ScriptedTool.executeSync()`.
+
+Custom builtins survive `reset()`. They are host-side config, so
+`fromSnapshot()` and `restoreSnapshot()` do not preserve them —
+pass `customBuiltins` again when restoring.
+
 ## Snapshot / Restore
 
 State snapshots are available on both `Bash` and `BashTool` instances:
@@ -371,6 +414,7 @@ import {
 - `execute(commands, options?)`
 - `executeSyncOrThrow(commands, options?)`
 - `executeOrThrow(commands, options?)`
+- `addBuiltin(name, callback)` — register a JS callback as a persistent custom builtin
 - `cancel()`
 - `clearCancel()`
 - `reset()`
@@ -382,6 +426,7 @@ import {
 ### BashTool
 
 - All execution, cancellation (`cancel()`, `clearCancel()`), reset, snapshot, restore, and direct VFS helpers from `Bash`
+- `addBuiltin(name, callback)` — register a JS callback as a persistent custom builtin
 - Tool metadata: `name`, `version`, `shortDescription`
 - `snapshot()`
 - `restoreSnapshot(data)`
@@ -415,6 +460,19 @@ import {
 - `mounts?: Array<{ path: string; root: string; writable?: boolean }>`
 - `python?: boolean`
 - `externalFunctions?: string[]`
+- `customBuiltins?: Record<string, BuiltinCallback>` — register JS callbacks as persistent bash builtins
+
+### BuiltinContext
+
+- `name: string` — the builtin command name
+- `argv: string[]` — arguments (not including the command name)
+- `stdin: string | null` — piped input, or `null` if no pipe
+- `env: Record<string, string>` — environment variables
+- `cwd: string` — current working directory
+
+### BuiltinCallback
+
+`(ctx: BuiltinContext) => string` — must return the stdout result.
 
 ### ExecuteOptions
 

--- a/crates/bashkit-js/__test__/custom-builtins.spec.ts
+++ b/crates/bashkit-js/__test__/custom-builtins.spec.ts
@@ -134,3 +134,126 @@ test("Bash customBuiltins — multiple builtins", async (t) => {
   t.is(result.stdout, "value=two\n");
   t.is(result.exitCode, 0);
 });
+
+// ============================================================================
+// Async callback tests
+// ============================================================================
+
+test("async customBuiltin — constructor time", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      greet: async (ctx: BuiltinContext) => {
+        await Promise.resolve();
+        return `hello ${ctx.argv[0] ?? "world"}\n`;
+      },
+    },
+  });
+  const result = await bash.execute("greet Alice");
+  t.is(result.stdout, "hello Alice\n");
+  t.is(result.exitCode, 0);
+});
+
+test("async customBuiltin — post-construction addBuiltin", async (t) => {
+  const bash = new Bash();
+  bash.addBuiltin("double", async (ctx: BuiltinContext) => {
+    await new Promise((r) => setTimeout(r, 5));
+    return `${Number(ctx.argv[0]) * 2}\n`;
+  });
+  const result = await bash.execute("double 21");
+  t.is(result.stdout, "42\n");
+  t.is(result.exitCode, 0);
+});
+
+test("async customBuiltin — pipe with stdin", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      double: async (ctx: BuiltinContext) => {
+        await Promise.resolve();
+        return `${Number(ctx.stdin.trim()) * 2}\n`;
+      },
+    },
+  });
+  const result = await bash.execute("echo 21 | double");
+  t.is(result.stdout, "42\n");
+  t.is(result.exitCode, 0);
+});
+
+test("async customBuiltin — VFS persistence across calls", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "get-order": async (ctx: BuiltinContext) => {
+        await Promise.resolve();
+        return JSON.stringify({ id: ctx.argv[0] ?? "?", status: "shipped" }) +
+          "\n";
+      },
+    },
+  });
+  await bash.execute("mkdir -p /scratch");
+  await bash.execute("get-order 42 > /scratch/order.json");
+  const result = await bash.execute("cat /scratch/order.json");
+  t.is(result.exitCode, 0);
+  t.deepEqual(JSON.parse(result.stdout.trim()), {
+    id: "42",
+    status: "shipped",
+  });
+});
+
+test("async customBuiltin — survive reset()", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "test-cmd": async () => {
+        await Promise.resolve();
+        return "ok\n";
+      },
+    },
+  });
+  const r1 = await bash.execute("test-cmd");
+  t.is(r1.stdout, "ok\n");
+
+  bash.reset();
+
+  const r2 = await bash.execute("test-cmd");
+  t.is(r2.stdout, "ok\n");
+});
+
+test("async customBuiltin — error handling", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      fail: async (_ctx: BuiltinContext) => {
+        throw new Error("async fail");
+      },
+    },
+  });
+  const result = await bash.execute("fail");
+  t.is(result.exitCode, 1);
+  t.true(result.stderr.includes("async fail"));
+});
+
+test("async customBuiltin — sync + async chain", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      prefix: (ctx: BuiltinContext) => `tag-${ctx.stdin.trim()}\n`,
+      suffix: async (ctx: BuiltinContext) => {
+        await Promise.resolve();
+        return `${ctx.stdin.trim()}-done\n`;
+      },
+    },
+  });
+  const result = await bash.execute("echo test | prefix | suffix");
+  t.is(result.stdout, "tag-test-done\n");
+  t.is(result.exitCode, 0);
+});
+
+test("async customBuiltin — BashTool", async (t) => {
+  const tool = new BashTool({
+    customBuiltins: {
+      greet: async (ctx: BuiltinContext) => {
+        await Promise.resolve();
+        return `hello ${ctx.argv[0] ?? "world"}\n`;
+      },
+    },
+  });
+  const result = await tool.execute("greet Bob");
+  t.is(result.stdout, "hello Bob\n");
+  t.is(result.exitCode, 0);
+});

--- a/crates/bashkit-js/__test__/custom-builtins.spec.ts
+++ b/crates/bashkit-js/__test__/custom-builtins.spec.ts
@@ -1,0 +1,136 @@
+import test from "ava";
+import { Bash, BashTool } from "../wrapper.js";
+import type { BuiltinContext } from "../wrapper.js";
+
+test("Bash constructor with customBuiltins", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      greet: (ctx: BuiltinContext) =>
+        `hello ${ctx.argv[0] ?? "world"}\n`,
+    },
+  });
+  const result = await bash.execute("greet Alice");
+  t.is(result.stdout, "hello Alice\n");
+  t.is(result.exitCode, 0);
+});
+
+test("Bash customBuiltins with argv and stdin", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      echo_args: (ctx: BuiltinContext) =>
+        `name=${ctx.name} argv=${ctx.argv.join(",")} stdin=${ctx.stdin ?? "null"}\n`,
+    },
+  });
+  const result = await bash.execute("echo foo | echo_args bar baz");
+  t.true(result.stdout.includes("stdin=foo\n"));
+});
+
+test("Bash customBuiltins — VFS persistence across calls", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "get-order": (ctx: BuiltinContext) =>
+        JSON.stringify({ id: ctx.argv[0] ?? "?", status: "shipped" }) +
+        "\n",
+    },
+  });
+  await bash.execute("mkdir -p /scratch");
+  await bash.execute("get-order 42 > /scratch/order.json");
+  const result = await bash.execute("cat /scratch/order.json");
+  t.is(result.exitCode, 0);
+  t.deepEqual(JSON.parse(result.stdout.trim()), {
+    id: "42",
+    status: "shipped",
+  });
+});
+
+test("Bash customBuiltins survive reset()", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "test-cmd": () => "ok\n",
+    },
+  });
+  const r1 = await bash.execute("test-cmd");
+  t.is(r1.stdout, "ok\n");
+
+  bash.reset();
+
+  const r2 = await bash.execute("test-cmd");
+  t.is(r2.stdout, "ok\n");
+});
+
+test("Bash addBuiltin after construction", async (t) => {
+  const bash = new Bash();
+  bash.addBuiltin("double", (ctx: BuiltinContext) => {
+    const n = parseInt(ctx.argv[0] ?? "0", 10);
+    return `${n * 2}\n`;
+  });
+  const result = await bash.execute("double 21");
+  t.is(result.stdout, "42\n");
+  t.is(result.exitCode, 0);
+});
+
+test("Bash customBuiltins with env", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      show_env: (ctx: BuiltinContext) =>
+        `HOME=${ctx.env["HOME"] ?? "?"}\n`,
+    },
+  });
+  const result = await bash.execute("show_env");
+  t.true(result.stdout.startsWith("HOME="));
+});
+
+test("Bash customBuiltins with cwd", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      whereami: (ctx: BuiltinContext) => `${ctx.cwd}\n`,
+    },
+  });
+  const result = await bash.execute("whereami");
+  t.true(result.stdout.includes("/"), "cwd should be a path");
+});
+
+test("BashTool constructor with customBuiltins", async (t) => {
+  const tool = new BashTool({
+    customBuiltins: {
+      greet: (ctx: BuiltinContext) =>
+        `hello ${ctx.argv[0] ?? "world"}\n`,
+    },
+  });
+  const result = await tool.execute("greet Alice");
+  t.is(result.stdout, "hello Alice\n");
+  t.is(result.exitCode, 0);
+});
+
+test("Bash customBuiltins — pipe between tools", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      double: (ctx: BuiltinContext) => {
+        const n = Math.trunc(Number(ctx.stdin));
+        return `${n * 2}\n`;
+      },
+    },
+  });
+  const result = await bash.execute("echo 5 | double");
+  t.is(result.stdout, "10\n");
+  t.is(result.exitCode, 0);
+});
+
+test("Bash customBuiltins — multiple builtins", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      mk: (ctx: BuiltinContext) =>
+        JSON.stringify({ key: ctx.argv[0], value: ctx.argv[1] }) + "\n",
+      get: (ctx: BuiltinContext) => {
+        const parsed = JSON.parse(ctx.stdin ?? "{}") as Record<
+          string,
+          unknown
+        >;
+        return `value=${parsed["value"] ?? "?"}\n`;
+      },
+    },
+  });
+  const result = await bash.execute("mk one two | get");
+  t.is(result.stdout, "value=two\n");
+  t.is(result.exitCode, 0);
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -33,9 +33,14 @@ use std::mem::{MaybeUninit, size_of};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use tokio::sync::Mutex;
+
+/// Registry for in-flight async custom builtin calls.
+type BuiltinCallRegistry =
+    StdMutex<HashMap<String, tokio::sync::oneshot::Sender<Result<String, String>>>>;
 
 // ---------------------------------------------------------------------------
 // Shared tokio runtime + concurrency limiter for JS tool callbacks (issue #982).
@@ -1075,6 +1080,11 @@ struct SharedState {
     /// Custom JS builtin callbacks registered at construction time.
     /// Wrapped in a Mutex so `add_builtin` can append without `&mut self`.
     custom_builtins: std::sync::Mutex<Vec<JsCustomBuiltinEntry>>,
+    /// Registry for in-flight async custom builtin calls.
+    /// Keyed by unique call ID, resolved via `respondToBuiltin`/`respondToBuiltinError`.
+    builtin_call_registry: Arc<BuiltinCallRegistry>,
+    /// Monotonic counter for generating unique builtin call IDs.
+    builtin_call_counter: Arc<AtomicU64>,
 }
 
 /// Wrapper for the external handler that can be stored and cloned.
@@ -1295,13 +1305,13 @@ impl Bash {
     /// Custom builtins survive `reset()` and are available to all subsequent
     /// `execute*()` calls. Call this before first use to avoid rebuilding
     /// the interpreter with existing VFS state.
-    #[napi(ts_args_type = "name: string, callback: (request: string) => string")]
+    #[napi(ts_args_type = "name: string, callback: (payload: string) => void")]
     pub fn add_builtin(
         &self,
         name: String,
-        callback: napi::bindgen_prelude::Function<(String,), String>,
+        callback: napi::bindgen_prelude::Function<(String,), ()>,
     ) -> napi::Result<()> {
-        let tsfn: ToolTsfn = callback
+        let tsfn: BuiltinDispatchTsfn = callback
             .build_threadsafe_function::<(String,)>()
             .weak::<true>()
             .build()?;
@@ -1320,6 +1330,28 @@ impl Bash {
             *s.cancelled.lock().unwrap() = bash.cancellation_token();
             Ok(())
         })
+    }
+
+    /// Called by JS to resolve an async custom builtin callback.
+    /// Delivers the result string to the Rust-side waiter.
+    #[napi]
+    pub fn respond_to_builtin(&self, call_id: String, result: String) {
+        if let Ok(mut reg) = self.state.builtin_call_registry.lock()
+            && let Some(sender) = reg.remove(&call_id)
+        {
+            let _ = sender.send(Ok(result));
+        }
+    }
+
+    /// Called by JS to reject an async custom builtin callback.
+    /// Delivers the error string to the Rust-side waiter.
+    #[napi]
+    pub fn respond_to_builtin_error(&self, call_id: String, error: String) {
+        if let Ok(mut reg) = self.state.builtin_call_registry.lock()
+            && let Some(sender) = reg.remove(&call_id)
+        {
+            let _ = sender.send(Err(error));
+        }
     }
 
     /// Reset interpreter to fresh state, preserving configuration.
@@ -1779,13 +1811,13 @@ impl BashTool {
     ///
     /// Custom builtins survive `reset()` and are available to all subsequent
     /// `execute*()` calls.
-    #[napi(ts_args_type = "name: string, callback: (request: string) => string")]
+    #[napi(ts_args_type = "name: string, callback: (payload: string) => void")]
     pub fn add_builtin(
         &self,
         name: String,
-        callback: napi::bindgen_prelude::Function<(String,), String>,
+        callback: napi::bindgen_prelude::Function<(String,), ()>,
     ) -> napi::Result<()> {
-        let tsfn: ToolTsfn = callback
+        let tsfn: BuiltinDispatchTsfn = callback
             .build_threadsafe_function::<(String,)>()
             .weak::<true>()
             .build()?;
@@ -1803,6 +1835,26 @@ impl BashTool {
             *s.cancelled.lock().unwrap() = bash.cancellation_token();
             Ok(())
         })
+    }
+
+    /// Called by JS to resolve an async custom builtin callback.
+    #[napi]
+    pub fn respond_to_builtin(&self, call_id: String, result: String) {
+        if let Ok(mut reg) = self.state.builtin_call_registry.lock()
+            && let Some(sender) = reg.remove(&call_id)
+        {
+            let _ = sender.send(Ok(result));
+        }
+    }
+
+    /// Called by JS to reject an async custom builtin callback.
+    #[napi]
+    pub fn respond_to_builtin_error(&self, call_id: String, error: String) {
+        if let Ok(mut reg) = self.state.builtin_call_registry.lock()
+            && let Some(sender) = reg.remove(&call_id)
+        {
+            let _ = sender.send(Err(error));
+        }
     }
 
     /// Reset interpreter to fresh state, preserving configuration.
@@ -2185,16 +2237,36 @@ struct JsToolEntry {
     callback: Arc<ToolTsfn>,
 }
 
+/// TSFN for custom builtin dispatch (fire-and-forget).
+/// JS receives a JSON string `{"callId": "...", "request": ...}`
+/// and responds via respondToBuiltin.
+type BuiltinDispatchTsfn = napi::threadsafe_function::ThreadsafeFunction<
+    (String,),
+    (),
+    (String,),
+    napi::Status,
+    false,
+    true,
+>;
+
 /// Entry for a registered JS custom builtin callback.
 struct JsCustomBuiltinEntry {
     name: String,
-    callback: Arc<ToolTsfn>,
+    callback: Arc<BuiltinDispatchTsfn>,
 }
 
 /// Adapter that implements `Builtin` for JS custom builtin callbacks.
+///
+/// Uses a two-phase protocol to support async JS callbacks:
+/// 1. Send (callId, requestJson) to JS via TSFN (fire-and-forget)
+/// 2. JS invokes the callback (sync or async), then calls
+///    `respondToBuiltin(callId, result)` or `respondToBuiltinError(callId, err)`
+/// 3. The registry oneshot completes and we return the result
 struct JsCustomBuiltinAdapter {
     name: String,
-    callback: Arc<ToolTsfn>,
+    callback: Arc<BuiltinDispatchTsfn>,
+    registry: Arc<BuiltinCallRegistry>,
+    call_counter: Arc<AtomicU64>,
 }
 
 #[async_trait]
@@ -2207,26 +2279,40 @@ impl Builtin for JsCustomBuiltinAdapter {
             "env": ctx.env,
             "cwd": ctx.cwd.to_string_lossy(),
         });
-        let request_str = serde_json::to_string(&request)
+
+        let call_id = self
+            .call_counter
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .to_string();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<String, String>>();
+
+        // Encode callId + request as a single JSON payload for TSFN
+        let payload = serde_json::json!({
+            "callId": call_id,
+            "request": request,
+        });
+        let payload_str = serde_json::to_string(&payload)
             .map_err(|e| bashkit::Error::Execution(format!("{}: {}", self.name, e)))?;
 
+        {
+            let mut reg = self.registry.lock().unwrap();
+            reg.insert(call_id.clone(), tx);
+        }
+
         let tsfn = self.callback.clone();
-        let (tx, rx) = tokio::sync::oneshot::channel();
+        let sem = callback_semaphore();
 
         tokio::task::spawn(async move {
-            let sem = callback_semaphore();
-            let result = match sem.acquire().await {
-                Ok(_permit) => tsfn.call_async((request_str,)).await,
-                Err(e) => Err(napi::Error::from_reason(format!("semaphore error: {}", e))),
-            };
-            let _ = tx.send(result);
+            let _permit = sem.acquire().await;
+            let _ = tsfn.call_async((payload_str,)).await;
         });
 
         match rx.await {
             Ok(Ok(stdout)) => Ok(RustExecResult::ok(stdout)),
-            Ok(Err(err)) => Ok(RustExecResult::err(err.to_string(), 1)),
+            Ok(Err(err)) => Ok(RustExecResult::err(err, 1)),
             Err(_) => Ok(RustExecResult::err(
-                format!("{}: callback channel closed", self.name),
+                format!("{}: builtin call cancelled (instance destroyed)", self.name),
                 1,
             )),
         }
@@ -2614,12 +2700,16 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
 
     // Register JS custom builtin callbacks.
     if let Ok(custom_builtins) = state.custom_builtins.lock() {
+        let registry = state.builtin_call_registry.clone();
+        let call_counter = state.builtin_call_counter.clone();
         for entry in custom_builtins.iter() {
             builder = builder.builtin(
                 entry.name.clone(),
                 Box::new(JsCustomBuiltinAdapter {
                     name: entry.name.clone(),
                     callback: entry.callback.clone(),
+                    registry: registry.clone(),
+                    call_counter: call_counter.clone(),
                 }),
             );
         }
@@ -2672,6 +2762,8 @@ fn shared_state_from_opts(
         external_functions: ext_fns.clone(),
         external_handler: external_handler.clone(),
         custom_builtins: std::sync::Mutex::new(Vec::new()),
+        builtin_call_registry: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        builtin_call_counter: Arc::new(AtomicU64::new(1)),
     };
 
     if let Some(ref mounts) = mounts {
@@ -2719,6 +2811,8 @@ fn shared_state_from_opts(
         external_functions: ext_fns,
         external_handler,
         custom_builtins: std::sync::Mutex::new(Vec::new()),
+        builtin_call_registry: tmp.builtin_call_registry.clone(),
+        builtin_call_counter: tmp.builtin_call_counter.clone(),
     })
 }
 

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -18,11 +18,11 @@ use bashkit::interop::fs::{
 };
 use bashkit::tool::VERSION;
 use bashkit::{
-    Bash as RustBash, BashTool as RustBashTool, ExecResult as RustExecResult, ExecutionLimits,
-    ExtFunctionResult, FileSystem as BashFileSystem, FileType, InMemoryFs, Metadata, MontyObject,
-    OutputCallback, PosixFs, PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode,
-    ScriptedTool as RustScriptedTool, SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs,
-    ToolDef, ToolRequest,
+    Bash as RustBash, BashTool as RustBashTool, Builtin, BuiltinContext,
+    ExecResult as RustExecResult, ExecutionLimits, ExtFunctionResult, FileSystem as BashFileSystem,
+    FileType, InMemoryFs, Metadata, MontyObject, OutputCallback, PosixFs, PythonExternalFnHandler,
+    PythonLimits, RealFs, RealFsMode, ScriptedTool as RustScriptedTool,
+    SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
 };
 use napi::bindgen_prelude::External;
 use napi::{Env, JsValue, Unknown, ValueType, sys};
@@ -1072,6 +1072,9 @@ struct SharedState {
     sqlite: bool,
     external_functions: Vec<String>,
     external_handler: Option<ExternalHandlerArc>,
+    /// Custom JS builtin callbacks registered at construction time.
+    /// Wrapped in a Mutex so `add_builtin` can append without `&mut self`.
+    custom_builtins: std::sync::Mutex<Vec<JsCustomBuiltinEntry>>,
 }
 
 /// Wrapper for the external handler that can be stored and cloned.
@@ -1281,6 +1284,42 @@ impl Bash {
     pub fn clear_cancel(&self) {
         let arc = self.state.cancelled.lock().unwrap().clone();
         arc.store(false, Ordering::SeqCst);
+    }
+
+    /// Register a JS callback as a custom builtin in the bash interpreter.
+    ///
+    /// The callback receives a JSON-serialized `BuiltinContext` string with
+    /// fields `name`, `argv`, `stdin`, `env`, `cwd`, and must return a
+    /// string result.
+    ///
+    /// Custom builtins survive `reset()` and are available to all subsequent
+    /// `execute*()` calls. Call this before first use to avoid rebuilding
+    /// the interpreter with existing VFS state.
+    #[napi(ts_args_type = "name: string, callback: (request: string) => string")]
+    pub fn add_builtin(
+        &self,
+        name: String,
+        callback: napi::bindgen_prelude::Function<(String,), String>,
+    ) -> napi::Result<()> {
+        let tsfn: ToolTsfn = callback
+            .build_threadsafe_function::<(String,)>()
+            .weak::<true>()
+            .build()?;
+
+        if let Ok(mut custom_builtins) = self.state.custom_builtins.lock() {
+            custom_builtins.push(JsCustomBuiltinEntry {
+                name: name.clone(),
+                callback: Arc::new(tsfn),
+            });
+        }
+
+        // Rebuild the interpreter with all registered custom builtins.
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
+            *bash = build_bash_from_state(&s, None);
+            *s.cancelled.lock().unwrap() = bash.cancellation_token();
+            Ok(())
+        })
     }
 
     /// Reset interpreter to fresh state, preserving configuration.
@@ -1732,6 +1771,40 @@ impl BashTool {
         arc.store(false, Ordering::SeqCst);
     }
 
+    /// Register a JS callback as a custom builtin in the bash interpreter.
+    ///
+    /// The callback receives a JSON-serialized `BuiltinContext` string with
+    /// fields `name`, `argv`, `stdin`, `env`, `cwd`, and must return a
+    /// string result.
+    ///
+    /// Custom builtins survive `reset()` and are available to all subsequent
+    /// `execute*()` calls.
+    #[napi(ts_args_type = "name: string, callback: (request: string) => string")]
+    pub fn add_builtin(
+        &self,
+        name: String,
+        callback: napi::bindgen_prelude::Function<(String,), String>,
+    ) -> napi::Result<()> {
+        let tsfn: ToolTsfn = callback
+            .build_threadsafe_function::<(String,)>()
+            .weak::<true>()
+            .build()?;
+
+        if let Ok(mut custom_builtins) = self.state.custom_builtins.lock() {
+            custom_builtins.push(JsCustomBuiltinEntry {
+                name: name.clone(),
+                callback: Arc::new(tsfn),
+            });
+        }
+
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
+            *bash = build_bash_from_state(&s, None);
+            *s.cancelled.lock().unwrap() = bash.cancellation_token();
+            Ok(())
+        })
+    }
+
     /// Reset interpreter to fresh state, preserving configuration.
     #[napi]
     pub fn reset(&self) -> napi::Result<()> {
@@ -2110,6 +2183,54 @@ struct JsToolEntry {
     /// Wrapped in Arc so we can share references with Rust ScriptedTool callbacks
     /// (ThreadsafeFunction doesn't implement Clone).
     callback: Arc<ToolTsfn>,
+}
+
+/// Entry for a registered JS custom builtin callback.
+struct JsCustomBuiltinEntry {
+    name: String,
+    callback: Arc<ToolTsfn>,
+}
+
+/// Adapter that implements `Builtin` for JS custom builtin callbacks.
+struct JsCustomBuiltinAdapter {
+    name: String,
+    callback: Arc<ToolTsfn>,
+}
+
+#[async_trait]
+impl Builtin for JsCustomBuiltinAdapter {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<RustExecResult> {
+        let request = serde_json::json!({
+            "name": self.name,
+            "argv": ctx.args,
+            "stdin": ctx.stdin,
+            "env": ctx.env,
+            "cwd": ctx.cwd.to_string_lossy(),
+        });
+        let request_str = serde_json::to_string(&request)
+            .map_err(|e| bashkit::Error::Execution(format!("{}: {}", self.name, e)))?;
+
+        let tsfn = self.callback.clone();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::task::spawn(async move {
+            let sem = callback_semaphore();
+            let result = match sem.acquire().await {
+                Ok(_permit) => tsfn.call_async((request_str,)).await,
+                Err(e) => Err(napi::Error::from_reason(format!("semaphore error: {}", e))),
+            };
+            let _ = tx.send(result);
+        });
+
+        match rx.await {
+            Ok(Ok(stdout)) => Ok(RustExecResult::ok(stdout)),
+            Ok(Err(err)) => Ok(RustExecResult::err(err.to_string(), 1)),
+            Err(_) => Ok(RustExecResult::err(
+                format!("{}: callback channel closed", self.name),
+                1,
+            )),
+        }
+    }
 }
 
 /// Compose JS callbacks as bash builtins for multi-tool orchestration.
@@ -2491,6 +2612,19 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
         builder = builder.env("BASHKIT_ALLOW_INPROCESS_SQLITE", "1");
     }
 
+    // Register JS custom builtin callbacks.
+    if let Ok(custom_builtins) = state.custom_builtins.lock() {
+        for entry in custom_builtins.iter() {
+            builder = builder.builtin(
+                entry.name.clone(),
+                Box::new(JsCustomBuiltinAdapter {
+                    name: entry.name.clone(),
+                    callback: entry.callback.clone(),
+                }),
+            );
+        }
+    }
+
     builder.build()
 }
 
@@ -2537,6 +2671,7 @@ fn shared_state_from_opts(
         sqlite: sql,
         external_functions: ext_fns.clone(),
         external_handler: external_handler.clone(),
+        custom_builtins: std::sync::Mutex::new(Vec::new()),
     };
 
     if let Some(ref mounts) = mounts {
@@ -2583,6 +2718,7 @@ fn shared_state_from_opts(
         sqlite: sql,
         external_functions: ext_fns,
         external_handler,
+        custom_builtins: std::sync::Mutex::new(Vec::new()),
     })
 }
 

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -102,6 +102,28 @@ export type FileValue = string | (() => string) | (() => Promise<string>);
 const MAX_JSON_NESTING_DEPTH = 64;
 
 /**
+ * Execution context passed to JS custom builtin callbacks.
+ *
+ * Fields are snapshots of the shell state at invocation time.
+ * All fields are read-only.
+ */
+export interface BuiltinContext {
+  readonly name: string;
+  readonly argv: string[];
+  readonly stdin: string | null;
+  readonly env: Record<string, string>;
+  readonly cwd: string;
+}
+
+/**
+ * Callback type for custom builtin commands registered via `customBuiltins`.
+ *
+ * Receives a `BuiltinContext` with `name`, `argv`, `stdin`, `env`, `cwd`.
+ * Must return a string result (stdout).
+ */
+export type BuiltinCallback = (ctx: BuiltinContext) => string;
+
+/**
  * Options for creating a Bash or BashTool instance.
  */
 export interface BashOptions {
@@ -197,6 +219,32 @@ export interface BashOptions {
    * the embedded interpreter. When called, they invoke the external handler.
    */
   externalFunctions?: string[];
+  /**
+   * Custom JS callbacks registered as persistent bash builtins.
+   *
+   * Each key/value pair registers a JS function as a bash builtin command.
+   * Callbacks receive a `BuiltinContext` and return a string result (stdout).
+   *
+   * Unlike `ScriptedTool`, these builtins share the `Bash` instance's
+   * persistent VFS — files survive across `execute()` calls.
+   *
+   * Custom builtins survive `reset()`. They are host-side config, so
+   * `fromSnapshot()` and `restoreSnapshot()` do not preserve them —
+   * pass `customBuiltins` again when restoring.
+   *
+   * @example
+   * ```typescript
+   * const bash = new Bash({
+   *   customBuiltins: {
+   *     "greet": (ctx) => `hello ${ctx.argv[0] ?? "world"}\n`,
+   *     "get-order": (ctx) => JSON.stringify({id: ctx.argv[0], status: "shipped"}) + "\n",
+   *   }
+   * });
+   * bash.executeSync('greet Alice');
+   * // stdout: "hello Alice\n"
+   * ```
+   */
+  customBuiltins?: Record<string, BuiltinCallback>;
 }
 
 export interface SnapshotOptions {
@@ -572,6 +620,7 @@ export class Bash {
   constructor(options?: BashOptions) {
     const resolved = resolveFilesSync(options?.files);
     this.native = new NativeBash(toNativeOptions(options, resolved));
+    this._registerCustomBuiltins(options?.customBuiltins);
   }
 
   /**
@@ -592,7 +641,21 @@ export class Bash {
     const resolved = await resolveFiles(options?.files);
     const instance = Object.create(Bash.prototype) as Bash;
     instance.native = new NativeBash(toNativeOptions(options, resolved));
+    instance._registerCustomBuiltins(options?.customBuiltins);
     return instance;
+  }
+
+  private _registerCustomBuiltins(
+    builtins?: Record<string, BuiltinCallback>,
+  ): void {
+    if (!builtins) return;
+    for (const [name, callback] of Object.entries(builtins)) {
+      const wrapped = (requestJson: string): string => {
+        const ctx = JSON.parse(requestJson) as BuiltinContext;
+        return callback(ctx);
+      };
+      this.native.addBuiltin(name, wrapped);
+    }
   }
 
   /**
@@ -722,6 +785,30 @@ export class Bash {
    */
   clearCancel(): void {
     this.native.clearCancel();
+  }
+
+  /**
+   * Register a JS callback as a custom builtin in the bash interpreter.
+   *
+   * The callback receives a `BuiltinContext` with `name`, `argv`, `stdin`,
+   * `env`, `cwd` and must return a string result.
+   *
+   * Custom builtins survive `reset()` and are available to all subsequent
+   * `execute*()` calls. Best called before first use.
+   *
+   * @example
+   * ```typescript
+   * const bash = new Bash();
+   * bash.addBuiltin("greet", (ctx) => `hello ${ctx.argv[0] ?? "world"}\n`);
+   * console.log(bash.executeSync("greet Alice").stdout); // hello Alice\n
+   * ```
+   */
+  addBuiltin(name: string, callback: BuiltinCallback): void {
+    const wrapped = (requestJson: string): string => {
+      const ctx = JSON.parse(requestJson) as BuiltinContext;
+      return callback(ctx);
+    };
+    this.native.addBuiltin(name, wrapped);
   }
 
   /**
@@ -930,6 +1017,7 @@ export class BashTool {
   constructor(options?: BashOptions) {
     const resolved = resolveFilesSync(options?.files);
     this.native = new NativeBashTool(toNativeOptions(options, resolved));
+    this._registerCustomBuiltins(options?.customBuiltins);
   }
 
   /**
@@ -939,7 +1027,21 @@ export class BashTool {
     const resolved = await resolveFiles(options?.files);
     const instance = Object.create(BashTool.prototype) as BashTool;
     instance.native = new NativeBashTool(toNativeOptions(options, resolved));
+    instance._registerCustomBuiltins(options?.customBuiltins);
     return instance;
+  }
+
+  private _registerCustomBuiltins(
+    builtins?: Record<string, BuiltinCallback>,
+  ): void {
+    if (!builtins) return;
+    for (const [name, callback] of Object.entries(builtins)) {
+      const wrapped = (requestJson: string): string => {
+        const ctx = JSON.parse(requestJson) as BuiltinContext;
+        return callback(ctx);
+      };
+      this.native.addBuiltin(name, wrapped);
+    }
   }
 
   /**
@@ -1059,6 +1161,26 @@ export class BashTool {
    */
   clearCancel(): void {
     this.native.clearCancel();
+  }
+
+  /**
+   * Register a JS callback as a custom builtin in the bash interpreter.
+   *
+   * The callback receives a `BuiltinContext` and must return a string result.
+   * Custom builtins survive `reset()`. Best called before first use.
+   *
+   * @example
+   * ```typescript
+   * const tool = new BashTool();
+   * tool.addBuiltin("greet", (ctx) => `hello ${ctx.argv[0] ?? "world"}\n`);
+   * ```
+   */
+  addBuiltin(name: string, callback: BuiltinCallback): void {
+    const wrapped = (requestJson: string): string => {
+      const ctx = JSON.parse(requestJson) as BuiltinContext;
+      return callback(ctx);
+    };
+    this.native.addBuiltin(name, wrapped);
   }
 
   /**

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -121,7 +121,7 @@ export interface BuiltinContext {
  * Receives a `BuiltinContext` with `name`, `argv`, `stdin`, `env`, `cwd`.
  * Must return a string result (stdout).
  */
-export type BuiltinCallback = (ctx: BuiltinContext) => string;
+export type BuiltinCallback = (ctx: BuiltinContext) => string | Promise<string>;
 
 /**
  * Options for creating a Bash or BashTool instance.
@@ -299,6 +299,35 @@ function cancelledExecResult(): ExecResult {
     stderrTruncated: false,
     finalEnv: undefined,
     success: false,
+  };
+}
+
+function makeBuiltinDispatcher(
+  callback: BuiltinCallback,
+  respondToBuiltin: (callId: string, result: string) => void,
+  respondToBuiltinError: (callId: string, error: string) => void,
+): (payload: string) => void {
+  return (payload: string): void => {
+    try {
+      const { callId, request } = JSON.parse(payload) as {
+        callId: string;
+        request: BuiltinContext;
+      };
+      const result = callback(request);
+      if (isPromiseLike(result)) {
+        Promise.resolve(result).then(
+          (v) => respondToBuiltin(callId, v as string),
+          (e) => respondToBuiltinError(callId, (e as Error)?.message ?? String(e)),
+        );
+      } else {
+        respondToBuiltin(callId, result);
+      }
+    } catch (e) {
+      respondToBuiltinError(
+        "?",
+        (e as Error)?.message ?? String(e),
+      );
+    }
   };
 }
 
@@ -650,12 +679,20 @@ export class Bash {
   ): void {
     if (!builtins) return;
     for (const [name, callback] of Object.entries(builtins)) {
-      const wrapped = (requestJson: string): string => {
-        const ctx = JSON.parse(requestJson) as BuiltinContext;
-        return callback(ctx);
-      };
-      this.native.addBuiltin(name, wrapped);
+      this._addBuiltinToNative(name, callback);
     }
+  }
+
+  private _addBuiltinToNative(
+    name: string,
+    callback: BuiltinCallback,
+  ): void {
+    const dispatch = makeBuiltinDispatcher(
+      callback,
+      (callId, result) => this.native.respondToBuiltin(callId, result),
+      (callId, error) => this.native.respondToBuiltinError(callId, error),
+    );
+    this.native.addBuiltin(name, dispatch);
   }
 
   /**
@@ -804,11 +841,7 @@ export class Bash {
    * ```
    */
   addBuiltin(name: string, callback: BuiltinCallback): void {
-    const wrapped = (requestJson: string): string => {
-      const ctx = JSON.parse(requestJson) as BuiltinContext;
-      return callback(ctx);
-    };
-    this.native.addBuiltin(name, wrapped);
+    this._addBuiltinToNative(name, callback);
   }
 
   /**
@@ -1036,12 +1069,20 @@ export class BashTool {
   ): void {
     if (!builtins) return;
     for (const [name, callback] of Object.entries(builtins)) {
-      const wrapped = (requestJson: string): string => {
-        const ctx = JSON.parse(requestJson) as BuiltinContext;
-        return callback(ctx);
-      };
-      this.native.addBuiltin(name, wrapped);
+      this._addBuiltinToNative(name, callback);
     }
+  }
+
+  private _addBuiltinToNative(
+    name: string,
+    callback: BuiltinCallback,
+  ): void {
+    const dispatch = makeBuiltinDispatcher(
+      callback,
+      (callId, result) => this.native.respondToBuiltin(callId, result),
+      (callId, error) => this.native.respondToBuiltinError(callId, error),
+    );
+    this.native.addBuiltin(name, dispatch);
   }
 
   /**
@@ -1176,11 +1217,7 @@ export class BashTool {
    * ```
    */
   addBuiltin(name: string, callback: BuiltinCallback): void {
-    const wrapped = (requestJson: string): string => {
-      const ctx = JSON.parse(requestJson) as BuiltinContext;
-      return callback(ctx);
-    };
-    this.native.addBuiltin(name, wrapped);
+    this._addBuiltinToNative(name, callback);
   }
 
   /**


### PR DESCRIPTION
Register JS callbacks as persistent bash builtins that share the Bash/BashTool instance's VFS. Files survive across execute() calls.

Constructor-time: new Bash({ customBuiltins: { name: callback } })
Post-construction: bash.addBuiltin(name, callback)

Callback receives BuiltinContext: { name, argv, stdin, env, cwd } Returns a string result (stdout).

Adds JsCustomBuiltinAdapter (Builtin trait impl) in the NAPI-RS bindings, stores entries in SharedState for reset() persistence, and exposes both customBuiltins option and addBuiltin() method.

10 new tests cover constructor registration, argv/stdin, VFS persistence across calls, reset survival, post-construction addBuiltin, env/cwd context, BashTool integration, and pipes.

#1646