### PR TITLE
fix(ci): bypass pnpm `--` separator that breaks napi build flag forwarding

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -38,24 +38,24 @@ jobs:
         settings:
           - host: macos-latest
             target: x86_64-apple-darwin
-            build: pnpm run build:napi -- --target x86_64-apple-darwin && pnpm run build:cjs && pnpm run build:ts
+            build: pnpm exec napi build --platform --release --target x86_64-apple-darwin && pnpm run build:cjs && pnpm run build:ts
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: pnpm run build:napi -- --target aarch64-apple-darwin && pnpm run build:cjs && pnpm run build:ts
+            build: pnpm exec napi build --platform --release --target aarch64-apple-darwin && pnpm run build:cjs && pnpm run build:ts
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: pnpm run build:napi -- --target x86_64-unknown-linux-gnu --use-napi-cross && pnpm run build:cjs && pnpm run build:ts
+            build: pnpm exec napi build --platform --release --target x86_64-unknown-linux-gnu --use-napi-cross && pnpm run build:cjs && pnpm run build:ts
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            build: pnpm run build:napi -- --target aarch64-unknown-linux-gnu && pnpm run build:cjs && pnpm run build:ts
+            build: pnpm exec napi build --platform --release --target aarch64-unknown-linux-gnu && pnpm run build:cjs && pnpm run build:ts
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-            build: pnpm run build:napi -- --target x86_64-pc-windows-msvc && pnpm run build:cjs && pnpm run build:ts
+            build: pnpm exec napi build --platform --release --target x86_64-pc-windows-msvc && pnpm run build:cjs && pnpm run build:ts
           # TODO: WASM disabled — tokio "full" features (from bashkit core) are
           # unsupported on wasm32. Needs architectural fix to gate tokio features.
           # - host: ubuntu-latest
           #   target: wasm32-wasip1-threads
-          #   build: pnpm run build:napi -- --target wasm32-wasip1-threads && pnpm run build:cjs && pnpm run build:ts
+          #   build: pnpm exec napi build --platform --release --target wasm32-wasip1-threads && pnpm run build:cjs && pnpm run build:ts
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

The v0.7.2 npm publish failed because `pnpm run build:napi -- ...` inserts a `--` separator that napi-rs CLI treats as "forward everything after to cargo." So `--use-napi-cross` (a napi flag) got routed to cargo and crashed with `error: unexpected argument '--use-napi-cross' found`. (With npm there was no inserted separator, so the flag stayed with napi — the pnpm migration in #1766 silently changed the behaviour, but it wasn't exercised until the v0.7.2 release run.)

Fix: replace `pnpm run build:napi -- ...` with `pnpm exec napi build ...` so napi is invoked directly with no separator inserted.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, manually dispatch `publish-js.yml` on `main` — npm should receive `@everruns/bashkit@0.7.2` (package.json on main is already at 0.7.2 from the v0.7.2 release).


---
_Generated by [Claude Code](https://claude.ai/code/session_019kNtzz8Ere2zoJnThMdbUY)_