### PR TITLE
fix(ci): scope Doppler token to secret fetch steps

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -31,7 +31,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
 jobs:
   typecheck:
@@ -205,16 +204,26 @@ jobs:
           ${{ matrix.run }} langchain_integration.mjs
           ${{ matrix.run }} custom_builtins.mjs
 
+      - name: Detect Doppler availability
+        id: doppler
+        if: github.event_name != 'pull_request'
+        run: echo "available=${{ secrets.DOPPLER_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Install Doppler CLI
-        if: env.DOPPLER_TOKEN != ''
+        if: steps.doppler.outputs.available == 'true'
         uses: dopplerhq/cli-action@v4
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       # `--only-secrets OPENAI_API_KEY` keeps the runtime env scoped to
       # just the key these scripts need, instead of injecting every
-      # secret in the Doppler config.
+      # secret in the Doppler config. DOPPLER_TOKEN stays scoped to this
+      # trusted secret-fetch step, not npm install/build/test/example code.
       - name: Run AI examples
-        if: env.DOPPLER_TOKEN != '' && github.event_name != 'pull_request'
+        if: steps.doppler.outputs.available == 'true'
         working-directory: examples
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           doppler run --only-secrets OPENAI_API_KEY -- ${{ matrix.run }} openai_tool.mjs
           doppler run --only-secrets OPENAI_API_KEY -- ${{ matrix.run }} vercel_ai_tool.mjs

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -22,7 +22,6 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   CARGO_INCREMENTAL: "1"
   DEBUG: "napi:*"
-  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
 jobs:
   # ============================================================================
@@ -209,20 +208,29 @@ jobs:
             ln -s ${{ github.workspace }}/crates/bashkit-js node_modules/@everruns/bashkit
           fi
 
+      - name: Detect Doppler availability
+        id: doppler
+        run: echo "available=${{ secrets.DOPPLER_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Install Doppler CLI
-        if: env.DOPPLER_TOKEN != ''
+        if: steps.doppler.outputs.available == 'true'
         uses: dopplerhq/cli-action@v4
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       # `--only-secrets OPENAI_API_KEY` keeps the runtime env scoped to
       # just the key these scripts need, instead of injecting every
-      # secret in the Doppler config.
+      # secret in the Doppler config. DOPPLER_TOKEN stays scoped to this
+      # trusted secret-fetch step, not npm install/build/test/example code.
       # Skipped on Windows + Node 24: libuv hits an assertion failure
       # (`!(handle->flags & UV_HANDLE_CLOSING)` in src/win/async.c) during
       # process shutdown of the example scripts on that combination; the
       # same examples pass on every other platform/Node combination.
       - name: Run AI examples
-        if: env.DOPPLER_TOKEN != '' && !(runner.os == 'Windows' && matrix.node == '24')
+        if: steps.doppler.outputs.available == 'true' && !(runner.os == 'Windows' && matrix.node == '24')
         shell: bash
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
           doppler run --only-secrets OPENAI_API_KEY -- node examples/openai_tool.mjs
           doppler run --only-secrets OPENAI_API_KEY -- node examples/vercel_ai_tool.mjs
@@ -320,12 +328,20 @@ jobs:
           mkdir -p node_modules/@everruns
           ln -s ${{ github.workspace }}/crates/bashkit-js node_modules/@everruns/bashkit
 
+      - name: Detect Doppler availability
+        id: doppler
+        run: echo "available=${{ secrets.DOPPLER_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Install Doppler CLI
-        if: env.DOPPLER_TOKEN != ''
+        if: steps.doppler.outputs.available == 'true'
         uses: dopplerhq/cli-action@v4
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
       - name: Run AI examples
-        if: env.DOPPLER_TOKEN != ''
+        if: steps.doppler.outputs.available == 'true'
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: >
           docker run --rm -v ${{ github.workspace }}:${{ github.workspace }}
           -w ${{ github.workspace }}


### PR DESCRIPTION
### Motivation
- Workflows placed `DOPPLER_TOKEN` in top-level `env`, exposing the secret to `pnpm install`, builds, tests and example runs.
- Limit secret exposure to only the trusted steps that need it (Doppler CLI / secret-fetch) to prevent exfiltration via lifecycle scripts or PR-controlled JS code.

### Description
- Removed workflow-level `DOPPLER_TOKEN` from `.github/workflows/js.yml` and `.github/workflows/publish-js.yml`.
- Added a lightweight detection step (`id: doppler`) that sets `steps.doppler.outputs.available` without placing the token into the global process env.
- Scoped `DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}` only on the Doppler CLI install and AI example secret-fetch steps so npm installs, builds and tests no longer inherit the secret.

### Testing
- Ran a Python static check to confirm no top-level `DOPPLER_TOKEN` remains and that scoped `DOPPLER_TOKEN` entries appear only on Doppler steps (`python3` script). (passed)
- Parsed both edited workflow files with Ruby YAML loader to validate syntax (`ruby -e 'require "yaml"; ...'`). (passed)
- Linted workflows with `actionlint` after edits to ensure workflow correctness. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bc27c77d0832b9d4230286b06127e)