### PR TITLE
fix(ci): close DOPPLER_AVAILABLE bypass in examples workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           fi
 
       - name: Install Doppler CLI
-        if: env.DOPPLER_AVAILABLE == 'true'
+        if: github.event.pull_request.head.repo.fork != true && env.DOPPLER_AVAILABLE == 'true'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         uses: dopplerhq/cli-action@v4
@@ -216,14 +216,14 @@ jobs:
       # PR-controlled cargo step sees ANTHROPIC_API_KEY only, not every
       # secret in the Doppler config.
       - name: Run LLM agent example
-        if: env.DOPPLER_AVAILABLE == 'true'
+        if: github.event.pull_request.head.repo.fork != true && env.DOPPLER_AVAILABLE == 'true'
         continue-on-error: true
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --only-secrets ANTHROPIC_API_KEY -- cargo run --example agent_tool --features http_client
 
       - name: Run harness OpenAI joke example
-        if: env.DOPPLER_AVAILABLE == 'true'
+        if: github.event.pull_request.head.repo.fork != true && env.DOPPLER_AVAILABLE == 'true'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |


### PR DESCRIPTION
### Motivation

- Close a CI secret-exfiltration bypass where an attacker-controlled earlier step can set `DOPPLER_AVAILABLE=true` via `$GITHUB_ENV` and make later secret-bearing steps run. 
- Ensure each step that receives `DOPPLER_TOKEN` or invokes `doppler run` is explicitly gated by the non-fork predicate to prevent fork-PRs from gaining secrets.

### Description

- Require `github.event.pull_request.head.repo.fork != true` in addition to `env.DOPPLER_AVAILABLE == 'true'` for the `Install Doppler CLI`, `Run LLM agent example`, and `Run harness OpenAI joke example` steps in `.github/workflows/ci.yml`. 
- Keep the existing Doppler availability probe but require both the probe and the non-fork predicate before attaching `DOPPLER_TOKEN` or running `doppler run --only-secrets <KEY>` so secret-bearing steps cannot be enabled solely by a mutable `$GITHUB_ENV` sentinel.

### Testing

- Ran targeted scans with `rg --line-number "DOPPLER_AVAILABLE|Detect Doppler availability|Run LLM agent example|pull_request.head.repo.fork" .github/workflows/ci.yml` to verify the guard locations, which succeeded. 
- Ran `rg --line-number "DOPPLER_TOKEN|doppler run" .github/workflows/ci.yml` and inspected the affected region with `nl -ba .github/workflows/ci.yml | sed -n '190,235p'` to confirm the predicates were applied, which succeeded. 
- Attempted `git fetch origin main && git rebase origin/main` as required by policy, which failed in this environment because no `origin` remote is configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131633c44c832b830001a22074c03b)