### PR TITLE
ci: reclaim runner disk before disk-hungry scheduled jobs

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,40 @@
+name: Free disk space
+description: >
+  Remove preinstalled tooling we never use to give cargo room to breathe.
+  `ubuntu-latest` ships with ~14-21 GB free on the data volume; periodic
+  jobs that build two Cargo workspaces (coreutils-args-drift) or rebuild
+  std with sanitizer instrumentation (-Z build-std + ASAN) exhaust that.
+  This frees roughly 25 GiB by deleting tooling sitting on the same volume
+  as $RUNNER_TEMP and the cargo target dir — runs in seconds, no apt-get,
+  so it's effectively free if a later step doesn't need disk pressure.
+
+runs:
+  using: composite
+  steps:
+    - name: Reclaim runner disk space
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Before:"
+        df -h /
+        # Each removal is best-effort: image layouts shift between
+        # ubuntu-latest releases and we'd rather skip a missing path
+        # than fail the whole workflow over disk hygiene.
+        sudo rm -rf \
+          /usr/local/lib/android \
+          /usr/share/dotnet \
+          /usr/local/.ghcup \
+          /opt/ghc \
+          /opt/hostedtoolcache/CodeQL \
+          /opt/microsoft \
+          /usr/share/swift \
+          /usr/local/share/powershell \
+          /usr/local/share/chromium \
+          /usr/lib/jvm 2>/dev/null || true
+        # Docker images preloaded by the runner image (Node, MySQL, etc.)
+        # are large and unused by our cargo builds.
+        if command -v docker >/dev/null 2>&1; then
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+        fi
+        echo "After:"
+        df -h /

--- a/.github/workflows/coreutils-args-drift.yml
+++ b/.github/workflows/coreutils-args-drift.yml
@@ -50,6 +50,12 @@ jobs:
           path: bashkit
           persist-credentials: false
 
+      # Two Cargo workspaces (bashkit + uutils) plus a release multicall
+      # build share one volume on ubuntu-latest. Reclaim ~25 GiB of unused
+      # preinstalled tooling before any cargo step touches target/.
+      - name: Free disk space
+        uses: ./bashkit/.github/actions/free-disk-space
+
       - name: Checkout uutils/coreutils
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,6 +80,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # `-Z build-std` rebuilds std + every dep + every bashkit test with
+      # ASAN instrumentation. Target dir grows past the default runner's
+      # ~14-21 GiB free volume; reclaim ~25 GiB of unused tooling first.
+      - name: Free disk space
+        uses: ./.github/actions/free-disk-space
+
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:


### PR DESCRIPTION
## Summary

Two periodic workflows can exhaust the `ubuntu-latest` runner's ~14–21 GiB free volume:

- **`coreutils-args-drift.yml`** (weekly Mon): builds two Cargo workspaces in one job — bashkit's test profile and a release-mode `uutils/coreutils` multicall.
- **`nightly.yml` `asan` job**: `cargo +nightly test -Z build-std` with `RUSTFLAGS=-Z sanitizer=address` rebuilds std, every dep, and every bashkit test with sanitizer instrumentation.

## Fix

New composite action `.github/actions/free-disk-space` that strips ~25 GiB of preinstalled tooling we never touch (Android SDK, .NET, GHCup, CodeQL, Swift, JVM, preloaded Docker images). Wired into those two scheduled jobs right after checkout, before any cargo step writes to `target/`.

- Best-effort `rm -rf` (`|| true`) so a future runner-image reshuffle doesn't fail the workflow on a missing path.
- Runs in ~10s; net CI time stays flat or improves because the heavy cargo builds no longer thrash a near-full disk.
- Scoped to the two scheduled workflows currently at risk. The action is reusable — drop a single `uses:` line to apply it elsewhere if another periodic job starts failing.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; ..."`).
- [ ] First post-merge nightly run reports the "After" `df -h /` line with markedly more free space than before.
- [ ] First post-merge weekly `coreutils-args-drift` run goes green end-to-end.