### PR TITLE
fix(rg): apply max-count after multiline invert

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4915,6 +4915,8 @@ impl Builtin for Rg {
                     && !opts.invert_match
                 {
                     Some(opts.max_count.unwrap_or(usize::MAX).min(1))
+                } else if opts.invert_match {
+                    None
                 } else {
                     opts.max_count
                 };
@@ -4925,13 +4927,18 @@ impl Builtin for Rg {
                 if opts.invert_match {
                     let matched_line_set: HashSet<usize> =
                         context_match_lines.iter().copied().collect();
-                    let inverted_match_lines: Vec<usize> = lines
+                    let mut inverted_match_lines: Vec<usize> = lines
                         .iter()
                         .enumerate()
                         .filter_map(|(line_idx, _)| {
                             (!matched_line_set.contains(&line_idx)).then_some(line_idx)
                         })
                         .collect();
+                    if let Some(limit) = opts.max_count
+                        && inverted_match_lines.len() > limit
+                    {
+                        inverted_match_lines.truncate(limit);
+                    }
                     match_count = inverted_match_lines.len();
                     count_value = inverted_match_lines.len();
                     let inverted_matches = if opts.count_only || opts.count_matches {
@@ -12411,6 +12418,18 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         let lines: Vec<&str> = result.stdout.trim().lines().collect();
         assert_eq!(lines.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_rg_multiline_invert_max_count() {
+        let result = run_rg(
+            &["-m", "1", "-v", "-U", "foo\nbar", "/test.txt"],
+            None,
+            &[("/test.txt", b"foo\nbar\nkeep1\nfoo\nbar\nkeep2\n")],
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "keep1\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Multiline `--invert-match` was passing `opts.max_count` into positive-span collection, truncating positive spans before inversion and producing too much inverted output.
- Goal is to match ripgrep semantics: collect all positive multiline spans, then apply `-m/--max-count` to the inverted result.

### Description
- In `crates/bashkit/src/builtins/rg/mod.rs` call `collect_rg_multiline_matches` with `None` when `opts.invert_match` so positive spans are fully collected instead of truncated by `opts.max_count`.
- After building `inverted_match_lines`, apply `opts.max_count` by truncating the vector to enforce the max-count limit on inverted output.
- Added a focused regression test `test_rg_multiline_invert_max_count` in `crates/bashkit/src/builtins/rg/mod.rs` that verifies `-m 1 -v -U 'foo\nbar'` returns only the first inverted line.

### Testing
- Added unit test `test_rg_multiline_invert_max_count` which reproduces the reported regression and asserts expected output.
- Ran `cargo test -p bashkit test_rg_multiline_invert_max_count -- --nocapture` and the test passed (`1 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c14ab4832bb8b9bd7d1318aec5)