### PR TITLE
fix(rg): keep parent dot-ignore active for --no-ignore-vcs

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -558,7 +558,6 @@ impl RgOptions {
                 opts.no_ignore_parent = false;
             } else if p.flag("--no-ignore-vcs") {
                 opts.no_ignore_vcs = true;
-                opts.no_ignore_parent = true;
             } else if p.flag("--ignore-vcs") {
                 opts.no_ignore = false;
                 opts.no_ignore_vcs = false;
@@ -6829,6 +6828,12 @@ mod tests {
         assert!(no_parent.stdout.contains("ignored.txt"));
         assert!(no_parent.stdout.contains("keep.txt"));
         assert!(no_parent.stdout.contains("vcs.txt"));
+
+        let no_vcs = run_rg(&["--no-ignore-vcs", "needle", "/proj/sub"], None, files).await;
+        assert_eq!(no_vcs.exit_code, 0);
+        assert!(!no_vcs.stdout.contains("ignored.txt"));
+        assert!(no_vcs.stdout.contains("keep.txt"));
+        assert!(no_vcs.stdout.contains("vcs.txt"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Fix incorrect semantics where `--no-ignore-vcs` also disabled parent ignore loading, causing parent `.ignore`/`.rgignore` to be skipped for child-root searches which diverges from real ripgrep behavior.

### Description
- Stop setting `opts.no_ignore_parent` when parsing `--no-ignore-vcs` so parent non‑VCS ignore files remain honored (change in `crates/bashkit/src/builtins/rg/mod.rs`).
- Add a regression assertion to `test_rg_parent_ignore_files` that `rg --no-ignore-vcs needle /proj/sub` still honors the parent `.ignore` while disabling parent `.gitignore`.

### Testing
- Ran `cargo test -p bashkit test_rg_parent_ignore_files -- --nocapture` and the test passed. 
- Ran package tests via `cargo test` during validation and observed no test failures in the executed test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c25f30832b946e8747b2da1dda)