### PR TITLE
feat(site): negotiate markdown docs

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "postbuild": "node scripts/normalize-generated-html.mjs && node scripts/verify-doc-routes.mjs && node scripts/verify-public-links.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs",
+    "postbuild": "node scripts/normalize-generated-html.mjs && node scripts/verify-doc-routes.mjs && node scripts/verify-doc-markdown-routes.mjs && node scripts/verify-public-links.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs",
     "preview": "wrangler dev",
     "deploy": "pnpm run build && wrangler deploy",
     "check": "astro check",

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,4 +1,4 @@
 # Decision: bashkit.sh does not publish an HTTP API catalog today, so advertise
-# the existing machine-readable Agent Skills index and human service docs.
+# the existing machine-readable Agent Skills index plus HTML/Markdown docs.
 /
-  Link: </.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json", </docs/>; rel="service-doc"; type="text/html"
+  Link: </.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json", </docs/>; rel="service-doc"; type="text/html", </docs.md>; rel="service-doc"; type="text/markdown"

--- a/site/scripts/verify-doc-markdown-routes.mjs
+++ b/site/scripts/verify-doc-markdown-routes.mjs
@@ -1,0 +1,158 @@
+// Decision: docs pages are dual-represented as HTML and canonical Markdown.
+// Verify the generated Markdown assets and Worker negotiation helpers together
+// so route metadata cannot drift from content negotiation behavior.
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(siteRoot, "..");
+const metaPath = path.join(siteRoot, "src/pages/docs/_meta.ts");
+const distDir = path.join(siteRoot, "dist");
+const publicDocsDir = path.join(repoRoot, "docs");
+const rustDocsDir = path.join(repoRoot, "crates/bashkit/docs");
+const workerPath = path.join(siteRoot, "src/worker.js");
+
+const entries = parseDocEntries(readFileSync(metaPath, "utf8"));
+
+const docsIndexPath = path.join(distDir, "docs.md");
+if (!existsSync(docsIndexPath)) {
+  throw new Error("Missing generated docs Markdown index: dist/docs.md");
+}
+
+const docsIndex = readFileSync(docsIndexPath, "utf8");
+assertYamlFrontmatter(docsIndex, "dist/docs.md");
+for (const entry of entries) {
+  const markdownPath = path.join(distDir, "docs", `${entry.slug}.md`);
+  if (!existsSync(markdownPath)) {
+    throw new Error(`Missing generated Markdown route: dist/docs/${entry.slug}.md`);
+  }
+
+  const sourceDir = entry.collection === "rustdocs" ? rustDocsDir : publicDocsDir;
+  const sourcePath = path.join(sourceDir, `${entry.sourceId}.md`);
+  const source = readFileSync(sourcePath, "utf8");
+  const generated = readFileSync(markdownPath, "utf8");
+  if (!generated.includes(source.trimEnd())) {
+    throw new Error(`Generated Markdown route omits source body: /docs/${entry.slug}.md`);
+  }
+
+  if (!sourceHasYamlFrontmatter(source)) {
+    assertYamlFrontmatter(generated, `dist/docs/${entry.slug}.md`);
+    for (const expected of [
+      `title: ${JSON.stringify(entry.title)}`,
+      `description: ${JSON.stringify(entry.seoDescription ?? entry.summary)}`,
+      `section: ${JSON.stringify(entry.section)}`,
+    ]) {
+      if (!generated.startsWith(`---\n`) || !generated.includes(`\n${expected}\n`)) {
+        throw new Error(`Generated Markdown front matter missing ${expected}`);
+      }
+    }
+  }
+
+  for (const expectedLink of navigationLinksFor(entry, entries)) {
+    if (!generated.includes(expectedLink)) {
+      throw new Error(`/docs/${entry.slug}.md navigation missing: ${expectedLink}`);
+    }
+  }
+
+  if (!docsIndex.includes(`(/docs/${entry.slug}/)`)) {
+    throw new Error(`docs Markdown index does not link /docs/${entry.slug}/`);
+  }
+}
+
+const { markdownAssetPath, prefersMarkdown } = await import(
+  pathToFileURL(workerPath).href
+);
+
+const cases = [
+  ["text/markdown", true],
+  ["text/markdown, text/html;q=0.9", true],
+  ["text/html, text/markdown;q=0.9", false],
+  ["text/markdown;q=0", false],
+  ["*/*", false],
+  ["", false],
+];
+
+for (const [accept, expected] of cases) {
+  const actual = prefersMarkdown(accept);
+  if (actual !== expected) {
+    throw new Error(
+      `prefersMarkdown(${JSON.stringify(accept)}) returned ${actual}, expected ${expected}`,
+    );
+  }
+}
+
+const pathCases = [
+  ["/docs", "/docs.md"],
+  ["/docs/", "/docs.md"],
+  ["/docs/cli", "/docs/cli.md"],
+  ["/docs/cli/", "/docs/cli.md"],
+  ["/docs/cli.md", null],
+  ["/builtins", null],
+];
+
+for (const [pathname, expected] of pathCases) {
+  const actual = markdownAssetPath(pathname);
+  if (actual !== expected) {
+    throw new Error(
+      `markdownAssetPath(${JSON.stringify(pathname)}) returned ${actual}, expected ${expected}`,
+    );
+  }
+}
+
+console.log(`Verified ${entries.length} docs Markdown routes and negotiation helpers.`);
+
+function parseDocEntries(source) {
+  const objectPattern = /\{\s*slug:\s*"([^"]+)"[\s\S]*?\}/g;
+  const entries = [];
+  let match;
+
+  while ((match = objectPattern.exec(source)) !== null) {
+    const block = match[0];
+    const slug = match[1];
+    entries.push({
+      slug,
+      title: extractString(block, "title"),
+      summary: extractString(block, "summary"),
+      section: extractString(block, "section"),
+      seoDescription: extractString(block, "seoDescription"),
+      collection: extractString(block, "collection") ?? "docs",
+      sourceId: extractString(block, "sourceId") ?? slug,
+    });
+  }
+
+  return entries;
+}
+
+function extractString(block, key) {
+  const fieldPattern = new RegExp(`${key}:\\s*"([^"]+)"`);
+  return fieldPattern.exec(block)?.[1];
+}
+
+function sourceHasYamlFrontmatter(source) {
+  return /^---\r?\n/.test(source);
+}
+
+function assertYamlFrontmatter(markdown, label) {
+  if (!/^---\n[\s\S]+?\n---\n/.test(markdown)) {
+    throw new Error(`${label} is missing YAML front matter`);
+  }
+}
+
+function navigationLinksFor(entry, allEntries) {
+  const index = allEntries.indexOf(entry);
+  const links = ["- [All docs](/docs/)"];
+  const previous = allEntries[index - 1];
+  const next = allEntries[index + 1];
+
+  if (previous) {
+    links.push(`- [Previous: ${previous.title}](/docs/${previous.slug}/)`);
+  }
+
+  if (next) {
+    links.push(`- [Next: ${next.title}](/docs/${next.slug}/)`);
+  }
+
+  return links;
+}

--- a/site/scripts/verify-link-headers.mjs
+++ b/site/scripts/verify-link-headers.mjs
@@ -24,6 +24,7 @@ const linkValue = linkHeaders.join(", ");
 const expectedLinks = [
   '</.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json"',
   '</docs/>; rel="service-doc"; type="text/html"',
+  '</docs.md>; rel="service-doc"; type="text/markdown"',
 ];
 
 for (const expectedLink of expectedLinks) {

--- a/site/src/pages/docs.md.ts
+++ b/site/src/pages/docs.md.ts
@@ -1,0 +1,48 @@
+// Decision: /docs has a Markdown representation for clients that prefer
+// text/markdown. Keep it generated from the same curated metadata as HTML nav.
+import type { APIRoute } from "astro";
+import { DOC_META } from "./docs/_meta";
+
+export const prerender = true;
+
+const sectionOrder = [
+  "Getting started",
+  "Reference",
+  "Features",
+  "Runtimes",
+  "Extending",
+  "Operations",
+];
+
+export const GET: APIRoute = () => {
+  const markdown = [
+    "---",
+    'title: "Bashkit docs"',
+    'description: "User-facing guides for the bashkit CLI, security model, embedded runtimes, and extension APIs."',
+    "---",
+    "",
+    "# Bashkit docs",
+    "",
+    "User-facing guides for the bashkit CLI, security model, embedded runtimes, and extension APIs.",
+    "",
+    ...sectionOrder.flatMap((section) => {
+      const docs = DOC_META.filter((doc) => doc.section === section);
+      if (docs.length === 0) {
+        return [];
+      }
+
+      return [
+        `## ${section}`,
+        "",
+        ...docs.map((doc) => `- [${doc.title}](/docs/${doc.slug}/) - ${doc.summary}`),
+        "",
+      ];
+    }),
+  ].join("\n");
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+};

--- a/site/src/pages/docs/[slug].md.ts
+++ b/site/src/pages/docs/[slug].md.ts
@@ -1,0 +1,101 @@
+// Decision: docs Markdown responses are the canonical source files, not a
+// lossy HTML-to-Markdown conversion. This keeps agents and humans reading the
+// same maintained guide text.
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { APIRoute, GetStaticPaths } from "astro";
+import { DOC_META, type DocMeta } from "./_meta";
+
+type Collection = "docs" | "rustdocs";
+
+type MarkdownRouteProps = {
+  meta: DocMeta;
+  previous?: DocMeta;
+  next?: DocMeta;
+  sourcePath: string;
+};
+
+const siteRoot = process.cwd();
+const repoRoot = path.resolve(siteRoot, "..");
+const sourceDirs: Record<Collection, string> = {
+  docs: path.join(repoRoot, "docs"),
+  rustdocs: path.join(repoRoot, "crates/bashkit/docs"),
+};
+
+export const prerender = true;
+
+export const getStaticPaths: GetStaticPaths = () =>
+  DOC_META.map((meta, index) => {
+    const collection = meta.collection ?? "docs";
+    const sourceId = meta.sourceId ?? meta.slug;
+
+    return {
+      params: { slug: meta.slug },
+      props: {
+        meta,
+        previous: DOC_META[index - 1],
+        next: DOC_META[index + 1],
+        sourcePath: path.join(sourceDirs[collection], `${sourceId}.md`),
+      } satisfies MarkdownRouteProps,
+    };
+  });
+
+export const GET: APIRoute<MarkdownRouteProps> = async ({ props }) => {
+  const source = await readFile(props.sourcePath, "utf8");
+  const markdown = renderMarkdownResponse(source, props.meta, props.previous, props.next);
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+};
+
+function renderMarkdownResponse(
+  source: string,
+  meta: DocMeta,
+  previous?: DocMeta,
+  next?: DocMeta,
+): string {
+  const parts = [];
+  const body = source.trimEnd();
+
+  if (!hasYamlFrontmatter(body)) {
+    parts.push(renderFrontmatter(meta));
+  }
+
+  parts.push(body, renderNavigation(previous, next));
+  return `${parts.join("\n\n")}\n`;
+}
+
+function hasYamlFrontmatter(markdown: string): boolean {
+  return /^---\r?\n/.test(markdown);
+}
+
+function renderFrontmatter(meta: DocMeta): string {
+  return [
+    "---",
+    `title: ${yamlString(meta.title)}`,
+    `description: ${yamlString(meta.seoDescription ?? meta.summary)}`,
+    `section: ${yamlString(meta.section)}`,
+    "---",
+  ].join("\n");
+}
+
+function renderNavigation(previous?: DocMeta, next?: DocMeta): string {
+  const links = ["- [All docs](/docs/)"];
+
+  if (previous) {
+    links.push(`- [Previous: ${previous.title}](/docs/${previous.slug}/)`);
+  }
+
+  if (next) {
+    links.push(`- [Next: ${next.title}](/docs/${next.slug}/)`);
+  }
+
+  return ["---", "", "## Navigation", "", ...links].join("\n");
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}

--- a/site/src/worker.js
+++ b/site/src/worker.js
@@ -1,0 +1,117 @@
+// Decision: keep the Astro site static and do content negotiation at the
+// Cloudflare Worker edge. HTML stays the default; Markdown is served only when
+// the client explicitly prefers `text/markdown`.
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const assetPath = markdownAssetPath(url.pathname);
+
+    if (
+      assetPath &&
+      (request.method === "GET" || request.method === "HEAD") &&
+      prefersMarkdown(request.headers.get("Accept") ?? "")
+    ) {
+      const markdownUrl = new URL(assetPath, url);
+      const response = await env.ASSETS.fetch(new Request(markdownUrl, request));
+      if (response.ok) {
+        return withVary(response, "Accept", "text/markdown; charset=utf-8");
+      }
+    }
+
+    const response = await env.ASSETS.fetch(request);
+    if (assetPath) {
+      return withVary(response, "Accept");
+    }
+    return response;
+  },
+};
+
+export function markdownAssetPath(pathname) {
+  if (pathname === "/docs" || pathname === "/docs/") {
+    return "/docs.md";
+  }
+
+  const match = /^\/docs\/([^/.]+)\/?$/.exec(pathname);
+  if (!match) {
+    return null;
+  }
+
+  return `/docs/${match[1]}.md`;
+}
+
+export function prefersMarkdown(acceptHeader) {
+  const markdownQ = qualityFor(acceptHeader, "text/markdown", {
+    includeWildcards: false,
+  });
+  if (markdownQ <= 0) {
+    return false;
+  }
+
+  const htmlQ = qualityFor(acceptHeader, "text/html");
+  return markdownQ >= htmlQ;
+}
+
+function qualityFor(acceptHeader, mediaType, options = {}) {
+  const includeWildcards = options.includeWildcards ?? true;
+  let best = 0;
+
+  for (const part of acceptHeader.split(",")) {
+    const [rawType, ...params] = part.trim().split(";");
+    const type = rawType.toLowerCase();
+    if (!type || !matchesMediaType(type, mediaType, includeWildcards)) {
+      continue;
+    }
+
+    const qParam = params.find((param) => param.trim().toLowerCase().startsWith("q="));
+    const q = qParam ? Number.parseFloat(qParam.split("=")[1]) : 1;
+    if (Number.isFinite(q)) {
+      best = Math.max(best, Math.min(Math.max(q, 0), 1));
+    }
+  }
+
+  return best;
+}
+
+function matchesMediaType(candidate, mediaType, includeWildcards) {
+  if (candidate === mediaType) {
+    return true;
+  }
+
+  if (!includeWildcards) {
+    return false;
+  }
+
+  const [candidateType, candidateSubtype] = candidate.split("/");
+  const [mediaTypeType, mediaTypeSubtype] = mediaType.split("/");
+  return (
+    (candidateType === "*" || candidateType === mediaTypeType) &&
+    (candidateSubtype === "*" || candidateSubtype === mediaTypeSubtype)
+  );
+}
+
+function withVary(response, headerName, contentType) {
+  const headers = new Headers(response.headers);
+  appendVary(headers, headerName);
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function appendVary(headers, headerName) {
+  const vary = headers.get("Vary");
+  if (!vary) {
+    headers.set("Vary", headerName);
+    return;
+  }
+
+  const values = vary.split(",").map((value) => value.trim().toLowerCase());
+  if (!values.includes(headerName.toLowerCase())) {
+    headers.set("Vary", `${vary}, ${headerName}`);
+  }
+}

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -1,8 +1,11 @@
 {
   "name": "bashkit",
+  "main": "./src/worker.js",
   "compatibility_date": "2025-10-01",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": ["/docs", "/docs/*"]
   },
   "observability": {
     "enabled": true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,9 +3,12 @@
 // the Astro project and generated assets live under site/.
 {
   "name": "bashkit",
+  "main": "./site/src/worker.js",
   "compatibility_date": "2025-10-01",
   "assets": {
-    "directory": "./site/dist"
+    "directory": "./site/dist",
+    "binding": "ASSETS",
+    "run_worker_first": ["/docs", "/docs/*"]
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## What
Add negotiated Markdown representations for Bashkit docs pages.

## Why
Docs should be readable by clients that explicitly prefer `text/markdown` without changing the default browser HTML experience.

## How
- Generate `/docs.md` and `/docs/<slug>.md` static Markdown assets from the existing curated docs metadata and canonical source markdown.
- Add a Cloudflare Worker that serves Markdown for docs URLs only when `Accept` explicitly prefers `text/markdown`, with `Vary: Accept` for cache correctness.
- Add YAML front matter and generated navigation to negotiated Markdown docs.
- Extend postbuild verification for generated Markdown routes, negotiation helpers, and Markdown docs discovery headers.

## Risk
- Low
- Docs routes could serve the wrong representation if Worker routing or Accept parsing regresses; postbuild and Wrangler smoke coverage guard this.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
