### PR TITLE
fix(rg): harden hyperlink URL interpolation

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3928,18 +3928,52 @@ fn write_rg_prefix(output: &mut String, prefix: RgPrefix<'_>) {
 
 fn format_hyperlink_url(format: &str, filename: &str, line: usize, column: usize) -> String {
     let path = hyperlink_path(filename);
-    format
-        .replace("{path}", &path)
-        .replace("{line}", &line.to_string())
-        .replace("{column}", &column.to_string())
+    let line = line.to_string();
+    let column = column.to_string();
+    let mut out = String::with_capacity(format.len() + path.len());
+    let mut rest = format;
+
+    while let Some(start) = rest.find('{') {
+        out.push_str(&rest[..start]);
+        let tail = &rest[start..];
+        if let Some(remaining) = tail.strip_prefix("{path}") {
+            out.push_str(&path);
+            rest = remaining;
+        } else if let Some(remaining) = tail.strip_prefix("{line}") {
+            out.push_str(&line);
+            rest = remaining;
+        } else if let Some(remaining) = tail.strip_prefix("{column}") {
+            out.push_str(&column);
+            rest = remaining;
+        } else {
+            out.push('{');
+            rest = &tail[1..];
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 fn hyperlink_path(filename: &str) -> String {
-    if filename.starts_with('/') {
+    let normalized = if filename.starts_with('/') {
         filename.to_string()
     } else {
         format!("/{}", filename.trim_start_matches("./"))
+    };
+    percent_encode_url_path(&normalized)
+}
+
+fn percent_encode_url_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for &b in path.as_bytes() {
+        if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~' | b'/') {
+            out.push(char::from(b));
+        } else {
+            out.push('%');
+            out.push_str(&format!("{b:02X}"));
+        }
     }
+    out
 }
 
 #[derive(Clone, Copy)]
@@ -13121,6 +13155,18 @@ mod tests {
             hyperlink.stdout,
             "\x1b]8;;file:///file.txt:1:1\x1b\\\x1b[0m\x1b[35m/file.txt\x1b[0m:\x1b[0m\x1b[32m1\x1b[0m:\x1b[0m1\x1b[0m\x1b]8;;\x1b\\:\x1b[0m\x1b[1m\x1b[31mneedle\x1b[0m again\n"
         );
+    }
+
+    #[test]
+    fn format_hyperlink_url_does_not_rewrite_placeholder_text_in_path() {
+        let url = format_hyperlink_url("file://{path}:{line}:{column}", "/proj/a{line}.txt", 12, 5);
+        assert_eq!(url, "file:///proj/a%7Bline%7D.txt:12:5");
+    }
+
+    #[test]
+    fn format_hyperlink_url_percent_encodes_url_delimiters_in_path() {
+        let url = format_hyperlink_url("file://{path}", "/proj/sp ace#q?.txt", 1, 1);
+        assert_eq!(url, "file:///proj/sp%20ace%23q%3F.txt");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation

- Prevent terminal/UI spoofing by ensuring `rg` OSC 8 hyperlink URLs cannot be altered by placeholder-like text inside filenames. 
- Ensure hyperlinks embed the intended path safely by encoding URL-sensitive characters before emission.

### Description

- Change `format_hyperlink_url` to single-pass token interpolation so `{path}` insertion cannot be rewritten by later `{line}`/`{column}` replacements. 
- Percent-encode filename-derived path bytes via `percent_encode_url_path` and use it from `hyperlink_path` so spaces, `#`, `?`, braces, etc. are safe in URLs. 
- Add focused unit tests `format_hyperlink_url_does_not_rewrite_placeholder_text_in_path` and `format_hyperlink_url_percent_encodes_url_delimiters_in_path` that assert placeholder preservation and correct percent-encoding.

### Testing

- Ran `cargo test -p bashkit format_hyperlink_url_` which executed the new focused tests and they passed (`2 passed; 0 failed`).
- Package test run completed with no failures observed for the exercised tests (many other tests were filtered out during the focused run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b5a39118832bb07dcacc327314d3)