### PR TITLE
fix(docs-grep-agent): stop mounting lockfile-bearing example dirs

### DIFF
--- a/examples/docs-grep-agent/docs_grep_agent/app.py
+++ b/examples/docs-grep-agent/docs_grep_agent/app.py
@@ -98,8 +98,6 @@ def create_docs_bash_tool(root: Path):
     docs_mounts = [
         (root / "docs", "/docs/public"),
         (root / "crates/bashkit/docs", "/docs/rustdoc"),
-        (root / "examples/bashkit-pi", "/docs/examples/bashkit-pi"),
-        (root / "examples/browser", "/docs/examples/browser"),
     ]
     return create_bash_tool(
         username="agent",


### PR DESCRIPTION
### Motivation
- Avoid a self-test regression that expects no lockfiles under `/docs/examples` by not mounting real example directories that contain `package-lock.json` files.

### Description
- Remove mounts for `examples/bashkit-pi` and `examples/browser` from `create_docs_bash_tool` while preserving the curated in-memory `/docs/examples` corpus produced by `build_example_files(root)`.

### Testing
- Ran `python -m py_compile examples/docs-grep-agent/docs_grep_agent/app.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d8c242b4832b81eb83653c9306aa)