### PR TITLE
fix(parser): charge heredoc reinjection to parser fuel

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1790,6 +1790,20 @@ impl<'a> Lexer<'a> {
     /// Read here document content with optional leading-tab stripping on the
     /// delimiter match (for `<<-`).
     pub fn read_heredoc_with_strip(&mut self, delimiter: &str, strip_tabs: bool) -> String {
+        self.read_heredoc_with_strip_metered(delimiter, strip_tabs)
+            .0
+    }
+
+    /// Read here document content and report rest-of-line work for parser fuel.
+    /// THREAT[TM-DOS-064]: Long heredoc command-line suffixes are re-injected so
+    /// list/pipeline tokens after `<<EOF` stay visible. Charging the suffix length
+    /// to parser fuel prevents chained heredocs from repeatedly copying suffixes
+    /// outside resource accounting.
+    pub(crate) fn read_heredoc_with_strip_metered(
+        &mut self,
+        delimiter: &str,
+        strip_tabs: bool,
+    ) -> (String, usize) {
         let mut content = String::new();
         let mut current_line = String::new();
 
@@ -1866,6 +1880,7 @@ impl<'a> Lexer<'a> {
 
         // Re-inject saved rest-of-line so subsequent tokens (pipes, commands, etc.)
         // are visible to the parser. Add a newline so the tokenizer sees the line break.
+        let rest_of_line_chars = rest_of_line.chars().count();
         if !rest_of_line.is_empty() {
             for ch in rest_of_line.chars() {
                 self.reinject_buf.push_back(ch);
@@ -1873,7 +1888,7 @@ impl<'a> Lexer<'a> {
             self.reinject_buf.push_back('\n');
         }
 
-        content
+        (content, rest_of_line_chars)
     }
 }
 

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -179,6 +179,27 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    /// Consume multiple parser fuel units for lexer work that can scale with input size.
+    /// THREAT[TM-DOS-064]: Heredoc rest-of-line re-injection copies command suffixes;
+    /// charge each copied character so repeated heredocs cannot hide quadratic work
+    /// outside parser fuel accounting.
+    fn tick_units(&mut self, units: usize) -> Result<()> {
+        if let Some(timeout) = self.timeout
+            && self.started_at.elapsed() > timeout
+        {
+            return Err(Error::ResourceLimit(LimitExceeded::ParserTimeout(timeout)));
+        }
+        if self.fuel < units {
+            let used = self.max_fuel;
+            return Err(Error::parse(format!(
+                "parser fuel exhausted ({} operations, max {})",
+                used, self.max_fuel
+            )));
+        }
+        self.fuel -= units;
+        Ok(())
+    }
+
     /// Push nesting depth and check limit
     fn push_depth(&mut self) -> Result<()> {
         self.current_depth += 1;
@@ -404,7 +425,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse redirections that follow a compound command (>, >>, 2>, etc.)
-    fn parse_trailing_redirects(&mut self) -> Vec<Redirect> {
+    fn parse_trailing_redirects(&mut self) -> Result<Vec<Redirect>> {
         let mut redirects = Vec::new();
         loop {
             match &self.current_token {
@@ -579,7 +600,10 @@ impl<'a> Parser<'a> {
                         | Some(tokens::Token::QuotedGlobWord(w)) => (w.clone(), true),
                         _ => break,
                     };
-                    let content = self.lexer.read_heredoc_with_strip(&delimiter, strip_tabs);
+                    let (content, rest_of_line_chars) = self
+                        .lexer
+                        .read_heredoc_with_strip_metered(&delimiter, strip_tabs);
+                    self.tick_units(rest_of_line_chars)?;
                     let content = if strip_tabs {
                         let had_trailing_newline = content.ends_with('\n');
                         let mut stripped: String = content
@@ -618,7 +642,7 @@ impl<'a> Parser<'a> {
                 _ => break,
             }
         }
-        redirects
+        Ok(redirects)
     }
 
     /// Parse a compound command and any trailing redirections
@@ -627,7 +651,7 @@ impl<'a> Parser<'a> {
         parser: impl FnOnce(&mut Self) -> Result<CompoundCommand>,
     ) -> Result<Option<Command>> {
         let compound = parser(self)?;
-        let redirects = self.parse_trailing_redirects();
+        let redirects = self.parse_trailing_redirects()?;
         Ok(Some(Command::Compound(compound, redirects)))
     }
 
@@ -2188,7 +2212,10 @@ impl<'a> Parser<'a> {
             _ => return Err(Error::parse("expected delimiter after <<".to_string())),
         };
 
-        let content = self.lexer.read_heredoc_with_strip(&delimiter, strip_tabs);
+        let (content, rest_of_line_chars) = self
+            .lexer
+            .read_heredoc_with_strip_metered(&delimiter, strip_tabs);
+        self.tick_units(rest_of_line_chars)?;
 
         // Strip leading tabs for <<-
         let content = if strip_tabs {
@@ -3948,6 +3975,16 @@ mod tests {
             AssignmentValue::Scalar(word) => assert_eq!(word.to_string(), "a+=b"),
             AssignmentValue::Array(_) => panic!("expected scalar assignment"),
         }
+    }
+
+    #[test]
+    fn test_chained_heredoc_reinjection_consumes_parser_fuel() {
+        let script = ": <<E && : <<E && : <<E\nE\nE\nE\n";
+        let err = Parser::with_fuel(script, 12).parse().unwrap_err();
+        assert!(
+            err.to_string().contains("parser fuel exhausted"),
+            "expected heredoc rest-of-line reinjection to consume parser fuel, got: {err}"
+        );
     }
 
     #[test]

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -242,6 +242,7 @@ runaway scripts without permanently breaking the session.
 | TM-DOS-021 | Command sub nesting | `$($($($())))` | Child parsers inherit remaining depth budget + fuel from parent | **MITIGATED** |
 | TM-DOS-022 | Parser recursion | Deeply nested `(((())))` | `max_ast_depth` limit (100) + `HARD_MAX_AST_DEPTH` cap (100) | **MITIGATED** |
 | TM-DOS-026 | Arithmetic recursion | `$(((((((...)))))))` deeply nested parens | `MAX_ARITHMETIC_DEPTH` limit (50) | **MITIGATED** |
+| TM-DOS-064 | Heredoc suffix re-injection CPU amplification | Many `: <<E && : <<E ...` heredocs on one logical line repeatedly copy command-line suffixes | `read_heredoc_with_strip_metered` reports re-injected suffix length; parser charges it to `max_parser_operations` fuel | **MITIGATED** |
 
 **Current Risk**: LOW - Both execution and parser protected
 
@@ -253,6 +254,7 @@ max_ast_depth: 100,           // Parser recursion (TM-DOS-022)
 // depth budget and fuel from parent parser (parser/mod.rs lines 1553, 1670)
 // TM-DOS-026: Arithmetic evaluator tracks recursion depth, capped at 50
 // (interpreter/mod.rs MAX_ARITHMETIC_DEPTH)
+// TM-DOS-064: Heredoc rest-of-line re-injection is charged to parser fuel
 ```
 
 **History** (TM-DOS-021): Previously marked MITIGATED but child parsers created via
@@ -1486,6 +1488,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Session-level cumulative counters | TM-ISO-005 | `SessionLimits` caps cumulative commands and `exec()` calls across the lifetime of a `Bash` instance | **MITIGATED** |
 | Per-instance memory budget | TM-ISO-006 | `MemoryLimits` capping variable count, total bytes, array entries, function count, function body bytes | **MITIGATED** |
 | jq file binding amplification | TM-DOS-062 | `MAX_FILE_VAR_REQUESTS` and `MAX_FILE_VAR_BYTES` bound `--rawfile` / `--slurpfile` globals | **MITIGATED** |
+| Heredoc suffix re-injection CPU amplification | TM-DOS-064 | Charge re-injected heredoc rest-of-line suffix length to parser fuel | **MITIGATED** |
 
 ---
 


### PR DESCRIPTION
### Motivation
- Heredoc handling re-injected the rest-of-line suffix into the lexer and pushed it character-by-character, allowing many `<<` heredocs on one logical line to repeatedly copy the same suffix and produce O(n^2) CPU work not accounted to parser fuel, enabling a CPU DoS.
- The intent is to prevent chained heredocs from hiding repeated suffix-copy work outside `max_parser_operations` while preserving heredoc semantics (pipes/redirects visible after the heredoc body).

### Description
- Added `Lexer::read_heredoc_with_strip_metered` which returns `(content, rest_of_line_chars)` so callers know how many characters were re-injected. The existing `read_heredoc_with_strip` delegates to the new metered helper to preserve the public lexer API and tests.
- Added `Parser::tick_units(units: usize)` to consume multiple parser fuel units at once and fail early if fuel/timeouts are insufficient.
- Parser now calls the metered lexer API and charges the returned `rest_of_line_chars` to fuel via `tick_units(...)` in the heredoc paths (both inline trailing-redirect and `parse_heredoc_redirect` flows), and adjusted `parse_trailing_redirects` to return `Result<Vec<Redirect>>` accordingly.
- Added a unit test `test_chained_heredoc_reinjection_consumes_parser_fuel` that asserts chained `: <<E && : <<E ...` scripts consume parser fuel (fail with `parser fuel exhausted`), and documented the mitigation as `TM-DOS-064` in `specs/threat-model.md`.

### Testing
- Ran `cargo fmt --check` (passed).
- Ran targeted parser unit tests `cargo test -p bashkit parser:: --lib` which passed, including the new regression test `test_chained_heredoc_reinjection_consumes_parser_fuel` (ok).
- Ran the full crate unit test suite `cargo test -p bashkit --lib` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bcb34190c832bb32231eeab2ca004)