### PR TITLE
fix(site): add homepage canonical link header

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,4 +1,4 @@
 # Decision: bashkit.sh does not publish an HTTP API catalog today, so advertise
 # the existing machine-readable Agent Skills index plus HTML/Markdown docs.
 /
-  Link: </index.md>; rel="alternate"; type="text/markdown", </.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json", </docs/>; rel="service-doc"; type="text/html", </docs.md>; rel="service-doc"; type="text/markdown"
+  Link: <https://bashkit.sh/>; rel="canonical", </index.md>; rel="alternate"; type="text/markdown", </.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json", </docs/>; rel="service-doc"; type="text/html", </docs.md>; rel="service-doc"; type="text/markdown"

--- a/site/scripts/verify-link-headers.mjs
+++ b/site/scripts/verify-link-headers.mjs
@@ -22,6 +22,7 @@ if (!homeHeaders) {
 const linkHeaders = homeHeaders.get("link") ?? [];
 const linkValue = linkHeaders.join(", ");
 const expectedLinks = [
+  '<https://bashkit.sh/>; rel="canonical"',
   '</index.md>; rel="alternate"; type="text/markdown"',
   '</.well-known/agent-skills/index.json>; rel="service-desc"; type="application/json"',
   '</docs/>; rel="service-doc"; type="text/html"',


### PR DESCRIPTION
## What
Add a canonical `Link` header for the bashkit.sh homepage.

## Why
Google Search Console reported `http://bashkit.sh/` as an alternate page with a canonical tag. The HTML canonical already points to `https://bashkit.sh/`; the response header should advertise the same canonical URL.

## How
- Adds `<https://bashkit.sh/>; rel="canonical"` to the `/` rule in `site/public/_headers`.
- Updates `site/scripts/verify-link-headers.mjs` so postbuild fails if the homepage canonical header is removed.

## Risk
- Low
- Static header-only site change. Main risk is malformed `Link` header syntax, covered by the existing build-time verifier.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] `pnpm --dir site run build`
- [x] `just pre-pr`