### PR TITLE
fix(interpreter): cap word-split array assignments

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4468,11 +4468,27 @@ impl Interpreter {
                     }
                 }
                 AssignmentValue::Array(words) => {
-                    // Expand each word, applying IFS word splitting for unquoted
-                    // variable expansions: x="a b"; arr=($x) → arr=([0]="a" [1]="b")
-                    // Quoted words (e.g., '' or "foo") are kept as single elements.
-                    let mut all_fields = Vec::new();
-                    for word in words.iter() {
+                    // Expand directly into the replacement array so word-split expansions cannot
+                    // accumulate an unbounded temporary Vec before max_array_entries is enforced.
+                    let arr_name = self.resolve_nameref(&assignment.name).to_string();
+                    let old_entries = self.arrays.get(&arr_name).map_or(0, |arr| arr.len());
+                    let remaining_entries = self
+                        .memory_limits
+                        .max_array_entries
+                        .saturating_sub(self.memory_budget.array_entries);
+                    let max_new_entries = old_entries.saturating_add(remaining_entries);
+                    let mut next_arr = if assignment.append {
+                        self.arrays.get(&arr_name).cloned().unwrap_or_default()
+                    } else {
+                        HashMap::new()
+                    };
+                    let mut idx = if assignment.append {
+                        next_arr.keys().max().map(|k| k + 1).unwrap_or(0)
+                    } else {
+                        0
+                    };
+
+                    'array_words: for word in words.iter() {
                         let is_unquoted_expansion = !word.quoted
                             && word.parts.iter().any(|p| {
                                 matches!(
@@ -4498,31 +4514,36 @@ impl Interpreter {
                                 &word.parts[0],
                                 WordPart::Variable(name) if name == "@"
                             );
-                        if is_unquoted_expansion || is_quoted_splat || is_quoted_positional_splat {
-                            let fields = self.expand_word_to_fields(word).await?;
-                            all_fields.extend(fields);
+
+                        if is_unquoted_expansion {
+                            let remaining = max_new_entries.saturating_sub(next_arr.len());
+                            if remaining == 0 {
+                                break;
+                            }
+                            let expanded = self.expand_word(word).await?;
+                            for field in self.ifs_split_limited(&expanded, remaining) {
+                                next_arr.insert(idx, field);
+                                idx += 1;
+                            }
+                            if next_arr.len() >= max_new_entries {
+                                break 'array_words;
+                            }
+                        } else if is_quoted_splat || is_quoted_positional_splat {
+                            for field in self.expand_word_to_fields(word).await? {
+                                if next_arr.len() >= max_new_entries {
+                                    break 'array_words;
+                                }
+                                next_arr.insert(idx, field);
+                                idx += 1;
+                            }
                         } else {
                             let value = self.expand_word(word).await?;
-                            all_fields.push(value);
+                            if next_arr.len() >= max_new_entries {
+                                break;
+                            }
+                            next_arr.insert(idx, value);
+                            idx += 1;
                         }
-                    }
-
-                    // Resolve nameref for array assignments and apply
-                    // max_array_entries accounting over the whole replacement.
-                    let arr_name = self.resolve_nameref(&assignment.name).to_string();
-                    let mut next_arr = if assignment.append {
-                        self.arrays.get(&arr_name).cloned().unwrap_or_default()
-                    } else {
-                        HashMap::new()
-                    };
-                    let start_idx = if assignment.append {
-                        next_arr.keys().max().map(|k| k + 1).unwrap_or(0)
-                    } else {
-                        0
-                    };
-
-                    for (idx, field) in (start_idx..).zip(all_fields) {
-                        next_arr.insert(idx, field);
                     }
 
                     let _ = self.insert_array_checked(arr_name, next_arr);
@@ -8606,6 +8627,15 @@ impl Interpreter {
     /// - `<ws><nws><ws>` = single delimiter (ws absorbed into the nws delimiter).
     /// - Empty IFS → no splitting. Unset IFS → default " \t\n".
     fn ifs_split(&self, s: &str) -> Vec<String> {
+        self.ifs_split_limited(s, usize::MAX)
+    }
+
+    /// Split a string on IFS characters, returning at most `limit` fields.
+    fn ifs_split_limited(&self, s: &str, limit: usize) -> Vec<String> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
         let ifs = self
             .variables
             .get("IFS")
@@ -8626,6 +8656,7 @@ impl Interpreter {
             return s
                 .split(|c: char| is_ifs(c))
                 .filter(|f| !f.is_empty())
+                .take(limit)
                 .map(|f| f.to_string())
                 .collect();
         }
@@ -8643,6 +8674,9 @@ impl Interpreter {
         // Leading non-whitespace IFS produces an empty first field
         if i < chars.len() && is_ifs_nws(chars[i]) {
             fields.push(String::new());
+            if fields.len() >= limit {
+                return fields;
+            }
             i += 1;
             while i < chars.len() && is_ifs_ws(chars[i]) {
                 i += 1;
@@ -8654,6 +8688,9 @@ impl Interpreter {
             if is_ifs_nws(c) {
                 // Non-whitespace IFS delimiter: finalize current field
                 fields.push(std::mem::take(&mut current));
+                if fields.len() >= limit {
+                    return fields;
+                }
                 i += 1;
                 // Consume trailing IFS whitespace
                 while i < chars.len() && is_ifs_ws(chars[i]) {
@@ -8667,6 +8704,9 @@ impl Interpreter {
                 if i < chars.len() && is_ifs_nws(chars[i]) {
                     // <ws><nws> = single delimiter. Push current field.
                     fields.push(std::mem::take(&mut current));
+                    if fields.len() >= limit {
+                        return fields;
+                    }
                     i += 1; // consume the nws char
                     while i < chars.len() && is_ifs_ws(chars[i]) {
                         i += 1;
@@ -8674,6 +8714,9 @@ impl Interpreter {
                 } else if i < chars.len() {
                     // ws alone as delimiter (no nws follows)
                     fields.push(std::mem::take(&mut current));
+                    if fields.len() >= limit {
+                        return fields;
+                    }
                 }
                 // trailing ws at end → ignore (don't push empty field)
             } else {
@@ -8682,7 +8725,7 @@ impl Interpreter {
             }
         }
 
-        if !current.is_empty() {
+        if !current.is_empty() && fields.len() < limit {
             fields.push(current);
         }
 

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -4431,10 +4431,9 @@ echo ${#arr[@]}
         let result = bash.exec(script).await.unwrap();
         assert_eq!(result.exit_code, 0);
         let count: usize = result.stdout.trim().parse().unwrap_or(0);
-        assert!(
-            count <= 100,
-            "Word-split array assignment should be capped at max_array_entries, got {}",
-            count
+        assert_eq!(
+            count, 100,
+            "Word-split array assignment should stop at max_array_entries"
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth when compound array assignments perform IFS word-splitting (e.g. `arr=($x)`), which could bypass `MemoryLimits::max_array_entries` and exhaust host memory.

### Description
- Avoid building an unbounded temporary `Vec` of split fields by expanding directly into the replacement array and stopping when the entry cap is reached.
- Compute allowed new entries from `memory_limits.max_array_entries` and `memory_budget.array_entries` and enforce this cap during insertion while preserving append semantics and index calculation.
- Add a bounded splitter `ifs_split_limited` and use it for unquoted expansion splitting so at-most-`remaining` fields are materialized; keep quoted splat handling via `expand_word_to_fields`.
- Apply the replacement via the existing `insert_array_checked` path so budget accounting is updated atomically, and tighten the integration threat-model test to assert the capped behavior exactly.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p bashkit array_assignment_word_split_respects_array_entry_limit --test integration --features http_client,ssh,sqlite` which passed.
- Ran `cargo test -p bashkit bash_spec_tests --test integration --features http_client,ssh,sqlite` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ba800aba0832b9584f72e2169eb19)