### PR TITLE
fix(rg): preserve collected diagnostics in quiet match paths

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4463,6 +4463,7 @@ fn rg_quiet_result(
     opts: &RgOptions,
     match_count: usize,
     any_match: &mut bool,
+    stderr: &str,
 ) -> Option<ExecResult> {
     let selected = if opts.files_without_matches {
         match_count == 0
@@ -4472,7 +4473,12 @@ fn rg_quiet_result(
     if selected {
         *any_match = true;
         if !opts.stats {
-            return Some(ExecResult::ok(String::new()));
+            return Some(ExecResult {
+                stdout: String::new(),
+                stderr: stderr.to_string(),
+                exit_code: 0,
+                ..Default::default()
+            });
         }
     }
     None
@@ -4743,7 +4749,9 @@ impl Builtin for Rg {
                 let matched = if opts.invert_match { !matched } else { matched };
                 if !matched {
                     if opts.quiet {
-                        if let Some(result) = rg_quiet_result(&opts, 0, &mut any_match) {
+                        if let Some(result) =
+                            rg_quiet_result(&opts, 0, &mut any_match, &collected_inputs.stderr)
+                        {
                             return Ok(result);
                         }
                         continue;
@@ -4775,7 +4783,9 @@ impl Builtin for Rg {
                 stats.matched_lines += 1;
                 stats.files_with_matches += 1;
                 if opts.quiet {
-                    if let Some(result) = rg_quiet_result(&opts, 1, &mut any_match) {
+                    if let Some(result) =
+                        rg_quiet_result(&opts, 1, &mut any_match, &collected_inputs.stderr)
+                    {
                         return Ok(result);
                     }
                     continue;
@@ -4952,7 +4962,12 @@ impl Builtin for Rg {
                     }
 
                     if opts.quiet {
-                        if let Some(result) = rg_quiet_result(&opts, match_count, &mut any_match) {
+                        if let Some(result) = rg_quiet_result(
+                            &opts,
+                            match_count,
+                            &mut any_match,
+                            &collected_inputs.stderr,
+                        ) {
                             return Ok(result);
                         }
                         continue;
@@ -5113,7 +5128,12 @@ impl Builtin for Rg {
                 }
 
                 if opts.quiet {
-                    if let Some(result) = rg_quiet_result(&opts, match_count, &mut any_match) {
+                    if let Some(result) = rg_quiet_result(
+                        &opts,
+                        match_count,
+                        &mut any_match,
+                        &collected_inputs.stderr,
+                    ) {
                         return Ok(result);
                     }
                     continue;
@@ -5543,7 +5563,9 @@ impl Builtin for Rg {
             }
 
             if opts.quiet {
-                if let Some(result) = rg_quiet_result(&opts, match_count, &mut any_match) {
+                if let Some(result) =
+                    rg_quiet_result(&opts, match_count, &mut any_match, &collected_inputs.stderr)
+                {
                     return Ok(result);
                 }
                 continue;
@@ -6777,6 +6799,28 @@ mod tests {
             files: DIFF_BASIC_FILES,
             cwd: "/proj",
             output: RgDiffOutput::UnorderedLines,
+        },
+        RgDiffCase {
+            name: "quiet keeps missing file diagnostics when match found",
+            args: &["-q", "needle", "proj/missing.txt", "proj/a.txt"],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "quiet no messages suppresses missing file diagnostics",
+            args: &[
+                "--no-messages",
+                "-q",
+                "needle",
+                "proj/missing.txt",
+                "proj/a.txt",
+            ],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
         },
         RgDiffCase {
             name: "relative recursive display",


### PR DESCRIPTION
### Motivation
- `collect_rg_inputs` now accumulates read errors into `collected_inputs.stderr`, but several `opts.quiet` early-return paths used `ExecResult::ok(...)` which dropped those diagnostics causing `rg -q needle missing.txt readable.txt` to lose missing-file messages when `--messages` is enabled.
- The change restores ripgrep-compatible behavior by ensuring collected read diagnostics are emitted even when quiet early-returns occur while preserving quiet-mode exit semantics.

### Description
- Replace early `return Ok(ExecResult::ok(String::new()))` quiet-path returns with `ExecResult` values that set `stdout` to empty, `stderr` to `collected_inputs.stderr.clone()`, and `exit_code` to `0` in the binary/text/multiline/line-match quiet branches.
- Add two differential test cases to the existing `rg` differential suite that cover `-q` with a missing file plus a matching readable file and the `--no-messages -q` counterpart to assert diagnostics are present or suppressed appropriately.
- Keep all other `rg` behavior and exit-code semantics unchanged.

### Testing
- Ran `cargo test -p bashkit rg::tests::test_rg_diff_cases -- --nocapture` which executed the `rg` differential cases and completed successfully with no test failures.
- Ran the repository test run during development and the test suite completed without failing tests for the exercised targets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c21c68832bb09d16321501d08b)