### PR TITLE
feat(rg): support escaped glob metacharacters

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -1722,6 +1722,10 @@ fn glob_to_regex(pattern: &str) -> String {
                     i += 1;
                 }
             }
+            '\\' if i + 1 < chars.len() => {
+                out.push_str(&regex::escape(&chars[i + 1].to_string()));
+                i += 2;
+            }
             c => {
                 out.push_str(&regex::escape(&c.to_string()));
                 i += 1;
@@ -1741,6 +1745,12 @@ fn glob_alternation_to_regex(chars: &[char], start: usize) -> Option<(String, us
 
     while i < chars.len() {
         match chars[i] {
+            '\\' if i + 1 < chars.len() => {
+                current.push('\\');
+                current.push(chars[i + 1]);
+                i += 2;
+                continue;
+            }
             '{' => {
                 depth += 1;
                 current.push('{');
@@ -4918,6 +4928,15 @@ mod tests {
         ("/proj/a.txt", b"needle\n"),
     ];
 
+    const DIFF_GLOB_ESCAPE_FILES: &[(&str, &[u8])] = &[
+        ("/proj/*.txt", b"needle\n"),
+        ("/proj/?.txt", b"needle\n"),
+        ("/proj/[x].txt", b"needle\n"),
+        ("/proj/{a,b}.txt", b"needle\n"),
+        ("/proj/a.txt", b"needle\n"),
+        ("/proj/x.txt", b"needle\n"),
+    ];
+
     const DIFF_COMMON_TYPE_FILES: &[(&str, &[u8])] = &[
         ("/proj/data.csv", b"needle\n"),
         ("/proj/Dockerfile", b"needle\n"),
@@ -5292,6 +5311,38 @@ mod tests {
             args: &["--files", "-g", "*.{rs,toml}", "proj"],
             stdin: None,
             files: DIFF_GLOB_BRACE_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "glob escaped star",
+            args: &["--files", "-g", r"\*.txt", "proj"],
+            stdin: None,
+            files: DIFF_GLOB_ESCAPE_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "glob escaped question",
+            args: &["--files", "-g", r"\?.txt", "proj"],
+            stdin: None,
+            files: DIFF_GLOB_ESCAPE_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "glob escaped class brackets",
+            args: &["--files", "-g", r"\[x\].txt", "proj"],
+            stdin: None,
+            files: DIFF_GLOB_ESCAPE_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "glob escaped brace alternation",
+            args: &["--files", "-g", r"\{a,b\}.txt", "proj"],
+            stdin: None,
+            files: DIFF_GLOB_ESCAPE_FILES,
             cwd: "/",
             output: RgDiffOutput::UnorderedLines,
         },


### PR DESCRIPTION
## What
Add rg glob parsing support for backslash-escaped glob metacharacters, including escaped star, question mark, bracket classes, and brace alternation syntax.

## Why
Real ripgrep treats backslash in glob patterns as quoting the next glob character. Bashkit rg previously interpreted escaped metacharacters as active glob syntax, so patterns like `-g '\*.txt'` did not match literal filenames the way real rg does.

## How
Teach the shared rg glob-to-regex translator to emit the next character literally after `\\`, and preserve escapes while parsing brace alternatives so escaped commas/braces do not affect alternation parsing. Add real-rg differential cases for escaped glob metacharacters.

## Risk
- Low
- Affects rg glob matching, type globs, and ignore glob translation through the shared converter. This should improve parity, but backslash-heavy patterns are the behavioral surface.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
