### PR TITLE
test(python): cover shared vfs open paths

### DIFF
--- a/crates/bashkit/tests/integration/python_integration_tests.rs
+++ b/crates/bashkit/tests/integration/python_integration_tests.rs
@@ -734,6 +734,23 @@ mod vfs_bridging {
     }
 
     #[tokio::test]
+    async fn bash_path_open_and_open_share_same_vfs_path() {
+        let mut bash = bash_python();
+        let r = bash
+            .exec(
+                "printf 'bash-1\\n' > /tmp/shared-open.txt\n\
+                 python3 -c \"from pathlib import Path\nwith Path('/tmp/shared-open.txt').open('a') as f:\n    f.write('path-open\\n')\"\n\
+                 python3 -c \"with open('/tmp/shared-open.txt', 'a') as f:\n    f.write('open\\n')\"\n\
+                 printf 'bash-2\\n' >> /tmp/shared-open.txt\n\
+                 cat /tmp/shared-open.txt",
+            )
+            .await
+            .unwrap();
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout, "bash-1\npath-open\nopen\nbash-2\n");
+    }
+
+    #[tokio::test]
     async fn open_append_text_preserves_existing_content() {
         let mut bash = bash_python();
         bash.exec("printf 'first' > /tmp/open-append.txt")


### PR DESCRIPTION
## What
Add an integration regression test that mutates the same VFS path through:
- Bash redirection
- `pathlib.Path.open()`
- Python builtin `open()`
- Bash append/readback

## Why
The previous Monty `open()` work had pairwise coverage, but not one same-path session test proving Bash, `Path.open()`, and builtin `open()` all share the exact same VFS file.

## How
Added `bash_path_open_and_open_share_same_vfs_path` under the Python integration VFS bridging tests with exact final-content assertion.

## Risk
- Low
- Test-only change.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Verification
- `cargo test --features python -p bashkit --test integration bash_path_open_and_open_share_same_vfs_path -- --nocapture`
- `cargo test --features python -p bashkit`
- `just pre-pr`