### PR TITLE
chore(ci): scope homebrew-tap push to dedicated PAT

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -167,8 +167,7 @@ jobs:
           # Fetch the homebrew-tap PAT from Doppler. This token is a
           # fine-grained PAT scoped to `everruns/homebrew-tap` only
           # (Contents: read+write, Metadata: read), so a leak cannot
-          # touch the main bashkit repo. Distinct from the broader
-          # GITHUB_TOKEN used by the cloud-agent env.
+          # touch the main bashkit repo.
           GH_PAT=$(doppler secrets get HOMEBREW_TAP_GITHUB_TOKEN --plain)
           export GH_PAT
           echo "::add-mask::$GH_PAT"

--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -164,8 +164,12 @@ jobs:
           TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
 
-          # Fetch the GitHub PAT from Doppler (has push access to homebrew-tap)
-          GH_PAT=$(doppler secrets get GITHUB_TOKEN --plain)
+          # Fetch the homebrew-tap PAT from Doppler. This token is a
+          # fine-grained PAT scoped to `everruns/homebrew-tap` only
+          # (Contents: read+write, Metadata: read), so a leak cannot
+          # touch the main bashkit repo. Distinct from the broader
+          # GITHUB_TOKEN used by the cloud-agent env.
+          GH_PAT=$(doppler secrets get HOMEBREW_TAP_GITHUB_TOKEN --plain)
           export GH_PAT
           echo "::add-mask::$GH_PAT"
 


### PR DESCRIPTION
## Summary

Splits the Doppler GitHub PAT into two least-privilege tokens so a CI
leak cannot reach the main `bashkit` repo.

- **`HOMEBREW_TAP_GITHUB_TOKEN`** (new) — fine-grained PAT scoped to
  `everruns/homebrew-tap` only, with `Contents: read+write` and
  `Metadata: read`. Used exclusively by the `update-homebrew` job in
  `cli-binaries.yml` to commit `Formula/bashkit.rb`.
- **`GITHUB_TOKEN`** (existing) — unchanged. Still used by the
  cloud-agent env (`scripts/init-cloud-env.sh`) for general `gh` CLI
  work in `everruns/bashkit`. Should also be a fine-grained PAT scoped
  to the repos the agent actually touches, but that's a separate
  rotation tracked outside this PR.

## Why

Today both purposes share a single Doppler `GITHUB_TOKEN`. A leak of
that single secret would give an attacker write access to whatever the
broader cloud-agent token can do — likely the main `bashkit` repo. By
splitting:

- A leak of the CI token only lets an attacker publish a malicious
  Homebrew formula. Bad, but recoverable — and a separate blast radius
  from `bashkit` source.
- A leak of the cloud-agent token is constrained by branch protection,
  required reviews, and required CI on `bashkit` itself.

## Files touched

- `.github/workflows/cli-binaries.yml:168` — fetch
  `HOMEBREW_TAP_GITHUB_TOKEN` instead of `GITHUB_TOKEN` from Doppler.
  Comment updated to record the new scoping decision.

The `doppler secrets get <KEY> --plain` form is already minimal — it
fetches a single named secret rather than injecting the whole config —
so no other change is needed at this call site.

## Test plan

- [ ] On the next release, observe the `update-homebrew` job in
      `cli-binaries.yml` resolve `HOMEBREW_TAP_GITHUB_TOKEN`, clone the
      tap, commit, and push successfully.
- [ ] After the next release lands, optionally revoke the previous
      `GITHUB_TOKEN`'s tap-write capability (if it was the same PAT
      with broader scope, narrow it).

## Follow-up

Apply the same fine-grained scoping to the remaining Doppler
`GITHUB_TOKEN` consumed by `scripts/init-cloud-env.sh` — limit it to
the repositories the cloud-agent actually works in, with no
`Workflows` permission unless the agent is allowed to touch
`.github/workflows/*`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXbig9Zj2sCRXWzNMEWoAY)_