### PR TITLE
test(js): benchmark customBuiltins callback overhead from bash

### DIFF
--- a/crates/bashkit-js/__test__/custom-builtins-perf.spec.ts
+++ b/crates/bashkit-js/__test__/custom-builtins-perf.spec.ts
@@ -1,0 +1,171 @@
+// Benchmark customBuiltins called from bash. Crosses the Node<->Rust boundary
+// (NAPI threadsafe function, async dispatch) — measure the per-call overhead
+// for sync and async callbacks, and compare against a baked-in builtin
+// (`:` / `true`) as a "no JS callback" baseline.
+//
+// These tests assert only very loose upper bounds so they don't flake on slow
+// CI hardware. The interesting output is the printed timings — run with
+// `npx ava __test__/custom-builtins-perf.spec.ts -v` to see them.
+
+import test from "ava";
+import { Bash } from "../wrapper.js";
+
+const ITERATIONS_IN_LOOP = 500;
+const EXECUTE_ROUNDTRIPS = 200;
+
+function fmt(ms: number, calls: number): string {
+  const perCall = ms / calls;
+  return `${ms.toFixed(1)} ms total, ${perCall.toFixed(3)} ms/call (${calls} calls)`;
+}
+
+async function timeIt(label: string, fn: () => Promise<void>): Promise<number> {
+  const t0 = performance.now();
+  await fn();
+  const elapsed = performance.now() - t0;
+  console.log(`  ${label}: ${elapsed.toFixed(1)} ms`);
+  return elapsed;
+}
+
+// ----------------------------------------------------------------------------
+// In-bash loop: many builtin invocations within a single execute() call.
+// Isolates the per-call cross-runtime overhead from parser/execute() setup.
+// ----------------------------------------------------------------------------
+
+test("perf: sync custom builtin in bash loop", async (t) => {
+  let counter = 0;
+  const bash = new Bash({
+    customBuiltins: {
+      tick: () => {
+        counter++;
+        return "";
+      },
+    },
+  });
+
+  const script = `for ((i=0; i<${ITERATIONS_IN_LOOP}; i++)); do tick; done`;
+  const elapsed = await timeIt(
+    `sync x${ITERATIONS_IN_LOOP} in-loop`,
+    async () => {
+      const r = await bash.execute(script);
+      t.is(r.exitCode, 0);
+    },
+  );
+
+  t.is(counter, ITERATIONS_IN_LOOP);
+  console.log(`  -> ${fmt(elapsed, ITERATIONS_IN_LOOP)}`);
+  t.true(elapsed < 60_000, `sync loop too slow: ${elapsed}ms`);
+});
+
+test("perf: async custom builtin in bash loop", async (t) => {
+  let counter = 0;
+  const bash = new Bash({
+    customBuiltins: {
+      tick: async () => {
+        counter++;
+        // Force a real microtask hop — the async path waits on a JS promise.
+        await Promise.resolve();
+        return "";
+      },
+    },
+  });
+
+  const script = `for ((i=0; i<${ITERATIONS_IN_LOOP}; i++)); do tick; done`;
+  const elapsed = await timeIt(
+    `async x${ITERATIONS_IN_LOOP} in-loop`,
+    async () => {
+      const r = await bash.execute(script);
+      t.is(r.exitCode, 0);
+    },
+  );
+
+  t.is(counter, ITERATIONS_IN_LOOP);
+  console.log(`  -> ${fmt(elapsed, ITERATIONS_IN_LOOP)}`);
+  t.true(elapsed < 60_000, `async loop too slow: ${elapsed}ms`);
+});
+
+test("perf: baseline baked-in `:` in bash loop (no JS callback)", async (t) => {
+  const bash = new Bash();
+  const script = `for ((i=0; i<${ITERATIONS_IN_LOOP}; i++)); do :; done`;
+  const elapsed = await timeIt(
+    `baseline x${ITERATIONS_IN_LOOP} in-loop`,
+    async () => {
+      const r = await bash.execute(script);
+      t.is(r.exitCode, 0);
+    },
+  );
+  console.log(`  -> ${fmt(elapsed, ITERATIONS_IN_LOOP)}`);
+  t.true(elapsed < 60_000, `baseline loop too slow: ${elapsed}ms`);
+});
+
+// ----------------------------------------------------------------------------
+// execute()-per-call: includes script parse + execute() setup each iteration.
+// Closer to the "tool call per turn" shape an LLM agent would generate.
+// ----------------------------------------------------------------------------
+
+test("perf: sync custom builtin via repeated execute()", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      tick: () => "",
+    },
+  });
+
+  const elapsed = await timeIt(
+    `sync x${EXECUTE_ROUNDTRIPS} execute() roundtrips`,
+    async () => {
+      for (let i = 0; i < EXECUTE_ROUNDTRIPS; i++) {
+        const r = await bash.execute("tick");
+        t.is(r.exitCode, 0);
+      }
+    },
+  );
+  console.log(`  -> ${fmt(elapsed, EXECUTE_ROUNDTRIPS)}`);
+  t.true(elapsed < 60_000, `sync execute() too slow: ${elapsed}ms`);
+});
+
+test("perf: async custom builtin via repeated execute()", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      tick: async () => {
+        await Promise.resolve();
+        return "";
+      },
+    },
+  });
+
+  const elapsed = await timeIt(
+    `async x${EXECUTE_ROUNDTRIPS} execute() roundtrips`,
+    async () => {
+      for (let i = 0; i < EXECUTE_ROUNDTRIPS; i++) {
+        const r = await bash.execute("tick");
+        t.is(r.exitCode, 0);
+      }
+    },
+  );
+  console.log(`  -> ${fmt(elapsed, EXECUTE_ROUNDTRIPS)}`);
+  t.true(elapsed < 60_000, `async execute() too slow: ${elapsed}ms`);
+});
+
+// ----------------------------------------------------------------------------
+// Stdin/argv roundtrip: payload moves bytes in both directions through the
+// JSON BuiltinContext envelope. Useful to see if argument marshaling
+// dominates the per-call cost.
+// ----------------------------------------------------------------------------
+
+test("perf: sync custom builtin with argv + stdin payload", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      passthru: (ctx) => `${ctx.argv.length}:${(ctx.stdin ?? "").length}\n`,
+    },
+  });
+
+  const N = 200;
+  const script = `for ((i=0; i<${N}; i++)); do echo "hello world" | passthru a b c d e; done`;
+  const elapsed = await timeIt(`payload x${N} in-loop`, async () => {
+    const r = await bash.execute(script);
+    t.is(r.exitCode, 0);
+    // Each call emits "5:12\n" (5 argv, "hello world\n" = 12 bytes).
+    t.is(r.stdout, "5:12\n".repeat(N));
+  });
+  console.log(`  -> ${fmt(elapsed, N)}`);
+  t.true(elapsed < 60_000, `payload loop too slow: ${elapsed}ms`);
+});


### PR DESCRIPTION
## Summary

Adds an AVA spec (`crates/bashkit-js/__test__/custom-builtins-perf.spec.ts`) that times `customBuiltins` callbacks invoked from bash across the Node<->Rust boundary, for both sync and async callbacks.

## Why

`customBuiltins` dispatch goes through NAPI threadsafe functions and is always async-wrapped (see `Promise.resolve()` in `wrapper.ts:618-629`). There was no visibility into the per-call cost relative to baked-in builtins. The user wanted a regular test that surfaces these numbers so regressions are easy to spot.

## How

Six AVA tests, each running 200-500 invocations and printing `ms/call`:

- **In-loop** (single `execute()`, N iterations in `for ((..))`) — isolates per-call cross-runtime cost
  - sync custom builtin
  - async custom builtin
  - baked-in `:` baseline (no JS callback)
- **Roundtrip** (one `execute()` per call) — sync + async
- **Payload** — sync builtin with `echo … | builtin a b c d e` to measure argv+stdin JSON envelope marshaling

Assertions are loose (`< 60 s` upper bounds) so the test won't flake on slow CI hardware; the value is in the printed timings (`-v` flag).

Sample local numbers (release build):

| Scenario | ms/call |
|----------|---------|
| baseline `:` (no JS) | 0.008 |
| sync custom builtin (in-loop) | 0.108 |
| async custom builtin (in-loop) | 0.113 |
| sync + argv/stdin payload | 0.166 |
| sync via execute() roundtrip | 0.291 |
| async via execute() roundtrip | 0.292 |

Sync and async paths are within ~5% — confirming the uniform `Promise<string>` dispatch.

## Test plan

- [x] `npx ava __test__/custom-builtins-perf.spec.ts -v` — 6/6 pass
- [x] `npx prettier --check` on new file
- [x] `npx oxlint` on new file
- [x] `tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzKLSs28VAS8WLStgsqptx)_