### PR TITLE
fix(rg): avoid quadratic glob toggle recompilation

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -338,10 +338,8 @@ impl RgOptions {
                 opts.glob_rules.push(RgGlobRule::parse(&val, true, true)?);
             } else if p.flag("--glob-case-insensitive") {
                 opts.glob_case_insensitive = true;
-                opts.set_glob_case_insensitive(true)?;
             } else if p.flag("--no-glob-case-insensitive") {
                 opts.glob_case_insensitive = false;
-                opts.set_glob_case_insensitive(false)?;
             } else if let Some(val) = long_value(&mut p, "--ignore-file")? {
                 opts.ignore_file_paths.push(val);
             } else if let Some(val) = p.flag_value("-t", "rg").map_err(Error::Execution)? {
@@ -930,6 +928,8 @@ impl RgOptions {
                 positional.push(arg.to_string());
             }
         }
+
+        opts.set_glob_case_insensitive(opts.glob_case_insensitive)?;
 
         if positional.is_empty() {
             if opts.patterns.is_empty()


### PR DESCRIPTION
### Motivation
- Prevent parse-time CPU amplification where repeated `--glob-case-insensitive`/`--no-glob-case-insensitive` flags would recompile all prior non-`--iglob` globs on each toggle, causing O(n^2) work and a potential CPU DoS during synchronous argument parsing.

### Description
- Stop performing immediate `set_glob_case_insensitive` calls while iterating arguments and instead only flip the `opts.glob_case_insensitive` state during parsing.
- Apply the final glob case-insensitive mode once after argument parsing by calling `opts.set_glob_case_insensitive(opts.glob_case_insensitive)?;`, ensuring each non-`iglob` rule is recompiled at most once.

### Testing
- Ran `cargo test -p bashkit test_rg_real_rg_diff -- --nocapture`, which compiled and executed the rg differential tests without error (tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d6885030832b93e7323134572f4c)