### PR TITLE
test(bench): cover VarAttrs/BashFlags + add VFS/rg/glob benches

### DIFF
--- a/crates/bashkit-bench/results/criterion-file_ops-linux-x86_64-1779759850.md
+++ b/crates/bashkit-bench/results/criterion-file_ops-linux-x86_64-1779759850.md
@@ -1,0 +1,52 @@
+# VFS / File-Ops Bench: Initial Baseline
+
+Criterion micro-benchmarks (`cargo bench --bench file_ops`) — first
+coverage for the VFS read path, tree traversal, glob expansion, `rg`,
+and `grep -r` vs `rg` parity.
+
+100 samples per case, default Criterion config. `[profile.bench]` =
+release + lto=fat + codegen-units=1. Shared seeded `InMemoryFs`
+(`FsLimits::unlimited`) per group.
+
+## Read throughput
+
+`Throughput::Bytes` reported, so the rows include MiB/s.
+
+| File size | `cat` | `grep <literal>` | `grep -c` |
+|---|---:|---:|---:|
+| 1 KB | 57 µs | 53 µs | 46 µs |
+| 1 MB | 2.97 ms (~329 MiB/s) | 4.50 ms (~217 MiB/s) | 3.70 ms (~264 MiB/s) |
+| 50 MB | 223 ms (~225 MiB/s) | 341 ms (~147 MiB/s) | 275 ms (~182 MiB/s) |
+
+## Traversal (1000-file tree across 10 subdirs)
+
+| Case | Time (median) |
+|---|---:|
+| `ls -R /work` | 1.25 ms |
+| `find /work -name 'f001.txt'` | 1.78 ms |
+| `find /work` (no filter) | 1.77 ms |
+| `for f in /work/d00/*` (shallow glob) | 267 µs |
+| `for f in /work/**/*` (globstar) | 3.35 ms |
+| `echo /work/**/*` (globstar → argv) | 2.00 ms |
+
+## `rg` workloads (same tree)
+
+| Case | Time (median) |
+|---|---:|
+| `rg needle /work` | 3.21 ms |
+| `rg '\balpha \d+ \d+\b' /work` | 3.58 ms |
+| `rg --no-ignore needle /work` | 3.17 ms |
+| `rg --multiline 'alpha.*\n.*beta' /work` | 3.60 ms |
+| `rg needle /work/d00/f000.txt` (single file) | 540 µs |
+
+## `grep -r` vs `rg` parity
+
+| Query | `grep -r` | `rg` | rg vs grep |
+|---|---:|---:|---|
+| literal `needle` | **2.06 ms** | 3.26 ms | rg **+58%** slower |
+| regex `alpha [0-9]+ [0-9]+` | **2.17 ms** | 3.38 ms | rg **+56%** slower |
+
+`rg` is consistently slower than `grep -r` on this 1000-file × ~6-line
+tree. Likely per-invocation init/threading overhead dominating on tiny
+files; `rg`'s strengths show on much larger inputs that aren't in this
+bench yet. The parity table makes the gap visible going forward.

--- a/crates/bashkit-bench/results/criterion-hotpath-attrs+shopt-linux-x86_64-1779759850.md
+++ b/crates/bashkit-bench/results/criterion-hotpath-attrs+shopt-linux-x86_64-1779759850.md
@@ -1,0 +1,68 @@
+# Hot-path Bench: Attributes + SHOPT Extensions
+
+Criterion micro-benchmarks (`cargo bench --bench hotpath`) after adding the
+`bench_attributes` group and extending `bench_shopt` to cover the parts of
+the CoW/bitset perf rework (`10cd01d`) that had no direct coverage:
+variable-attribute bitset (`declare -i/-u/-l/-r`, namerefs) and the
+remaining `BashFlags` bits (`-x`, pipefail, `-a`, `expand_aliases`).
+
+100 samples per case, default Criterion config. `[profile.bench]` =
+release + lto=fat + codegen-units=1.
+
+## New: `attributes/*`
+
+| Case | Time (median) |
+|---|---:|
+| `integer_assign_1k` | 2.39 ms |
+| `uppercase_attr_500` | 631 µs |
+| `lowercase_attr_500` | 624 µs |
+| `nameref_rw_500` | 996 µs |
+| `readonly_reassign_attempts_500` | 484 µs |
+
+## New: extra `shopt/*` cases
+
+| Case | Time (median) | vs `plain_1k_loop` |
+|---|---:|---|
+| `plain_1k_loop` (existing) | 2.65 ms | — |
+| `strict_mode_1k_loop` (existing) | 2.63 ms | flat |
+| `xtrace_1k_loop` | 2.72 ms | +2.7% (bit-test on hot path is cheap) |
+| `pipefail_pipeline_200` | 474 µs | n/a (different shape) |
+| `allexport_assign_200` | 376 µs | n/a |
+| `expand_aliases_500` | 2.64 ms | flat vs plain alias-less |
+
+## Full hotpath table (all 32 cases for the record)
+
+| Group / case | Time (median) |
+|---|---:|
+| `startup/empty` | 34.4 µs |
+| `startup/echo_hi` | 35.6 µs |
+| `startup/assign_echo` | 37.6 µs |
+| `loops/for_range_1k_arith` | 2.64 ms |
+| `loops/while_inc_1k` | 1.83 ms |
+| `loops/for_list_100` | 229 µs |
+| `loops/nested_for_50x50` | 5.64 ms |
+| `variables/assign_200` | 293 µs |
+| `variables/read_200` | 894 µs |
+| `variables/local_in_function` | 1.17 ms |
+| `attributes/integer_assign_1k` | 2.39 ms |
+| `attributes/uppercase_attr_500` | 631 µs |
+| `attributes/lowercase_attr_500` | 624 µs |
+| `attributes/nameref_rw_500` | 996 µs |
+| `attributes/readonly_reassign_attempts_500` | 484 µs |
+| `cmdsubst/subst_simple_100` | 558 µs |
+| `cmdsubst/subst_nested_3` | 50.2 µs |
+| `cmdsubst/subst_with_vars_50` | 385 µs |
+| `cmdsubst/subst_with_many_vars` | 414 µs |
+| `shopt/strict_mode_1k_loop` | 2.63 ms |
+| `shopt/plain_1k_loop` | 2.65 ms |
+| `shopt/xtrace_1k_loop` | 2.72 ms |
+| `shopt/pipefail_pipeline_200` | 474 µs |
+| `shopt/allexport_assign_200` | 376 µs |
+| `shopt/expand_aliases_500` | 2.64 ms |
+| `pipelines/seq_grep_wc` | 87.3 µs |
+| `pipelines/seq_sort_uniq` | 109 µs |
+| `functions/call_500` | 2.58 ms |
+| `functions/recursive_fib_10` | 2.38 ms |
+| `param_exp/default_op_500` | 504 µs |
+| `param_exp/substring_500` | 602 µs |
+| `param_exp/uppercase_300` | 334 µs |

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -178,6 +178,10 @@ name = "hotpath"
 harness = false
 
 [[bench]]
+name = "file_ops"
+harness = false
+
+[[bench]]
 name = "sqlite"
 harness = false
 required-features = ["sqlite"]

--- a/crates/bashkit/benches/file_ops.rs
+++ b/crates/bashkit/benches/file_ops.rs
@@ -1,0 +1,405 @@
+//! VFS / file-operation benchmarks.
+//!
+//! Today's bench coverage stops at trivial three-line `grep`/`awk`/`sed`
+//! cases. This file fills in the workloads users actually hit:
+//!
+//!   - **Read throughput** — `cat`/`grep` over 1 KB, 1 MB, 50 MB files.
+//!     Modeled on `sqlite.rs`'s backend-comparison shape (parametrized
+//!     by file size instead of backend).
+//!   - **Traversal** — `ls -R`, `find . -name`, and `for f in *` over a
+//!     1000-file generated tree.
+//!   - **`rg` workloads** — literal, regex, `--no-ignore`, `--multiline`,
+//!     recursive over the same tree. Highest-churn builtin right now
+//!     (~15 fixes in PRs #1742–#1767) with zero perf guard until this file.
+//!   - **`grep -r` vs `rg`** at parity, so regressions in either show up.
+//!   - **Glob expansion** — `echo **/*` (interpreter glob path, not a
+//!     builtin) over the same tree.
+//!
+//! The seeded VFS is built once per bench group and shared via
+//! `Bash::builder().fs(fs.clone()).build()` for each iteration — same
+//! pattern `sqlite.rs` uses for shared-VFS parallel sessions. Iterations
+//! pay one `Bash::new()` constant overhead; read paths are what we time.
+//!
+//! Run with: `cargo bench --bench file_ops`
+
+use bashkit::{Bash, FileSystem, FsLimits, InMemoryFs};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+/// File sizes for read-throughput benches.
+/// Tune the "large" entry down (e.g. to 5 MB) if running on memory-constrained
+/// CI: criterion's default 100 samples × 50 MB = 5 GB of reads per bench.
+const FILE_SIZES: &[(&str, usize)] = &[
+    ("1KB", 1024),
+    ("1MB", 1024 * 1024),
+    ("50MB", 50 * 1024 * 1024),
+];
+
+/// Total files in the generated tree, fanned out across `TREE_DIRS` subdirs.
+const TREE_FILES: usize = 1000;
+const TREE_DIRS: usize = 10;
+const TREE_ROOT: &str = "/work";
+
+/// Build a fresh seeded FS containing one `/data/file.txt` of `size` bytes.
+/// Pattern is `"abc\n"` repeated — predictable line count so we can
+/// sanity-check `wc -l` from a `verify_*` test if needed.
+fn seed_single_file(rt: &Runtime, size: usize) -> Arc<InMemoryFs> {
+    // Default FsLimits caps individual file size at 10 MB; bench needs 50 MB.
+    let fs = Arc::new(InMemoryFs::with_limits(FsLimits::unlimited()));
+    rt.block_on(async {
+        let fs_dyn: Arc<dyn FileSystem> = fs.clone();
+        fs_dyn
+            .mkdir(Path::new("/data"), true)
+            .await
+            .expect("mkdir /data");
+        let mut buf = Vec::with_capacity(size);
+        let chunk = b"abcdefghij\n"; // 11 bytes, includes newline
+        while buf.len() + chunk.len() <= size {
+            buf.extend_from_slice(chunk);
+        }
+        // Pad with zeros (no extra newlines) to hit `size` exactly.
+        buf.resize(size, b'.');
+        fs_dyn
+            .write_file(Path::new("/data/file.txt"), &buf)
+            .await
+            .expect("write /data/file.txt");
+    });
+    fs
+}
+
+/// Build a 1000-file tree fanned across 10 subdirs. Each file gets the
+/// same small body with a per-file marker, so `grep`/`rg` benches have
+/// real content to match.
+fn seed_tree(rt: &Runtime) -> Arc<InMemoryFs> {
+    let fs = Arc::new(InMemoryFs::with_limits(FsLimits::unlimited()));
+    rt.block_on(async {
+        let fs_dyn: Arc<dyn FileSystem> = fs.clone();
+        fs_dyn
+            .mkdir(Path::new(TREE_ROOT), true)
+            .await
+            .expect("mkdir root");
+        let per_dir = TREE_FILES / TREE_DIRS;
+        for d in 0..TREE_DIRS {
+            let dir = format!("{TREE_ROOT}/d{d:02}");
+            fs_dyn
+                .mkdir(Path::new(&dir), true)
+                .await
+                .expect("mkdir subdir");
+            for f in 0..per_dir {
+                let path = format!("{dir}/f{f:03}.txt");
+                // ~6 lines per file; one in five carries "needle" so
+                // recursive search has a non-trivial hit count.
+                let mut body =
+                    format!("alpha {d} {f}\nbeta {d} {f}\ngamma\ndelta\nepsilon\nzeta\n");
+                if (d * per_dir + f).is_multiple_of(5) {
+                    body.push_str("needle here\n");
+                }
+                fs_dyn
+                    .write_file(Path::new(&path), body.as_bytes())
+                    .await
+                    .expect("write tree file");
+            }
+        }
+    });
+    fs
+}
+
+/// Spin up a Bash sharing the pre-seeded VFS. One construction per iter
+/// (constant overhead) — same pattern as `parallel_execution.rs::single_*`.
+fn bash_with(fs: &Arc<InMemoryFs>) -> Bash {
+    let fs_dyn: Arc<dyn FileSystem> = fs.clone();
+    Bash::builder().fs(fs_dyn).build()
+}
+
+// ---------------------------------------------------------------------------
+// VFS read throughput: cat + grep over 1 KB / 1 MB / 50 MB.
+// ---------------------------------------------------------------------------
+
+fn bench_read_throughput(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut g = c.benchmark_group("read_throughput");
+    for (label, size) in FILE_SIZES {
+        let fs = seed_single_file(&rt, *size);
+        g.throughput(Throughput::Bytes(*size as u64));
+
+        g.bench_with_input(BenchmarkId::new("cat", label), &fs, |b, fs| {
+            b.to_async(&rt).iter(|| {
+                let fs = fs.clone();
+                async move {
+                    let mut bash = bash_with(&fs);
+                    let _ = bash.exec("cat /data/file.txt >/dev/null").await;
+                }
+            });
+        });
+
+        g.bench_with_input(BenchmarkId::new("grep_literal", label), &fs, |b, fs| {
+            b.to_async(&rt).iter(|| {
+                let fs = fs.clone();
+                async move {
+                    let mut bash = bash_with(&fs);
+                    let _ = bash.exec("grep abcdef /data/file.txt >/dev/null").await;
+                }
+            });
+        });
+
+        g.bench_with_input(BenchmarkId::new("grep_count", label), &fs, |b, fs| {
+            b.to_async(&rt).iter(|| {
+                let fs = fs.clone();
+                async move {
+                    let mut bash = bash_with(&fs);
+                    let _ = bash.exec("grep -c abc /data/file.txt >/dev/null").await;
+                }
+            });
+        });
+    }
+    g.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Tree traversal: ls -R, find, glob expansion.
+// ---------------------------------------------------------------------------
+
+fn bench_traversal(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_tree(&rt);
+    let mut g = c.benchmark_group("traversal");
+
+    g.bench_function("ls_R_1k_files", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("ls -R /work >/dev/null").await;
+            }
+        });
+    });
+
+    g.bench_function("find_by_name_1k_files", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("find /work -name 'f001.txt' >/dev/null").await;
+            }
+        });
+    });
+
+    g.bench_function("find_no_filter_1k_files", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("find /work >/dev/null").await;
+            }
+        });
+    });
+
+    // Interpreter glob expansion (NOT a builtin). Two shapes:
+    //   - shallow `*` glob (one directory level)
+    //   - recursive `**/*` glob (globstar shopt)
+    g.bench_function("glob_shallow_subdir", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("for f in /work/d00/*; do :; done").await;
+            }
+        });
+    });
+
+    g.bench_function("glob_globstar_1k_files", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash
+                    .exec("shopt -s globstar; for f in /work/**/*; do :; done")
+                    .await;
+            }
+        });
+    });
+
+    // Interpreter glob materialized into a single command's argv.
+    g.bench_function("glob_echo_globstar", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash
+                    .exec("shopt -s globstar; echo /work/**/* >/dev/null")
+                    .await;
+            }
+        });
+    });
+
+    g.finish();
+}
+
+// ---------------------------------------------------------------------------
+// rg workloads — literal, regex, --no-ignore, --multiline, recursive.
+// ---------------------------------------------------------------------------
+
+fn bench_rg(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_tree(&rt);
+    let mut g = c.benchmark_group("rg");
+
+    g.bench_function("literal_recursive", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("rg needle /work >/dev/null").await;
+            }
+        });
+    });
+
+    g.bench_function("regex_recursive", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec(r"rg '\balpha \d+ \d+\b' /work >/dev/null").await;
+            }
+        });
+    });
+
+    // --no-ignore: forces traversal to ignore .gitignore-style rules.
+    // No ignore files in the seeded tree, but the flag still exercises
+    // a different code path through the ignore stack.
+    g.bench_function("no_ignore_recursive", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("rg --no-ignore needle /work >/dev/null").await;
+            }
+        });
+    });
+
+    g.bench_function("multiline_recursive", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash
+                    .exec(r"rg --multiline 'alpha.*\n.*beta' /work >/dev/null")
+                    .await;
+            }
+        });
+    });
+
+    // Single-file rg — separates per-file overhead from traversal cost.
+    g.bench_function("literal_single_file", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("rg needle /work/d00/f000.txt >/dev/null").await;
+            }
+        });
+    });
+
+    g.finish();
+}
+
+// ---------------------------------------------------------------------------
+// grep -r vs rg parity — same query, same tree, different builtins.
+// Regressions in either show up as a divergence on the same chart.
+// ---------------------------------------------------------------------------
+
+fn bench_grep_rg_parity(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_tree(&rt);
+    let mut g = c.benchmark_group("grep_vs_rg");
+
+    g.bench_function("grep_r_literal", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("grep -r needle /work >/dev/null").await;
+            }
+        });
+    });
+
+    g.bench_function("rg_literal", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash.exec("rg needle /work >/dev/null").await;
+            }
+        });
+    });
+
+    g.bench_function("grep_r_regex", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash
+                    .exec(r"grep -rE 'alpha [0-9]+ [0-9]+' /work >/dev/null")
+                    .await;
+            }
+        });
+    });
+
+    g.bench_function("rg_regex", |b| {
+        b.to_async(&rt).iter(|| {
+            let fs = fs.clone();
+            async move {
+                let mut bash = bash_with(&fs);
+                let _ = bash
+                    .exec(r"rg 'alpha [0-9]+ [0-9]+' /work >/dev/null")
+                    .await;
+            }
+        });
+    });
+
+    g.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Sanity checks (compile-time-cheap, runs under `cargo test`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verify_seed_single_file() {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_single_file(&rt, 1024);
+    rt.block_on(async {
+        let mut bash = bash_with(&fs);
+        let res = bash.exec("wc -c </data/file.txt").await.expect("exec wc");
+        assert_eq!(res.stdout.trim(), "1024", "expected 1024 bytes");
+    });
+}
+
+#[test]
+fn verify_seed_tree() {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_tree(&rt);
+    rt.block_on(async {
+        let mut bash = bash_with(&fs);
+        let res = bash
+            .exec("find /work -type f | wc -l")
+            .await
+            .expect("exec find");
+        assert_eq!(
+            res.stdout.trim(),
+            TREE_FILES.to_string(),
+            "expected {TREE_FILES} files"
+        );
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_read_throughput,
+    bench_traversal,
+    bench_rg,
+    bench_grep_rg_parity,
+);
+criterion_main!(benches);

--- a/crates/bashkit/benches/hotpath.rs
+++ b/crates/bashkit/benches/hotpath.rs
@@ -2,8 +2,9 @@
 //!
 //! Targets the specific code paths flagged in the perf analysis:
 //!   - tight integer loops (set_variable + expand_variable)
-//!   - command substitution (subshell state snapshot cost)
-//!   - SHOPT flag checks (set -e, set -u, pipefail)
+//!   - command substitution (subshell state snapshot cost, CoW Arc maps)
+//!   - SHOPT flag checks (BashFlags bitfield: -e/-u/-x/pipefail/-a/aliases)
+//!   - variable attributes (VarAttrs bitset: -i/-u/-l/-r, namerefs map)
 //!   - parameter expansion / attribute lookups
 //!   - large pipelines
 //!
@@ -141,6 +142,102 @@ fn bench_shopt(c: &mut Criterion) {
             )
         })
     });
+    // set -x: highest-frequency BashFlags bit-test. Trace output redirected
+    // away so we measure the flag-check path, not stderr writes.
+    g.bench_function("xtrace_1k_loop", |b| {
+        b.iter(|| {
+            run_script(
+                &rt,
+                "exec 2>/dev/null; set -x\n\
+                 n=0; for ((i=0;i<1000;i++)); do n=$((n+i)); done; echo $n",
+            )
+        })
+    });
+    g.bench_function("pipefail_pipeline_200", |b| {
+        b.iter(|| {
+            run_script(
+                &rt,
+                "set -o pipefail\n\
+                 for i in $(seq 1 200); do echo $i; done | grep 5 | wc -l",
+            )
+        })
+    });
+    // set -a: every assignment also marks for export. Hits the attribute
+    // bitset + env-rebuild path that the perf commit reworked.
+    g.bench_function("allexport_assign_200", |b| {
+        let mut s = String::from("set -a\n");
+        for i in 0..200 {
+            s.push_str(&format!("v{i}={i}\n"));
+        }
+        s.push_str("echo done");
+        b.iter(|| run_script(&rt, &s));
+    });
+    g.bench_function("expand_aliases_500", |b| {
+        b.iter(|| {
+            run_script(
+                &rt,
+                "shopt -s expand_aliases\nalias e=echo\n\
+                 for i in $(seq 1 500); do e $i >/dev/null; done",
+            )
+        })
+    });
+    g.finish();
+}
+
+/// Variable-attribute hot paths reworked in the CoW/bitset commit:
+/// integer/lower/upper/readonly/nameref. Each loop forces the attribute
+/// lookup or coercion on every iteration.
+fn bench_attributes(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut g = c.benchmark_group("attributes");
+    // declare -i: every assign goes through the integer-attr branch.
+    g.bench_function("integer_assign_1k", |b| {
+        b.iter(|| {
+            run_script(
+                &rt,
+                "declare -i n=0; for ((i=0;i<1000;i++)); do n+=$i; done; echo $n",
+            )
+        })
+    });
+    // declare -u / -l: case-coercion on assign. Exercises the typed
+    // VarAttrs path (was 4-5 format!() allocs per assign pre-commit).
+    g.bench_function("uppercase_attr_500", |b| {
+        let mut s = String::from("declare -u v\n");
+        for i in 0..500 {
+            s.push_str(&format!("v=hello{i}\n"));
+        }
+        s.push_str("echo $v");
+        b.iter(|| run_script(&rt, &s));
+    });
+    g.bench_function("lowercase_attr_500", |b| {
+        let mut s = String::from("declare -l v\n");
+        for i in 0..500 {
+            s.push_str(&format!("v=HELLO{i}\n"));
+        }
+        s.push_str("echo $v");
+        b.iter(|| run_script(&rt, &s));
+    });
+    // declare -n: dedicated namerefs map. Read + write per iter.
+    g.bench_function("nameref_rw_500", |b| {
+        b.iter(|| {
+            run_script(
+                &rt,
+                "target=0; declare -n ref=target\n\
+                 for i in $(seq 1 500); do ref=$i; x=$ref; done; echo $target",
+            )
+        })
+    });
+    // declare -r: readonly check is now a bit-test; the reassignment fails
+    // but the check itself is what we time.
+    g.bench_function("readonly_reassign_attempts_500", |b| {
+        b.iter(|| {
+            run_script(
+                &rt,
+                "declare -r v=fixed; exec 2>/dev/null\n\
+                 for i in $(seq 1 500); do v=$i; done; echo $v",
+            )
+        })
+    });
     g.finish();
 }
 
@@ -205,6 +302,7 @@ criterion_group!(
     bench_startup,
     bench_loops,
     bench_variables,
+    bench_attributes,
     bench_cmdsubst,
     bench_shopt,
     bench_pipelines,


### PR DESCRIPTION
## Summary

Fills two coverage gaps in the criterion benches:

1. The CoW/bitset perf rework in `10cd01d` reworked variable attributes (`VarAttrs` bitset, dedicated namerefs map) and shell flags (`BashFlags` bitfield), but `bench_attributes` did not exist and `bench_shopt` only covered `set -eu`. Both groups are now extended directly.
2. File-builtin coverage stopped at three-line `grep`/`awk`/`sed` smoke tests. `rg` has ~15 fixes in PRs #1742–#1767 with **zero** perf guard. Added a new `file_ops` bench covering VFS reads, traversal, `rg`, and `grep -r` vs `rg` parity.

## What

**`crates/bashkit/benches/hotpath.rs`**
- New `bench_attributes`: `declare -i` integer loop, `declare -u`/`-l` coercion, `declare -n` nameref read+write, `declare -r` reassignment-check loop.
- `bench_shopt` extended: `set -x` (the highest-frequency `BashFlags` bit-test), `set -o pipefail` with a real pipeline, `set -a` auto-export, `shopt -s expand_aliases`.

**`crates/bashkit/benches/file_ops.rs`** (new)
- **Read throughput** with `Throughput::Bytes`: `cat` / `grep` / `grep -c` over 1 KB / 1 MB / 50 MB. Uses `FsLimits::unlimited()` on the seeded `InMemoryFs` because the default 10 MB cap blocks the 50 MB case.
- **Traversal**: `ls -R`, `find -name`, `find` no-filter, shallow glob, globstar, globstar-into-argv over a 1000-file / 10-subdir tree.
- **`rg`**: literal recursive, regex recursive, `--no-ignore`, `--multiline`, single-file.
- **`grep -r` vs `rg`** parity (literal + regex) on the same tree so regressions in either show up as a divergence on the same chart.

**`crates/bashkit-bench/results/criterion-{hotpath-attrs+shopt,file_ops}-linux-x86_64-1779759850.md`**
- 100-sample initial baselines following the same convention as `criterion-hotpath-perf-linux-x86_64-1779744742.md`.

## Notable finding

On the 1000-file × ~6-line tree, `rg` is consistently **~58% slower** than `grep -r`:

| Query | `grep -r` | `rg` |
|---|---:|---:|
| literal | 2.06 ms | 3.26 ms |
| regex | 2.17 ms | 3.38 ms |

Per-invocation `rg` init/threading overhead dominates on tiny files. The parity table makes the gap visible going forward.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p bashkit --benches --no-deps -- -D warnings` clean
- [x] `cargo test -p bashkit --bench hotpath --bench file_ops` — every criterion test-mode iteration prints `Success`
- [x] `cargo bench --bench hotpath` ran end-to-end with real measurements (all 32 cases)
- [x] `cargo bench --bench file_ops` ran end-to-end with real measurements (all 24 cases)
- [x] Numbers reproduced in `crates/bashkit-bench/results/criterion-*-1779759850.md`

CI to run the full `just pre-pr` sweep — the local container's disk quota is too small to fit the dev + all-features workspace build for `clippy --all-targets`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014uZkBbGt6J1FmqW2cp5tpT)_