### PR TITLE
feat(core,js): host-owned mutable BuiltinRegistry

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -285,6 +285,71 @@ const result = tool.executeSync("get_user --id 1 | jq -r '.name'");
 console.log(result.stdout); // Alice
 ```
 
+## Custom Builtins
+
+Register JS callbacks as bash builtins that share the `Bash` / `BashTool`
+instance's VFS — files created in one call persist across `execute()` calls.
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
+// Constructor-time registration
+const bash = new Bash({
+  customBuiltins: {
+    "get-order": (ctx) =>
+      JSON.stringify({ id: ctx.argv[0], status: "shipped" }) + "\n",
+  },
+});
+
+// Or post-construction (safe to call at any time — no interpreter rebuild)
+bash.addBuiltin("greet", (ctx) => `hello ${ctx.argv[0] ?? "world"}\n`);
+
+// Tool output flows through the shared VFS
+await bash.execute("mkdir -p /scratch");
+await bash.execute("get-order 42 > /scratch/order.json");
+console.log((await bash.execute("cat /scratch/order.json")).stdout);
+// {"id":"42","status":"shipped"}
+
+bash.removeBuiltin("greet"); // when you no longer need it
+```
+
+Callbacks can be sync (`string` return) or async (`Promise<string>`). Both
+are awaited uniformly by the Rust side. Exceptions / rejections become
+stderr with exit code 1.
+
+```typescript
+const bash = new Bash({
+  customBuiltins: {
+    fetch: async (ctx) => {
+      const data = await fetchSomething(ctx.argv[0]);
+      return JSON.stringify(data) + "\n";
+    },
+    fail: () => {
+      throw new Error("nope");   // → stderr, exit 1
+    },
+  },
+});
+```
+
+The callback receives a `BuiltinContext`:
+
+- `name: string` — command name as invoked
+- `argv: string[]` — arguments (not including the command name)
+- `stdin: string | null` — piped input, or `null` if no pipe
+- `env: Record<string, string>` — environment variables (only exported names)
+- `cwd: string` — current working directory
+
+Override precedence: shell function > POSIX special builtin > custom builtin
+> baked-in builtin > `PATH`. Custom builtins can override baked-in commands
+(e.g. wrap `cat`), but shell functions defined in the script still win.
+
+Custom builtins survive `reset()`. They are host-side configuration and are
+**not** preserved by `snapshot()` / `restoreSnapshot()` — pass
+`customBuiltins` again or call `addBuiltin` after restoring.
+
+Use `execute()` (async). `executeSync()` will deadlock if the script invokes
+a custom builtin — same caveat as `ScriptedTool.executeSync()`.
+
 ## Snapshot / Restore
 
 State snapshots are available on both `Bash` and `BashTool` instances:
@@ -374,6 +439,7 @@ import {
 - `cancel()`
 - `clearCancel()`
 - `reset()`
+- `addBuiltin(name, callback)` / `removeBuiltin(name)` — register/unregister persistent JS builtins
 - `snapshot()`
 - `restoreSnapshot(data)`
 - `Bash.fromSnapshot(data)`
@@ -381,7 +447,7 @@ import {
 
 ### BashTool
 
-- All execution, cancellation (`cancel()`, `clearCancel()`), reset, snapshot, restore, and direct VFS helpers from `Bash`
+- All execution, cancellation (`cancel()`, `clearCancel()`), reset, custom builtins, snapshot, restore, and direct VFS helpers from `Bash`
 - Tool metadata: `name`, `version`, `shortDescription`
 - `snapshot()`
 - `restoreSnapshot(data)`
@@ -415,6 +481,15 @@ import {
 - `mounts?: Array<{ path: string; root: string; writable?: boolean }>`
 - `python?: boolean`
 - `externalFunctions?: string[]`
+- `customBuiltins?: Record<string, (ctx: BuiltinContext) => string | Promise<string>>` — JS callbacks registered as bash builtins (see [Custom Builtins](#custom-builtins))
+
+### BuiltinContext
+
+- `name: string` — command name as invoked
+- `argv: string[]` — arguments (not including the command name)
+- `stdin: string | null` — piped input, `null` if no pipe
+- `env: Record<string, string>` — exported environment variables
+- `cwd: string` — current working directory
 
 ### ExecuteOptions
 

--- a/crates/bashkit-js/__test__/custom-builtins.spec.ts
+++ b/crates/bashkit-js/__test__/custom-builtins.spec.ts
@@ -1,0 +1,271 @@
+import test from "ava";
+import { Bash, BashTool } from "../wrapper.js";
+import type { BuiltinContext } from "../wrapper.js";
+
+// ----------------------------------------------------------------------------
+// Constructor-time registration
+// ----------------------------------------------------------------------------
+
+test("Bash constructor with customBuiltins (sync)", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      greet: (ctx) => `hello ${ctx.argv[0] ?? "world"}\n`,
+    },
+  });
+  const result = await bash.execute("greet Alice");
+  t.is(result.stdout, "hello Alice\n");
+  t.is(result.exitCode, 0);
+});
+
+test("Bash constructor with customBuiltins (async)", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      greet: async (ctx) => {
+        await new Promise((r) => setTimeout(r, 5));
+        return `hello ${ctx.argv[0] ?? "world"}\n`;
+      },
+    },
+  });
+  const result = await bash.execute("greet Bob");
+  t.is(result.stdout, "hello Bob\n");
+  t.is(result.exitCode, 0);
+});
+
+test("BashTool constructor with customBuiltins", async (t) => {
+  const tool = new BashTool({
+    customBuiltins: {
+      greet: (ctx) => `hello ${ctx.argv[0] ?? "world"}\n`,
+    },
+  });
+  const result = await tool.execute("greet Carol");
+  t.is(result.stdout, "hello Carol\n");
+  t.is(result.exitCode, 0);
+});
+
+// ----------------------------------------------------------------------------
+// BuiltinContext fields
+// ----------------------------------------------------------------------------
+
+test("BuiltinContext exposes name, argv, stdin, env, cwd", async (t) => {
+  const seen: BuiltinContext[] = [];
+  const bash = new Bash({
+    customBuiltins: {
+      inspect: (ctx) => {
+        seen.push(ctx);
+        return "";
+      },
+    },
+  });
+  // Export a var so we have a known env entry to assert on; bashkit only
+  // exposes *exported* names in ctx.env (shell variables stay in ctx.variables
+  // on the Rust side, which we don't surface to JS).
+  await bash.execute("export FOO=bar; echo piped | inspect a b c");
+
+  t.is(seen.length, 1);
+  const ctx = seen[0]!;
+  t.is(ctx.name, "inspect");
+  t.deepEqual(ctx.argv, ["a", "b", "c"]);
+  t.is(ctx.stdin, "piped\n");
+  t.is(ctx.env["FOO"], "bar");
+  t.true(ctx.cwd.startsWith("/"));
+});
+
+test("stdin is null when no pipe", async (t) => {
+  let observed: string | null | undefined;
+  const bash = new Bash({
+    customBuiltins: {
+      inspect: (ctx) => {
+        observed = ctx.stdin;
+        return "";
+      },
+    },
+  });
+  await bash.execute("inspect");
+  t.is(observed, null);
+});
+
+// ----------------------------------------------------------------------------
+// VFS persistence
+// ----------------------------------------------------------------------------
+
+test("customBuiltins share the VFS across execute() calls", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "get-order": (ctx) =>
+        JSON.stringify({ id: ctx.argv[0] ?? "?", status: "shipped" }) + "\n",
+    },
+  });
+  await bash.execute("mkdir -p /scratch");
+  await bash.execute("get-order 42 > /scratch/order.json");
+  const result = await bash.execute("cat /scratch/order.json");
+  t.is(result.exitCode, 0);
+  t.deepEqual(JSON.parse(result.stdout.trim()), {
+    id: "42",
+    status: "shipped",
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Post-construction registration — the previous design rebuilt the
+// interpreter here and wiped the VFS. With BuiltinRegistry the VFS survives.
+// ----------------------------------------------------------------------------
+
+test("addBuiltin after execute() preserves the VFS", async (t) => {
+  const bash = new Bash();
+  await bash.execute("mkdir -p /scratch && echo seed > /scratch/seed.txt");
+
+  bash.addBuiltin("double", (ctx) => `${Number(ctx.argv[0]) * 2}\n`);
+
+  // New builtin works…
+  const r1 = await bash.execute("double 21");
+  t.is(r1.stdout, "42\n");
+
+  // …and the pre-existing VFS contents are still there.
+  const r2 = await bash.execute("cat /scratch/seed.txt");
+  t.is(r2.stdout, "seed\n");
+});
+
+test("addBuiltin works on BashTool too", async (t) => {
+  const tool = new BashTool();
+  tool.addBuiltin("greet", (ctx) => `hi ${ctx.argv[0]}\n`);
+  const result = await tool.execute("greet Dana");
+  t.is(result.stdout, "hi Dana\n");
+});
+
+test("removeBuiltin makes the command unavailable", async (t) => {
+  const bash = new Bash();
+  bash.addBuiltin("tmp", () => "ok\n");
+  t.is((await bash.execute("tmp")).stdout, "ok\n");
+
+  bash.removeBuiltin("tmp");
+  const r = await bash.execute("tmp");
+  t.is(r.exitCode, 127);
+});
+
+// ----------------------------------------------------------------------------
+// reset() preserves host-registered builtins
+// ----------------------------------------------------------------------------
+
+test("customBuiltins survive reset()", async (t) => {
+  const bash = new Bash({
+    customBuiltins: { ping: () => "pong\n" },
+  });
+  t.is((await bash.execute("ping")).stdout, "pong\n");
+
+  bash.reset();
+
+  t.is((await bash.execute("ping")).stdout, "pong\n");
+});
+
+test("addBuiltin entries survive reset()", async (t) => {
+  const bash = new Bash();
+  bash.addBuiltin("ping", () => "pong\n");
+  bash.reset();
+  t.is((await bash.execute("ping")).stdout, "pong\n");
+});
+
+// ----------------------------------------------------------------------------
+// Pipes / chains
+// ----------------------------------------------------------------------------
+
+test("custom builtin participates in pipes", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      double: (ctx) => `${Number((ctx.stdin ?? "").trim()) * 2}\n`,
+    },
+  });
+  const result = await bash.execute("echo 5 | double");
+  t.is(result.stdout, "10\n");
+});
+
+test("sync + async builtins chain via pipe", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      prefix: (ctx) => `tag-${(ctx.stdin ?? "").trim()}\n`,
+      suffix: async (ctx) => {
+        await Promise.resolve();
+        return `${(ctx.stdin ?? "").trim()}-done\n`;
+      },
+    },
+  });
+  const result = await bash.execute("echo test | prefix | suffix");
+  t.is(result.stdout, "tag-test-done\n");
+});
+
+// ----------------------------------------------------------------------------
+// Error handling
+// ----------------------------------------------------------------------------
+
+test("sync throw becomes stderr + exit 1", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      fail: () => {
+        throw new Error("nope");
+      },
+    },
+  });
+  const r = await bash.execute("fail");
+  t.is(r.exitCode, 1);
+  t.true(r.stderr.includes("nope"), `stderr: ${r.stderr}`);
+});
+
+test("async reject becomes stderr + exit 1", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      fail: async () => {
+        throw new Error("async nope");
+      },
+    },
+  });
+  const r = await bash.execute("fail");
+  t.is(r.exitCode, 1);
+  t.true(r.stderr.includes("async nope"), `stderr: ${r.stderr}`);
+});
+
+// ----------------------------------------------------------------------------
+// Override semantics
+// ----------------------------------------------------------------------------
+
+test("custom builtin overrides baked-in builtin of the same name", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      echo: (ctx) => `OVERRIDE:${ctx.argv.join(",")}\n`,
+    },
+  });
+  const r = await bash.execute("echo a b c");
+  t.is(r.stdout, "OVERRIDE:a,b,c\n");
+});
+
+test("shell function still wins over custom builtin", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      thing: () => "from-builtin\n",
+    },
+  });
+  const r = await bash.execute("thing() { echo from-function; }\nthing");
+  t.is(r.stdout, "from-function\n");
+});
+
+// ----------------------------------------------------------------------------
+// addBuiltin after constructor option
+// ----------------------------------------------------------------------------
+
+test("addBuiltin coexists with constructor customBuiltins", async (t) => {
+  const bash = new Bash({
+    customBuiltins: { first: () => "1\n" },
+  });
+  bash.addBuiltin("second", () => "2\n");
+
+  t.is((await bash.execute("first")).stdout, "1\n");
+  t.is((await bash.execute("second")).stdout, "2\n");
+});
+
+test("addBuiltin replaces an existing custom builtin", async (t) => {
+  const bash = new Bash({
+    customBuiltins: { tag: () => "v1\n" },
+  });
+  t.is((await bash.execute("tag")).stdout, "v1\n");
+
+  bash.addBuiltin("tag", () => "v2\n");
+  t.is((await bash.execute("tag")).stdout, "v2\n");
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -18,11 +18,11 @@ use bashkit::interop::fs::{
 };
 use bashkit::tool::VERSION;
 use bashkit::{
-    Bash as RustBash, BashTool as RustBashTool, ExecResult as RustExecResult, ExecutionLimits,
-    ExtFunctionResult, FileSystem as BashFileSystem, FileType, InMemoryFs, Metadata, MontyObject,
-    OutputCallback, PosixFs, PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode,
-    ScriptedTool as RustScriptedTool, SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs,
-    ToolDef, ToolRequest,
+    Bash as RustBash, BashTool as RustBashTool, Builtin, BuiltinContext, BuiltinRegistry,
+    ExecResult as RustExecResult, ExecutionLimits, ExtFunctionResult, FileSystem as BashFileSystem,
+    FileType, InMemoryFs, Metadata, MontyObject, OutputCallback, PosixFs, PythonExternalFnHandler,
+    PythonLimits, RealFs, RealFsMode, ScriptedTool as RustScriptedTool,
+    SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
 };
 use napi::bindgen_prelude::External;
 use napi::{Env, JsValue, Unknown, ValueType, sys};
@@ -1072,6 +1072,11 @@ struct SharedState {
     sqlite: bool,
     external_functions: Vec<String>,
     external_handler: Option<ExternalHandlerArc>,
+    /// Host-owned mutable registry of custom builtins. The same handle is
+    /// passed to the bashkit builder *and* retained here so JS-side
+    /// `addBuiltin()` calls insert into the live interpreter without rebuilding
+    /// it (and without disturbing the VFS).
+    host_registry: BuiltinRegistry,
 }
 
 /// Wrapper for the external handler that can be stored and cloned.
@@ -1283,7 +1288,52 @@ impl Bash {
         arc.store(false, Ordering::SeqCst);
     }
 
+    /// Register a JS callback as a custom bash builtin.
+    ///
+    /// The callback receives a JSON-serialized `BuiltinContext`
+    /// (`{name, argv, stdin, env, cwd}`) and returns the stdout to emit —
+    /// either as a string (sync) or a `Promise<string>` (async). Exceptions
+    /// surface as stderr with exit code 1.
+    ///
+    /// Unlike `customBuiltins` at construction time, this can be called at
+    /// any point in the instance's lifetime — the interpreter consults the
+    /// shared registry on every dispatch, so subsequent `execute*()` calls
+    /// pick up the new builtin without rebuilding the interpreter or
+    /// disturbing the VFS.
+    #[napi(ts_args_type = "name: string, callback: (request: string) => Promise<string>")]
+    pub fn add_builtin(
+        &self,
+        name: String,
+        callback: napi::bindgen_prelude::Function<
+            (String,),
+            napi::bindgen_prelude::Promise<String>,
+        >,
+    ) -> napi::Result<()> {
+        let tsfn: BuiltinTsfn = callback
+            .build_threadsafe_function::<(String,)>()
+            .weak::<true>()
+            .build()?;
+        self.state.host_registry.insert(
+            name.clone(),
+            Arc::new(JsCustomBuiltinAdapter {
+                name,
+                callback: Arc::new(tsfn),
+            }),
+        );
+        Ok(())
+    }
+
+    /// Remove a previously registered custom builtin. No-op if not present.
+    #[napi]
+    pub fn remove_builtin(&self, name: String) {
+        self.state.host_registry.remove(&name);
+    }
+
     /// Reset interpreter to fresh state, preserving configuration.
+    ///
+    /// Custom builtins registered via `addBuiltin` or `customBuiltins` are
+    /// preserved (the registry is host-owned, separate from the interpreter
+    /// state that `reset()` discards).
     #[napi]
     pub fn reset(&self) -> napi::Result<()> {
         block_on_with(&self.state, |s| async move {
@@ -1732,7 +1782,42 @@ impl BashTool {
         arc.store(false, Ordering::SeqCst);
     }
 
+    /// Register a JS callback as a custom bash builtin.
+    /// See [`Bash::add_builtin`] for semantics.
+    #[napi(ts_args_type = "name: string, callback: (request: string) => Promise<string>")]
+    pub fn add_builtin(
+        &self,
+        name: String,
+        callback: napi::bindgen_prelude::Function<
+            (String,),
+            napi::bindgen_prelude::Promise<String>,
+        >,
+    ) -> napi::Result<()> {
+        let tsfn: BuiltinTsfn = callback
+            .build_threadsafe_function::<(String,)>()
+            .weak::<true>()
+            .build()?;
+        self.state.host_registry.insert(
+            name.clone(),
+            Arc::new(JsCustomBuiltinAdapter {
+                name,
+                callback: Arc::new(tsfn),
+            }),
+        );
+        Ok(())
+    }
+
+    /// Remove a previously registered custom builtin. No-op if not present.
+    #[napi]
+    pub fn remove_builtin(&self, name: String) {
+        self.state.host_registry.remove(&name);
+    }
+
     /// Reset interpreter to fresh state, preserving configuration.
+    ///
+    /// Custom builtins registered via `addBuiltin` or `customBuiltins` are
+    /// preserved (the registry is host-owned, separate from the interpreter
+    /// state that `reset()` discards).
     #[napi]
     pub fn reset(&self) -> napi::Result<()> {
         block_on_with(&self.state, |s| async move {
@@ -2098,6 +2183,64 @@ type ToolTsfn = napi::threadsafe_function::ThreadsafeFunction<
     false,
     true,
 >;
+
+/// Threadsafe callback used by custom builtins registered via `addBuiltin`.
+///
+/// The JS dispatcher always wraps its result in `Promise.resolve(...)`, so
+/// the TSFN return is uniformly `Promise<String>` regardless of whether the
+/// user's callback was sync or async. Both branches resolve via the same
+/// `.await` on the returned `Promise<String>` future.
+type BuiltinTsfn = napi::threadsafe_function::ThreadsafeFunction<
+    (String,),
+    napi::bindgen_prelude::Promise<String>,
+    (String,),
+    napi::Status,
+    false,
+    true,
+>;
+
+/// Adapts a JS callback into a bashkit [`Builtin`].
+///
+/// The callback receives a JSON string `{"name", "argv", "stdin", "env", "cwd"}`
+/// and resolves with the stdout to emit. Exceptions/rejections surface as
+/// stderr + exit-code-1 (real-shell semantics).
+struct JsCustomBuiltinAdapter {
+    name: String,
+    callback: Arc<BuiltinTsfn>,
+}
+
+#[async_trait]
+impl Builtin for JsCustomBuiltinAdapter {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<RustExecResult> {
+        let request = serde_json::json!({
+            "name": self.name,
+            "argv": ctx.args,
+            "stdin": ctx.stdin,
+            "env": ctx.env,
+            "cwd": ctx.cwd.to_string_lossy(),
+        });
+        let request_str = serde_json::to_string(&request)
+            .map_err(|e| bashkit::Error::Execution(format!("{}: {}", self.name, e)))?;
+
+        // Bound concurrent JS callbacks across all instances (issue #982).
+        let sem = callback_semaphore();
+        let _permit = sem
+            .acquire()
+            .await
+            .map_err(|e| bashkit::Error::Execution(format!("{}: semaphore: {}", self.name, e)))?;
+
+        // Two-step await: first call_async returns the `Promise<String>`
+        // handle from JS, then awaiting the Promise resolves to its value.
+        let promise = match self.callback.call_async((request_str,)).await {
+            Ok(p) => p,
+            Err(e) => return Ok(RustExecResult::err(format!("{}\n", e), 1)),
+        };
+        match promise.await {
+            Ok(stdout) => Ok(RustExecResult::ok(stdout)),
+            Err(e) => Ok(RustExecResult::err(format!("{}\n", e), 1)),
+        }
+    }
+}
 
 /// Entry for a registered JS tool callback.
 ///
@@ -2491,6 +2634,10 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
         builder = builder.env("BASHKIT_ALLOW_INPROCESS_SQLITE", "1");
     }
 
+    // Attach the host-owned builtin registry. Entries inserted via JS
+    // `addBuiltin()` are visible to the running interpreter without rebuilding.
+    builder = builder.builtin_registry(state.host_registry.clone());
+
     builder.build()
 }
 
@@ -2504,6 +2651,9 @@ fn shared_state_from_opts(
     let ext_fns = opts.external_functions.clone().unwrap_or_default();
     let mounts = opts.mounts.clone();
     let allowed_mount_paths = opts.allowed_mount_paths.clone();
+    // A single registry handle threaded through the tmp + final SharedState
+    // *and* the built interpreter — all observe the same underlying storage.
+    let host_registry = BuiltinRegistry::new();
 
     // Build a temporary SharedState to pass to build_bash_from_state
     let tmp = SharedState {
@@ -2537,6 +2687,7 @@ fn shared_state_from_opts(
         sqlite: sql,
         external_functions: ext_fns.clone(),
         external_handler: external_handler.clone(),
+        host_registry: host_registry.clone(),
     };
 
     if let Some(ref mounts) = mounts {
@@ -2583,6 +2734,7 @@ fn shared_state_from_opts(
         sqlite: sql,
         external_functions: ext_fns,
         external_handler,
+        host_registry,
     })
 }
 

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -102,6 +102,32 @@ export type FileValue = string | (() => string) | (() => Promise<string>);
 const MAX_JSON_NESTING_DEPTH = 64;
 
 /**
+ * Execution context passed to a custom builtin registered via
+ * `customBuiltins` or `addBuiltin`.
+ *
+ * All fields are snapshots of the shell state at invocation time.
+ */
+export interface BuiltinContext {
+  /** The command name as invoked. */
+  readonly name: string;
+  /** Arguments (not including the command name). */
+  readonly argv: string[];
+  /** Piped input, or `null` if there is no pipe. */
+  readonly stdin: string | null;
+  /** Environment variables visible at the call site. */
+  readonly env: Record<string, string>;
+  /** Current working directory. */
+  readonly cwd: string;
+}
+
+/**
+ * Callback signature for custom builtins. Return the stdout to emit.
+ * Both sync (`string`) and async (`Promise<string>`) returns are supported.
+ * Exceptions / rejections surface as stderr with exit code 1.
+ */
+export type BuiltinCallback = (ctx: BuiltinContext) => string | Promise<string>;
+
+/**
  * Options for creating a Bash or BashTool instance.
  */
 export interface BashOptions {
@@ -197,6 +223,35 @@ export interface BashOptions {
    * the embedded interpreter. When called, they invoke the external handler.
    */
   externalFunctions?: string[];
+  /**
+   * Custom JS callbacks registered as bash builtins.
+   *
+   * Each entry becomes a bash command that shares the instance's VFS — files
+   * created by the callback persist across `execute()` calls. Callbacks can be
+   * sync (`string` return) or async (`Promise<string>`); exceptions surface as
+   * stderr with exit code 1.
+   *
+   * Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+   * `reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+   * the option again after restoring.
+   *
+   * Override precedence: shell function > POSIX special builtin > custom
+   * builtin > baked-in builtin > PATH.
+   *
+   * @example
+   * ```typescript
+   * const bash = new Bash({
+   *   customBuiltins: {
+   *     "get-order": (ctx) =>
+   *       JSON.stringify({ id: ctx.argv[0], status: "shipped" }) + "\n",
+   *   },
+   * });
+   * await bash.execute("mkdir -p /scratch");
+   * await bash.execute("get-order 42 > /scratch/order.json");
+   * console.log((await bash.execute("cat /scratch/order.json")).stdout);
+   * ```
+   */
+  customBuiltins?: Record<string, BuiltinCallback>;
 }
 
 export interface SnapshotOptions {
@@ -552,6 +607,42 @@ export class FileSystem {
 }
 
 /**
+ * Wrap a {@link BuiltinCallback} for the native `addBuiltin` ABI.
+ *
+ * The Rust side expects a uniform `Promise<string>` return, so we always
+ * route the callback result through `Promise.resolve` — sync `string`
+ * returns get wrapped, native `Promise<string>` returns pass through, and
+ * synchronous throws become rejected promises. Either way, the Rust adapter
+ * sees one shape: a Promise it can `.await`.
+ */
+function makeBuiltinDispatcher(
+  callback: BuiltinCallback,
+): (payload: string) => Promise<string> {
+  return (payload: string) => {
+    try {
+      const ctx = JSON.parse(payload) as BuiltinContext;
+      return Promise.resolve(callback(ctx));
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  };
+}
+
+/**
+ * Register each entry of `builtins` on `native` via `addBuiltin`.
+ * Idempotent for empty/undefined input.
+ */
+function registerCustomBuiltins(
+  native: { addBuiltin(name: string, dispatch: (payload: string) => Promise<string>): void },
+  builtins: Record<string, BuiltinCallback> | undefined,
+): void {
+  if (!builtins) return;
+  for (const [name, cb] of Object.entries(builtins)) {
+    native.addBuiltin(name, makeBuiltinDispatcher(cb));
+  }
+}
+
+/**
  * Core bash interpreter with virtual filesystem.
  *
  * State persists between calls — files created in one `execute()` are
@@ -572,6 +663,7 @@ export class Bash {
   constructor(options?: BashOptions) {
     const resolved = resolveFilesSync(options?.files);
     this.native = new NativeBash(toNativeOptions(options, resolved));
+    registerCustomBuiltins(this.native, options?.customBuiltins);
   }
 
   /**
@@ -592,7 +684,28 @@ export class Bash {
     const resolved = await resolveFiles(options?.files);
     const instance = Object.create(Bash.prototype) as Bash;
     instance.native = new NativeBash(toNativeOptions(options, resolved));
+    registerCustomBuiltins(instance.native, options?.customBuiltins);
     return instance;
+  }
+
+  /**
+   * Register a JS callback as a custom bash builtin.
+   *
+   * The callback receives a {@link BuiltinContext} and returns the stdout to
+   * emit. Sync (`string`) and async (`Promise<string>`) returns are both
+   * supported. Exceptions become stderr + exit code 1.
+   *
+   * Safe to call at any time — the new builtin is visible to the next
+   * `execute*()` invocation with no interpreter rebuild or VFS disturbance.
+   * Survives `reset()`.
+   */
+  addBuiltin(name: string, callback: BuiltinCallback): void {
+    this.native.addBuiltin(name, makeBuiltinDispatcher(callback));
+  }
+
+  /** Remove a previously registered custom builtin. */
+  removeBuiltin(name: string): void {
+    this.native.removeBuiltin(name);
   }
 
   /**
@@ -930,6 +1043,7 @@ export class BashTool {
   constructor(options?: BashOptions) {
     const resolved = resolveFilesSync(options?.files);
     this.native = new NativeBashTool(toNativeOptions(options, resolved));
+    registerCustomBuiltins(this.native, options?.customBuiltins);
   }
 
   /**
@@ -939,7 +1053,18 @@ export class BashTool {
     const resolved = await resolveFiles(options?.files);
     const instance = Object.create(BashTool.prototype) as BashTool;
     instance.native = new NativeBashTool(toNativeOptions(options, resolved));
+    registerCustomBuiltins(instance.native, options?.customBuiltins);
     return instance;
+  }
+
+  /** Register a JS callback as a custom builtin. See {@link Bash.addBuiltin}. */
+  addBuiltin(name: string, callback: BuiltinCallback): void {
+    this.native.addBuiltin(name, makeBuiltinDispatcher(callback));
+  }
+
+  /** Remove a previously registered custom builtin. */
+  removeBuiltin(name: string): void {
+    this.native.removeBuiltin(name);
   }
 
   /**

--- a/crates/bashkit/docs/custom_builtins.md
+++ b/crates/bashkit/docs/custom_builtins.md
@@ -147,6 +147,59 @@ The same extension can be added to `BashTool::builder().extension(...)`.
 `TypeScriptExtension` uses this model to register the embedded
 TypeScript/JavaScript builtins.
 
+## BuiltinRegistry — Runtime-Mutable Builtins
+
+`BashBuilder::builtin` and `Extension` are both *build-time*: the set of
+builtins is frozen when `Bash::builder().build()` returns. For embedders
+that need to register or remove builtins after construction without
+rebuilding the interpreter, use `BuiltinRegistry`.
+
+```rust,ignore
+use bashkit::{Bash, Builtin, BuiltinContext, BuiltinRegistry, ExecResult, async_trait};
+use std::sync::Arc;
+
+struct Greet;
+
+#[async_trait]
+impl Builtin for Greet {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let who = ctx.args.first().map(String::as_str).unwrap_or("world");
+        Ok(ExecResult::ok(format!("hello {}\n", who)))
+    }
+}
+
+// Keep a clone of the registry handle so the embedder can mutate it later.
+let registry = BuiltinRegistry::new();
+let mut bash = Bash::builder()
+    .builtin_registry(registry.clone())
+    .build();
+
+// Run something first — VFS state accumulates.
+bash.exec("mkdir -p /scratch && echo seed > /scratch/seed.txt").await?;
+
+// Register a builtin after the interpreter is live. No rebuild, no VFS reset.
+registry.insert("greet", Arc::new(Greet));
+let r = bash.exec("greet Alice").await?;
+assert_eq!(r.stdout, "hello Alice\n");
+
+// Pre-existing files are still there.
+let r = bash.exec("cat /scratch/seed.txt").await?;
+assert_eq!(r.stdout, "seed\n");
+```
+
+The registry handle is `Clone`; clones share the same underlying storage,
+so mutations made via any clone are visible to all others (including the
+interpreter that owns one).
+
+**Resolution order**: shell function → POSIX special builtin → registry
+entry → baked-in builtin → `$PATH`. Registry entries can override
+baked-in commands (e.g. wrap `cat` with tracing) but shell functions
+still win — matching standard bash precedence.
+
+The registry is host-owned: not part of interpreter state, so it survives
+`exec()` calls automatically and is not serialized by `Bash::snapshot()`.
+Re-attach the handle after restoring from a snapshot.
+
 ### Arguments
 
 Arguments are passed as a slice of strings, excluding the command name itself:

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -320,6 +320,63 @@ pub trait Extension: Send + Sync {
     fn builtins(&self) -> Vec<(String, Box<dyn Builtin>)>;
 }
 
+/// Host-owned, mutable registry of builtin commands.
+///
+/// Unlike [`BashBuilder::builtin`](crate::BashBuilder::builtin), entries can be
+/// inserted and removed at any point during the lifetime of the `Bash`
+/// instance — the interpreter consults the registry at command-dispatch time.
+///
+/// Cloning the registry produces a new handle that shares the same underlying
+/// storage; mutations made via any handle are visible to all others. This
+/// lets embedders (FFI bindings, REPLs, plugin systems) hand a handle to the
+/// builder and retain another for runtime registration.
+///
+/// In the command-resolution order, host-registered builtins are checked
+/// after shell functions and POSIX special builtins, but before baked-in
+/// builtins — so embedders can override baked-in commands.
+#[derive(Clone, Default)]
+pub struct BuiltinRegistry {
+    inner: Arc<std::sync::RwLock<HashMap<String, Arc<dyn Builtin>>>>,
+}
+
+impl BuiltinRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register or replace a builtin under `name`.
+    pub fn insert(&self, name: impl Into<String>, builtin: Arc<dyn Builtin>) {
+        if let Ok(mut guard) = self.inner.write() {
+            guard.insert(name.into(), builtin);
+        }
+    }
+
+    /// Remove the entry for `name`, returning the previously registered
+    /// builtin if any.
+    pub fn remove(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+        self.inner.write().ok().and_then(|mut g| g.remove(name))
+    }
+
+    /// Look up the builtin registered under `name`, returning a cloned handle.
+    pub fn lookup(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+        self.inner.read().ok().and_then(|g| g.get(name).cloned())
+    }
+
+    /// Return the set of currently registered builtin names.
+    pub fn names(&self) -> Vec<String> {
+        self.inner
+            .read()
+            .map(|g| g.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// True if no builtins are registered.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().map(|g| g.is_empty()).unwrap_or(true)
+    }
+}
+
 /// Typed, per-execution data exposed to builtin implementations.
 ///
 /// This is intentionally separate from shell state: extensions live for one

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -261,7 +261,7 @@ pub(crate) struct ShellRef<'a> {
     /// Direct mutable access to trap handlers.
     pub(crate) traps: &'a mut HashMap<String, String>,
     /// Registered builtin commands (read-only, accessed via `has_builtin`).
-    pub(crate) builtins: &'a HashMap<String, Box<dyn Builtin>>,
+    pub(crate) builtins: &'a HashMap<String, Arc<dyn Builtin>>,
     /// Defined shell functions (read-only, accessed via `has_function`).
     pub(crate) functions: &'a HashMap<String, FunctionDef>,
     /// Call stack frames (read-only, accessed via `call_stack_depth`/`call_stack_frame_name`).
@@ -748,8 +748,18 @@ pub struct Interpreter {
     assoc_arrays: HashMap<String, HashMap<String, String>>,
     cwd: PathBuf,
     last_exit_code: i32,
-    /// Built-in commands (default + custom)
-    builtins: HashMap<String, Box<dyn Builtin>>,
+    /// Built-in commands (default + custom).
+    ///
+    /// Stored as `Arc` so the dispatcher can clone the handle out of the map
+    /// and execute the builtin without keeping a borrow on `self.builtins`,
+    /// which lets it freely take `&mut self` for `self.variables`,
+    /// `self.cwd`, etc. during execution.
+    builtins: HashMap<String, Arc<dyn Builtin>>,
+    /// Optional host-owned mutable registry. Consulted after shell functions
+    /// and special builtins but before `builtins` — so host entries can
+    /// override baked-in commands. Survives `reset_transient_state` because
+    /// it lives behind an `Arc<RwLock>` shared with the embedder.
+    host_builtins: Option<crate::builtins::BuiltinRegistry>,
     /// Defined functions
     functions: HashMap<String, FunctionDef>,
     /// Call stack for local variable scoping
@@ -885,6 +895,7 @@ impl Interpreter {
             None,
             None,
             HashMap::new(),
+            None,
             ShellProfile::Full,
         )
     }
@@ -897,6 +908,7 @@ impl Interpreter {
     /// * `username` - Optional custom username for virtual identity
     /// * `hostname` - Optional custom hostname for virtual identity
     /// * `custom_builtins` - Custom builtins to register (override defaults if same name)
+    #[allow(clippy::too_many_arguments)]
     pub fn with_config(
         fs: Arc<dyn FileSystem>,
         username: Option<String>,
@@ -904,17 +916,18 @@ impl Interpreter {
         fixed_epoch: Option<i64>,
         epoch_offset: Option<i64>,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
+        host_builtins: Option<crate::builtins::BuiltinRegistry>,
         shell_profile: ShellProfile,
     ) -> Self {
         // Macro to reduce boilerplate for simple zero-arg builtin registration.
         // Custom-construction builtins (date, source, hostname, etc.) are registered below.
         macro_rules! register_builtins {
             ($map:ident, $( $name:literal => $type:ident ),+ $(,)?) => {
-                $( $map.insert($name.to_string(), Box::new(builtins::$type) as Box<dyn Builtin>); )+
+                $( $map.insert($name.to_string(), Arc::new(builtins::$type) as Arc<dyn Builtin>); )+
             };
         }
 
-        let mut builtins: HashMap<String, Box<dyn Builtin>> = HashMap::new();
+        let mut builtins: HashMap<String, Arc<dyn Builtin>> = HashMap::new();
 
         register_builtins!(builtins,
             // Core shell builtins
@@ -1074,22 +1087,22 @@ impl Interpreter {
 
         // jq builtin (requires jq feature)
         #[cfg(feature = "jq")]
-        builtins.insert("jq".to_string(), Box::new(builtins::Jq));
+        builtins.insert("jq".to_string(), Arc::new(builtins::Jq));
 
         // Custom-construction builtins that need parameters
 
         // source/. requires filesystem access
         builtins.insert(
             "source".to_string(),
-            Box::new(builtins::Source::new(fs.clone())),
+            Arc::new(builtins::Source::new(fs.clone())),
         );
-        builtins.insert(".".to_string(), Box::new(builtins::Source::new(fs.clone())));
+        builtins.insert(".".to_string(), Arc::new(builtins::Source::new(fs.clone())));
 
         // THREAT[TM-INF-018]: Resolve the virtual clock mode for `date`.
         // Priority: fixed_epoch > epoch_offset > real clock.
         builtins.insert(
             "date".to_string(),
-            Box::new(if let Some(epoch) = fixed_epoch {
+            Arc::new(if let Some(epoch) = fixed_epoch {
                 use chrono::DateTime;
                 builtins::Date::with_fixed_epoch(
                     DateTime::from_timestamp(epoch, 0).unwrap_or_default(),
@@ -1106,40 +1119,41 @@ impl Interpreter {
         let username_val = username.unwrap_or_else(|| builtins::DEFAULT_USERNAME.to_string());
         builtins.insert(
             "hostname".to_string(),
-            Box::new(builtins::Hostname::with_hostname(&hostname_val)),
+            Arc::new(builtins::Hostname::with_hostname(&hostname_val)),
         );
         builtins.insert(
             "uname".to_string(),
-            Box::new(builtins::Uname::with_hostname(&hostname_val)),
+            Arc::new(builtins::Uname::with_hostname(&hostname_val)),
         );
         builtins.insert(
             "whoami".to_string(),
-            Box::new(builtins::Whoami::with_username(&username_val)),
+            Arc::new(builtins::Whoami::with_username(&username_val)),
         );
         builtins.insert(
             "id".to_string(),
-            Box::new(builtins::Id::with_username(&username_val)),
+            Arc::new(builtins::Id::with_username(&username_val)),
         );
 
         // Git builtin (requires git feature and configuration at runtime)
         #[cfg(feature = "git")]
-        builtins.insert("git".to_string(), Box::new(builtins::Git));
+        builtins.insert("git".to_string(), Arc::new(builtins::Git));
 
         // SSH builtins (requires ssh feature and configuration at runtime)
         #[cfg(feature = "ssh")]
         {
-            builtins.insert("ssh".to_string(), Box::new(builtins::Ssh));
-            builtins.insert("scp".to_string(), Box::new(builtins::Scp));
-            builtins.insert("sftp".to_string(), Box::new(builtins::Sftp));
+            builtins.insert("ssh".to_string(), Arc::new(builtins::Ssh));
+            builtins.insert("scp".to_string(), Arc::new(builtins::Scp));
+            builtins.insert("sftp".to_string(), Arc::new(builtins::Sftp));
         }
 
         if shell_profile.is_logic_only() {
             builtins.retain(|name, _| logic_only_builtin_allowed(name));
         }
 
-        // Merge custom builtins (override defaults if same name)
+        // Merge custom builtins (override defaults if same name).
+        // `Arc::from(Box<dyn Builtin>)` reuses the existing allocation.
         for (name, builtin) in custom_builtins {
-            builtins.insert(name, builtin);
+            builtins.insert(name, Arc::from(builtin));
         }
 
         // Initialize default shell variables
@@ -1171,6 +1185,7 @@ impl Interpreter {
             cwd: PathBuf::from("/home/user"),
             last_exit_code: 0,
             builtins,
+            host_builtins,
             functions: HashMap::new(),
             call_stack: Vec::new(),
             bash_source_stack: Vec::new(),
@@ -4727,6 +4742,34 @@ impl Interpreter {
         stdin: Option<&'a str>,
         redirects: &'a [Redirect],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
+        // Clone the Arc out of the map so the call doesn't hold a borrow on
+        // self.builtins while we take &mut self for the execution body.
+        let builtin = self.builtins.get(name).unwrap().clone();
+        self.execute_builtin_arc(name, builtin, args, stdin, redirects)
+    }
+
+    /// Execute a builtin resolved via the host-owned [`BuiltinRegistry`].
+    fn execute_host_builtin<'a>(
+        &'a mut self,
+        name: &'a str,
+        builtin: Arc<dyn Builtin>,
+        args: &'a [String],
+        stdin: Option<&'a str>,
+        redirects: &'a [Redirect],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
+        self.execute_builtin_arc(name, builtin, args, stdin, redirects)
+    }
+
+    /// Shared execution path for builtins regardless of source
+    /// (baked-in, builder-`builtin`, or host registry).
+    fn execute_builtin_arc<'a>(
+        &'a mut self,
+        name: &'a str,
+        builtin: Arc<dyn Builtin>,
+        args: &'a [String],
+        stdin: Option<&'a str>,
+        redirects: &'a [Redirect],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         Box::pin(async move {
             // Fire before_tool hooks — may modify args or cancel the invocation
             let args = if !self.hooks.before_tool.is_empty() {
@@ -4748,8 +4791,6 @@ impl Interpreter {
                 std::borrow::Cow::Borrowed(args)
             };
             let args: &[String] = &args;
-
-            let builtin = self.builtins.get(name).unwrap();
 
             // Check for execution plan first
             {
@@ -4804,7 +4845,6 @@ impl Interpreter {
                 }
             }
 
-            let builtin = self.builtins.get(name).unwrap();
             let execution_extensions = self.current_execution_extensions();
             let shell_ref = ShellRef {
                 builtins: &self.builtins,
@@ -4918,6 +4958,13 @@ impl Interpreter {
         }
     }
 
+    /// True if `name` resolves through the host-owned builtin registry.
+    fn has_host_builtin(&self, name: &str) -> bool {
+        self.host_builtins
+            .as_ref()
+            .is_some_and(|reg| reg.lookup(name).is_some())
+    }
+
     // THREAT[TM-DOS-089]: Box the final dispatch split so function lookup,
     // special builtin handling, registered builtin execution, and path search
     // do not contribute another large async frame per nested substitution level.
@@ -4942,6 +4989,19 @@ impl Interpreter {
                 .await
             {
                 return result;
+            }
+
+            // Host-registered builtins (mutable, may override baked-in builtins).
+            if let Some(builtin) = self.host_builtins.as_ref().and_then(|reg| reg.lookup(name)) {
+                return self
+                    .execute_host_builtin(
+                        name,
+                        builtin,
+                        &args,
+                        stdin.as_deref(),
+                        &command.redirects,
+                    )
+                    .await;
             }
 
             // Registered builtins
@@ -4974,12 +5034,18 @@ impl Interpreter {
             }
 
             // Command not found
+            let host_names: Vec<String> = self
+                .host_builtins
+                .as_ref()
+                .map(|reg| reg.names())
+                .unwrap_or_default();
             let known: Vec<&str> = self
                 .builtins
                 .keys()
                 .map(|s| s.as_str())
                 .chain(self.functions.keys().map(|s| s.as_str()))
                 .chain(self.aliases.keys().map(|s| s.as_str()))
+                .chain(host_names.iter().map(|s| s.as_str()))
                 .collect();
             let msg = command_not_found_message(name, &known);
             Ok(ExecResult::err(msg, 127))
@@ -6227,6 +6293,7 @@ impl Interpreter {
                 // command -v: print name/path if it's a known command
                 let output = if self.functions.contains_key(cmd_name.as_str())
                     || self.builtins.contains_key(cmd_name.as_str())
+                    || self.has_host_builtin(cmd_name)
                     || is_keyword(cmd_name)
                 {
                     Some(cmd_name.to_string())
@@ -6251,7 +6318,9 @@ impl Interpreter {
                 // command -V: verbose description
                 let description = if self.functions.contains_key(cmd_name.as_str()) {
                     format!("{} is a function\n", cmd_name)
-                } else if self.builtins.contains_key(cmd_name.as_str()) {
+                } else if self.has_host_builtin(cmd_name)
+                    || self.builtins.contains_key(cmd_name.as_str())
+                {
                     format!("{} is a shell builtin\n", cmd_name)
                 } else if is_keyword(cmd_name) {
                     format!("{} is a shell keyword\n", cmd_name)
@@ -6271,7 +6340,14 @@ impl Interpreter {
                 // command name args...: run bypassing functions (use builtin only)
                 // Build a synthetic simple command and execute it, skipping function lookup
                 let remaining = &args[cmd_args_start..];
-                if let Some(builtin) = self.builtins.get(remaining[0].as_str()) {
+                let target = remaining[0].as_str();
+                // Resolve host-registered builtins first (same precedence as dispatch_command).
+                let builtin = self
+                    .host_builtins
+                    .as_ref()
+                    .and_then(|reg| reg.lookup(target))
+                    .or_else(|| self.builtins.get(target).cloned());
+                if let Some(builtin) = builtin {
                     let builtin_args = &remaining[1..];
                     let execution_extensions = self.current_execution_extensions();
                     let shell_ref = ShellRef {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1894,10 +1894,11 @@ impl BashBuilder {
     /// Attach a host-owned mutable builtin registry.
     ///
     /// Unlike [`BashBuilder::builtin`], entries in a [`BuiltinRegistry`] can
-    /// be inserted and removed after the `Bash` instance has been built, and
-    /// they survive [`Bash::reset`]. This is intended for embedders (FFI
-    /// bindings, REPLs) that want to register host callbacks at runtime
-    /// without rebuilding the interpreter.
+    /// be inserted and removed after the `Bash` instance has been built. The
+    /// registry is host-owned, so its contents survive `exec()` calls
+    /// unchanged. This is intended for embedders (FFI bindings, REPLs) that
+    /// want to register host callbacks at runtime without rebuilding the
+    /// interpreter.
     ///
     /// The registry is consulted during command dispatch after shell
     /// functions and POSIX special builtins, but before baked-in builtins —

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -440,7 +440,8 @@ pub use async_trait::async_trait;
 pub use builtins::git::GitConfig;
 pub use builtins::ssh::{SshAllowlist, SshConfig, TrustedHostKey};
 pub use builtins::{
-    BashkitContext, Builtin, ClapBuiltin, Context as BuiltinContext, ExecutionExtensions, Extension,
+    BashkitContext, Builtin, BuiltinRegistry, ClapBuiltin, Context as BuiltinContext,
+    ExecutionExtensions, Extension,
 };
 pub use clap;
 #[cfg(feature = "http_client")]
@@ -1213,6 +1214,9 @@ pub struct BashBuilder {
     epoch_offset: Option<i64>,
     shell_profile: interpreter::ShellProfile,
     custom_builtins: HashMap<String, Box<dyn Builtin>>,
+    /// Optional host-owned mutable registry. Entries here are consulted at
+    /// dispatch time, so embedders can register/remove builtins after build.
+    host_builtins: Option<BuiltinRegistry>,
     /// Files to mount in the virtual filesystem
     mounted_files: Vec<MountedFile>,
     /// Lazy files to mount (loaded on first read)
@@ -1887,6 +1891,26 @@ impl BashBuilder {
         self
     }
 
+    /// Attach a host-owned mutable builtin registry.
+    ///
+    /// Unlike [`BashBuilder::builtin`], entries in a [`BuiltinRegistry`] can
+    /// be inserted and removed after the `Bash` instance has been built, and
+    /// they survive [`Bash::reset`]. This is intended for embedders (FFI
+    /// bindings, REPLs) that want to register host callbacks at runtime
+    /// without rebuilding the interpreter.
+    ///
+    /// The registry is consulted during command dispatch after shell
+    /// functions and POSIX special builtins, but before baked-in builtins —
+    /// so entries can override baked-in commands of the same name.
+    ///
+    /// The registry handle is `Clone`; clones share the same underlying
+    /// storage. Keep a clone after calling this method to retain
+    /// post-build mutation access.
+    pub fn builtin_registry(mut self, registry: BuiltinRegistry) -> Self {
+        self.host_builtins = Some(registry);
+        self
+    }
+
     /// Register a capability extension.
     ///
     /// Extensions contribute a related set of builtins as one unit. Commands
@@ -2478,6 +2502,7 @@ impl BashBuilder {
             self.trace_mode,
             self.trace_callback,
             self.custom_builtins,
+            self.host_builtins,
             self.history_file,
             #[cfg(feature = "http_client")]
             self.network_allowlist,
@@ -2719,6 +2744,7 @@ impl BashBuilder {
         trace_mode: TraceMode,
         trace_callback: Option<TraceCallback>,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
+        host_builtins: Option<BuiltinRegistry>,
         history_file: Option<PathBuf>,
         #[cfg(feature = "http_client")] network_allowlist: Option<NetworkAllowlist>,
         #[cfg(feature = "http_client")] http_handler: Option<Box<dyn network::HttpHandler>>,
@@ -2746,6 +2772,7 @@ impl BashBuilder {
             fixed_epoch,
             epoch_offset,
             custom_builtins,
+            host_builtins,
             shell_profile,
         );
 

--- a/crates/bashkit/tests/builtin_registry_tests.rs
+++ b/crates/bashkit/tests/builtin_registry_tests.rs
@@ -1,0 +1,183 @@
+//! Integration tests for the host-owned `BuiltinRegistry`.
+//!
+//! Verifies that builtins registered through a `BuiltinRegistry` handle
+//! survive interpreter mutation (VFS writes, variable assignments,
+//! `reset_transient_state`) and that the host can add/remove entries
+//! after the `Bash` instance has been built — without rebuilding it.
+
+use async_trait::async_trait;
+use bashkit::{Bash, Builtin, BuiltinContext, BuiltinRegistry, ExecResult};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+struct EchoArgs;
+
+#[async_trait]
+impl Builtin for EchoArgs {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        Ok(ExecResult::ok(format!("{}\n", ctx.args.join(","))))
+    }
+}
+
+struct CountCalls {
+    counter: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl Builtin for CountCalls {
+    async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let n = self.counter.fetch_add(1, Ordering::SeqCst) + 1;
+        Ok(ExecResult::ok(format!("call #{}\n", n)))
+    }
+}
+
+#[tokio::test]
+async fn registry_lookup_dispatches_builtin() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("greet", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+    let result = bash.exec("greet hello world").await.unwrap();
+
+    assert_eq!(result.stdout, "hello,world\n");
+    assert_eq!(result.exit_code, 0);
+}
+
+#[tokio::test]
+async fn registry_entries_added_after_build_are_visible() {
+    let registry = BuiltinRegistry::new();
+    let mut bash = Bash::builder().builtin_registry(registry.clone()).build();
+
+    // Run something first so the interpreter has state.
+    bash.exec("mkdir -p /scratch && echo seed > /scratch/seed.txt")
+        .await
+        .unwrap();
+
+    // Now register a new builtin — must be visible without rebuilding.
+    registry.insert("post-build", Arc::new(EchoArgs));
+    let result = bash.exec("post-build alpha beta").await.unwrap();
+    assert_eq!(result.stdout, "alpha,beta\n");
+
+    // Critical: pre-existing VFS contents are preserved.
+    let result = bash.exec("cat /scratch/seed.txt").await.unwrap();
+    assert_eq!(result.stdout, "seed\n");
+}
+
+#[tokio::test]
+async fn registry_removal_takes_effect_immediately() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("tmp", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder().builtin_registry(registry.clone()).build();
+
+    assert_eq!(bash.exec("tmp ok").await.unwrap().stdout, "ok\n");
+
+    registry.remove("tmp");
+    let result = bash.exec("tmp ok").await.unwrap();
+    assert_eq!(result.exit_code, 127);
+}
+
+#[tokio::test]
+async fn registry_overrides_baked_in_builtin() {
+    let registry = BuiltinRegistry::new();
+    // Override `echo`: host wins over baked-in.
+    registry.insert("echo", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+    let result = bash.exec("echo a b c").await.unwrap();
+
+    // Baked-in echo emits "a b c\n"; our override emits "a,b,c\n".
+    assert_eq!(result.stdout, "a,b,c\n");
+}
+
+#[tokio::test]
+async fn shell_function_overrides_host_registry() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("name", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+    let result = bash
+        .exec("name() { echo from-function; }\nname host")
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout, "from-function\n");
+}
+
+#[tokio::test]
+async fn registry_shared_across_clones() {
+    let counter = Arc::new(AtomicU32::new(0));
+    let registry = BuiltinRegistry::new();
+    registry.insert(
+        "count",
+        Arc::new(CountCalls {
+            counter: counter.clone(),
+        }),
+    );
+
+    // Hand a clone to the builder, keep the original for mutation.
+    let mut bash = Bash::builder().builtin_registry(registry.clone()).build();
+
+    bash.exec("count").await.unwrap();
+    bash.exec("count").await.unwrap();
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+
+    // Inserting via the original clone is visible to the interpreter.
+    registry.insert("count2", Arc::new(EchoArgs));
+    let result = bash.exec("count2 x").await.unwrap();
+    assert_eq!(result.stdout, "x\n");
+}
+
+#[tokio::test]
+async fn registry_survives_multiple_exec_calls_with_state() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("emit", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+
+    bash.exec("mkdir -p /data").await.unwrap();
+    bash.exec("emit 1 > /data/a.txt").await.unwrap();
+    bash.exec("emit 2 > /data/b.txt").await.unwrap();
+
+    let result = bash.exec("cat /data/a.txt /data/b.txt").await.unwrap();
+    assert_eq!(result.stdout, "1\n2\n");
+}
+
+#[tokio::test]
+async fn registry_pipe_chain() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("emit", Arc::new(EchoArgs));
+
+    struct Upper;
+    #[async_trait]
+    impl Builtin for Upper {
+        async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+            Ok(ExecResult::ok(ctx.stdin.unwrap_or("").to_uppercase()))
+        }
+    }
+    registry.insert("upper", Arc::new(Upper));
+
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+    let result = bash.exec("emit hello world | upper").await.unwrap();
+    assert_eq!(result.stdout, "HELLO,WORLD\n");
+}
+
+#[tokio::test]
+async fn command_v_finds_host_builtin() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("custom-cmd", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+
+    // `command -v custom-cmd` should print its name (found).
+    let result = bash.exec("command -v custom-cmd").await.unwrap();
+    assert_eq!(result.stdout, "custom-cmd\n");
+
+    // `command -V` should describe it as a builtin.
+    let result = bash.exec("command -V custom-cmd").await.unwrap();
+    assert!(
+        result.stdout.contains("is a shell builtin"),
+        "got: {}",
+        result.stdout
+    );
+}

--- a/specs/builtins.md
+++ b/specs/builtins.md
@@ -129,6 +129,61 @@ Current extension:
 - `TypeScriptExtension` registers `ts`/`typescript` and, when enabled by
   `TypeScriptConfig`, `node`/`deno`/`bun`
 
+### BuiltinRegistry — Host-Owned Mutable Builtins
+
+`BashBuilder::builtin(name, ...)` and `Extension::builtins()` are both
+*build-time* registration: the set of builtins is frozen once the `Bash`
+instance is built. For embedders that need to register or remove builtins
+*after* construction (FFI bindings, REPLs, plugin systems),
+`BuiltinRegistry` provides a host-owned mutable registry consulted at
+command-dispatch time.
+
+```rust
+#[derive(Clone, Default)]
+pub struct BuiltinRegistry {
+    inner: Arc<RwLock<HashMap<String, Arc<dyn Builtin>>>>,
+}
+
+impl BuiltinRegistry {
+    pub fn new() -> Self;
+    pub fn insert(&self, name: impl Into<String>, builtin: Arc<dyn Builtin>);
+    pub fn remove(&self, name: &str) -> Option<Arc<dyn Builtin>>;
+    pub fn lookup(&self, name: &str) -> Option<Arc<dyn Builtin>>;
+    pub fn names(&self) -> Vec<String>;
+    pub fn is_empty(&self) -> bool;
+}
+```
+
+Wired in via `BashBuilder::builtin_registry(registry)`. The handle is
+`Clone`; clones share the same underlying storage, so the embedder keeps a
+clone for runtime mutation while the builder takes another.
+
+Command-resolution order (see `Interpreter::dispatch_command`):
+
+1. Shell functions (defined in scripts)
+2. POSIX special builtins (`exec`, `set`, `:`, `eval`, …)
+3. **Host registry** (`BuiltinRegistry::lookup`)
+4. Baked-in + builder-registered builtins
+5. Script execution by path / `$PATH` search
+
+So registry entries can override baked-in commands (e.g. wrap `cat` with
+tracing) but shell functions still win — matching standard bash
+precedence. `command -v` / `command -V` / `command name args…` consult
+the registry too.
+
+Implementation notes:
+
+- Storage is `Arc<RwLock<HashMap<String, Arc<dyn Builtin>>>>` (std only,
+  no extra deps). Lookup clones the `Arc` out of the lock, releasing it
+  before execution.
+- `Interpreter::builtins` was migrated from `HashMap<String, Box<dyn Builtin>>`
+  to `HashMap<String, Arc<dyn Builtin>>` so registered and host-registry
+  paths share one execution helper (`execute_builtin_arc`).
+- The registry is host-owned: not part of interpreter state, so
+  `reset_transient_state` leaves it untouched and snapshots do not
+  serialize it. Restoring from a snapshot requires re-attaching the
+  registry handle.
+
 ### Execution Extensions
 
 `Bash::exec_with_extensions()` and `Bash::exec_streaming_with_extensions()`


### PR DESCRIPTION
## Summary

- Adds `BuiltinRegistry` — a host-owned, mutable builtin extension point on `Bash::builder()` so embedders (FFI bindings, REPLs, plugin systems) can register and remove builtins at any point in the interpreter's lifetime without rebuilding the interpreter or disturbing the VFS.
- Wires the registry through the bashkit-js NAPI bindings, exposing `Bash.addBuiltin(name, cb)`, `BashTool.addBuiltin(name, cb)`, `removeBuiltin(name)`, and a `customBuiltins: Record<string, BuiltinCallback>` constructor option.
- Replaces the rebuild-on-register approach from the external proposal in #1647, which silently wiped the in-memory filesystem when `addBuiltin` was called after `execute()`.

## Design

The bashkit core was the wrong layer to work around: previously the only way to add a builtin after construction would have been to discard the interpreter and rebuild it. With `BuiltinRegistry`:

1. **Core (`crates/bashkit`)**: New `BuiltinRegistry` (cloneable `Arc<RwLock<HashMap<String, Arc<dyn Builtin>>>>`) with `insert`/`remove`/`lookup`. `BashBuilder::builtin_registry(registry)` attaches it; the interpreter consults the registry at command dispatch time. Internally, `self.builtins` moves from `Box<dyn Builtin>` to `Arc<dyn Builtin>` so the dispatcher clones the handle out of the map and the registered + host-registry paths share one execution helper (`execute_builtin_arc`).
2. **Resolution order**: shell function → POSIX special builtin → **host registry** → baked-in builtin → `$PATH`. Host entries can override baked-in commands; shell functions still win (matching standard bash precedence). `command -v` / `-V` / `name` resolve through the registry too.
3. **NAPI bindings (`crates/bashkit-js`)**: `JsCustomBuiltinAdapter` implements `Builtin` via a `Promise<String>` TSFN. The JS dispatcher always wraps callback results with `Promise.resolve`, so the Rust adapter sees a uniform `Promise<String>` regardless of whether the user's callback is sync or async — no call-ID registry, no two-phase `respondToBuiltin` protocol. `customBuiltins` is purely a convenience that iterates `addBuiltin`.

The registry is host-owned, so it survives `reset()` automatically (it's not part of the interpreter state that `reset` discards). Snapshots/restore do not preserve it — embedders pass `customBuiltins` again after restoring.

## Test plan

- [x] `cargo test -p bashkit --test builtin_registry_tests` — 9 new integration tests pass, including:
  - `registry_entries_added_after_build_are_visible` (the VFS-preservation regression test)
  - `registry_removal_takes_effect_immediately`
  - `registry_overrides_baked_in_builtin`
  - `shell_function_overrides_host_registry`
  - `registry_shared_across_clones`
  - `command_v_finds_host_builtin`
- [x] `npm test` in `crates/bashkit-js` — 457 tests pass, including 19 new in `__test__/custom-builtins.spec.ts` (sync/async, BuiltinTool, pipes, error handling, VFS persistence, reset survival, override precedence, `addBuiltin after execute()`).
- [x] `cargo test -p bashkit --test custom_builtins_tests` — pre-existing 20 tests still pass.
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy -p bashkit -p bashkit-js --all-targets -- -D warnings` clean.
- [ ] Two pre-existing lib/integration test failures (`builtins::rg::tests::diff_rg_matches_real_rg_cases`, `builtin_parser_depth::threat_jq_moderate_nesting_works`) confirmed to also fail on `origin/main` — unrelated to this change.

Closes/supersedes: #1647


---
_Generated by [Claude Code](https://claude.ai/code/session_015mE2cLkgjAPrzt5u2Yivo8)_