### PR TITLE
fix(js): expose keyed snapshot APIs

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -325,7 +325,7 @@ const bash = new Bash({
       return JSON.stringify(data) + "\n";
     },
     fail: () => {
-      throw new Error("nope");   // → stderr, exit 1
+      throw new Error("nope"); // → stderr, exit 1
     },
   },
 });
@@ -340,8 +340,9 @@ The callback receives a `BuiltinContext`:
 - `cwd: string` — current working directory
 
 Override precedence: shell function > POSIX special builtin > custom builtin
+
 > baked-in builtin > `PATH`. Custom builtins can override baked-in commands
-(e.g. wrap `cat`), but shell functions defined in the script still win.
+> (e.g. wrap `cat`), but shell functions defined in the script still win.
 
 Custom builtins survive `reset()`. They are host-side configuration and are
 **not** preserved by `snapshot()` / `restoreSnapshot()` — pass
@@ -355,7 +356,10 @@ in flight, so the underlying `Promise<string>` callback could never run.
 
 ## Snapshot / Restore
 
-State snapshots are available on both `Bash` and `BashTool` instances:
+State snapshots are available on both `Bash` and `BashTool` instances.
+The default snapshot methods use an unkeyed checksum for accidental-corruption
+checks only; use the `*Keyed` methods with a secret key for snapshots that cross
+trust boundaries such as user uploads, shared storage, or network transport.
 
 ```typescript
 import { Bash, BashTool } from "@everruns/bashkit";
@@ -372,12 +376,17 @@ const promptOnly = bash.snapshot({
   excludeFunctions: true,
 });
 
+const secretKey = Buffer.from(process.env.BASHKIT_SNAPSHOT_KEY!, "hex");
+const keyedSnapshot = bash.snapshotKeyed(secretKey);
+const keyedRestored = Bash.fromSnapshotKeyed(keyedSnapshot, secretKey);
+
 const restored = Bash.fromSnapshot(snapshot);
 console.log((await restored.execute("echo $BUILD_ID")).stdout); // 42\n
 
 restored.reset();
 restored.restoreSnapshot(snapshot);
 restored.restoreSnapshot(shellOnly);
+restored.restoreSnapshotKeyed(keyedSnapshot, secretKey);
 console.log(restored.executeSync("pwd").stdout); // /workspace\n
 
 const tool = new BashTool({ username: "agent", maxCommands: 5 });
@@ -443,18 +452,18 @@ import {
 - `clearCancel()`
 - `reset()`
 - `addBuiltin(name, callback)` / `removeBuiltin(name)` — register/unregister persistent JS builtins
-- `snapshot()`
-- `restoreSnapshot(data)`
-- `Bash.fromSnapshot(data)`
+- `snapshot()` / `snapshotKeyed(key, options?)`
+- `restoreSnapshot(data)` / `restoreSnapshotKeyed(data, key)`
+- `Bash.fromSnapshot(data)` / `Bash.fromSnapshotKeyed(data, key, options?)`
 - Direct VFS helpers: `readFile`, `writeFile`, `appendFile`, `mkdir`, `remove`, `exists`, `stat`, `readDir`, `ls`, `glob`, `mount`, `unmount`, `fs`
 
 ### BashTool
 
 - All execution, cancellation (`cancel()`, `clearCancel()`), reset, custom builtins, snapshot, restore, and direct VFS helpers from `Bash`
 - Tool metadata: `name`, `version`, `shortDescription`
-- `snapshot()`
-- `restoreSnapshot(data)`
-- `BashTool.fromSnapshot(data, options?)`
+- `snapshot()` / `snapshotKeyed(key, options?)`
+- `restoreSnapshot(data)` / `restoreSnapshotKeyed(data, key)`
+- `BashTool.fromSnapshot(data, options?)` / `BashTool.fromSnapshotKeyed(data, key, options?)`
 - `description()`
 - `help()`
 - `systemPrompt()`

--- a/crates/bashkit-js/__test__/integration.spec.ts
+++ b/crates/bashkit-js/__test__/integration.spec.ts
@@ -357,6 +357,40 @@ test("integration: BashTool invalid snapshot throws", (t) => {
   t.throws(() => BashTool.fromSnapshot(invalid));
 });
 
+test("integration: Bash keyed snapshot rejects wrong key", (t) => {
+  const key = Buffer.from("correct-key");
+  const wrongKey = Buffer.from("wrong-key");
+  const bash = new Bash();
+  bash.executeSync("export SNAP_KEYED=yes");
+
+  const snapshot = bash.snapshotKeyed(key);
+  const restored = Bash.fromSnapshotKeyed(snapshot, key);
+  t.is(restored.executeSync("echo $SNAP_KEYED").stdout.trim(), "yes");
+
+  t.throws(() => Bash.fromSnapshotKeyed(snapshot, wrongKey));
+
+  bash.executeSync("export SNAP_KEYED=no");
+  t.throws(() => bash.restoreSnapshotKeyed(snapshot, wrongKey));
+});
+
+test("integration: BashTool keyed snapshot preserves options", (t) => {
+  const key = Buffer.from("tool-key");
+  const tool = new BashTool({ username: "agent", maxCommands: 5 });
+  tool.executeSync("export TOOL_KEYED=ready");
+
+  const snapshot = tool.snapshotKeyed(key, { excludeFilesystem: true });
+  const restored = BashTool.fromSnapshotKeyed(snapshot, key, {
+    username: "agent",
+    maxCommands: 5,
+  });
+
+  t.is(restored.executeSync("echo $TOOL_KEYED").stdout.trim(), "ready");
+  t.is(restored.executeSync("whoami").stdout.trim(), "agent");
+  t.throws(() =>
+    restored.restoreSnapshotKeyed(snapshot, Buffer.from("bad-key")),
+  );
+});
+
 test("integration: multiple resets remain stable", (t) => {
   const bash = new Bash();
   for (let i = 0; i < 10; i++) {

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -1409,6 +1409,39 @@ impl Bash {
         })
     }
 
+    /// Serialize interpreter state to HMAC-protected bytes using a caller-provided key.
+    ///
+    /// Use this when snapshots cross trust boundaries.
+    #[napi]
+    pub fn snapshot_keyed(
+        &self,
+        key: napi::bindgen_prelude::Buffer,
+        options: Option<SnapshotOptions>,
+    ) -> napi::Result<napi::bindgen_prelude::Buffer> {
+        let options = to_snapshot_options(options);
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
+            let bytes = bash
+                .snapshot_to_bytes_keyed_with_options(&key, options)
+                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            Ok(napi::bindgen_prelude::Buffer::from(bytes))
+        })
+    }
+
+    /// Restore interpreter state from a HMAC-protected snapshot.
+    #[napi]
+    pub fn restore_snapshot_keyed(
+        &self,
+        data: napi::bindgen_prelude::Buffer,
+        key: napi::bindgen_prelude::Buffer,
+    ) -> napi::Result<()> {
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
+            bash.restore_snapshot_keyed(&data, &key)
+                .map_err(|e| napi::Error::from_reason(e.to_string()))
+        })
+    }
+
     /// Create a new Bash instance from a snapshot.
     ///
     /// Accepts optional `BashOptions` to re-apply execution limits.
@@ -1426,6 +1459,29 @@ impl Bash {
             .inner
             .get_mut()
             .restore_snapshot(&data)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+        Ok(Self {
+            state: Arc::new(state),
+        })
+    }
+
+    /// Create a new Bash instance from a HMAC-protected snapshot.
+    ///
+    /// Accepts optional `BashOptions` to re-apply execution limits.
+    #[napi(factory)]
+    pub fn from_snapshot_keyed(
+        data: napi::bindgen_prelude::Buffer,
+        key: napi::bindgen_prelude::Buffer,
+        options: Option<BashOptions>,
+    ) -> napi::Result<Self> {
+        let opts = options.unwrap_or_else(default_opts);
+        let mut state = shared_state_from_opts(opts, None)?;
+
+        state
+            .inner
+            .get_mut()
+            .restore_snapshot_keyed(&data, &key)
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
         Ok(Self {
@@ -1892,6 +1948,37 @@ impl BashTool {
         })
     }
 
+    /// Serialize interpreter state to HMAC-protected bytes using a caller-provided key.
+    #[napi]
+    pub fn snapshot_keyed(
+        &self,
+        key: napi::bindgen_prelude::Buffer,
+        options: Option<SnapshotOptions>,
+    ) -> napi::Result<napi::bindgen_prelude::Buffer> {
+        let options = to_snapshot_options(options);
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
+            let bytes = bash
+                .snapshot_to_bytes_keyed_with_options(&key, options)
+                .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+            Ok(napi::bindgen_prelude::Buffer::from(bytes))
+        })
+    }
+
+    /// Restore interpreter state from a HMAC-protected snapshot.
+    #[napi]
+    pub fn restore_snapshot_keyed(
+        &self,
+        data: napi::bindgen_prelude::Buffer,
+        key: napi::bindgen_prelude::Buffer,
+    ) -> napi::Result<()> {
+        block_on_with(&self.state, |s| async move {
+            let mut bash = s.inner.lock().await;
+            bash.restore_snapshot_keyed(&data, &key)
+                .map_err(|e| napi::Error::from_reason(e.to_string()))
+        })
+    }
+
     /// Create a new BashTool instance from a snapshot.
     ///
     /// Accepts optional `BashOptions` so restored instances preserve caller-provided
@@ -1908,6 +1995,30 @@ impl BashTool {
             .inner
             .get_mut()
             .restore_snapshot(&data)
+            .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+
+        Ok(Self {
+            state: Arc::new(state),
+        })
+    }
+
+    /// Create a new BashTool instance from a HMAC-protected snapshot.
+    ///
+    /// Accepts optional `BashOptions` so restored instances preserve caller-provided
+    /// execution limits and identity settings.
+    #[napi(factory)]
+    pub fn from_snapshot_keyed(
+        data: napi::bindgen_prelude::Buffer,
+        key: napi::bindgen_prelude::Buffer,
+        options: Option<BashOptions>,
+    ) -> napi::Result<Self> {
+        let opts = options.unwrap_or_else(default_opts);
+        let mut state = shared_state_from_opts(opts, None)?;
+
+        state
+            .inner
+            .get_mut()
+            .restore_snapshot_keyed(&data, &key)
             .map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
         Ok(Self {

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -633,7 +633,12 @@ function makeBuiltinDispatcher(
  * Idempotent for empty/undefined input.
  */
 function registerCustomBuiltins(
-  native: { addBuiltin(name: string, dispatch: (payload: string) => Promise<string>): void },
+  native: {
+    addBuiltin(
+      name: string,
+      dispatch: (payload: string) => Promise<string>,
+    ): void;
+  },
   builtins: Record<string, BuiltinCallback> | undefined,
 ): void {
   if (!builtins) return;
@@ -876,6 +881,24 @@ export class Bash {
   }
 
   /**
+   * Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
+   * Use for snapshots crossing trust boundaries.
+   */
+  snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array {
+    return this.native.snapshotKeyed(
+      Buffer.from(key),
+      toNativeSnapshotOptions(options),
+    );
+  }
+
+  /**
+   * Restore interpreter state from a HMAC-protected snapshot.
+   */
+  restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void {
+    this.native.restoreSnapshotKeyed(Buffer.from(data), Buffer.from(key));
+  }
+
+  /**
    * Create a new Bash instance from a snapshot.
    *
    * @example
@@ -887,6 +910,18 @@ export class Bash {
   static fromSnapshot(data: Uint8Array): Bash {
     const instance = new Bash();
     instance.native = NativeBash.fromSnapshot(Buffer.from(data));
+    return instance;
+  }
+
+  /**
+   * Create a new Bash instance from a HMAC-protected snapshot.
+   */
+  static fromSnapshotKeyed(data: Uint8Array, key: Uint8Array): Bash {
+    const instance = new Bash();
+    instance.native = NativeBash.fromSnapshotKeyed(
+      Buffer.from(data),
+      Buffer.from(key),
+    );
     return instance;
   }
 
@@ -1210,6 +1245,23 @@ export class BashTool {
   }
 
   /**
+   * Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
+   */
+  snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array {
+    return this.native.snapshotKeyed(
+      Buffer.from(key),
+      toNativeSnapshotOptions(options),
+    );
+  }
+
+  /**
+   * Restore interpreter state from a HMAC-protected snapshot.
+   */
+  restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void {
+    this.native.restoreSnapshotKeyed(Buffer.from(data), Buffer.from(key));
+  }
+
+  /**
    * Create a new BashTool instance from a snapshot.
    *
    * Any provided options are applied before restoring the snapshot so limits
@@ -1220,6 +1272,24 @@ export class BashTool {
     const instance = Object.create(BashTool.prototype) as BashTool;
     instance.native = NativeBashTool.fromSnapshot(
       Buffer.from(data),
+      toNativeOptions(options, resolved),
+    );
+    return instance;
+  }
+
+  /**
+   * Create a new BashTool instance from a HMAC-protected snapshot.
+   */
+  static fromSnapshotKeyed(
+    data: Uint8Array,
+    key: Uint8Array,
+    options?: BashOptions,
+  ): BashTool {
+    const resolved = resolveFilesSync(options?.files);
+    const instance = Object.create(BashTool.prototype) as BashTool;
+    instance.native = NativeBashTool.fromSnapshotKeyed(
+      Buffer.from(data),
+      Buffer.from(key),
       toNativeOptions(options, resolved),
     );
     return instance;


### PR DESCRIPTION
### Motivation

- The unkeyed SHA-256 checksum on snapshots is a corruption-only check and is forgeable, so callers that need tamper-proof snapshots must use a keyed MAC; the JS bindings did not expose the keyed APIs. 
- Add minimal JS-facing APIs and docs/tests so callers can create/verify HMAC-SHA256-protected snapshots when crossing trust boundaries.

### Description

- Expose keyed snapshot APIs on the native JS binding (`snapshot_keyed`, `restore_snapshot_keyed`, `from_snapshot_keyed`) in `crates/bashkit-js/src/lib.rs` so callers can pass an HMAC key. 
- Add TypeScript wrapper methods and static factories (`snapshotKeyed`, `restoreSnapshotKeyed`, `fromSnapshotKeyed`) for both `Bash` and `BashTool` in `crates/bashkit-js/wrapper.ts`. 
- Add JS integration tests exercising keyed snapshot roundtrips and wrong-key rejection in `crates/bashkit-js/__test__/integration.spec.ts`. 
- Update `crates/bashkit-js/README.md` to document that unkeyed snapshots are corruption checks only and show usage of the keyed APIs; also a few small formatting adjustments.

### Testing

- Ran `cargo test -p bashkit --test integration snapshot --features http_client,ssh,sqlite` and all snapshot/integration tests passed (40 passed, 0 failed). 
- Ran `cargo check -p bashkit-js`, `cargo fmt --check`, and `pnpm --dir crates/bashkit-js exec prettier --check README.md __test__/integration.spec.ts wrapper.ts` which all succeeded. 
- `pnpm --dir crates/bashkit-js type-check` failed in this environment due to missing Node dependencies and generated/native JS types (e.g. `@types/node`, `zod`, `@langchain/core`, `./index.cjs`), not because of the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba7dd6a30832b8a023d8e5bbf33f1)