### PR TITLE
fix(interpreter): prevent brace step overflow

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -11112,22 +11112,24 @@ impl Interpreter {
             }
 
             let mut results = Vec::new();
-            // Bash behavior: direction is determined by start/end,
-            // step sign determines actual increment direction
+            // Bash behavior: direction is determined by start/end. Keep stepping in i128 so
+            // huge but valid i64 steps cannot overflow after the precomputed range cap passes.
+            let step_magnitude = step.unsigned_abs() as i128;
             let effective_step = if start_num <= end_num {
-                step.abs()
+                step_magnitude
             } else {
-                -(step.abs())
+                -step_magnitude
             };
 
-            let mut i = start_num;
+            let mut i = start_num as i128;
+            let end = end_num as i128;
             if effective_step > 0 {
-                while i <= end_num {
+                while i <= end {
                     results.push(i.to_string());
                     i += effective_step;
                 }
             } else {
-                while i >= end_num {
+                while i >= end {
                     results.push(i.to_string());
                     i += effective_step;
                 }
@@ -11230,6 +11232,24 @@ mod tests {
         assert_eq!(
             interp.try_expand_range("z..a..-256"),
             Some(vec!["z".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_try_expand_range_numeric_large_step_does_not_overflow() {
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let interp = Interpreter::new(Arc::clone(&fs));
+
+        assert_eq!(
+            interp
+                .try_expand_range("9223372036854775802..9223372036854775807..9223372036854775807"),
+            Some(vec!["9223372036854775802".to_string()])
+        );
+        assert_eq!(
+            interp.try_expand_range(
+                "-9223372036854775803..-9223372036854775808..-9223372036854775808"
+            ),
+            Some(vec!["-9223372036854775803".to_string()])
         );
     }
 


### PR DESCRIPTION
### Motivation
- Prevent DoS and non-terminating brace expansions where large or specially-crafted `..step` values could overflow or leave the loop unadvanced, bypassing the existing range-size cap and causing panics or unbounded resource growth.

### Description
- Use i128 arithmetic for numeric brace range stepping by converting the step magnitude to `i128` and iterating `i` and `end` as `i128` so valid large `i64` steps cannot overflow during iteration.
- Preserve the precomputed range-size cap (`MAX_BRACE_RANGE`) and the existing validation logic that rejects zero or non-numeric steps.
- Add a regression unit test `test_try_expand_range_numeric_large_step_does_not_overflow` that asserts correct behavior for ascending and descending large-step numeric ranges near `i64` bounds.
- Modified file: `crates/bashkit/src/interpreter/mod.rs`.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p bashkit test_try_expand_range_numeric_large_step_does_not_overflow --lib` and it passed.
- Ran `cargo test -p bashkit test_try_expand_range_alpha_large_step_does_not_loop --lib` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bba8333fc832b9ad5c559dfa257a6)