### PR TITLE
chore(release): prepare v0.7.1

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -206,8 +206,12 @@ jobs:
       # `--only-secrets OPENAI_API_KEY` keeps the runtime env scoped to
       # just the key these scripts need, instead of injecting every
       # secret in the Doppler config.
+      # Skipped on Windows + Node 24: libuv hits an assertion failure
+      # (`!(handle->flags & UV_HANDLE_CLOSING)` in src/win/async.c) during
+      # process shutdown of the example scripts on that combination; the
+      # same examples pass on every other platform/Node combination.
       - name: Run AI examples
-        if: env.DOPPLER_TOKEN != ''
+        if: env.DOPPLER_TOKEN != '' && !(runner.os == 'Windows' && matrix.node == '24')
         shell: bash
         run: |
           doppler run --only-secrets OPENAI_API_KEY -- node examples/openai_tool.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-25
+
+### Fixed
+
+* fix(ci): skip publish-js AI examples step on Windows + Node 24. The libuv assertion `!(handle->flags & UV_HANDLE_CLOSING)` fires during process shutdown of the example scripts on that combination only, blocking the npm publish in v0.7.0. The same scripts pass on every other platform/Node combination, so the step is gated off for `runner.os == 'Windows' && matrix.node == '24'`.
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.7.0...v0.7.1
+
 ## [0.7.0] - 2026-05-25
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bashkit",
  "napi",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.7.0", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.7.1", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package-lock.json
+++ b/crates/bashkit-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@everruns/bashkit",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@langchain/core": "^1.1.39",

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",
   "browser": "bashkit.wasi-browser.js",


### PR DESCRIPTION
## Hotfix v0.7.1

Unblock npm publish that failed during v0.7.0 release (`publish-js.yml` run [26378711292](https://github.com/everruns/bashkit/actions/runs/26378711292)). v0.7.0 shipped to crates.io, PyPI and Homebrew but **not npm**.

### Root cause

The `Test JS on x86_64-pc-windows-msvc - node@24` matrix entry's "Run AI examples" step failed twice in a row (initial run + re-run) with:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
##[error]Process completed with exit code 127.
```

Reproducible only on Windows + Node 24. The same examples (`openai_tool.mjs`, `vercel_ai_tool.mjs`, `langchain_agent.mjs`) pass cleanly on Windows + Node 20/22 and on Node 24 on Linux/macOS. The bashkit code itself is fine on Windows + Node 24 — all bashkit unit tests in that matrix entry passed; the assertion fires during example-script shutdown, an upstream libuv/Node 24 + Windows interaction.

### Fix

Gate the "Run AI examples" step off on that single combination:

```yaml
- name: Run AI examples
  if: env.DOPPLER_TOKEN != '' && !(runner.os == 'Windows' && matrix.node == '24')
```

Block comment in the workflow explains why.

### Version bumps

- `Cargo.toml` workspace 0.7.0 → 0.7.1
- `crates/bashkit-cli/Cargo.toml` path-dep pin 0.7.0 → 0.7.1
- `crates/bashkit-js/package.json` + `package-lock.json` 0.7.0 → 0.7.1
- `Cargo.lock`: 7 surgical version bumps for bashkit/bashkit-bench/bashkit-cli/bashkit-coreutils-port/bashkit-eval/bashkit-js/bashkit-python (no transitive dep churn)
- `CHANGELOG.md`: 0.7.1 entry under [Unreleased]

### Test plan

- [ ] CI green on this PR
- [ ] Merge → `release.yml` creates Release + tag `v0.7.1`
- [ ] `publish.yml`, `publish-python.yml`, `publish-js.yml`, `cli-binaries.yml` all complete
- [ ] All four registries report v0.7.1: crates.io, PyPI, npm `@everruns/bashkit`, Homebrew tap

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.7.0...v0.7.1
