### PR TITLE
fix(scripted-tool): isolate extension invocation traces

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -478,7 +478,7 @@ pub use scripted_tool::{
     AsyncToolCallback, CallbackKind, DiscoverTool, DiscoveryMode, ScriptedCommandInvocation,
     ScriptedCommandKind, ScriptedExecutionTrace, ScriptedTool, ScriptedToolBuilder,
     ScriptingToolSet, ScriptingToolSetBuilder, ToolArgs, ToolCallback, ToolDef, ToolDefExtension,
-    ToolDefExtensionBuilder,
+    ToolDefExtensionBuilder, ToolDefInvocationTrace,
 };
 #[cfg(feature = "scripted_tool")]
 pub use tool_def::{AsyncToolExec, SyncToolExec, ToolImpl};

--- a/crates/bashkit/src/scripted_tool/extension.rs
+++ b/crates/bashkit/src/scripted_tool/extension.rs
@@ -130,9 +130,10 @@ impl ToolDefExtensionBuilder {
     /// Build the extension.
     ///
     /// Each call mints a fresh, isolated invocation log. Clones of the
-    /// returned extension share the log with the original — keep a clone
-    /// before passing the extension to a `Bash` if you intend to call
-    /// [`ToolDefExtension::take_invocations`] later.
+    /// returned extension also get a fresh log so cloned configuration can be
+    /// reused across tenants without sharing traces. Use
+    /// [`ToolDefExtension::invocation_trace`] before registration when a caller
+    /// intentionally wants a handle for this extension's trace.
     pub fn build(&self) -> ToolDefExtension {
         ToolDefExtension {
             tools: self.tools.clone(),
@@ -145,14 +146,46 @@ impl ToolDefExtensionBuilder {
 /// Bash extension that registers ToolDef-backed commands plus `help` and `discover`.
 ///
 /// Each [`ToolDefExtensionBuilder::build`] mints a fresh invocation log, so
-/// distinct builds (e.g. per tenant) never share traces. Cloning shares the
-/// log with the original — that is the supported pattern for retaining a
-/// `take_invocations` handle after passing the extension to a `Bash`.
-#[derive(Clone)]
+/// distinct builds (e.g. per tenant) never share traces. Cloning also creates
+/// a fresh log, allowing cloned configuration to be installed into separate
+/// `Bash` instances without cross-tenant trace leakage. Use
+/// [`ToolDefExtension::invocation_trace`] to intentionally retain a trace
+/// handle before registering an extension.
 pub struct ToolDefExtension {
     tools: Vec<RegisteredTool>,
     sanitize_errors: bool,
     invocation_log: InvocationLog,
+}
+
+/// Explicit handle for reading and clearing one extension's invocation trace.
+///
+/// Cloning this handle intentionally shares trace state with the source
+/// extension. Clone [`ToolDefExtension`] itself only for reusable command
+/// configuration; extension clones receive fresh, isolated logs.
+#[derive(Clone)]
+pub struct ToolDefInvocationTrace {
+    invocation_log: InvocationLog,
+}
+
+impl ToolDefInvocationTrace {
+    /// Return and clear accumulated command invocation trace entries.
+    pub fn take_invocations(&self) -> Vec<ScriptedCommandInvocation> {
+        let mut invocations = self
+            .invocation_log
+            .lock()
+            .expect("tool-def invocation log poisoned");
+        std::mem::take(&mut *invocations).into()
+    }
+}
+
+impl Clone for ToolDefExtension {
+    fn clone(&self) -> Self {
+        Self {
+            tools: self.tools.clone(),
+            sanitize_errors: self.sanitize_errors,
+            invocation_log: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
 }
 
 impl ToolDefExtension {
@@ -180,13 +213,20 @@ impl ToolDefExtension {
         self
     }
 
+    /// Return an explicit handle for this extension's invocation trace.
+    ///
+    /// The handle intentionally shares trace state with this extension and can
+    /// be retained after moving the extension into a `Bash` builder. Prefer a
+    /// distinct extension/handle pair per tenant.
+    pub fn invocation_trace(&self) -> ToolDefInvocationTrace {
+        ToolDefInvocationTrace {
+            invocation_log: Arc::clone(&self.invocation_log),
+        }
+    }
+
     /// Return and clear accumulated command invocation trace entries.
     pub fn take_invocations(&self) -> Vec<ScriptedCommandInvocation> {
-        let mut invocations = self
-            .invocation_log
-            .lock()
-            .expect("tool-def invocation log poisoned");
-        std::mem::take(&mut *invocations).into()
+        self.invocation_trace().take_invocations()
     }
 
     fn snapshots(&self) -> Vec<ToolDefSnapshot> {

--- a/crates/bashkit/src/scripted_tool/mod.rs
+++ b/crates/bashkit/src/scripted_tool/mod.rs
@@ -131,7 +131,7 @@ mod execute;
 mod extension;
 mod toolset;
 
-pub use extension::{ToolDefExtension, ToolDefExtensionBuilder};
+pub use extension::{ToolDefExtension, ToolDefExtensionBuilder, ToolDefInvocationTrace};
 pub use toolset::{DiscoverTool, DiscoveryMode, ScriptingToolSet, ScriptingToolSetBuilder};
 
 // Re-export foundational types from tool_def (they used to live here).
@@ -1477,8 +1477,8 @@ mod tests {
             });
         let ext_a = builder.build();
         let ext_b = builder.build();
-        let handle_a = ext_a.clone();
-        let handle_b = ext_b.clone();
+        let handle_a = ext_a.invocation_trace();
+        let handle_b = ext_b.invocation_trace();
 
         let mut bash_a = crate::Bash::builder().extension(ext_a).build();
         let mut bash_b = crate::Bash::builder().extension(ext_b).build();
@@ -1506,26 +1506,40 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tool_def_extension_clones_share_invocation_log() {
-        // Cloning is the supported way to retain a `take_invocations` handle
-        // after passing the extension to a `Bash`.
+    async fn test_tool_def_extension_clones_have_isolated_invocation_logs() {
+        // Cloning copies command configuration only; trace sharing requires an
+        // explicit ToolDefInvocationTrace handle.
         let extension = ToolDefExtension::builder()
             .tool_fn(ToolDef::new("echo_arg", "Echo"), |args: &ToolArgs| {
                 Ok(format!("{}\n", args.param_str("msg").unwrap_or_default()))
             })
             .build();
-        let handle = extension.clone();
+        let clone = extension.clone();
+        let extension_trace = extension.invocation_trace();
+        let clone_trace = clone.invocation_trace();
 
-        let mut bash = crate::Bash::builder().extension(extension).build();
-        bash.exec("echo_arg --msg gamma")
+        let mut bash_a = crate::Bash::builder().extension(extension).build();
+        let mut bash_b = crate::Bash::builder().extension(clone).build();
+        bash_a
+            .exec("echo_arg --msg gamma")
             .await
-            .expect("bash should execute");
+            .expect("bash a should execute");
+        bash_b
+            .exec("echo_arg --msg delta")
+            .await
+            .expect("bash b should execute");
 
-        let trace = handle.take_invocations();
-        assert_eq!(trace.len(), 1);
+        let trace_a = extension_trace.take_invocations();
+        let trace_b = clone_trace.take_invocations();
+        assert_eq!(trace_a.len(), 1);
         assert_eq!(
-            trace[0].args,
+            trace_a[0].args,
             vec!["--msg".to_string(), "gamma".to_string()]
+        );
+        assert_eq!(trace_b.len(), 1);
+        assert_eq!(
+            trace_b[0].args,
+            vec!["--msg".to_string(), "delta".to_string()]
         );
     }
 
@@ -1536,7 +1550,7 @@ mod tests {
                 Ok("ok\n".to_string())
             })
             .build();
-        let handle = extension.clone();
+        let handle = extension.invocation_trace();
         let mut bash = crate::Bash::builder().extension(extension).build();
 
         for _ in 0..300 {
@@ -1562,7 +1576,7 @@ mod tests {
                 Ok("ok\n".to_string())
             })
             .build();
-        let handle = extension.clone();
+        let handle = extension.invocation_trace();
         let mut bash = crate::Bash::builder().extension(extension).build();
 
         let big = "\u{1F600}".repeat(400);

--- a/specs/scripted-tool-orchestration.md
+++ b/specs/scripted-tool-orchestration.md
@@ -169,6 +169,13 @@ The extension contributes:
 `ScriptedTool` builds its per-call logic-only shell by installing this extension,
 so plain `Bash` and `ScriptedTool` use one command adapter path.
 
+Invocation tracing is isolated by default. Every `ToolDefExtensionBuilder::build()`
+call mints a fresh bounded trace log, and `Clone` for `ToolDefExtension` copies
+command configuration into a new empty log rather than sharing trace state. Hosts
+that intentionally need to read traces after moving an extension into a `Bash`
+must call `ToolDefExtension::invocation_trace()` first and retain the returned
+`ToolDefInvocationTrace` handle. Do not share one trace handle across tenants.
+
 ### ContextVar propagation (Python)
 
 Python callbacks (both sync and async) automatically see `contextvars.ContextVar`


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant leakage caused by a shared `Arc<Mutex<...>>` invocation log that could mix raw argv across builds/clones. 
- Ensure trace state is per-extension (or explicitly shared) and bounded to avoid unbounded growth and accidental disclosure.

### Description
- Make `ToolDefExtension::clone()` allocate a fresh invocation log so clones do not share trace state. 
- Add `ToolDefInvocationTrace` (with `take_invocations`) and `ToolDefExtension::invocation_trace()` to provide an explicit, intentional trace handle that can be cloned to share traces when desired. 
- Change `ToolDefExtension::take_invocations()` to forward to the explicit trace handle and update `ToolDefExtensionBuilder::build()` docs to document the isolation contract. 
- Re-export `ToolDefInvocationTrace` from the `scripted_tool` module and crate root, update tests to use `invocation_trace()`, and update `specs/scripted-tool-orchestration.md` to document the new behavior.

### Testing
- Ran `cargo test -p bashkit scripted_tool::tests::test_tool_def_extension --features scripted_tool` and all scripted-tool tests in that group passed (5 passed, 0 failed). 
- Ran `cargo fmt --check` and `git diff --check` with no reported issues. 
- Updated unit tests under `crates/bashkit/src/scripted_tool/mod.rs` to assert per-build and per-clone isolation and to verify bounded/truncated invocation storage, and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8fdc9d64832b8de81d2b4ebf4990)