### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-28
+
+### Highlights
+
+- **Python `open()` support** — VFS-backed `open()` / `Path.open()` read, write, and append now work in the embedded Python builtin, so LLM-generated `with open("/tmp/...")` scripts run instead of failing. Host filesystem and network stay unavailable to Python ([#1800](https://github.com/everruns/bashkit/pull/1800)).
+- Further `rg` parity and hardening fixes (default type globs, JSON context fanout cap, root-arg allocation) plus interpreter fixes for variable attribute/nameref persistence and persistent file descriptor validation.
+
+### What's Changed
+
+* ci: reclaim runner disk before disk-hungry scheduled jobs ([#1807](https://github.com/everruns/bashkit/pull/1807)) by @chaliy
+* fix(rg): align r and tf default type globs with ripgrep ([#1805](https://github.com/everruns/bashkit/pull/1805)) by @chaliy
+* fix(rg): cap JSON context event fanout ([#1804](https://github.com/everruns/bashkit/pull/1804)) by @chaliy
+* fix(interpreter): persist var attrs and namerefs across shell state restore ([#1803](https://github.com/everruns/bashkit/pull/1803)) by @chaliy
+* fix(interpreter): reject negative persistent file descriptors ([#1802](https://github.com/everruns/bashkit/pull/1802)) by @chaliy
+* fix(rg): avoid root arg string cloning across candidates ([#1801](https://github.com/everruns/bashkit/pull/1801)) by @chaliy
+* feat(python): support vfs-backed open ([#1800](https://github.com/everruns/bashkit/pull/1800)) by @chaliy
+* feat(site): add bashkit logo assets ([#1799](https://github.com/everruns/bashkit/pull/1799)) by @chaliy
+* fix(ci): bypass pnpm `--` separator that breaks napi build flag forwarding ([#1798](https://github.com/everruns/bashkit/pull/1798)) by @chaliy
+* fix(site): add homepage canonical link header ([#1797](https://github.com/everruns/bashkit/pull/1797)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.7.2...v0.8.0
+
 ## [0.7.2] - 2026-05-27
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.7.2", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.8.0", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",


### PR DESCRIPTION
## Release v0.8.0

Minor release. New feature: VFS-backed Python `open()` support.

### Highlights

- **Python `open()` support** — VFS-backed `open()` / `Path.open()` read, write, and append now work in the embedded Python builtin, so LLM-generated `with open("/tmp/...")` scripts run instead of failing. Host filesystem and network stay unavailable to Python ([#1800](https://github.com/everruns/bashkit/pull/1800)).
- Further `rg` parity and hardening fixes (default type globs, JSON context fanout cap, root-arg allocation) plus interpreter fixes for variable attribute/nameref persistence and persistent file descriptor validation.

### What's Changed

* ci: reclaim runner disk before disk-hungry scheduled jobs ([#1807](https://github.com/everruns/bashkit/pull/1807)) by @chaliy
* fix(rg): align r and tf default type globs with ripgrep ([#1805](https://github.com/everruns/bashkit/pull/1805)) by @chaliy
* fix(rg): cap JSON context event fanout ([#1804](https://github.com/everruns/bashkit/pull/1804)) by @chaliy
* fix(interpreter): persist var attrs and namerefs across shell state restore ([#1803](https://github.com/everruns/bashkit/pull/1803)) by @chaliy
* fix(interpreter): reject negative persistent file descriptors ([#1802](https://github.com/everruns/bashkit/pull/1802)) by @chaliy
* fix(rg): avoid root arg string cloning across candidates ([#1801](https://github.com/everruns/bashkit/pull/1801)) by @chaliy
* feat(python): support vfs-backed open ([#1800](https://github.com/everruns/bashkit/pull/1800)) by @chaliy
* feat(site): add bashkit logo assets ([#1799](https://github.com/everruns/bashkit/pull/1799)) by @chaliy
* fix(ci): bypass pnpm `--` separator that breaks napi build flag forwarding ([#1798](https://github.com/everruns/bashkit/pull/1798)) by @chaliy
* fix(site): add homepage canonical link header ([#1797](https://github.com/everruns/bashkit/pull/1797)) by @chaliy

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.7.2...v0.8.0

### Version bump

`0.7.2` → `0.8.0` across `Cargo.toml`, `crates/bashkit-cli/Cargo.toml`, `crates/bashkit-js/package.json`, and `Cargo.lock`.

### Publish-readiness report

- ✅ `cargo fmt --check` — clean
- ✅ `cargo clippy --workspace --all-targets --features http_client,ssh,sqlite -- -D warnings` — clean
- ✅ `cargo test --workspace --lib --bins --tests --features http_client,ssh,sqlite` — green (with pinned ripgrep 15.1.0, matching CI's `RG_VERSION`)
- ✅ `cargo test --features python -p bashkit` — green
- ✅ `cargo publish --dry-run -p bashkit` — succeeds after replicating the workflow's monty/python strip step (git-only `monty` dep is stripped before publish, as in `publish.yml`)
- ✅ `bashkit-cli` packages cleanly; its dry-run's only remaining step is resolving `bashkit ^0.8.0` from crates.io, which the workflow satisfies by publishing `bashkit` first (30s index wait) then `bashkit-cli`
- ✅ Version sync: all manifests read `0.8.0`; crates.io latest is `0.7.2`, so `0.8.0` is a strict increment on every registry (npm/PyPI versions are derived from the same pipeline)

Notes: in this sandbox the `rg` differential case and `ssh_supabase_connects` test initially failed only because of environment (preinstalled ripgrep 14.1.0 vs CI's pinned 15.1.0, and no egress to the external `supabase.sh` SSH host); both are environmental, not code regressions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01URKhGRWFuMgjHQR1YhyNHN)_