### PR TITLE
fix(rg): stream summary scans to avoid eager line allocation

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4085,26 +4085,29 @@ struct RgMultilineMatch<'a> {
     column: usize,
 }
 
-fn split_rg_lines(content: &str, crlf: bool, null_data: bool) -> Vec<RgLine<'_>> {
-    let mut lines = Vec::new();
+fn iter_rg_lines(content: &str, crlf: bool, null_data: bool) -> impl Iterator<Item = RgLine<'_>> {
     let mut offset = 0usize;
     let terminator = if null_data { '\0' } else { '\n' };
-    for raw in content.split_inclusive(terminator) {
+    content.split_inclusive(terminator).map(move |raw| {
+        let start_offset = offset;
+        offset += raw.len();
         let text = raw.strip_suffix(terminator).unwrap_or(raw);
         let match_text = if crlf {
             text.strip_suffix('\r').unwrap_or(text)
         } else {
             text
         };
-        lines.push(RgLine {
+        RgLine {
             text,
             match_text,
             raw,
-            start_offset: offset,
-        });
-        offset += raw.len();
-    }
-    lines
+            start_offset,
+        }
+    })
+}
+
+fn split_rg_lines(content: &str, crlf: bool, null_data: bool) -> Vec<RgLine<'_>> {
+    iter_rg_lines(content, crlf, null_data).collect()
 }
 
 fn rg_record_terminator(opts: &RgOptions) -> char {
@@ -5139,13 +5142,196 @@ impl Builtin for Rg {
             } else {
                 content
             };
-            let lines = split_rg_lines(content, opts.crlf, opts.null_data);
             let record_terminator = rg_record_terminator(&opts);
             json_bytes_searched += content.len();
             if !json_binary_search {
                 json_searches += 1;
             }
             stats.bytes_searched += content.len();
+
+            if opts.multiline
+                && !opts.invert_match
+                && !opts.stats
+                && !json_output
+                && (opts.quiet || opts.files_with_matches || opts.files_without_matches)
+            {
+                // THREAT[TM-DOS-RG-LINES]: multiline existence modes can decide
+                // from the whole buffer without materializing one `RgLine` per
+                // input record. Invert/stats modes still need line accounting.
+                let matched = regex.is_match(content);
+                let match_count = usize::from(matched);
+                if matched {
+                    stats.matches += 1;
+                    stats.matched_lines += 1;
+                    stats.files_with_matches += 1;
+                    if !opts.files_without_matches {
+                        any_match = true;
+                    }
+                }
+
+                if opts.quiet {
+                    if let Some(result) = rg_quiet_result(
+                        &opts,
+                        match_count,
+                        &mut any_match,
+                        &collected_inputs.stderr,
+                    ) {
+                        return Ok(result);
+                    }
+                    continue;
+                }
+                if opts.files_with_matches && matched {
+                    output.push_str(&color_path(
+                        filename,
+                        opts.color_enabled(),
+                        &opts.color_scheme,
+                    ));
+                    output.push(if opts.null || opts.null_data {
+                        '\0'
+                    } else {
+                        '\n'
+                    });
+                    continue;
+                }
+                if opts.files_without_matches {
+                    if !matched {
+                        any_match = true;
+                        output.push_str(&color_path(
+                            filename,
+                            opts.color_enabled(),
+                            &opts.color_scheme,
+                        ));
+                        output.push(if opts.null || opts.null_data {
+                            '\0'
+                        } else {
+                            '\n'
+                        });
+                    }
+                    continue;
+                }
+            }
+
+            let summary_only = !opts.multiline
+                && !json_output
+                && !opts.passthru
+                && !has_context
+                && (opts.quiet
+                    || opts.files_with_matches
+                    || opts.files_without_matches
+                    || opts.count_only
+                    || opts.count_matches);
+            if summary_only {
+                // THREAT[TM-DOS-RG-LINES]: summary/early-exit modes do not need
+                // random line access. Stream them to avoid one allocation per
+                // attacker-controlled input line before `-q`/`-l` can return.
+                for line in iter_rg_lines(content, opts.crlf, opts.null_data) {
+                    let matched = regex.is_match(line.match_text);
+                    let matched = if opts.invert_match { !matched } else { matched };
+
+                    if !matched {
+                        if opts.stop_on_nonmatch && match_count > 0 {
+                            break;
+                        }
+                        continue;
+                    }
+
+                    if let Some(max) = opts.max_count
+                        && match_count >= max
+                    {
+                        break;
+                    }
+
+                    match_count += 1;
+                    let matches_on_line = if opts.invert_match {
+                        if opts.count_only || opts.count_matches {
+                            1
+                        } else {
+                            0
+                        }
+                    } else {
+                        regex.count_matches(line.match_text)
+                    };
+                    if opts.count_matches && !opts.invert_match {
+                        count_value += matches_on_line;
+                    } else {
+                        count_value += 1;
+                    }
+                    stats.matches += matches_on_line;
+                    stats.matched_lines += 1;
+                    if !opts.files_without_matches {
+                        any_match = true;
+                    }
+
+                    if (opts.files_with_matches || opts.files_without_matches || opts.quiet)
+                        && !opts.stats
+                    {
+                        break;
+                    }
+                }
+
+                if match_count > 0 {
+                    stats.files_with_matches += 1;
+                }
+
+                if opts.quiet {
+                    if let Some(result) = rg_quiet_result(
+                        &opts,
+                        match_count,
+                        &mut any_match,
+                        &collected_inputs.stderr,
+                    ) {
+                        return Ok(result);
+                    }
+                    continue;
+                }
+                if opts.files_with_matches && match_count > 0 {
+                    output.push_str(&color_path(
+                        filename,
+                        opts.color_enabled(),
+                        &opts.color_scheme,
+                    ));
+                    output.push(if opts.null || opts.null_data {
+                        '\0'
+                    } else {
+                        '\n'
+                    });
+                    continue;
+                }
+                if opts.files_without_matches {
+                    if match_count == 0 {
+                        any_match = true;
+                        output.push_str(&color_path(
+                            filename,
+                            opts.color_enabled(),
+                            &opts.color_scheme,
+                        ));
+                        output.push(if opts.null || opts.null_data {
+                            '\0'
+                        } else {
+                            '\n'
+                        });
+                    }
+                    continue;
+                }
+                if opts.count_only || opts.count_matches {
+                    if count_value == 0 && !opts.include_zero {
+                        continue;
+                    }
+                    if show_filename {
+                        output.push_str(&color_path(
+                            filename,
+                            opts.color_enabled(),
+                            &opts.color_scheme,
+                        ));
+                        output.push(if opts.null { '\0' } else { ':' });
+                    }
+                    output.push_str(&count_value.to_string());
+                    output.push(record_terminator);
+                    continue;
+                }
+            }
+
+            let lines = split_rg_lines(content, opts.crlf, opts.null_data);
 
             if opts.multiline {
                 // Early-exit modes only need to know whether any match exists, so cap
@@ -6192,6 +6378,42 @@ mod tests {
     use std::io::Write;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
+
+    #[test]
+    fn rg_line_iterator_tracks_offsets_without_eager_collection() {
+        let mut lines = iter_rg_lines("a\nb\r\nc", true, false);
+
+        let first = lines.next().expect("first line");
+        assert_eq!(first.text, "a");
+        assert_eq!(first.match_text, "a");
+        assert_eq!(first.raw, "a\n");
+        assert_eq!(first.start_offset, 0);
+
+        let second = lines.next().expect("second line");
+        assert_eq!(second.text, "b\r");
+        assert_eq!(second.match_text, "b");
+        assert_eq!(second.raw, "b\r\n");
+        assert_eq!(second.start_offset, 2);
+
+        let third = lines.next().expect("third line");
+        assert_eq!(third.text, "c");
+        assert_eq!(third.match_text, "c");
+        assert_eq!(third.raw, "c");
+        assert_eq!(third.start_offset, 5);
+        assert!(lines.next().is_none());
+    }
+
+    #[test]
+    fn rg_line_iterator_honors_null_data_records() {
+        let lines: Vec<_> = iter_rg_lines("a\0b", false, true).collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].text, "a");
+        assert_eq!(lines[0].raw, "a\0");
+        assert_eq!(lines[0].start_offset, 0);
+        assert_eq!(lines[1].text, "b");
+        assert_eq!(lines[1].raw, "b");
+        assert_eq!(lines[1].start_offset, 2);
+    }
 
     #[test]
     fn glob_brace_alternation_depth_limit_does_not_expand_nested_pattern() {


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory amplification from eagerly materializing every input line for `rg` when early-exit/summary modes (quiet, files-with-matches, files-without-match, count modes) only need existence/count information.
- Preserve existing behavior for output modes that require random access/context while eliminating the OOM attack surface introduced by per-line `RgLine` Vec collection.

### Description
- Add a streaming helper `iter_rg_lines(content, crlf, null_data) -> impl Iterator<Item=RgLine<'_>>` that yields `RgLine` with `text`, `match_text`, `raw`, and `start_offset` without allocating a `Vec` per input line.
- Keep `split_rg_lines` as a thin wrapper (`iter_rg_lines(...).collect()`) for code paths that still need random access/context.
- Route safe early-exit/multiline-existence cases to cheaper checks: whole-buffer match short-circuit for certain multiline-existence modes, and streaming per-line scans for summary/early-exit modes (`-q`, `-l`, `--files-without-match`, `-c`, `--count-matches`) to avoid allocating one `RgLine` per input record.
- Add unit tests exercising the iterator behavior (`rg_line_iterator_tracks_offsets_without_eager_collection` and `rg_line_iterator_honors_null_data_records`) to cover offsets, CRLF behavior, and NUL-terminated records.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran `cargo test -p bashkit builtins::rg::tests::rg_line_iterator -- --nocapture` and the new iterator tests passed (`2 passed`).
- Ran the full `rg` unit test group `cargo test -p bashkit builtins::rg::tests:: -- --nocapture` and all `rg` tests passed (`70 passed; 0 failed`).
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8a4aea14832b8e2f4d25b859aa72)