### PR TITLE
fix(rg): skip indexed prefilter for --crlf searches

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -2330,6 +2330,7 @@ async fn try_indexed_search(
 ) -> Option<Vec<(String, String)>> {
     if opts.invert_match
         || opts.files_without_matches
+        || opts.crlf
         || opts.uses_ignore_files()
         || opts.patterns.len() != 1
         || opts.max_filesize.is_some()
@@ -7534,6 +7535,25 @@ mod tests {
         let result = run_rg_with_fs(&["--no-ignore", "secret", "/safe"], None, fs).await;
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.stdout, "");
+    }
+
+    #[tokio::test]
+    async fn test_rg_crlf_skips_indexed_prefilter_and_falls_back_to_linear_scan() {
+        let inner = InMemoryFs::new();
+        inner.mkdir(Path::new("/safe"), true).await.unwrap();
+        inner
+            .write_file(Path::new("/safe/crlf.txt"), b"needle\r\nother\r\n")
+            .await
+            .unwrap();
+
+        let fs = Arc::new(IndexedTestFs {
+            inner,
+            matches: Vec::new(),
+        });
+
+        let result = run_rg_with_fs(&["--crlf", "needle$", "/safe/crlf.txt"], None, fs).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "needle\r\n");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The indexed prefilter (`try_indexed_search`) could run when `--crlf` is enabled, but `SearchQuery` has no CRLF-aware flag, allowing indexed providers to incorrectly omit candidate files and cause false-negative matches for patterns like `needle$` on CRLF files.
- The change forces fallback to the linear CRLF-aware matching path to preserve correctness when CRLF semantics are requested.

### Description
- Disable the indexed prefilter for CRLF-aware searches by adding `|| opts.crlf` to the early-return conditions in `try_indexed_search` in `crates/bashkit/src/builtins/rg/mod.rs`.
- Add a regression test `test_rg_crlf_skips_indexed_prefilter_and_falls_back_to_linear_scan` that constructs an `IndexedTestFs` with no index matches and verifies `rg --crlf 'needle$'` still finds the CRLF-terminated line via the linear scan.
- Adjusted the test assertion to match actual `rg` output for the linear path (`needle\r\n`).

### Testing
- Ran the added test with `cargo test -p bashkit test_rg_crlf_skips_indexed_prefilter_and_falls_back_to_linear_scan -- --nocapture`, which initially surfaced the failing expectation and then passed after the assertion fix.
- Ran the package test suite; the new test passed and the test run completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c192ec832b9c80d5b6b9876830)