### PR TITLE
fix(interpreter): enforce tool hooks for `command` host-builtins

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6622,52 +6622,38 @@ impl Interpreter {
                 // Build a synthetic simple command and execute it, skipping function lookup
                 let remaining = &args[cmd_args_start..];
                 let target = remaining[0].as_str();
+                let builtin_args = &remaining[1..];
                 // Resolve host-registered builtins first (same precedence as dispatch_command).
-                let builtin = self
+                if let Some(builtin) = self
                     .host_builtins
                     .as_ref()
                     .and_then(|reg| reg.lookup(target))
-                    .or_else(|| self.builtins.get(target).cloned());
-                if let Some(builtin) = builtin {
-                    let builtin_args = &remaining[1..];
-                    let execution_extensions = self.current_execution_extensions();
-                    let shell_ref = ShellRef {
-                        builtins: &self.builtins,
-                        functions: &self.functions,
-                        aliases: Arc::make_mut(&mut self.aliases),
-                        traps: Arc::make_mut(&mut self.traps),
-                        var_attrs: Arc::make_mut(&mut self.var_attrs),
-                        namerefs: Arc::make_mut(&mut self.namerefs),
-                        call_stack: &self.call_stack,
-                        history: &self.history,
-                        jobs: &self.jobs,
-                        execution_extensions,
-                    };
-                    let ctx = builtins::Context {
-                        args: builtin_args,
-                        env: &self.env,
-                        variables: Arc::make_mut(&mut self.variables),
-                        cwd: &mut self.cwd,
-                        fs: Arc::clone(&self.fs),
-                        stdin: _stdin.as_deref(),
-                        #[cfg(feature = "http_client")]
-                        http_client: self.http_client.as_ref(),
-                        #[cfg(feature = "git")]
-                        git_client: self.git_client.as_ref(),
-                        #[cfg(feature = "ssh")]
-                        ssh_client: self.ssh_client.as_ref(),
-                        shell: Some(shell_ref),
-                    };
-                    let mut result = builtin.execute(ctx).await?;
-                    self.apply_builtin_side_effects(&result);
-                    result = self.apply_redirections(result, redirects).await?;
-                    Ok(result)
-                } else {
-                    Ok(ExecResult::err(
-                        format!("bash: {}: command not found\n", remaining[0]),
-                        127,
-                    ))
+                {
+                    return self
+                        .execute_host_builtin(
+                            target,
+                            builtin,
+                            builtin_args,
+                            _stdin.as_deref(),
+                            redirects,
+                        )
+                        .await;
                 }
+                if let Some(builtin) = self.builtins.get(target).cloned() {
+                    return self
+                        .execute_builtin_arc(
+                            target,
+                            builtin,
+                            builtin_args,
+                            _stdin.as_deref(),
+                            redirects,
+                        )
+                        .await;
+                }
+                Ok(ExecResult::err(
+                    format!("bash: {}: command not found\n", remaining[0]),
+                    127,
+                ))
             }
         }
     }

--- a/crates/bashkit/tests/builtin_registry_tests.rs
+++ b/crates/bashkit/tests/builtin_registry_tests.rs
@@ -6,7 +6,7 @@
 //! after the `Bash` instance has been built — without rebuilding it.
 
 use async_trait::async_trait;
-use bashkit::{Bash, Builtin, BuiltinContext, BuiltinRegistry, ExecResult};
+use bashkit::{Bash, Builtin, BuiltinContext, BuiltinRegistry, ExecResult, hooks};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -180,4 +180,29 @@ async fn command_v_finds_host_builtin() {
         "got: {}",
         result.stdout
     );
+}
+
+#[tokio::test]
+async fn command_respects_before_tool_for_host_builtin() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("sensitive", Arc::new(EchoArgs));
+
+    let mut bash = Bash::builder()
+        .builtin_registry(registry)
+        .before_tool(Box::new(|event: hooks::ToolEvent| {
+            if event.name == "sensitive" {
+                hooks::HookAction::Cancel("sensitive blocked".to_string())
+            } else {
+                hooks::HookAction::Continue(event)
+            }
+        }))
+        .build();
+
+    let direct = bash.exec("sensitive direct").await.unwrap();
+    assert_eq!(direct.exit_code, 1);
+    assert!(direct.stderr.contains("cancelled by before_tool hook"));
+
+    let via_command = bash.exec("command sensitive via-command").await.unwrap();
+    assert_eq!(via_command.exit_code, 1);
+    assert!(via_command.stderr.contains("cancelled by before_tool hook"));
 }


### PR DESCRIPTION
### Motivation
- Close a security regression where `command <name>` could bypass `before_tool`/`after_tool` hooks and panic/execution-plan wrappers for host-registered builtins, allowing hook-based policy to be avoided.
- Make `command` dispatch semantics identical to normal builtin dispatch so embedder-enforced interceptors and safety wrappers always run.

### Description
- Route `command <name>` host-builtin execution through the shared helper `execute_host_builtin(...)` so `before_tool`/`after_tool`, execution-plan handling, and panic catching apply (change in `crates/bashkit/src/interpreter/mod.rs`).
- Route baked-in builtin execution in the same `command` path via `execute_builtin_arc(...)` for parity instead of calling `builtin.execute(...)` directly.
- Remove the direct `builtin.execute(ctx).await` path and return consistent `ExecResult`/redirection handling.
- Add regression test `command_respects_before_tool_for_host_builtin` in `crates/bashkit/tests/builtin_registry_tests.rs` and import `hooks` to verify `before_tool` cancellation blocks both direct and `command`-invoked host builtins.

### Testing
- Ran `cargo test -p bashkit --test builtin_registry_tests` and all tests passed (`10 passed; 0 failed`).
- No other automated test suites were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b303a1a8832b8323508227c11a56)