### PR TITLE
fix(rg): reject empty pattern with --only-matching

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -1130,6 +1130,13 @@ impl RgOptions {
         }
 
         opts.paths = positional;
+
+        if opts.only_matching && opts.patterns.iter().any(|pattern| pattern.is_empty()) {
+            return Err(Error::Execution(
+                "rg: empty pattern is not allowed with --only-matching".to_string(),
+            ));
+        }
+
         Ok(opts)
     }
 
@@ -9983,6 +9990,23 @@ mod tests {
         assert!(result.stdout.contains("./src/main.rs:needle"));
         assert!(!result.stdout.contains("main.txt"));
         assert!(!result.stdout.contains("vendor"));
+    }
+
+    #[test]
+    fn test_rg_only_matching_rejects_empty_pattern() {
+        let args = vec![
+            "-o".to_string(),
+            "-e".to_string(),
+            "".to_string(),
+            "/test.txt".to_string(),
+        ];
+        match RgOptions::parse(&args) {
+            Err(Error::Execution(msg)) => {
+                assert_eq!(msg, "rg: empty pattern is not allowed with --only-matching")
+            }
+            Err(other) => panic!("unexpected error: {other}"),
+            Ok(_) => panic!("expected parse error"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent resource-exhaustion triggered by `rg -o/--only-matching` with an empty pattern, which produces zero-width matches at every UTF-8 boundary and can amplify builtin output allocations before interpreter truncation.

### Description
- Add a parse-time check in `RgOptions::parse` (in `crates/bashkit/src/builtins/rg.rs`) to return `Err(Error::Execution("rg: empty pattern is not allowed with --only-matching"))` when `--only-matching` is enabled and any provided pattern is empty, and add a unit test `test_rg_only_matching_rejects_empty_pattern` to cover `-o -e ''`.

### Testing
- Ran `cargo test -p bashkit rg_only_matching` and the targeted tests including `test_rg_only_matching_rejects_empty_pattern` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fa7290f08832b97de581326fb2b30)