### PR TITLE
feat(site): add bashkit logo assets

### DIFF
--- a/logo-dark.svg
+++ b/logo-dark.svg
@@ -1,5 +1,7 @@
-<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bashkit">
-  <!-- Decision: favicon uses the same Everruns navy/gold tile as the primary mark. -->
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <!-- Decision: dark-surface variant removes the tile and keeps Everruns gold plus white/gold prompt contrast. -->
+  <title id="title">Bashkit dark logo</title>
+  <desc id="desc">Three gold speed lines and a shell prompt arrow for dark backgrounds.</desc>
   <defs>
     <linearGradient id="prompt" x1="212" y1="154" x2="368" y2="358" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#FFFFFF"/>
@@ -7,7 +9,6 @@
       <stop offset="1" stop-color="#D4A43A"/>
     </linearGradient>
   </defs>
-  <rect width="512" height="512" rx="112" fill="#0A1636"/>
   <rect x="112" y="177" width="74" height="18" rx="9" fill="#D4A43A"/>
   <rect x="82" y="247" width="104" height="18" rx="9" fill="#D4A43A"/>
   <rect x="122" y="317" width="64" height="18" rx="9" fill="#D4A43A"/>

--- a/logo-mono.svg
+++ b/logo-mono.svg
@@ -1,0 +1,15 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <!-- Decision: mono uses the exact final geometry for one-color package, print, and mask surfaces. -->
+  <title id="title">Bashkit mono logo</title>
+  <desc id="desc">Three speed lines and a shell prompt arrow in one color.</desc>
+  <rect x="112" y="177" width="74" height="18" rx="9" fill="#0A0A0A"/>
+  <rect x="82" y="247" width="104" height="18" rx="9" fill="#0A0A0A"/>
+  <rect x="122" y="317" width="64" height="18" rx="9" fill="#0A0A0A"/>
+  <path
+    d="M212 154L368 256L212 358"
+    stroke="#0A0A0A"
+    stroke-width="52"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/logo.svg
+++ b/logo.svg
@@ -1,5 +1,7 @@
-<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bashkit">
-  <!-- Decision: favicon uses the same Everruns navy/gold tile as the primary mark. -->
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <!-- Decision: final Bashkit primary mark uses Everruns navy/gold on the approved fast-prompt geometry. -->
+  <title id="title">Bashkit logo</title>
+  <desc id="desc">A rounded navy tile with three gold speed lines and a shell prompt arrow.</desc>
   <defs>
     <linearGradient id="prompt" x1="212" y1="154" x2="368" y2="358" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#FFFFFF"/>

--- a/site/public/logo-dark.svg
+++ b/site/public/logo-dark.svg
@@ -1,5 +1,7 @@
-<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bashkit">
-  <!-- Decision: favicon uses the same Everruns navy/gold tile as the primary mark. -->
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <!-- Decision: dark-surface variant removes the tile and keeps Everruns gold plus white/gold prompt contrast. -->
+  <title id="title">Bashkit dark logo</title>
+  <desc id="desc">Three gold speed lines and a shell prompt arrow for dark backgrounds.</desc>
   <defs>
     <linearGradient id="prompt" x1="212" y1="154" x2="368" y2="358" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#FFFFFF"/>
@@ -7,7 +9,6 @@
       <stop offset="1" stop-color="#D4A43A"/>
     </linearGradient>
   </defs>
-  <rect width="512" height="512" rx="112" fill="#0A1636"/>
   <rect x="112" y="177" width="74" height="18" rx="9" fill="#D4A43A"/>
   <rect x="82" y="247" width="104" height="18" rx="9" fill="#D4A43A"/>
   <rect x="122" y="317" width="64" height="18" rx="9" fill="#D4A43A"/>

--- a/site/public/logo-mono.svg
+++ b/site/public/logo-mono.svg
@@ -1,0 +1,15 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <!-- Decision: mono uses the exact final geometry for one-color package, print, and mask surfaces. -->
+  <title id="title">Bashkit mono logo</title>
+  <desc id="desc">Three speed lines and a shell prompt arrow in one color.</desc>
+  <rect x="112" y="177" width="74" height="18" rx="9" fill="#0A0A0A"/>
+  <rect x="82" y="247" width="104" height="18" rx="9" fill="#0A0A0A"/>
+  <rect x="122" y="317" width="64" height="18" rx="9" fill="#0A0A0A"/>
+  <path
+    d="M212 154L368 256L212 358"
+    stroke="#0A0A0A"
+    stroke-width="52"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/site/public/logo.svg
+++ b/site/public/logo.svg
@@ -1,5 +1,7 @@
-<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Bashkit">
-  <!-- Decision: favicon uses the same Everruns navy/gold tile as the primary mark. -->
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <!-- Decision: final Bashkit primary mark uses Everruns navy/gold on the approved fast-prompt geometry. -->
+  <title id="title">Bashkit logo</title>
+  <desc id="desc">A rounded navy tile with three gold speed lines and a shell prompt arrow.</desc>
   <defs>
     <linearGradient id="prompt" x1="212" y1="154" x2="368" y2="358" gradientUnits="userSpaceOnUse">
       <stop offset="0" stop-color="#FFFFFF"/>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -6,7 +6,7 @@ const currentYear = new Date().getFullYear();
   <div class="container">
     <div class="footer-top">
       <a href="/" class="logo-link">
-        <span class="logo-mark">$_</span>
+        <img src="/logo-dark.svg" alt="" class="logo-mark" width="32" height="32" aria-hidden="true" />
         <span class="logo-text">bashkit</span>
       </a>
       <nav class="footer-nav">
@@ -69,14 +69,10 @@ const currentYear = new Date().getFullYear();
   }
   .logo-link:hover { text-decoration: none; }
   .logo-mark {
-    font-family: var(--font-mono);
-    font-weight: 700;
-    font-size: 1rem;
-    color: var(--color-gold);
-    background: var(--color-obsidian);
-    padding: 0.18rem 0.4rem;
-    line-height: 1;
-    border: 1px solid var(--color-slate);
+    display: block;
+    width: 2rem;
+    height: 2rem;
+    flex: 0 0 auto;
   }
   .logo-text {
     font-size: 1.125rem;

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -5,7 +5,7 @@
 <header class="header">
   <div class="container header-inner">
     <a href="/" class="logo-link">
-      <span class="logo-mark">$_</span>
+      <img src="/logo.svg" alt="" class="logo-mark" width="32" height="32" aria-hidden="true" />
       <span class="logo-text">bashkit</span>
     </a>
     <button class="menu-toggle" aria-label="Open menu" aria-expanded="false">
@@ -105,13 +105,10 @@
     text-decoration: none;
   }
   .logo-mark {
-    font-family: var(--font-mono);
-    font-weight: 700;
-    font-size: 1.15rem;
-    color: var(--color-gold);
-    background: var(--color-obsidian);
-    padding: 0.2rem 0.45rem;
-    line-height: 1;
+    display: block;
+    width: 2rem;
+    height: 2rem;
+    flex: 0 0 auto;
   }
   .logo-text {
     font-size: 1.25rem;


### PR DESCRIPTION
## What
Adds the final Bashkit logo asset set:
- primary navy/gold tile mark
- dark-background transparent mark
- mono mark

Updates the site favicon, header, and footer to use the new assets.

## Why
Bashkit needed a real logo aligned with the Everruns brand colors instead of the placeholder monospace `` mark.

## How
Uses the approved fast-prompt geometry with Everruns navy/gold palette, keeps duplicated root and site public SVG assets in sync, and swaps header/footer rendering to image assets.

## Risk
- Low
- Visual asset change only; possible impact is logo sizing or contrast in header/footer/favicon.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Verified with:
- `xmllint --noout` on logo SVGs
- `pnpm --dir site run build`
- `just pre-pr`