### PR TITLE
chore(site): allow AI content signals

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Allow: /
-# Content Signals: allow search indexing; disallow AI training and AI-input/RAG use.
-Content-Signal: ai-train=no, search=yes, ai-input=no
+# Content Signals: allow search indexing, AI training, and AI-input/RAG use.
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 
 Sitemap: https://bashkit.sh/sitemap.xml

--- a/site/scripts/verify-robots.mjs
+++ b/site/scripts/verify-robots.mjs
@@ -1,5 +1,5 @@
-// Decision: verify Content Signals in generated robots.txt so AI usage
-// preferences stay declared for bashkit.sh after future site edits.
+// Decision: verify Content Signals in generated robots.txt so permissive AI
+// usage preferences stay declared for bashkit.sh after future site edits.
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,9 +30,9 @@ const preferences = new Map(
 );
 
 const expectedPreferences = new Map([
-  ["ai-train", "no"],
+  ["ai-train", "yes"],
   ["search", "yes"],
-  ["ai-input", "no"],
+  ["ai-input", "yes"],
 ]);
 
 for (const [key, expectedValue] of expectedPreferences) {


### PR DESCRIPTION
## What
Allow bashkit.sh Content Signals for search indexing, AI training, and AI-input/RAG use.

## Why
The current robots policy allows search crawlers but opts out of AI training and AI-input use. The site policy should be permissive.

## How
- Set robots.txt Content-Signal values to `ai-train=yes, search=yes, ai-input=yes`.
- Update the postbuild verifier to enforce the permissive values.

## Risk
- Low
- Public site robots metadata changes only. Search and AI consumers that honor Content Signals may now treat the site as allowed for those uses.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verification:
- `npm run build`
- `just test`
- `just pre-pr`