### PR TITLE
fix(rg): bound color match amplification for dense patterns

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3703,6 +3703,7 @@ struct RgPrefix<'a> {
 }
 
 const RG_ANSI_RESET: &str = "\x1b[0m";
+const RG_COLOR_MATCH_EXTRA_BYTES_LIMIT: usize = 64 * 1024;
 
 fn color_path(path: &str, color: bool, color_scheme: &RgColorScheme) -> String {
     if color {
@@ -3807,6 +3808,24 @@ fn intense_ansi_code(code: &str, intense: bool) -> String {
 
 fn color_matches(text: &str, regex: &RgMatcher, opts: &RgOptions) -> String {
     if !opts.color_enabled() {
+        return text.to_string();
+    }
+    let mut estimated_extra = 0usize;
+    let per_match_extra = 32usize;
+    let mut bailout = false;
+    regex.for_each_match(text, |mat| {
+        if bailout {
+            return;
+        }
+        estimated_extra = estimated_extra.saturating_add(per_match_extra);
+        if mat.start() == mat.end() {
+            estimated_extra = estimated_extra.saturating_add(1);
+        }
+        if estimated_extra > RG_COLOR_MATCH_EXTRA_BYTES_LIMIT {
+            bailout = true;
+        }
+    });
+    if bailout {
         return text.to_string();
     }
     if opts.color_scheme.highlight.enabled {
@@ -13121,6 +13140,15 @@ mod tests {
             hyperlink.stdout,
             "\x1b]8;;file:///file.txt:1:1\x1b\\\x1b[0m\x1b[35m/file.txt\x1b[0m:\x1b[0m\x1b[32m1\x1b[0m:\x1b[0m1\x1b[0m\x1b]8;;\x1b\\:\x1b[0m\x1b[1m\x1b[31mneedle\x1b[0m again\n"
         );
+    }
+
+    #[tokio::test]
+    async fn test_rg_color_always_falls_back_for_dense_matches() {
+        let dense = "a".repeat((RG_COLOR_MATCH_EXTRA_BYTES_LIMIT / 8) + 16);
+        let files = vec![("/file.txt", dense.as_bytes())];
+        let result = run_rg(&["--color=always", "a", "/file.txt"], None, &files).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, format!("{dense}\n"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- The `rg` builtin built fully colorized match output in memory when `--color=always`/`ansi` is used, allowing dense or zero-width matches to amplify small inputs into very large allocations and cause DoS/OOM before the interpreter-level stdout cap applies. 
- Prevent unbounded per-line expansion while preserving normal coloring for typical inputs.

### Description
- Add a per-line guard constant `RG_COLOR_MATCH_EXTRA_BYTES_LIMIT` and pre-scan in `color_matches` that estimates ANSI overhead and returns the original plain `text` when estimated expansion would exceed the limit, avoiding large allocations. 
- Use a conservative per-match estimate to cover ANSI prefixes/suffixes and zero-length matches. 
- Add a regression test `test_rg_color_always_falls_back_for_dense_matches` that exercises dense one-byte matches with `--color=always` to verify the fallback to plain output. 
- Modified file: `crates/bashkit/src/builtins/rg/mod.rs`.

### Testing
- Ran the focused unit test with `cargo test -p bashkit test_rg_color_always_falls_back_for_dense_matches -- --nocapture`, and the test passed (`1 passed`).
- Note: attempted `git fetch origin main && git rebase origin/main` could not run in this environment because the `origin` remote is not configured, so the branch was not rebased onto remote `main` here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b5a37514832b8c83eeef0cb6ea39)