### PR TITLE
fix(parser): debit nested process substitution budgets

### DIFF
--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -208,6 +208,10 @@ impl<'a> Parser<'a> {
 
     /// Parse the input and return the AST.
     pub fn parse(mut self) -> Result<Script> {
+        self.parse_script()
+    }
+
+    fn parse_script(&mut self) -> Result<Script> {
         // Check if the very first token is an error
         self.check_error_token()?;
 
@@ -2747,14 +2751,38 @@ impl<'a> Parser<'a> {
                     .source_slice(body_start_offset, body_end_offset)
                     .unwrap_or_default();
 
-                // THREAT[TM-DOS-021]: Propagate parent parser limits to child parser
-                // to prevent depth limit bypass via nested process substitution.
-                // Child inherits remaining depth budget and fuel from parent.
-                let remaining_depth = self.max_depth.saturating_sub(self.current_depth);
-                let inner_parser = Parser::with_limits(&cmd_str, remaining_depth, self.fuel);
-                let commands = match inner_parser.parse() {
-                    Ok(script) => script.commands,
-                    Err(_) => Vec::new(),
+                // THREAT[TM-DOS-021]: Charge nested process-substitution parsers
+                // against the same depth/fuel/timeout budget. A fresh child parser
+                // without inherited current depth or fuel debit lets repeated `<(...)`
+                // recurse until stack overflow before normal parser limits fire.
+                if self.current_depth >= self.max_depth {
+                    return Err(Error::parse(format!(
+                        "AST nesting too deep ({} levels, max {})",
+                        self.current_depth + 1,
+                        self.max_depth
+                    )));
+                }
+                let mut inner_parser = Parser::with_limits_and_timeout(
+                    &cmd_str,
+                    self.max_depth,
+                    self.fuel,
+                    self.timeout,
+                );
+                inner_parser.current_depth = self.current_depth + 1;
+                inner_parser.started_at = self.started_at;
+                let commands = match inner_parser.parse_script() {
+                    Ok(script) => {
+                        self.fuel = inner_parser.fuel;
+                        script.commands
+                    }
+                    Err(err) if Self::is_parser_budget_error(&err) => {
+                        self.fuel = inner_parser.fuel;
+                        return Err(err);
+                    }
+                    Err(_) => {
+                        self.fuel = inner_parser.fuel;
+                        Vec::new()
+                    }
                 };
 
                 Ok(Word {
@@ -2764,6 +2792,17 @@ impl<'a> Parser<'a> {
                 })
             }
             _ => Err(self.error("expected word")),
+        }
+    }
+
+    fn is_parser_budget_error(err: &Error) -> bool {
+        match err {
+            Error::ResourceLimit(_) => true,
+            Error::Parse { message, .. } => {
+                message.starts_with("AST nesting too deep")
+                    || message.starts_with("parser fuel exhausted")
+            }
+            _ => false,
         }
     }
 
@@ -3948,6 +3987,53 @@ mod tests {
             AssignmentValue::Scalar(word) => assert_eq!(word.to_string(), "a+=b"),
             AssignmentValue::Array(_) => panic!("expected scalar assignment"),
         }
+    }
+
+    fn nested_process_substitution(levels: usize) -> String {
+        let mut script = String::from("cat ");
+        for _ in 0..levels {
+            script.push_str("<(cat ");
+        }
+        script.push_str("echo x");
+        for _ in 0..levels {
+            script.push_str("; )");
+        }
+        script
+    }
+
+    #[test]
+    fn test_nested_process_substitution_within_budget_parses() {
+        let script = nested_process_substitution(3);
+        let parser = Parser::with_limits(&script, 8, 1_000);
+        parser
+            .parse()
+            .expect("nested process substitution within budget should parse");
+    }
+
+    #[test]
+    fn test_nested_process_substitution_consumes_depth_budget() {
+        let script = nested_process_substitution(5);
+        let parser = Parser::with_limits(&script, 4, 10_000);
+        let err = parser
+            .parse()
+            .expect_err("nested process substitution must not bypass AST depth");
+        assert!(
+            err.to_string().contains("AST nesting too deep"),
+            "expected AST depth error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_nested_process_substitution_consumes_fuel_budget() {
+        let script = nested_process_substitution(8);
+        let parser = Parser::with_limits(&script, 100, 8);
+        let err = parser
+            .parse()
+            .expect_err("nested process substitution must not get fresh parser fuel");
+        assert!(
+            err.to_string().contains("parser fuel exhausted"),
+            "expected parser fuel error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- A recent change preserved nested `ProcessSubIn`/`ProcessSubOut` when reconstructing `<(...)`/`>(...)` bodies but created fresh child `Parser` instances that did not debit the parent's AST depth or parser fuel, allowing nested process substitutions to bypass parser limits and cause DoS/stack overflow.\

### Description
- Update parsing entrypoint by refactoring `parse()` -> `parse_script()` so nested parsing can reuse a mutable parser path.\
- Replace the previous fresh-child `Parser::with_limits(...)` usage with a child created via `Parser::with_limits_and_timeout(...)` and initialize the child with `current_depth = parent.current_depth + 1`, `started_at = parent.started_at`, and inheriting `timeout`.\
- After the child parse returns, debit the parent `fuel` from the child (`self.fuel = inner_parser.fuel`) and propagate budget errors instead of silently dropping them; add `is_parser_budget_error()` helper to detect and propagate depth/fuel/timeout failures.\
- Add regression tests exercising nested process substitutions: a generator `nested_process_substitution()` and three tests: `test_nested_process_substitution_within_budget_parses`, `test_nested_process_substitution_consumes_depth_budget`, and `test_nested_process_substitution_consumes_fuel_budget`.\
- Modified file: `crates/bashkit/src/parser/mod.rs` (refactor + budget charging + tests).\

### Testing
- Ran `cargo fmt --check` and it passed.\
- Ran `cargo test -p bashkit --lib nested_process_substitution -- --nocapture` and the three new parser tests passed.\
- Ran `cargo test -p bashkit --lib -- test_process_sub --nocapture` and existing process-substitution-related interpreter tests passed (7 tests).\
- Ran `cargo clippy -p bashkit --lib -- -D warnings` and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba5695a80832b84bee368bb5db0f3)