### PR TITLE
fix(interpreter): reject negative persistent file descriptors

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5012,7 +5012,16 @@ impl Interpreter {
     }
 
     fn ensure_persistent_fd_capacity(&self, fd: i32) -> Result<()> {
-        if fd <= 2 || self.exec_fd_table.contains_key(&fd) || self.coproc_buffers.contains_key(&fd)
+        if fd < 0 {
+            return Err(crate::error::Error::Execution(format!(
+                "invalid file descriptor: {}",
+                fd
+            )));
+        }
+
+        if (0..=2).contains(&fd)
+            || self.exec_fd_table.contains_key(&fd)
+            || self.coproc_buffers.contains_key(&fd)
         {
             return Ok(());
         }

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -74,6 +74,41 @@ mod resource_exhaustion {
         assert_eq!(result.stdout.trim(), "ok");
     }
 
+    /// TM-DOS-063: Negative fd vars must be rejected and must not bypass fd limits.
+    #[tokio::test]
+    async fn fd_limit_rejects_negative_fd_var_output() {
+        let limits = ExecutionLimits::new().max_file_descriptors(1);
+        let mut bash = Bash::builder().limits(limits).build();
+
+        let result = bash.exec("v=-1; exec {v}>/tmp/neg-out").await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("invalid file descriptor"),
+            "Expected invalid file descriptor error, got: {}",
+            err
+        );
+    }
+
+    /// TM-DOS-063: Negative fd vars for input must be rejected.
+    #[tokio::test]
+    async fn fd_limit_rejects_negative_fd_var_input() {
+        let limits = ExecutionLimits::new().max_file_descriptors(1);
+        let mut bash = Bash::builder().limits(limits).build();
+        bash.exec("echo hi >/tmp/neg-in").await.unwrap();
+
+        let result = bash.exec("v=-1; exec {v}</tmp/neg-in").await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("invalid file descriptor"),
+            "Expected invalid file descriptor error, got: {}",
+            err
+        );
+    }
+
     /// Subsequent exec() calls recover after a prior call hits the command limit.
     /// Each exec() is a separate script invocation and gets its own budget.
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- A persistent FD-cap bypass was found where `ensure_persistent_fd_capacity` treated `fd <= 2` as exempt, which incorrectly allowed negative fd values from brace-var redirections to create unbounded entries. 
- This could let untrusted scripts bypass `max_file_descriptors` and exhaust memory by inserting many distinct negative keys for coproc buffers or exec fd table. 

### Description
- Validate and reject negative fds by returning an error for `fd < 0` in `ensure_persistent_fd_capacity`. 
- Narrow the standard-fd exemption to only `0..=2` so only real standard descriptors are exempt. 
- Add regression tests `fd_limit_rejects_negative_fd_var_output` and `fd_limit_rejects_negative_fd_var_input` to verify `v=-1; exec {v}>...` and `v=-1; exec {v}<...` fail and do not bypass the limit. 

### Testing
- Ran `cargo test -p bashkit fd_limit_rejects_negative_fd_var -- --nocapture` which compiled and executed the added tests. 
- The two new threat-model tests (`fd_limit_rejects_negative_fd_var_output` and `fd_limit_rejects_negative_fd_var_input`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152938e768832ba9783afa1c95f018)