### PR TITLE
fix(interpreter): resolve array elements in arithmetic param expansion

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -9631,7 +9631,7 @@ impl Interpreter {
             match ch {
                 '%' => {
                     let name = &inner[..pos];
-                    let value = self.expand_variable(name);
+                    let value = self.expand_name_or_array_element(name);
                     if inner[pos..].starts_with("%%") {
                         let pattern = &inner[pos + 2..];
                         return self.remove_pattern(&value, pattern, false, true);
@@ -9641,7 +9641,7 @@ impl Interpreter {
                 }
                 '#' if pos > 0 => {
                     let name = &inner[..pos];
-                    let value = self.expand_variable(name);
+                    let value = self.expand_name_or_array_element(name);
                     if inner[pos..].starts_with("##") {
                         let pattern = &inner[pos + 2..];
                         return self.remove_pattern(&value, pattern, true, true);
@@ -9652,7 +9652,7 @@ impl Interpreter {
                 ':' if inner[pos..].starts_with(":-") => {
                     let name = &inner[..pos];
                     let default = &inner[pos + 2..];
-                    let value = self.expand_variable(name);
+                    let value = self.expand_name_or_array_element(name);
                     if value.is_empty() {
                         return default.to_string();
                     }
@@ -9662,7 +9662,32 @@ impl Interpreter {
             }
         }
         // Fallback
-        self.expand_variable(inner)
+        self.expand_name_or_array_element(inner)
+    }
+
+    /// Resolve `name` or `arr[idx]` to its current string value.
+    /// Used by parameter expansion inside arithmetic so `${arr[$key]:-N}` and
+    /// friends can read associative/indexed array elements — `expand_variable`
+    /// alone only handles scalar names. Fixes issue #1776.
+    fn expand_name_or_array_element(&self, name: &str) -> String {
+        if let Some(bracket) = name.find('[')
+            && name.ends_with(']')
+        {
+            let arr_name = &name[..bracket];
+            let resolved = self.resolve_nameref(arr_name);
+            let idx_str = &name[bracket + 1..name.len() - 1];
+            if let Some(arr) = self.assoc_arrays.get(resolved) {
+                let key = self.expand_variable_or_literal(idx_str);
+                return arr.get(&key).cloned().unwrap_or_default();
+            }
+            if let Some(arr) = self.arrays.get(resolved) {
+                let idx_val = self.evaluate_arithmetic(idx_str);
+                let idx_usize: usize = idx_val.try_into().unwrap_or(0);
+                return arr.get(&idx_usize).cloned().unwrap_or_default();
+            }
+            return String::new();
+        }
+        self.expand_variable(name)
     }
 
     /// Parse and evaluate a simple arithmetic expression with depth tracking.

--- a/crates/bashkit/tests/issue_1776_test.rs
+++ b/crates/bashkit/tests/issue_1776_test.rs
@@ -1,0 +1,50 @@
+//! Test for issue #1776: associative array element assignment doesn't persist
+//! across `for` loop iterations when the right-hand-side is an arithmetic
+//! expansion that reads the same element via `${arr[$key]:-default}`.
+
+use bashkit::Bash;
+
+#[tokio::test]
+async fn assoc_array_increment_across_for_loop() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+declare -A counts
+for item in a b a c a b; do
+    counts[$item]=$(( ${counts[$item]:-0} + 1 ))
+done
+echo "a=${counts[a]} b=${counts[b]} c=${counts[c]}"
+"#,
+        )
+        .await
+        .unwrap();
+    assert!(
+        result.stdout.contains("a=3 b=2 c=1"),
+        "expected a=3 b=2 c=1, got: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn assoc_array_default_in_arithmetic_with_variable_subscript() {
+    // Narrow repro: ${arr[$key]:-N} inside $(( )) must resolve the subscript
+    // through the array lookup path, not via `expand_variable("arr[$key]")`.
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+declare -A counts
+counts[a]=5
+item=a
+echo "outside=$(( ${counts[$item]:-0} ))"
+"#,
+        )
+        .await
+        .unwrap();
+    assert!(
+        result.stdout.contains("outside=5"),
+        "expected outside=5, got: {}",
+        result.stdout
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1776.

`${arr[$key]:-N}` and the other parameter-expansion operators (`%`, `%%`, `#`, `##`) inside `$(( ))` used to call `expand_variable("arr[$key]")`, which only handles scalar names. The lookup therefore returned empty and `:-` always fell through to the default — so a loop like

```bash
declare -A counts
for item in a b a c a b; do
    counts[$item]=$(( ${counts[$item]:-0} + 1 ))
done
```

stored `1` for every key instead of accumulating counts. The write side was fine; the read side inside `$(( ))` simply never saw the prior element.

## Changes

- New helper `expand_name_or_array_element(name)` resolves `arr[idx]` via `assoc_arrays`/`arrays` (with `expand_variable_or_literal` on the subscript so `$item`/`${item}` keys work) and falls back to `expand_variable` for scalar names.
- `expand_param_op_in_arithmetic` now calls the helper from every branch (`%`, `%%`, `#`, `##`, `:-`, and the fallback).

## Out of scope

The issue notes an adjacent observation about `((arr[$key]++))` not storing (and `${!arr[@]}` then yielding duplicate/empty keys). That's a separate bug in `evaluate_arithmetic_with_assign` — the `++`/`--`/compound-assign branches reject `arr[idx]` via `is_valid_var_name` and silently fall through. Tracked separately so this PR stays small.

## Test plan

- [x] `cargo test -p bashkit --test issue_1776_test` — two new tests covering the loop case and a narrow `$(( ${arr[$key]:-0} ))` repro
- [x] `cargo test -p bashkit --lib` — 2284 passed; only pre-existing `diff_rg_matches_real_rg_cases` fails locally (rg 14 vs CI rg 15)
- [x] `cargo clippy --lib -p bashkit -- -D warnings`
- [x] `cargo fmt --check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVEjQVorcJhCU1L76M6Tbp)_