### PR TITLE
fix(rg): avoid false --generate detection in value arguments

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4477,12 +4477,68 @@ fn rg_quiet_result(
     None
 }
 
+fn rg_option_takes_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-e" | "--regexp"
+            | "-f"
+            | "--file"
+            | "-r"
+            | "--replace"
+            | "-A"
+            | "--after-context"
+            | "-B"
+            | "--before-context"
+            | "-C"
+            | "--context"
+            | "-d"
+            | "--max-depth"
+            | "-E"
+            | "--encoding"
+            | "--engine"
+            | "--field-context-separator"
+            | "--field-match-separator"
+            | "-g"
+            | "--glob"
+            | "--iglob"
+            | "--ignore-file"
+            | "-M"
+            | "--max-columns"
+            | "-m"
+            | "--max-count"
+            | "--max-filesize"
+            | "--path-separator"
+            | "--pre"
+            | "--pre-glob"
+            | "--regex-size-limit"
+            | "--dfa-size-limit"
+            | "--sort"
+            | "--sortr"
+            | "-j"
+            | "--threads"
+            | "-t"
+            | "--type"
+            | "-T"
+            | "--type-not"
+            | "--type-add"
+            | "--type-clear"
+            | "--context-separator"
+            | "--hostname-bin"
+            | "--hyperlink-format"
+            | "--colors"
+    )
+}
+
 fn rg_generate_kind(args: &[String]) -> Result<Option<String>> {
     let mut i = 0;
     while i < args.len() {
         let arg = &args[i];
         if arg == "--" {
             break;
+        }
+        if rg_option_takes_value(arg) {
+            i += 2;
+            continue;
         }
         if arg == "--generate" {
             let Some(kind) = args.get(i + 1) else {
@@ -11895,6 +11951,29 @@ mod tests {
         assert_eq!(man.exit_code, 0);
         assert!(man.stdout.contains(".TH RG"));
         assert!(man.stdout.contains(".SH NAME"));
+    }
+
+    #[tokio::test]
+    async fn test_rg_generate_not_detected_inside_value_args() {
+        let files = [("/tmp/input.txt", b"--generate=complete-bash\n".as_slice())];
+
+        let with_short_regexp = run_rg(
+            &["-e", "--generate=complete-bash", "/tmp/input.txt"],
+            None,
+            &files,
+        )
+        .await;
+        assert_eq!(with_short_regexp.exit_code, 0);
+        assert_eq!(with_short_regexp.stdout, "--generate=complete-bash\n");
+
+        let with_long_regexp = run_rg(
+            &["--regexp", "--generate=complete-bash", "/tmp/input.txt"],
+            None,
+            &files,
+        )
+        .await;
+        assert_eq!(with_long_regexp.exit_code, 0);
+        assert_eq!(with_long_regexp.stdout, "--generate=complete-bash\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- The `rg` builtin pre-scan `rg_generate_kind` looked for `--generate` by scanning raw argv, causing `--generate=...` inside values (e.g. after `-e`/`--regexp`) to be misinterpreted as generation mode instead of search data.
- This produced incompatible behavior vs upstream `rg` where value-taking flags consume the following token.

### Description
- Add `rg_option_takes_value(arg: &str) -> bool` to enumerate flags that take a value and must consume the next token.
- Update `rg_generate_kind` to skip tokens consumed by value-taking flags by advancing the index, so `--generate=...` inside such values is not treated as a generation request.
- Add a regression test `test_rg_generate_not_detected_inside_value_args` that verifies both `-e` and `--regexp` treat `--generate=complete-bash` as a pattern value and perform a normal search.
- Small test-data fix to use `.as_slice()` for the binary fixture used by the new test.

### Testing
- Ran `cargo test -p bashkit test_rg_generate_not_detected_inside_value_args` and the test passed.
- Ran `cargo test -p bashkit test_rg_generate_errors` and the test passed.
- Ran focused crate tests while iterating; the two targeted tests above were validated green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c22474832b8ad02b6f1e36ebd2)