### PR TITLE
fix(limits): enforce budgets for local compound arrays

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6206,12 +6206,8 @@ impl Interpreter {
                     let is_compound = value.starts_with('(') && value.ends_with(')');
                     if is_compound {
                         let inner = &value[1..value.len() - 1];
-                        if flags.assoc {
-                            let arr = self
-                                .assoc_arrays_mut()
-                                .entry(var_name.to_string())
-                                .or_default();
-                            arr.clear();
+                        let inserted = if flags.assoc {
+                            let mut arr = HashMap::new();
                             let mut rest = inner.trim();
                             while let Some(bracket_start) = rest.find('[') {
                                 if let Some(bracket_end) = rest[bracket_start..].find(']') {
@@ -6246,15 +6242,18 @@ impl Interpreter {
                                     break;
                                 }
                             }
+                            self.insert_assoc_array_checked(var_name.to_string(), arr)
                         } else {
-                            let arr = self.arrays_mut().entry(var_name.to_string()).or_default();
-                            arr.clear();
+                            let mut arr = HashMap::new();
                             for (idx, val) in inner.split_whitespace().enumerate() {
                                 arr.insert(idx, val.trim_matches('"').to_string());
                             }
+                            self.insert_array_checked(var_name.to_string(), arr)
+                        };
+                        // Mark local only when the backing array fit the memory budget.
+                        if inserted {
+                            self.insert_local_checked(var_name.to_string(), String::new());
                         }
-                        // Mark local
-                        self.insert_local_checked(var_name.to_string(), String::new());
                     } else if flags.nameref {
                         self.insert_local_checked(var_name.to_string(), String::new());
                     } else if flags.integer {
@@ -6302,11 +6301,7 @@ impl Interpreter {
                     if is_compound {
                         let inner = &value[1..value.len() - 1];
                         if flags.assoc {
-                            let arr = self
-                                .assoc_arrays_mut()
-                                .entry(var_name.to_string())
-                                .or_default();
-                            arr.clear();
+                            let mut arr = HashMap::new();
                             let mut rest = inner.trim();
                             while let Some(bracket_start) = rest.find('[') {
                                 if let Some(bracket_end) = rest[bracket_start..].find(']') {
@@ -6341,12 +6336,13 @@ impl Interpreter {
                                     break;
                                 }
                             }
+                            let _ = self.insert_assoc_array_checked(var_name.to_string(), arr);
                         } else {
-                            let arr = self.arrays_mut().entry(var_name.to_string()).or_default();
-                            arr.clear();
+                            let mut arr = HashMap::new();
                             for (idx, val) in inner.split_whitespace().enumerate() {
                                 arr.insert(idx, val.trim_matches('"').to_string());
                             }
+                            let _ = self.insert_array_checked(var_name.to_string(), arr);
                         }
                     } else if flags.nameref {
                         self.set_nameref(var_name, value.to_string());

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3702,6 +3702,58 @@ printf "%s\n" "${a:-unset}" "${b:-unset}" "${c:-unset}"
         assert_eq!(lines[2], "unset");
     }
 
+    /// TM-DOS-060: local builtin assignments in functions must honor variable count budget.
+    #[tokio::test]
+    async fn tm_dos_060_function_local_assignment_respects_budget() {
+        let mem = MemoryLimits::new().max_variable_count(2);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+f() {
+    local a=1 b=2
+    printf "%s\n" "${a:-unset}" "${b:-unset}"
+}
+f
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["1", "unset"]);
+    }
+
+    /// TM-DOS-060: local compound array assignments must honor array entry budget.
+    #[tokio::test]
+    async fn tm_dos_060_local_compound_array_respects_budget() {
+        let mem = MemoryLimits::new().max_array_entries(1);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+local arr=(a b c)
+printf "%s\n" "${#arr[@]}"
+f() {
+    local inner=(x y z)
+    printf "%s\n" "${#inner[@]}"
+}
+f
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        let counts: Vec<usize> = result
+            .stdout
+            .lines()
+            .map(|line| line.parse::<usize>().unwrap())
+            .collect();
+        assert_eq!(counts, vec![0, 0]);
+    }
+
     /// TM-DOS-060: Array entry bomb — indexed array with many entries.
     #[tokio::test]
     async fn tm_dos_060_array_entry_bomb() {


### PR DESCRIPTION
### Motivation
- Memory budget helpers existed (`insert_variable_checked`, `insert_array_checked`) but compound `local` array assignments mutated backing maps directly, allowing `max_array_entries` and `max_variable_count` to be bypassed. 
- Fix prevents attacker-controlled scripts from growing interpreter heap by routing all compound array writes through the budgeted insert helpers.

### Description
- Route `local arr=(...)` and `local -A arr=(...)` (both function-local and non-function/global paths) to build a temporary `HashMap` and call `insert_array_checked` / `insert_assoc_array_checked` instead of mutating `self.arrays` / `self.assoc_arrays` directly in `execute_local_builtin` (`crates/bashkit/src/interpreter/mod.rs`).
- Only mark a name as a local via `insert_local_checked` when the checked array insert actually succeeded, avoiding unsynchronized local creation when budget is exceeded.
- Add regression tests that cover function-local variable-budget enforcement and local compound array entry budget enforcement (`crates/bashkit/tests/integration/threat_model_tests.rs`).
- Small refactor to reuse existing memory-budget helpers and keep behavior unchanged when budgets are not exceeded.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran targeted integration tests `cargo test -p bashkit --test integration memory_limits` and the added tests passed (integration memory_limits suite: all tests passed). 
- Ran `cargo clippy -p bashkit --test integration -- -D warnings` which completed without warnings. 
- Note: `git fetch origin main && git rebase origin/main` could not be executed because this checkout has no `origin` remote configured, so the change was created against the current branch head.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bba37fed4832baf67de74caf732ca)