### PR TITLE
fix(rg): skip indexed prefilter for --no-unicode non-literal queries

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3544,6 +3544,7 @@ async fn try_indexed_search(
     opts: &RgOptions,
     cwd: &Path,
 ) -> Option<Vec<RgInput>> {
+    let index_can_use_literal = opts.fixed_strings && !opts.word_boundary && !opts.line_regexp;
     if opts.invert_match
         || opts.files_without_matches
         || opts.crlf
@@ -3555,7 +3556,7 @@ async fn try_indexed_search(
         || opts.follow_symlinks
         || opts.search_zip
         || opts.preprocessor.is_some()
-        || (!opts.unicode && !opts.fixed_strings)
+        || (!opts.unicode && !index_can_use_literal)
         || opts.sort != RgSort::Path
     {
         return None;
@@ -3587,7 +3588,6 @@ async fn try_indexed_search(
         if !caps.content_search || (!opts.fixed_strings && !caps.regex) {
             return None;
         }
-        let index_can_use_literal = opts.fixed_strings && !opts.word_boundary && !opts.line_regexp;
         let pattern = if index_can_use_literal {
             opts.patterns[0].clone()
         } else {
@@ -12874,6 +12874,30 @@ mod tests {
         let result = run_rg_with_fs(&["--crlf", "needle$", "/safe/crlf.txt"], None, fs).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "needle\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_rg_indexed_search_skipped_for_no_unicode_non_literal_queries() {
+        let inner = InMemoryFs::new();
+        inner.mkdir(Path::new("/safe"), true).await.unwrap();
+        inner
+            .write_file(Path::new("/safe/unicode.txt"), b"cafe\ncafe\ncaf\xc3\xa9\n")
+            .await
+            .unwrap();
+
+        let fs = Arc::new(IndexedTestFs {
+            inner,
+            matches: vec![],
+        });
+
+        let result = run_rg_with_fs(
+            &["--no-ignore", "--no-unicode", "-F", "-w", "caf", "/safe"],
+            None,
+            fs,
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "/safe/unicode.txt:café\n");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Indexed prefilter could return an incomplete candidate set for ASCII-mode searches when `--no-unicode` was combined with non-literal indexed queries (e.g. `-F -w`), causing false-negative search results.
- The root cause is that the indexed fast-path was only disabled for `--no-unicode` when `fixed_strings` was false, while `-F -w` produces a non-literal index query but still hit the indexed path.
- The index query type lacks an explicit Unicode/ASCII mode, so the safe fix is to avoid the indexed prefilter whenever ASCII semantics are required but the index query is not a pure literal.

### Description
- Compute `index_can_use_literal` earlier and use it in the fast-path eligibility check inside `try_indexed_search` so the indexed prefilter is skipped when `!opts.unicode && !index_can_use_literal` (file: `crates/bashkit/src/builtins/rg/mod.rs`).
- Keep the existing `SearchQuery` usage but ensure the code does not trust indexed results for cases the index cannot faithfully represent under ASCII regex semantics.
- Add a regression test `test_rg_indexed_search_skipped_for_no_unicode_non_literal_queries` that exercises `--no-unicode -F -w caf` against an indexed provider that returns no candidates and asserts the final ASCII-mode matching still finds `café` (file: `crates/bashkit/src/builtins/rg/mod.rs`).

### Testing
- Ran `cargo test -p bashkit test_rg_indexed_search_skipped_for_no_unicode_non_literal_queries -- --nocapture` and the test passed (`ok`).
- Ran the package test run during the change and observed no test failures in the `bashkit` test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c14d58832bb2309acfb76deecf)