### PR TITLE
feat(js): guardrail against executeSync + custom builtin deadlock

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -347,8 +347,11 @@ Custom builtins survive `reset()`. They are host-side configuration and are
 **not** preserved by `snapshot()` / `restoreSnapshot()` — pass
 `customBuiltins` again or call `addBuiltin` after restoring.
 
-Use `execute()` (async). `executeSync()` will deadlock if the script invokes
-a custom builtin — same caveat as `ScriptedTool.executeSync()`.
+Use `execute()` (async). If the script invokes a custom builtin under
+`executeSync()` the builtin fails fast with exit code 1 and stderr
+`"<name>: custom builtins require execute() (async). ..."` instead of
+deadlocking — the JS event loop is blocked while the synchronous call is
+in flight, so the underlying `Promise<string>` callback could never run.
 
 ## Snapshot / Restore
 

--- a/crates/bashkit-js/__test__/custom-builtins.spec.ts
+++ b/crates/bashkit-js/__test__/custom-builtins.spec.ts
@@ -269,3 +269,66 @@ test("addBuiltin replaces an existing custom builtin", async (t) => {
   bash.addBuiltin("tag", () => "v2\n");
   t.is((await bash.execute("tag")).stdout, "v2\n");
 });
+
+// ----------------------------------------------------------------------------
+// executeSync + custom builtin: fail fast instead of deadlocking
+// ----------------------------------------------------------------------------
+
+test("executeSync with custom builtin returns error instead of deadlocking", (t) => {
+  let invoked = false;
+  const bash = new Bash({
+    customBuiltins: {
+      mybuiltin: () => {
+        invoked = true;
+        return "should-not-run\n";
+      },
+    },
+  });
+  const result = bash.executeSync("mybuiltin");
+  t.is(result.exitCode, 1);
+  t.false(invoked, "JS callback must not run when the loop is blocked");
+  t.regex(result.stderr, /mybuiltin: custom builtins require execute\(\) \(async\)/);
+});
+
+test("executeSync with addBuiltin custom builtin returns error", (t) => {
+  let invoked = false;
+  const bash = new Bash();
+  bash.addBuiltin("dyn", () => {
+    invoked = true;
+    return "should-not-run\n";
+  });
+  const result = bash.executeSync("dyn");
+  t.is(result.exitCode, 1);
+  t.false(invoked);
+  t.regex(result.stderr, /dyn: custom builtins require execute\(\) \(async\)/);
+});
+
+test("BashTool executeSync with custom builtin returns error", (t) => {
+  let invoked = false;
+  const tool = new BashTool({
+    customBuiltins: {
+      mybuiltin: () => {
+        invoked = true;
+        return "should-not-run\n";
+      },
+    },
+  });
+  const result = tool.executeSync("mybuiltin");
+  t.is(result.exitCode, 1);
+  t.false(invoked);
+  t.regex(result.stderr, /mybuiltin: custom builtins require execute\(\) \(async\)/);
+});
+
+test("async execute() still works after a guardrail-rejected executeSync", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      mybuiltin: () => "via-async\n",
+    },
+  });
+  const sync = bash.executeSync("mybuiltin");
+  t.is(sync.exitCode, 1);
+
+  const result = await bash.execute("mybuiltin");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, "via-async\n");
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -68,6 +68,14 @@ fn callback_semaphore() -> &'static tokio::sync::Semaphore {
 // sync paths fail with a JS error instead of deadlocking or panicking.
 const ON_OUTPUT_REENTRY_ERROR: &str = "onOutput cannot re-enter the same Bash instance; use collected output or another Bash instance for live access";
 
+// Decision: surface the executeSync+custom-builtin deadlock as a normal script
+// error instead of a silent hang. executeSync blocks the JS event loop via
+// block_on, but a JsCustomBuiltinAdapter dispatches its callback over a
+// threadsafe function that requires the loop to be free — the call would never
+// resolve. Detect that case and fail the builtin with exit 1 + a clear message
+// so the user sees a real error and can migrate to async execute().
+const SYNC_BUILTIN_DEADLOCK_ERROR: &str = "custom builtins require execute() (async). executeSync() would deadlock because the JS event loop is blocked while the synchronous call is in flight";
+
 struct OnOutputReentryScope {
     depth: Arc<AtomicUsize>,
 }
@@ -90,6 +98,23 @@ fn reject_on_output_reentry(state: &Arc<SharedState>) -> napi::Result<()> {
         return Err(napi::Error::from_reason(ON_OUTPUT_REENTRY_ERROR));
     }
     Ok(())
+}
+
+struct SyncExecuteScope {
+    depth: Arc<AtomicUsize>,
+}
+
+impl SyncExecuteScope {
+    fn enter(depth: Arc<AtomicUsize>) -> Self {
+        depth.fetch_add(1, Ordering::SeqCst);
+        Self { depth }
+    }
+}
+
+impl Drop for SyncExecuteScope {
+    fn drop(&mut self) {
+        self.depth.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 // ============================================================================
@@ -1051,6 +1076,11 @@ struct SharedState {
     rt: Mutex<tokio::runtime::Runtime>,
     cancelled: std::sync::Mutex<Arc<AtomicBool>>,
     on_output_reentry_depth: Arc<AtomicUsize>,
+    /// Tracks whether the JS event loop is currently blocked inside an
+    /// `executeSync` call. Custom builtins dispatched through a threadsafe
+    /// function check this and fail closed instead of deadlocking on a
+    /// callback the loop can never service. See [`SYNC_BUILTIN_DEADLOCK_ERROR`].
+    in_sync_execute_depth: Arc<AtomicUsize>,
     username: Option<String>,
     hostname: Option<String>,
     max_commands: Option<u32>,
@@ -1180,6 +1210,7 @@ impl Bash {
         commands: String,
         on_output: Option<napi::bindgen_prelude::Function<'_, (String, String), Option<String>>>,
     ) -> napi::Result<ExecResult> {
+        let _sync_scope = SyncExecuteScope::enter(self.state.in_sync_execute_depth.clone());
         let env_raw = on_output
             .as_ref()
             .map(|on_output| on_output.value().env as usize);
@@ -1318,6 +1349,7 @@ impl Bash {
             Arc::new(JsCustomBuiltinAdapter {
                 name,
                 callback: Arc::new(tsfn),
+                in_sync_execute_depth: self.state.in_sync_execute_depth.clone(),
             }),
         );
         Ok(())
@@ -1677,6 +1709,7 @@ impl BashTool {
         commands: String,
         on_output: Option<napi::bindgen_prelude::Function<'_, (String, String), Option<String>>>,
     ) -> napi::Result<ExecResult> {
+        let _sync_scope = SyncExecuteScope::enter(self.state.in_sync_execute_depth.clone());
         let env_raw = on_output
             .as_ref()
             .map(|on_output| on_output.value().env as usize);
@@ -1802,6 +1835,7 @@ impl BashTool {
             Arc::new(JsCustomBuiltinAdapter {
                 name,
                 callback: Arc::new(tsfn),
+                in_sync_execute_depth: self.state.in_sync_execute_depth.clone(),
             }),
         );
         Ok(())
@@ -2207,11 +2241,23 @@ type BuiltinTsfn = napi::threadsafe_function::ThreadsafeFunction<
 struct JsCustomBuiltinAdapter {
     name: String,
     callback: Arc<BuiltinTsfn>,
+    /// Shared depth counter incremented by the binding's `executeSync` entry
+    /// points. When non-zero the JS event loop is blocked, so dispatching the
+    /// TSFN callback would never resolve. We surface a real error in that case
+    /// instead of hanging.
+    in_sync_execute_depth: Arc<AtomicUsize>,
 }
 
 #[async_trait]
 impl Builtin for JsCustomBuiltinAdapter {
     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<RustExecResult> {
+        if self.in_sync_execute_depth.load(Ordering::SeqCst) > 0 {
+            return Ok(RustExecResult::err(
+                format!("{}: {}\n", self.name, SYNC_BUILTIN_DEADLOCK_ERROR),
+                1,
+            ));
+        }
+
         let request = serde_json::json!({
             "name": self.name,
             "argv": ctx.args,
@@ -2666,6 +2712,7 @@ fn shared_state_from_opts(
         ),
         cancelled: std::sync::Mutex::new(Arc::new(AtomicBool::new(false))),
         on_output_reentry_depth: Arc::new(AtomicUsize::new(0)),
+        in_sync_execute_depth: Arc::new(AtomicUsize::new(0)),
         username: opts.username.clone(),
         hostname: opts.hostname.clone(),
         max_commands: opts.max_commands,
@@ -2713,6 +2760,7 @@ fn shared_state_from_opts(
         rt: Mutex::new(rt),
         cancelled: std::sync::Mutex::new(cancelled),
         on_output_reentry_depth: tmp.on_output_reentry_depth,
+        in_sync_execute_depth: tmp.in_sync_execute_depth,
         username: opts.username,
         hostname: opts.hostname,
         max_commands: opts.max_commands,


### PR DESCRIPTION
Closes #1725.

## What
`executeSync` blocks the JS event loop via `block_on`, but `JsCustomBuiltinAdapter` dispatches its callback over a NAPI threadsafe function that requires the loop to be free. A script that invoked a custom builtin from `executeSync` hung silently until the process was killed.

## How
Mirror the existing `OnOutputReentryScope` pattern:

- New `in_sync_execute_depth: Arc<AtomicUsize>` on `SharedState`.
- New `SyncExecuteScope` RAII guard.
- `Bash::execute_sync` and `BashTool::execute_sync` enter the scope before `block_on`.
- `JsCustomBuiltinAdapter` carries an `Arc<AtomicUsize>` clone and checks it at dispatch; if non-zero it returns `ExecResult::err(.., 1)` with a clear message instead of awaiting the TSFN it can never service.

Failure becomes a normal script error (exit code 1 + stderr `"<name>: custom builtins require execute() (async). ..."`) instead of a hang.

## Tests
`__test__/custom-builtins.spec.ts` covers:
- `executeSync` + constructor `customBuiltins` (Bash and BashTool)
- `executeSync` + runtime `addBuiltin`
- Async `execute()` still works after a guardrail-rejected sync call

All 23 tests in the suite pass locally.

## Notes
- Cross-instance detection (instance A in `executeSync`, instance B's builtin fires) is intentionally out of scope per the issue — lower priority and rarely hit.
- README caveat updated to describe the new fail-fast behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YcS3ETpsWHZnT6Hw4gNEdA)_