### PR TITLE
fix(rg): align r and tf default type globs with ripgrep

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -1935,7 +1935,7 @@ impl RgTypeDatabase {
         db.insert_defaults("qml", &["*.qml"]);
         db.insert_defaults("qrc", &["*.qrc"]);
         db.insert_defaults("qui", &["*.ui"]);
-        db.insert_defaults("r", &["*.R", "*.Rmd", "*.Rnw", "*.r", "*.rmd", "*.rnw"]);
+        db.insert_defaults("r", &["*.R", "*.Rmd", "*.Rnw", "*.r"]);
         db.insert_defaults("racket", &["*.rkt"]);
         db.insert_defaults(
             "raku",
@@ -2006,9 +2006,11 @@ impl RgTypeDatabase {
                 "*.tf",
                 "*.tf.json",
                 "*.tfrc",
-                "*.tfvars",
-                "*.tfvars.json",
+                "*.auto.tfvars",
+                "*.auto.tfvars.json",
                 "terraform.rc",
+                "terraform.tfvars",
+                "terraform.tfvars.json",
             ],
         );
         db.insert_defaults("ts", &["*.cts", "*.mts", "*.ts", "*.tsx"]);


### PR DESCRIPTION
### Motivation
- Correct an overmatch in the built-in `rg` type database where the `r` and `tf` type globs were broader than real ripgrep defaults, causing `-t r`, `-t tf`, and `--type all` to include files (e.g. `secrets.tfvars`) that ripgrep would not.

### Description
- Update `crates/bashkit/src/builtins/rg/mod.rs` to make the default type globs match ripgrep: remove lowercase `*.rmd`/`*.rnw` from the `r` defaults and replace broad `*.tfvars`/`*.tfvars.json` with `*.auto.tfvars`, `*.auto.tfvars.json`, `terraform.tfvars`, and `terraform.tfvars.json` for the `tf` type.

### Testing
- Ran the targeted differential test case via `cargo test -p bashkit builtins::rg::tests::rg_diff_cases -- --nocapture`, and the test run completed with no test failures for the exercised cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1528607ea8832ba3c021725f262166)