### PR TITLE
fix(fs): enforce readonly_filesystem for runtime live mounts

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -554,6 +554,8 @@ pub struct Bash {
     fs: Arc<dyn FileSystem>,
     /// Outermost MountableFs layer for live mount/unmount after build.
     mountable: Arc<MountableFs>,
+    /// Whether runtime mounts are forced read-only.
+    readonly_filesystem: bool,
     interpreter: Interpreter,
     /// Parser timeout (stored separately for use before interpreter runs)
     parser_timeout: std::time::Duration,
@@ -594,6 +596,7 @@ impl Bash {
         Self {
             fs,
             mountable,
+            readonly_filesystem: false,
             interpreter,
             parser_timeout,
             max_input_bytes,
@@ -1033,6 +1036,11 @@ impl Bash {
         vfs_path: impl AsRef<std::path::Path>,
         fs: Arc<dyn FileSystem>,
     ) -> Result<()> {
+        let fs: Arc<dyn FileSystem> = if self.readonly_filesystem {
+            Arc::new(ReadOnlyFs::new(fs))
+        } else {
+            fs
+        };
         self.mountable.mount(vfs_path, fs)
     }
 
@@ -2490,6 +2498,7 @@ impl BashBuilder {
         let mut result = Self::build_with_fs(
             fs,
             mountable,
+            self.readonly_filesystem,
             self.env,
             self.username,
             self.hostname,
@@ -2732,6 +2741,7 @@ impl BashBuilder {
     fn build_with_fs(
         fs: Arc<dyn FileSystem>,
         mountable: Arc<MountableFs>,
+        readonly_filesystem: bool,
         env: HashMap<String, String>,
         username: Option<String>,
         hostname: Option<String>,
@@ -2851,6 +2861,7 @@ impl BashBuilder {
         Bash {
             fs,
             mountable,
+            readonly_filesystem,
             interpreter,
             parser_timeout,
             max_input_bytes,

--- a/crates/bashkit/tests/live_mount_tests.rs
+++ b/crates/bashkit/tests/live_mount_tests.rs
@@ -154,3 +154,17 @@ async fn live_mount_replace() {
     let result = bash.exec("cat /app/version").await.unwrap();
     assert_eq!(result.stdout, "v2");
 }
+
+#[tokio::test]
+async fn live_mount_is_readonly_when_builder_enables_readonly_filesystem() {
+    let mut bash = Bash::builder().readonly_filesystem(true).build();
+
+    let data_fs = Arc::new(InMemoryFs::new());
+    bash.mount("/mnt/data", data_fs).unwrap();
+
+    let result = bash
+        .exec("echo blocked > /mnt/data/new.txt 2>&1")
+        .await
+        .unwrap();
+    assert_ne!(result.exit_code, 0);
+}


### PR DESCRIPTION
### Motivation
- A read-only sandbox option was applied beneath the outer `MountableFs`, allowing live `mount()` calls to bypass the `ReadOnlyFs` and receive writes. 
- That bypass lets post-build mounts (including host-backed `RealFs`) become writable despite `readonly_filesystem(true)`, breaking intended isolation. 
- The Python bindings expose the same live mount API, making the bypass reachable from embedders.

### Description
- Persist `readonly_filesystem` in the runtime `Bash` struct and wire the builder flag through `build_with_fs(...)` so the instance knows the mode. 
- Enforce read-only semantics at the live mount boundary by wrapping runtime-mounted filesystems in `ReadOnlyFs` when the instance was built with `readonly_filesystem(true)`. 
- Keep existing build-time `ReadOnlyFs` wrapping in place so pre-configured mounts remain protected. 
- Add a regression test `live_mount_is_readonly_when_builder_enables_readonly_filesystem` proving writes fail on live mounts when readonly mode is enabled.

### Testing
- Ran `cargo test -p bashkit --test live_mount_tests` which executed the live-mount test suite and all tests passed (`8 passed; 0 failed`). 
- The new regression test verifies that a `bash` built with `readonly_filesystem(true)` blocks write redirections to a subsequently live-mounted filesystem.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc5cdc440832bbea293d45f84f012)