### PR TITLE
feat(examples): reduce docs agent token waste

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -489,7 +489,7 @@ tool = create_bash_tool(
     ],
     allowed_mount_paths=["/path/to/docs"],
     readonly_filesystem=True,
-    max_output_length=12_000,
+    max_output_length=8_000,
 )
 ```
 

--- a/examples/docs-grep-agent/README.md
+++ b/examples/docs-grep-agent/README.md
@@ -6,12 +6,12 @@ The LangChain 1.0 `create_agent` helper builds the LangGraph agent directly
 with `bashkit.langchain.create_bash_tool()`. The agent writes the bash script
 itself, and the script runs inside a bashkit interpreter with real docs mounted
 read-only at `/docs/public` and `/docs/rustdoc`, plus a curated `/docs/examples`
-view that excludes local generated artifacts. The full bashkit filesystem is
-also read-only, so commands cannot copy docs into `/tmp` or create scratch
-files. Tool output is capped before it reaches the model, and the prompt steers
-the agent toward compact search pipelines. By default the console only streams
-the final answer. Pass `--show-tools` to also print each bash script as a
-one-liner to stderr.
+view that excludes local generated artifacts and lockfiles. The full bashkit
+filesystem is also read-only, so commands cannot copy docs into `/tmp` or
+create scratch files. Tool output is capped before it reaches the model, and
+the prompt steers the agent toward compact search pipelines. By default the
+console only streams the final answer. Pass `--show-tools` to also print each
+bash script as a one-liner to stderr.
 
 ## Run
 
@@ -42,18 +42,24 @@ effort. Override with `--model` or `BASHKIT_DOCS_MODEL`.
 The agent uses Bashkit's builtin shell tools directly:
 
 - `rg -i -n PATTERN ... | head -20` for broad discovery.
+- `rg -i -l PATTERN ... | head -10` to identify likely files before reading.
 - `grep -R -i -n -C 1 -m 3 -- PATTERN ...` for contextual evidence snippets.
-- `sed -n 'START,ENDp' FILE` after a relevant file and line range are known.
+- `sed -n 'START,ENDp' FILE` after a relevant file and line range are known,
+  with ranges kept under 120 lines.
 - `find` only for targeted filename discovery.
 
 Bashkit `rg` is a compact ripgrep-style builtin, not full ripgrep. It is useful
 for first-pass searches, while `grep` is still better when context flags or
 include/exclude filters matter.
 
+The prompt tells the agent not to use `cat` for docs or examples. The LangChain
+tool also truncates each bash call at 8000 characters as a final guardrail.
+
 ## Smoke Test
 
 The self-test does not require an API key. It verifies the docs corpus, the
-read-only bashkit mount, blocked `/tmp` copies, and direct bash tool execution:
+read-only bashkit mount, blocked `/tmp` copies, direct bash tool execution, and
+prints approximate token counts for focused retrieval versus a full-file read:
 
 ```bash
 uv run docs-grep-agent --self-test

--- a/examples/docs-grep-agent/docs_grep_agent/app.py
+++ b/examples/docs-grep-agent/docs_grep_agent/app.py
@@ -14,8 +14,11 @@ from langchain_openai import ChatOpenAI
 from bashkit.langchain import create_bash_tool
 
 DEFAULT_MODEL = "gpt-5.5-low"
-MAX_CONTEXT_CHARS = 12000
+# Public docs chat should retrieve snippets first; this cap is a backstop, not
+# a substitute for narrow searches.
+MAX_CONTEXT_CHARS = 8000
 SPINNER_INTERVAL_SECONDS = 0.25
+EXCLUDED_EXAMPLE_FILES = {"package-lock.json", "uv.lock"}
 
 SYSTEM_PROMPT = """You answer questions about Bashkit from documentation snippets.
 
@@ -35,12 +38,14 @@ Rules:
 - Write the bash script yourself.
 - Use one multi-command bash script, or make multiple bash tool calls when separate searches are useful.
 - Only inspect files under /docs/public, /docs/rustdoc, and /docs/examples.
-- Generated local artifacts such as .venv, .ruff_cache, and __pycache__ are intentionally not mounted.
-- Keep tool output compact. Bound every broad search with `head`, `-m`, `-l`, or a narrow `sed -n` range, and aim to keep total tool output under 12000 characters.
+- Generated local artifacts such as .venv, .ruff_cache, __pycache__, and lockfiles are intentionally not mounted.
+- Keep tool output compact. Bound every broad search with `head`, `-m`, `-l`, or a narrow `sed -n` range, and aim to keep total tool output under 8000 characters.
 - Search progressively:
   1. Use `rg -i -n PATTERN PATH... | head -20` for broad discovery.
-  2. Use `grep -R -i -n -C 1 -m 3 -- PATTERN PATH...` when you need context around matches.
-  3. Use `sed -n 'START,ENDp' FILE` after finding the best file and line range.
+  2. Use `rg -i -l PATTERN PATH... | head -10` before reading content for broad questions.
+  3. Use `grep -R -i -n -C 1 -m 3 -- PATTERN PATH...` when you need context around matches.
+  4. Use `sed -n 'START,ENDp' FILE` after finding the best file and line range.
+- Never use `cat` for docs or examples. Read focused excerpts with `sed -n`, and keep each range under 120 lines.
 - Use `grep` instead of `rg` when you need context flags (`-A`, `-B`, `-C`) or include/exclude filters. Bashkit `rg` is intentionally simpler than full ripgrep.
 - Use `-F` with `rg` or `grep` for exact strings.
 - For multi-topic questions, print short section labels and run one compact search per topic.
@@ -73,13 +78,12 @@ def build_example_files(root: Path) -> dict[str, str]:
     files = {
         f"/docs/examples/{path.name}": path.read_text(encoding="utf-8")
         for path in sorted(examples.iterdir())
-        if path.is_file()
+        if path.is_file() and path.name not in EXCLUDED_EXAMPLE_FILES
     }
     for rel in [
         "docs-grep-agent/.gitignore",
         "docs-grep-agent/README.md",
         "docs-grep-agent/pyproject.toml",
-        "docs-grep-agent/uv.lock",
         "docs-grep-agent/docs_grep_agent/__init__.py",
         "docs-grep-agent/docs_grep_agent/__main__.py",
         "docs-grep-agent/docs_grep_agent/app.py",
@@ -112,6 +116,10 @@ def create_docs_bash_tool(root: Path):
         readonly_filesystem=True,
         max_output_length=MAX_CONTEXT_CHARS,
     )
+
+
+def approx_tokens(text: str) -> int:
+    return (len(text) + 3) // 4
 
 
 async def spinner(stop: asyncio.Event) -> None:
@@ -212,12 +220,21 @@ def self_test(root: Path) -> None:
     examples = bash_tool.invoke(
         {"commands": "find /docs/examples -maxdepth 2 -type f | head"}
     )
+    shortlist = bash_tool.invoke(
+        {
+            "commands": "rg -i -l 'cli' /docs/public /docs/rustdoc /docs/examples | head -10"
+        }
+    )
+    focused_cli = bash_tool.invoke({"commands": "sed -n '1,80p' /docs/public/cli.md"})
+    full_cli = bash_tool.invoke({"commands": "cat /docs/public/cli.md"})
     generated = bash_tool.invoke(
         {
             "commands": (
                 "find /docs/examples -maxdepth 4 -name .venv -print; "
                 "find /docs/examples -maxdepth 4 -name .ruff_cache -print; "
-                "find /docs/examples -maxdepth 4 -name __pycache__ -print"
+                "find /docs/examples -maxdepth 4 -name __pycache__ -print; "
+                "find /docs/examples -maxdepth 4 -name uv.lock -print; "
+                "find /docs/examples -maxdepth 4 -name package-lock.json -print"
             )
         }
     )
@@ -229,7 +246,16 @@ def self_test(root: Path) -> None:
     assert "[Exit code:" in readonly
     assert "[Exit code:" in copy
     assert "/docs/examples/" in examples
+    assert len(shortlist) < 1000
+    assert len(focused_cli) < len(full_cli)
     assert generated.strip() == ""
+    print(
+        "token-efficiency "
+        f"shortlist~{approx_tokens(shortlist)}t "
+        f"focused~{approx_tokens(focused_cli)}t "
+        f"full-file~{approx_tokens(full_cli)}t "
+        f"avoided~{approx_tokens(full_cli) - approx_tokens(focused_cli)}t"
+    )
     print("self-test ok")
 
 


### PR DESCRIPTION
## What
Reduce token waste in the docs grep agent example.

## Why
The public docs chat should prefer compact retrieval over full-file reads and avoid irrelevant mounted lockfile content.

## How
- Lower the LangChain bash tool output cap from 12000 to 8000 chars.
- Steer the agent to shortlist files with rg -l, avoid cat, and use focused sed ranges under 120 lines.
- Exclude mounted example lockfiles from the docs corpus.
- Extend --self-test with token-efficiency measurements and assertions.

Token measurement with o200k_base:
- shortlist: 85 tokens
- focused 80-line CLI excerpt: 656 tokens
- full cli.md: 2049 tokens
- avoided by focused read: 1393 tokens
- worst-case truncation after new cap: 3004 tokens

## Risk
Low. Example and docs-only change; no runtime core behavior change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verified locally:
- uv run docs-grep-agent --self-test
- uvx ruff check crates/bashkit-python examples/docs-grep-agent
- uvx ruff format --check crates/bashkit-python examples/docs-grep-agent
- uv lock --check
- cargo test --all-features
- just test
- just pre-pr