### PR TITLE
feat(rg): support all file types

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -1439,6 +1439,16 @@ impl RgTypeDatabase {
     }
 
     fn parse(&self, name: &str) -> Result<RgFileType> {
+        if name == "all" {
+            return Ok(RgFileType {
+                globs: self
+                    .definitions
+                    .values()
+                    .flat_map(|globs| globs.iter().cloned())
+                    .collect(),
+            });
+        }
+
         let Some(globs) = self.definitions.get(name) else {
             return Err(Error::Execution(format!(
                 "rg: unrecognized file type: {}",
@@ -5851,6 +5861,37 @@ mod tests {
             files: DIFF_BASIC_FILES,
             cwd: "/",
             output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "type all searches recognized types",
+            args: &["--type", "all", "needle", "proj/lang"],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "type all includes added custom types",
+            args: &[
+                "--type-add",
+                "foo:*.foo",
+                "--type",
+                "all",
+                "needle",
+                "proj/lang",
+            ],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "type not all searches unrecognized types",
+            args: &["--type-not", "all", "needle", "proj/lang"],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
         },
         RgDiffCase {
             name: "type not rust",


### PR DESCRIPTION
## What
Adds rg support for the special `all` file type.

## Why
Real rg accepts `--type all` and `--type-not all`. Bashkit previously treated `all` as an unknown file type.

## How
- Resolves `all` to the union of currently registered file type globs.
- Includes custom types added earlier via `--type-add`.
- Adds real-rg differential coverage for `--type all`, custom types in `all`, and `--type-not all`.

## Risk
- Low / Medium
- Affects rg type filtering only.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered