### PR TITLE
fix(ci): harden python wheel builds

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,6 +33,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  MATURIN_VERSION: ">=1.4,<2.0"
 
 jobs:
   lint:
@@ -77,13 +78,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install maturin
+        run: python -m pip install "maturin${MATURIN_VERSION}"
+
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          args: --release --out dist -i python${{ matrix.python-version }}
-          rust-toolchain: stable
-          working-directory: crates/bashkit-python
+        working-directory: crates/bashkit-python
+        run: python -m maturin build --release --out dist -i python${{ matrix.python-version }}
 
       - name: Install wheel and test dependencies
         run: |
@@ -118,13 +118,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install maturin
+        run: python -m pip install "maturin${MATURIN_VERSION}"
+
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          args: --release --out dist -i python3.12
-          rust-toolchain: stable
-          working-directory: crates/bashkit-python
+        working-directory: crates/bashkit-python
+        run: python -m maturin build --release --out dist -i python3.12
 
       - name: Install local wheel
         run: |
@@ -164,13 +163,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install maturin
+        run: python -m pip install "maturin${MATURIN_VERSION}"
+
       - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        with:
-          command: build
-          args: --release --out dist
-          rust-toolchain: stable
-          working-directory: crates/bashkit-python
+        working-directory: crates/bashkit-python
+        run: python -m maturin build --release --out dist
 
       - name: Verify wheel metadata
         run: |


### PR DESCRIPTION
## What
Replace Python CI usage of `PyO3/maturin-action@v1` with explicit `python -m pip install "maturin>=1.4,<2.0"` plus `python -m maturin build` commands.

## Why
Main went red after the #1719 merge because Python CI hit infrastructure/action failures: one checkout auth failure and one `PyO3/maturin-action@v1` JavaScript error, `TypeError: candidates is not iterable`, in the Python 3.13 build path. Rerunning restored main, but the workflow should avoid the brittle action path.

## How
Keep the existing Rust/setup/cache flow, install maturin directly under the selected Python interpreter, and invoke the same build arguments from shell in test, examples, and build-wheel jobs.

## Risk
- Low
- This keeps the same maturin version range already declared by the project and preserves the existing wheel build commands.

## Checklist
- [x] YAML parses locally
- [x] `git diff --check` passed
- [x] `just pre-pr` passed locally
- [x] Main Python workflow rerun is green