### PR TITLE
fix(interpreter): clear transient stdin after timeouts

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1590,7 +1590,7 @@ impl Interpreter {
 
     /// THREAT[TM-ISO-005/006/007]: Reset per-exec transient state.
     /// Called by Bash::exec() before each top-level execution to prevent
-    /// traps, exit code, and `set` options from leaking across calls.
+    /// traps, exit code, `set` options, and transient stdin from leaking across calls.
     /// `shopt` options (expand_aliases, extglob, etc.) are intentionally
     /// preserved — they are persistent session configuration.
     pub fn reset_transient_state(&mut self) {
@@ -1602,6 +1602,11 @@ impl Interpreter {
                 self.flags.remove(bit);
             }
         }
+        self.pipeline_stdin = None;
+    }
+
+    pub(crate) fn clear_transient_stdin(&mut self) {
+        self.pipeline_stdin = None;
     }
 
     /// Set an environment variable.
@@ -7217,6 +7222,7 @@ impl Interpreter {
 
                 let baseline_call_stack_len = self.call_stack.len();
                 let baseline_bash_source_len = self.bash_source_stack.len();
+                let baseline_pipeline_stdin = self.pipeline_stdin.clone();
                 let exec_future = self.execute_command(&inner_cmd);
                 match timeout(duration, exec_future).await {
                     Ok(Ok(result)) => result,
@@ -7225,6 +7231,7 @@ impl Interpreter {
                         self.reconcile_cancelled_execution_state(
                             baseline_call_stack_len,
                             baseline_bash_source_len,
+                            baseline_pipeline_stdin,
                         );
                         // Timeout expired.
                         // --preserve-status: in real bash, returns the signal+128 status
@@ -7342,6 +7349,7 @@ impl Interpreter {
         &mut self,
         baseline_call_stack_len: usize,
         baseline_bash_source_len: usize,
+        baseline_pipeline_stdin: Option<String>,
     ) {
         let leaked_call_frames = self
             .call_stack
@@ -7363,6 +7371,8 @@ impl Interpreter {
         for _ in 0..leaked_call_frames.max(leaked_bash_source_entries) {
             self.counters.pop_function();
         }
+
+        self.pipeline_stdin = baseline_pipeline_stdin;
 
         if self.call_stack.is_empty() {
             self.arrays_mut().remove("FUNCNAME");
@@ -11276,6 +11286,16 @@ mod tests {
         let ast = parser.parse().unwrap();
         let result = interp.execute(&ast).await.unwrap();
         assert_eq!(result.stdout.trim(), "<>");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_does_not_leak_bash_stdin_to_following_command() {
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mut interp = Interpreter::new(Arc::clone(&fs));
+        let parser = Parser::new("printf secret | timeout 0.001 bash -c 'sleep 10'; cat");
+        let ast = parser.parse().unwrap();
+        let result = interp.execute(&ast).await.unwrap();
+        assert_eq!(result.stdout, "");
     }
 
     /// Test that parse_duration preserves subsecond precision

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -824,9 +824,12 @@ impl Bash {
         let result =
             match tokio::time::timeout(execution_timeout, self.interpreter.execute(&ast)).await {
                 Ok(r) => r,
-                Err(_elapsed) => Err(Error::ResourceLimit(LimitExceeded::Timeout(
-                    execution_timeout,
-                ))),
+                Err(_elapsed) => {
+                    self.interpreter.clear_transient_stdin();
+                    Err(Error::ResourceLimit(LimitExceeded::Timeout(
+                        execution_timeout,
+                    )))
+                }
             };
         #[cfg(target_family = "wasm")]
         let result = self.interpreter.execute(&ast).await;
@@ -3132,6 +3135,21 @@ mod tests {
         let mut bash = Bash::new();
         let result = bash.exec("echo hello | cat").await.unwrap();
         assert_eq!(result.stdout, "hello\n");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timed_out_bash_c_does_not_leak_stdin_to_next_exec() {
+        let limits = ExecutionLimits::new().timeout(std::time::Duration::from_millis(1));
+        let mut bash = Bash::builder().limits(limits).build();
+
+        let timed_out = bash.exec("printf secret | bash -c 'sleep 10'").await;
+        assert!(matches!(
+            timed_out,
+            Err(Error::ResourceLimit(LimitExceeded::Timeout(_)))
+        ));
+
+        let result = bash.exec("cat").await.unwrap();
+        assert_eq!(result.stdout, "");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Fix a cancellation-safety bug where piped stdin stored in the interpreter (`pipeline_stdin`) could survive a dropped/timeout'd child future and be consumed by a later exec, causing cross-exec information disclosure.

### Description
- Clear `pipeline_stdin` in `Interpreter::reset_transient_state()` to ensure per-exec transient stdin does not persist across `Bash::exec()` calls. 
- Add `Interpreter::clear_transient_stdin()` and call it from the top-level `Bash::exec()` timeout branch so a timed-out top-level execution cannot leave stdin installed. 
- Make the `timeout` builtin snapshot the baseline `pipeline_stdin` before running the child and restore it in `reconcile_cancelled_execution_state()` when a child future is cancelled. 
- Add regression tests covering a timed-out `bash -c` not leaking stdin to the next `exec`, and a nested `timeout bash -c` case that ensures stdin is not visible to a following `cat`.

### Testing
- Ran the new unit tests: `test_timed_out_bash_c_does_not_leak_stdin_to_next_exec` and `test_timeout_does_not_leak_bash_stdin_to_following_command`, both passed. 
- Ran `cargo fmt --check` and `git diff --check`, both succeeded. 
- Ran package tests that exercise the changes; the added tests passed in the test run (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba825a3d4832bbf06e5e0f732f305)