### PR TITLE
fix(rg): count unrestricted flags independently

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -96,6 +96,7 @@ struct RgOptions {
     ignore_file_case_insensitive: bool,
     unicode: bool,
     messages: bool,
+    unrestricted_level: u8,
     context_separator: String,
     no_context_separator: bool,
     field_match_separator: String,
@@ -159,12 +160,11 @@ struct RgTypeGlob {
 
 impl RgOptions {
     fn apply_unrestricted(&mut self) {
-        if !self.no_ignore {
-            self.no_ignore = true;
-        } else if !self.hidden {
-            self.hidden = true;
-        } else {
-            self.binary = true;
+        self.unrestricted_level = self.unrestricted_level.saturating_add(1);
+        match self.unrestricted_level {
+            1 => self.no_ignore = true,
+            2 => self.hidden = true,
+            _ => self.binary = true,
         }
     }
 
@@ -235,6 +235,7 @@ impl RgOptions {
             ignore_file_case_insensitive: false,
             unicode: true,
             messages: true,
+            unrestricted_level: 0,
             context_separator: "--".to_string(),
             no_context_separator: false,
             field_match_separator: ":".to_string(),
@@ -5572,6 +5573,22 @@ mod tests {
         RgDiffCase {
             name: "unrestricted three times includes binary",
             args: &["-uuu", "needle", "proj"],
+            stdin: None,
+            files: DIFF_UNRESTRICTED_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "explicit no-ignore does not advance unrestricted level",
+            args: &["--no-ignore", "-u", "needle", "proj"],
+            stdin: None,
+            files: DIFF_UNRESTRICTED_FILES,
+            cwd: "/",
+            output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "explicit hidden does not advance unrestricted level",
+            args: &["--hidden", "-uu", "needle", "proj"],
             stdin: None,
             files: DIFF_UNRESTRICTED_FILES,
             cwd: "/",


### PR DESCRIPTION
### Motivation
- Fix correctness regression where `-u/--unrestricted` advanced behavior by inspecting current `no_ignore`/`hidden` booleans, causing explicit `--no-ignore`/`--hidden` flags to incorrectly consume unrestricted levels and producing order-dependent semantics.

### Description
- Add a new `unrestricted_level: u8` field to `RgOptions` and initialize it in `RgOptions::parse` so unrestricted usage is tracked independently of explicit flags.
- Replace `apply_unrestricted()` logic to increment `unrestricted_level` and map levels `1 => no_ignore`, `2 => hidden`, `>=3 => binary` to match ripgrep semantics regardless of flag order.
- Add two regression differential tests to `rg` test cases to cover `--no-ignore -u` and `--hidden -uu` so explicit flags do not advance unrestricted levels.
- Commit message: `fix(rg): count unrestricted flags independently`.

### Testing
- Ran the focused test with `cargo test -p bashkit rg::tests::rg_real_diff_unrestricted -- --nocapture`, and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c25518832b9c316ddf9c649175)