### PR TITLE
fix(rg): align -u ignore classes with --no-ignore

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -473,7 +473,14 @@ impl RgOptions {
     fn apply_unrestricted(&mut self) {
         self.unrestricted_level = self.unrestricted_level.saturating_add(1);
         match self.unrestricted_level {
-            1 => self.no_ignore = true,
+            1 => {
+                self.no_ignore = true;
+                self.no_ignore_dot = true;
+                self.no_ignore_exclude = true;
+                self.no_ignore_global = true;
+                self.no_ignore_parent = true;
+                self.no_ignore_vcs = true;
+            }
             2 => self.hidden = true,
             _ => self.binary = true,
         }
@@ -10432,6 +10439,14 @@ mod tests {
             args: &["--unrestricted", "--unrestricted", "needle", "proj"],
             stdin: None,
             files: DIFF_UNRESTRICTED_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "unrestricted and ignore-dot only restores dot ignores",
+            args: &["-u", "--ignore-dot", "needle", "proj"],
+            stdin: None,
+            files: DIFF_IGNORE_FILES,
             cwd: "/",
             output: RgDiffOutput::UnorderedLines,
         },


### PR DESCRIPTION
### Motivation

- Make `-u/--unrestricted` match `--no-ignore` semantics by disabling all per-class ignore toggles on the first `-u` so later positive flags only re-enable their intended classes.
- Fix bug where `-u --ignore-dot` unintentionally left VCS/exclude/global/parent ignore classes enabled, causing incorrect ignore-file loading.

### Description

- Updated `RgOptions::apply_unrestricted` to set `no_ignore_dot`, `no_ignore_exclude`, `no_ignore_global`, `no_ignore_parent`, and `no_ignore_vcs` when `no_ignore` is first set.
- Added a differential test case `unrestricted and ignore-dot only restores dot ignores` to prevent regressions in partial re-enable behavior.
- Modified file: `crates/bashkit/src/builtins/rg/mod.rs`.

### Testing

- Ran `cargo test -p bashkit builtins::rg::tests -- --nocapture` and the test run exercised the rg suite; the new/related rg tests passed while one unrelated existing differential test (`diff_rg_matches_real_rg_cases`) failed due to a timing-line mismatch. 
- The added differential case for `-u --ignore-dot` executed and matched the expected output in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c248f0832ba7464a23f54d9f9a)