### PR TITLE
fix(rg): honor --no-context-separator between files

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3250,7 +3250,11 @@ impl Builtin for Rg {
                         show_filename
                     };
                     if has_context {
-                        if !opts.heading && !output.is_empty() && !inverted_match_lines.is_empty() {
+                        if !opts.no_context_separator
+                            && !opts.heading
+                            && !output.is_empty()
+                            && !inverted_match_lines.is_empty()
+                        {
                             output.push_str(&opts.context_separator);
                             output.push(record_terminator);
                         }
@@ -3465,7 +3469,11 @@ impl Builtin for Rg {
                         output.push(record_terminator);
                     }
                 } else if has_context {
-                    if !opts.heading && !output.is_empty() && !context_match_lines.is_empty() {
+                    if !opts.no_context_separator
+                        && !opts.heading
+                        && !output.is_empty()
+                        && !context_match_lines.is_empty()
+                    {
                         output.push_str(&opts.context_separator);
                         output.push(record_terminator);
                     }
@@ -3776,7 +3784,11 @@ impl Builtin for Rg {
                     }
                 }
             } else if has_context {
-                if !opts.heading && !output.is_empty() && !match_lines.is_empty() {
+                if !opts.no_context_separator
+                    && !opts.heading
+                    && !output.is_empty()
+                    && !match_lines.is_empty()
+                {
                     output.push_str(&opts.context_separator);
                     output.push(record_terminator);
                 }
@@ -4800,6 +4812,21 @@ mod tests {
             ],
             stdin: None,
             files: DIFF_CONTEXT_GAP_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "no context separator between files",
+            args: &[
+                "-n",
+                "-C1",
+                "--no-context-separator",
+                "needle",
+                "proj/a.txt",
+                "proj/b.txt",
+            ],
+            stdin: None,
+            files: DIFF_TWO_CONTEXT_FILES,
             cwd: "/",
             output: RgDiffOutput::Exact,
         },


### PR DESCRIPTION
### Motivation
- `rg` honored `--no-context-separator` only for intra-file gaps but still emitted the context separator unconditionally before starting matches for a later file, causing output to differ from real ripgrep.

### Description
- Gate inter-file context-separator emissions on `!opts.no_context_separator` in all three output paths (multiline inverted, multiline normal, and regular) in `crates/bashkit/src/builtins/rg/mod.rs`.
- Add a differential test case `no context separator between files` exercising `-n -C1 --no-context-separator` across two files to cover the regression.
- Update is small and localized to `crates/bashkit/src/builtins/rg/mod.rs` and the rg differential test table.

### Testing
- Ran `cargo test -p bashkit builtins::rg::tests -- --nocapture`, which compiled and executed the rg tests; 46 tests passed and 1 test failed (`diff_rg_matches_real_rg_cases`) due to an existing timing-line mismatch with real `rg` that is unrelated to this fix.
- Attempted to sync with remote via `git fetch origin main` but it failed because this checkout has no `origin` remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c2aa70832bb8ee7755b7c6b5fa)