### PR TITLE
ci(nightly): raise ASAN timeout to 90 minutes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,10 @@ jobs:
   asan:
     name: AddressSanitizer
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # ASAN with --test-threads=1 plus the expanded rg/coreutils
+    # differential corpora needs well over the previous 30-minute cap;
+    # the last two nightly runs cancelled mid-suite at exactly 30 min.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## What
Bump the `AddressSanitizer` job's `timeout-minutes` in `.github/workflows/nightly.yml` from 30 → 90.

## Why
The ASAN job has cancelled on the last two nightly runs (2026-05-24 and 2026-05-25), both at exactly 30 minutes into the run, both at the same `builtins::retry::tests::*` boundary in the output. That's the `timeout-minutes: 30` cap firing — the test suite simply needs more wall time under `--test-threads=1` with the expanded `rg` differential corpus and the coreutils differential harness added since the previous successful run on 2026-05-23.

Other nightly jobs (Miri, Security Analysis) finish well within their existing budgets and are unaffected.

## How
Single `timeout-minutes` value bumped to 90, with a comment explaining why.

## Risk
- Low. Only enlarges a CI timeout; cannot mask hangs since the job will still fail at 90 min if a test actually deadlocks.

## Testing
- Workflow-only change; no runtime behavior touched. CI will demonstrate the suite finishes within 90 min on the next scheduled run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDMeW6YZw6Kf9jUfXHgbbv)_