### PR TITLE
fix(rg): clear explicit line-number state on negation

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -733,6 +733,7 @@ impl RgOptions {
                 opts.show_filename = true;
             } else if p.flag("--no-line-number") {
                 opts.line_numbers = false;
+                opts.line_numbers_explicit = false;
             } else if p.flag("--line-number") {
                 opts.line_numbers = true;
                 opts.line_numbers_explicit = true;
@@ -1023,7 +1024,10 @@ impl RgOptions {
                             opts.line_numbers = true;
                             opts.line_numbers_explicit = true;
                         }
-                        'N' => opts.line_numbers = false,
+                        'N' => {
+                            opts.line_numbers = false;
+                            opts.line_numbers_explicit = false;
+                        }
                         'c' => opts.set_count_only(),
                         'l' => opts.set_files_with_matches(),
                         'v' => opts.invert_match = true,
@@ -12594,6 +12598,37 @@ mod tests {
         // --no-line-number flag explicitly disables line numbers
         let result = run_rg(
             &["--no-line-number", "world", "/test.txt"],
+            None,
+            &[("/test.txt", b"hello\nworld\n")],
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "world");
+    }
+
+    #[tokio::test]
+    async fn test_rg_no_line_number_clears_explicit_state_short() {
+        let result = run_rg(
+            &["-n", "-N", "--column", "--no-column", "world", "/test.txt"],
+            None,
+            &[("/test.txt", b"hello\nworld\n")],
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "world");
+    }
+
+    #[tokio::test]
+    async fn test_rg_no_line_number_clears_explicit_state_long() {
+        let result = run_rg(
+            &[
+                "--line-number",
+                "--no-line-number",
+                "--column",
+                "--no-column",
+                "world",
+                "/test.txt",
+            ],
             None,
             &[("/test.txt", b"hello\nworld\n")],
         )


### PR DESCRIPTION
### Motivation
- Fix correctness bug in `rg` option parsing where an earlier explicit `--line-number`/`-n` remained sticky via `line_numbers_explicit`, causing `-n -N --column --no-column` to incorrectly keep line numbers.
- Ensure behavior matches real `rg` semantics where a negation (`--no-line-number`/`-N`) clears the explicit request state.

### Description
- Clear `opts.line_numbers_explicit` when parsing `--no-line-number` in the long-flag branch of the parser (`crates/bashkit/src/builtins/rg/mod.rs`).
- Clear `opts.line_numbers_explicit` when parsing short `-N` in the combined-short-flag handling in the same file.
- Add two regression tests validating the sequences `-n -N --column --no-column` and `--line-number --no-line-number --column --no-column` to ensure final output omits line-number prefixes.

### Testing
- Ran the focused test invocation `cargo test -p bashkit test_rg_no_line_number_clears_explicit_state -- --nocapture` and the two new tests passed.
- Ran the crate test suite; unit tests completed with the new tests passing and no failures observed in the executed test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c229ec832ba28cb32b561142d9)