### PR TITLE
fix(rg): cap replacement expansion

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -400,6 +400,34 @@ impl<'a> RgMatch<'a> {
     }
 }
 
+fn rg_replacement_cap_marker() -> String {
+    format!(
+        "[rg: replacement output capped at {} bytes]",
+        RG_MAX_REPLACEMENT_OUTPUT_BYTES
+    )
+}
+
+fn replacement_output_exceeds_cap(
+    haystack_len: usize,
+    replacement: &str,
+    match_count: usize,
+    include_unmatched_text: bool,
+) -> bool {
+    let capture_ref_count = replacement.bytes().filter(|&byte| byte == b'$').count();
+    let per_match = replacement
+        .len()
+        .saturating_add(capture_ref_count.saturating_mul(haystack_len));
+    let projected =
+        match_count
+            .saturating_mul(per_match)
+            .saturating_add(if include_unmatched_text {
+                haystack_len
+            } else {
+                0
+            });
+    projected > RG_MAX_REPLACEMENT_OUTPUT_BYTES
+}
+
 impl RgMatcher {
     fn is_match(&self, text: &str) -> bool {
         match self {
@@ -455,19 +483,12 @@ impl RgMatcher {
 
     fn replace_all(&self, text: &str, replacement: &str) -> String {
         // THREAT[TM-DOS-RG-REPLACE]: attacker-controlled `--replace` text combined
-        // with many matches can allocate output ≈ matches × replacement_len before
-        // interpreter stdout truncation, enabling memory amplification / OOM.
-        // Project the size up front and refuse to allocate past the cap; surface a
-        // visible marker in the output instead of silently truncating.
+        // with many matches can allocate output before interpreter stdout
+        // truncation. Budget on a conservative expansion upper bound so capture
+        // references like `$1` cannot bypass the plain replacement length check.
         let match_count = self.count_matches(text);
-        let projected = text
-            .len()
-            .saturating_add(match_count.saturating_mul(replacement.len()));
-        if projected > RG_MAX_REPLACEMENT_OUTPUT_BYTES {
-            return format!(
-                "[rg: replacement output capped at {} bytes]",
-                RG_MAX_REPLACEMENT_OUTPUT_BYTES
-            );
+        if replacement_output_exceeds_cap(text.len(), replacement, match_count, true) {
+            return rg_replacement_cap_marker();
         }
         match self {
             Self::Rust(regex) => regex.replace_all(text, replacement).into_owned(),
@@ -476,20 +497,17 @@ impl RgMatcher {
     }
 
     fn replace_first(&self, text: &str, replacement: &str) -> String {
-        // Same cap as replace_all — for a single match the worst case is
-        // text.len() + replacement.len(), so the cap mainly guards against
-        // an attacker-supplied giant replacement string.
-        let projected = text.len().saturating_add(replacement.len());
-        if projected > RG_MAX_REPLACEMENT_OUTPUT_BYTES {
-            return format!(
-                "[rg: replacement output capped at {} bytes]",
-                RG_MAX_REPLACEMENT_OUTPUT_BYTES
-            );
+        if replacement_output_exceeds_cap(text.len(), replacement, 1, true) {
+            return rg_replacement_cap_marker();
         }
         match self {
             Self::Rust(regex) => regex.replace(text, replacement).into_owned(),
             Self::Fancy(regex) => regex.replacen(text, 1, replacement).into_owned(),
         }
+    }
+
+    fn replacement_matches_exceed_cap(&self, text: &str, replacement: &str) -> bool {
+        replacement_output_exceeds_cap(text.len(), replacement, self.count_matches(text), false)
     }
 }
 
@@ -6015,6 +6033,17 @@ impl Builtin for Rg {
                 }
             } else if opts.vimgrep && !opts.invert_match {
                 for &line_idx in &match_lines {
+                    if opts.only_matching
+                        && let Some(replacement) = &opts.replacement
+                        && regex.replacement_matches_exceed_cap(
+                            lines[line_idx].match_text,
+                            replacement.as_str(),
+                        )
+                    {
+                        output.push_str(&rg_replacement_cap_marker());
+                        output.push(record_terminator);
+                        continue;
+                    }
                     regex.for_each_match(lines[line_idx].match_text, |mat| {
                         write_rg_prefix(
                             &mut output,
@@ -6048,6 +6077,16 @@ impl Builtin for Rg {
                 }
             } else if opts.only_matching && !opts.invert_match {
                 for &line_idx in &match_lines {
+                    if let Some(replacement) = &opts.replacement
+                        && regex.replacement_matches_exceed_cap(
+                            lines[line_idx].match_text,
+                            replacement.as_str(),
+                        )
+                    {
+                        output.push_str(&rg_replacement_cap_marker());
+                        output.push(record_terminator);
+                        continue;
+                    }
                     regex.for_each_match(lines[line_idx].match_text, |mat| {
                         write_rg_prefix(
                             &mut output,
@@ -13214,6 +13253,71 @@ mod tests {
             all.stdout.len() < 2 * RG_MAX_REPLACEMENT_OUTPUT_BYTES,
             "replace_all output bypassed the cap: {} bytes",
             all.stdout.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rg_only_matching_replace_caps_amplified_output() {
+        let payload = "a".repeat(10_000);
+        let replacement = "x".repeat(2048);
+        let files: &[(&str, &[u8])] = &[("/big.txt", payload.as_bytes())];
+
+        for args in [
+            vec![
+                "--only-matching",
+                "--replace",
+                replacement.as_str(),
+                "a",
+                "/big.txt",
+            ],
+            vec![
+                "--vimgrep",
+                "--only-matching",
+                "--replace",
+                replacement.as_str(),
+                "a",
+                "/big.txt",
+            ],
+        ] {
+            let result = run_rg(&args, None, files).await;
+
+            assert_eq!(result.exit_code, 0);
+            assert!(
+                result.stdout.contains("replacement output capped"),
+                "expected cap marker, got: {:?}", // debug-ok: assert-failure message
+                &result.stdout[..result.stdout.len().min(200)]
+            );
+            assert!(
+                result.stdout.len() < 2 * RG_MAX_REPLACEMENT_OUTPUT_BYTES,
+                "only-matching replacement output bypassed the cap: {} bytes",
+                result.stdout.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rg_replace_caps_capture_amplified_output() {
+        let payload = "a".repeat(500_000);
+        let replacement = "$1$1$1$1";
+        let files: &[(&str, &[u8])] = &[("/big.txt", payload.as_bytes())];
+
+        let result = run_rg(
+            &["--replace", replacement, "(a{1000})", "/big.txt"],
+            None,
+            files,
+        )
+        .await;
+
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.stdout.contains("replacement output capped"),
+            "expected cap marker, got: {:?}", // debug-ok: assert-failure message
+            &result.stdout[..result.stdout.len().min(200)]
+        );
+        assert!(
+            result.stdout.len() < 2 * RG_MAX_REPLACEMENT_OUTPUT_BYTES,
+            "capture replacement output bypassed the cap: {} bytes",
+            result.stdout.len()
         );
     }
 


### PR DESCRIPTION
### Motivation

- Fix a memory-amplification DoS where attacker-controlled `--replace` values could expand to allocations ≈ matches × replacement_len before the interpreter applied `max_stdout_bytes` truncation.  

### Description

- Add conservative pre-expansion budgeting helpers (`replacement_output_exceeds_cap`, `rg_replacement_cap_marker`) and a `replacement_matches_exceed_cap` check in `crates/bashkit/src/builtins/rg/mod.rs`.  
- Enforce the cap in `RgMatcher::replace_all` / `replace_first` and pre-check `--only-matching`/`--vimgrep` per-line code paths so repeated per-match expansion cannot allocate unbounded memory.  
- Add regression tests covering normal replacement amplification, `--only-matching`/`--vimgrep` replacement amplification, and capture-reference amplification in the same `rg` test module.  

### Testing

- Ran formatting and lints: `cargo fmt --check` and `cargo clippy -p bashkit -- -D warnings` — passed.  
- Ran targeted unit tests: `cargo test -p bashkit test_rg_replace_caps -- --nocapture` and `cargo test -p bashkit test_rg_only_matching_replace_caps -- --nocapture` — all new/affected tests passed.  
- Verified no diff-check failures (`git diff --check`) and overall test binary completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8a39341c832bafab177a1ef62759)