### PR TITLE
fix(rg): avoid quadratic multiline matching hot path

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3762,15 +3762,9 @@ fn rg_record_terminator(opts: &RgOptions) -> char {
 }
 
 fn rg_line_index_for_offset(lines: &[RgLine<'_>], offset: usize) -> usize {
-    let mut idx = 0usize;
-    for (line_idx, line) in lines.iter().enumerate() {
-        if line.start_offset <= offset {
-            idx = line_idx;
-        } else {
-            break;
-        }
-    }
-    idx
+    lines
+        .partition_point(|line| line.start_offset <= offset)
+        .saturating_sub(1)
 }
 
 fn collect_rg_multiline_matches<'a>(
@@ -4599,7 +4593,16 @@ impl Builtin for Rg {
             stats.bytes_searched += content.len();
 
             if opts.multiline {
-                let matches = collect_rg_multiline_matches(&regex, content, &lines, opts.max_count);
+                // Early-exit modes only need to know whether any match exists, so cap
+                // collection to 1. Invert mode needs all matches to compute the inverse.
+                let collect_limit = if (opts.quiet && !opts.stats || opts.files_with_matches)
+                    && !opts.invert_match
+                {
+                    Some(opts.max_count.unwrap_or(usize::MAX).min(1))
+                } else {
+                    opts.max_count
+                };
+                let matches = collect_rg_multiline_matches(&regex, content, &lines, collect_limit);
                 let match_line_indices = rg_multiline_match_lines(&matches);
                 let context_match_lines = rg_unique_sorted_lines(&match_line_indices);
 
@@ -11926,6 +11929,27 @@ mod tests {
         .await;
         assert_eq!(quiet.exit_code, 0);
         assert_eq!(quiet.stdout, "");
+    }
+
+    #[tokio::test]
+    async fn test_rg_multiline_quiet_and_files_with_matches() {
+        let quiet = run_rg(
+            &["-q", "-U", "foo\nbar", "/test.txt"],
+            None,
+            &[("/test.txt", b"foo\nbar\nfoo\nbar\n")],
+        )
+        .await;
+        assert_eq!(quiet.exit_code, 0);
+        assert_eq!(quiet.stdout, "");
+
+        let files = run_rg(
+            &["-l", "-U", "foo\nbar", "/test.txt"],
+            None,
+            &[("/test.txt", b"foo\nbar\nfoo\nbar\n")],
+        )
+        .await;
+        assert_eq!(files.exit_code, 0);
+        assert_eq!(files.stdout, "/test.txt\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Multiline `rg` previously mapped each regex match offset to a line index by scanning from the first line, producing O(matches * lines) CPU for attacker-controlled inputs and enabling a DoS attack. 
- The multiline path also collected and line-mapped all matches before honoring early-exit modes like `-q` and `-l`, so quiet/filename-only searches could still trigger the heavy loop.

### Description
- Replace `rg_line_index_for_offset` linear scan with a `partition_point` lookup to compute the line index in O(log n) instead of O(n). 
- Add a `collect_limit` when collecting multiline matches so `-q` (without `--stats`) and `-l/--files-with-matches` use a max collection of 1 and avoid collecting all matches unnecessarily. 
- Add `test_rg_multiline_quiet_and_files_with_matches` to cover multiline behavior for `-q` and `-l` and prevent regressions.

### Testing
- Ran `cargo test -p bashkit test_rg_multiline_quiet_and_files_with_matches` and the new test passed. 
- The `rg` multiline regression test executes in the package test run and passed locally during validation. 
- The fix retains existing `max_count` semantics for normal multiline usage while preventing expensive collection in early-exit modes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10172b71a0832b96dcc617de7c458a)