### PR TITLE
fix(rg): avoid eager rg allocations in low-output/search-json paths

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4151,23 +4151,39 @@ fn write_rg_json_match(
     // collecting them into a Vec<serde_json::Value> and then serializing the
     // whole tree. Avoids an O(matches_per_line) intermediate allocation on
     // attacker-controlled lines with many matches.
-    let header = json!({
-        "type":"match",
-        "data":{
-            "path":{"text":filename},
-            "lines":{"text":line.raw},
-            "line_number":line_idx + 1,
-            "absolute_offset":line.start_offset,
-        }
+    //
+    // serde_json serializes Object keys in lexicographic order, so the outer
+    // event looks like `{"data":{...},"type":"match"}` — only one trailing `}`.
+    // Build the inner `data` object on its own, strip its trailing `}`,
+    // append `"submatches":[...]` (which sorts last alphabetically after
+    // `path`), close `data`, then close the outer envelope by hand.
+    let data = json!({
+        "path":{"text":filename},
+        "lines":{"text":line.raw},
+        "line_number":line_idx + 1,
+        "absolute_offset":line.start_offset,
     });
-    let header_str = header.to_string();
-    let Some(stripped) = header_str.strip_suffix("}}") else {
-        // Defensive fallback — preserve the old behavior on any unexpected
-        // serializer output rather than emit malformed JSON.
-        write_rg_json_event(output, header);
+    let data_str = data.to_string();
+    let Some(data_open) = data_str.strip_suffix('}') else {
+        // Defensive fallback — preserve the previous semantics if serde_json
+        // ever produces an unexpected shape.
+        write_rg_json_event(
+            output,
+            json!({
+                "type":"match",
+                "data":{
+                    "path":{"text":filename},
+                    "lines":{"text":line.raw},
+                    "line_number":line_idx + 1,
+                    "absolute_offset":line.start_offset,
+                    "submatches":[],
+                }
+            }),
+        );
         return;
     };
-    output.push_str(stripped);
+    output.push_str("{\"data\":");
+    output.push_str(data_open);
     output.push_str(",\"submatches\":[");
     let mut first = true;
     for mat in regex.find_iter(line.match_text) {
@@ -4190,7 +4206,7 @@ fn write_rg_json_match(
         }
         output.push_str(&value.to_string());
     }
-    output.push_str("]}}\n");
+    output.push_str("]},\"type\":\"match\"}\n");
 }
 
 fn write_rg_json_context(output: &mut String, filename: &str, line: RgLine<'_>, line_idx: usize) {

--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4147,39 +4147,50 @@ fn write_rg_json_match(
     regex: &RgMatcher,
     replacement: Option<&str>,
 ) {
-    let submatches: Vec<_> = regex
-        .find_iter(line.match_text)
-        .into_iter()
-        .map(|mat| {
-            let mut value = json!({
-                "match":{"text":mat.as_str()},
-                "start":mat.start(),
-                "end":mat.end()
-            });
-            if let Some(replacement) = replacement
-                && let Some(obj) = value.as_object_mut()
-            {
-                obj.insert(
-                    "replacement".to_string(),
-                    json!({"text":regex.replace_first(mat.as_str(), replacement)}),
-                );
-            }
-            value
-        })
-        .collect();
-    write_rg_json_event(
-        output,
-        json!({
-            "type":"match",
-            "data":{
-                "path":{"text":filename},
-                "lines":{"text":line.raw},
-                "line_number":line_idx + 1,
-                "absolute_offset":line.start_offset,
-                "submatches":submatches,
-            }
-        }),
-    );
+    // Stream submatches straight into the JSON output buffer instead of first
+    // collecting them into a Vec<serde_json::Value> and then serializing the
+    // whole tree. Avoids an O(matches_per_line) intermediate allocation on
+    // attacker-controlled lines with many matches.
+    let header = json!({
+        "type":"match",
+        "data":{
+            "path":{"text":filename},
+            "lines":{"text":line.raw},
+            "line_number":line_idx + 1,
+            "absolute_offset":line.start_offset,
+        }
+    });
+    let header_str = header.to_string();
+    let Some(stripped) = header_str.strip_suffix("}}") else {
+        // Defensive fallback — preserve the old behavior on any unexpected
+        // serializer output rather than emit malformed JSON.
+        write_rg_json_event(output, header);
+        return;
+    };
+    output.push_str(stripped);
+    output.push_str(",\"submatches\":[");
+    let mut first = true;
+    for mat in regex.find_iter(line.match_text) {
+        if !first {
+            output.push(',');
+        }
+        first = false;
+        let mut value = json!({
+            "match":{"text":mat.as_str()},
+            "start":mat.start(),
+            "end":mat.end()
+        });
+        if let Some(replacement) = replacement
+            && let Some(obj) = value.as_object_mut()
+        {
+            obj.insert(
+                "replacement".to_string(),
+                json!({"text":regex.replace_first(mat.as_str(), replacement)}),
+            );
+        }
+        output.push_str(&value.to_string());
+    }
+    output.push_str("]}}\n");
 }
 
 fn write_rg_json_context(output: &mut String, filename: &str, line: RgLine<'_>, line_idx: usize) {


### PR DESCRIPTION
### Motivation
- Remediate an availability issue where `rg` eagerly built per-line and per-match vectors, allowing attacker-controlled files to exhaust memory before output caps applied. 
- Preserve existing behavior and output modes while removing unbounded O(number_of_lines) and O(matches_per_line) temporary allocations.

### Description
- Only build the indexed `Vec<RgLine>` when an output mode requires random-access line metadata (JSON, passthru, vimgrep, only-matching output, context, or non-count outputs). 
- Replaced eager per-file `split_rg_lines` usage with a streaming line scan (`split_inclusive('
')` + `scan`) for match detection and counting in low-output modes. 
- Eliminated the temporary `Vec<serde_json::Value>` for JSON submatches by streaming submatch serialization directly into the output buffer in `write_rg_json_match`. 
- Kept all existing output formats and semantics unchanged while avoiding large intermediate allocations.

### Testing
- Ran `cargo fmt` and formatting check succeeded. 
- Ran `cargo test -p bashkit builtins::rg::tests:: -- --nocapture` and the rg test cases passed (30 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc5c953d8832bb1231657debdad94)