### PR TITLE
fix(sqlite): cap result memory growth

### DIFF
--- a/crates/bashkit/src/builtins/sqlite/dot_commands.rs
+++ b/crates/bashkit/src/builtins/sqlite/dot_commands.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 
 use turso_core::Value;
 
-use super::engine::{Deadline, SqliteEngine};
+use super::engine::{Deadline, QueryLimits, SqliteEngine};
 use super::formatter::{OutputMode, OutputOpts};
 use super::parser::tokenize_dot;
 
@@ -74,7 +74,7 @@ pub(super) fn dispatch(
     engine: &SqliteEngine,
     opts: &mut OutputOpts,
     deadline: Deadline,
-    max_rows: usize,
+    limits: QueryLimits,
 ) -> Result<DotOutcome, DotError> {
     let (name, args) = tokenize_dot(line);
     match name.as_str() {
@@ -84,12 +84,12 @@ pub(super) fn dispatch(
         "mode" => set_mode(args, opts).map(|_| DotOutcome::Configured),
         "separator" | "sep" => set_separator(args, opts).map(|_| DotOutcome::Configured),
         "nullvalue" | "null" => set_null(args, opts).map(|_| DotOutcome::Configured),
-        "tables" => tables(args, engine, opts, deadline, max_rows).map(DotOutcome::Stdout),
-        "schema" => schema(args, engine, deadline, max_rows).map(DotOutcome::Stdout),
+        "tables" => tables(args, engine, opts, deadline, limits).map(DotOutcome::Stdout),
+        "schema" => schema(args, engine, deadline, limits).map(DotOutcome::Stdout),
         "indexes" | "indices" => {
-            indexes(args, engine, opts, deadline, max_rows).map(DotOutcome::Stdout)
+            indexes(args, engine, opts, deadline, limits).map(DotOutcome::Stdout)
         }
-        "dump" => dump(engine, deadline, max_rows).map(DotOutcome::Stdout),
+        "dump" => dump(engine, deadline, limits).map(DotOutcome::Stdout),
         "read" => {
             let path = args
                 .into_iter()
@@ -191,7 +191,7 @@ fn tables(
     engine: &SqliteEngine,
     opts: &OutputOpts,
     deadline: Deadline,
-    max_rows: usize,
+    limits: QueryLimits,
 ) -> Result<String, DotError> {
     let pattern = args.into_iter().next();
     let sql = match pattern {
@@ -202,7 +202,7 @@ fn tables(
         None => "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name".to_string(),
     };
     let outcome = engine
-        .execute(&sql, deadline, max_rows)
+        .execute(&sql, deadline, limits)
         .map_err(DotError::Engine)?;
     let mut names = Vec::new();
     for row in &outcome.rows {
@@ -225,7 +225,7 @@ fn schema(
     args: Vec<String>,
     engine: &SqliteEngine,
     deadline: Deadline,
-    max_rows: usize,
+    limits: QueryLimits,
 ) -> Result<String, DotError> {
     let pattern = args.into_iter().next();
     let sql = match pattern {
@@ -236,7 +236,7 @@ fn schema(
         None => "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name".to_string(),
     };
     let outcome = engine
-        .execute(&sql, deadline, max_rows)
+        .execute(&sql, deadline, limits)
         .map_err(DotError::Engine)?;
     let mut out = String::new();
     for row in &outcome.rows {
@@ -253,7 +253,7 @@ fn indexes(
     engine: &SqliteEngine,
     _opts: &OutputOpts,
     deadline: Deadline,
-    max_rows: usize,
+    limits: QueryLimits,
 ) -> Result<String, DotError> {
     let pattern = args.into_iter().next();
     let sql = match pattern {
@@ -264,7 +264,7 @@ fn indexes(
         None => "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name".to_string(),
     };
     let outcome = engine
-        .execute(&sql, deadline, max_rows)
+        .execute(&sql, deadline, limits)
         .map_err(DotError::Engine)?;
     let mut out = String::new();
     for row in &outcome.rows {
@@ -279,7 +279,11 @@ fn indexes(
 /// Emit `BEGIN; <CREATE TABLE>...; <INSERT INTO ... VALUES (...)>; COMMIT;`.
 /// This matches sqlite3's `.dump` for tables; views/triggers/indexes only get
 /// their CREATE statement, no rows. Blob literals are emitted as `X'..'`.
-fn dump(engine: &SqliteEngine, deadline: Deadline, max_rows: usize) -> Result<String, DotError> {
+fn dump(
+    engine: &SqliteEngine,
+    deadline: Deadline,
+    limits: QueryLimits,
+) -> Result<String, DotError> {
     let mut out = String::from("PRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\n");
 
     // Schema first.
@@ -287,7 +291,7 @@ fn dump(engine: &SqliteEngine, deadline: Deadline, max_rows: usize) -> Result<St
         .execute(
             "SELECT type, name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY rowid",
             deadline,
-            max_rows,
+            limits,
         )
         .map_err(DotError::Engine)?;
     for row in &schema_outcome.rows {
@@ -302,7 +306,7 @@ fn dump(engine: &SqliteEngine, deadline: Deadline, max_rows: usize) -> Result<St
         .execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
             deadline,
-            max_rows,
+            limits,
         )
         .map_err(DotError::Engine)?;
     for row in &tables_outcome.rows {
@@ -313,7 +317,7 @@ fn dump(engine: &SqliteEngine, deadline: Deadline, max_rows: usize) -> Result<St
         let quoted = name.replace('"', "\"\"");
         let sql = format!("SELECT * FROM \"{quoted}\"");
         let data = engine
-            .execute(&sql, deadline, max_rows)
+            .execute(&sql, deadline, limits)
             .map_err(DotError::Engine)?;
         for data_row in &data.rows {
             let values: Vec<String> = data_row.iter().map(format_sql_literal).collect();
@@ -368,12 +372,20 @@ mod tests {
         Deadline::new(std::time::Duration::ZERO)
     }
 
+    fn unlimited_limits() -> QueryLimits {
+        QueryLimits {
+            max_rows: usize::MAX,
+            max_value_bytes: usize::MAX,
+            max_result_bytes: usize::MAX,
+        }
+    }
+
     fn dispatch_t(
         line: &str,
         engine: &SqliteEngine,
         opts: &mut OutputOpts,
     ) -> Result<DotOutcome, DotError> {
-        dispatch(line, engine, opts, no_deadline(), usize::MAX)
+        dispatch(line, engine, opts, no_deadline(), unlimited_limits())
     }
 
     #[test]
@@ -466,10 +478,10 @@ mod tests {
     fn tables_lists_existing() {
         let engine = mk_engine();
         engine
-            .execute("CREATE TABLE foo(a)", no_deadline(), usize::MAX)
+            .execute("CREATE TABLE foo(a)", no_deadline(), unlimited_limits())
             .unwrap();
         engine
-            .execute("CREATE TABLE bar(b)", no_deadline(), usize::MAX)
+            .execute("CREATE TABLE bar(b)", no_deadline(), unlimited_limits())
             .unwrap();
         let mut o = opts();
         let DotOutcome::Stdout(s) = dispatch_t(".tables", &engine, &mut o).unwrap() else {
@@ -483,10 +495,10 @@ mod tests {
     fn tables_with_pattern() {
         let engine = mk_engine();
         engine
-            .execute("CREATE TABLE foo(a)", no_deadline(), usize::MAX)
+            .execute("CREATE TABLE foo(a)", no_deadline(), unlimited_limits())
             .unwrap();
         engine
-            .execute("CREATE TABLE bar(b)", no_deadline(), usize::MAX)
+            .execute("CREATE TABLE bar(b)", no_deadline(), unlimited_limits())
             .unwrap();
         let mut o = opts();
         let DotOutcome::Stdout(s) = dispatch_t(".tables foo", &engine, &mut o).unwrap() else {
@@ -513,7 +525,7 @@ mod tests {
             .execute(
                 "CREATE TABLE foo(a INTEGER, b TEXT)",
                 no_deadline(),
-                usize::MAX,
+                unlimited_limits(),
             )
             .unwrap();
         let mut o = opts();
@@ -530,14 +542,14 @@ mod tests {
             .execute(
                 "CREATE TABLE t(x INTEGER, y TEXT)",
                 no_deadline(),
-                usize::MAX,
+                unlimited_limits(),
             )
             .unwrap();
         engine
             .execute(
                 "INSERT INTO t VALUES (1, 'hello'), (2, 'O''Brien')",
                 no_deadline(),
-                usize::MAX,
+                unlimited_limits(),
             )
             .unwrap();
         let mut o = opts();

--- a/crates/bashkit/src/builtins/sqlite/engine.rs
+++ b/crates/bashkit/src/builtins/sqlite/engine.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use turso_core::{Connection, Database, IO, MemoryIO, OpenFlags, StepResult, Value};
+use turso_core::{Connection, Database, IO, MemoryIO, Numeric, OpenFlags, StepResult, Value};
 
 use super::vfs_io::BashkitVfsIO;
 
@@ -71,6 +71,14 @@ pub(super) enum Backend {
     /// VFS-backed `BashkitVfsIO`. The owner calls `flush_dirty` on the IO
     /// when it wants the in-memory pages flushed back to the VFS.
     Vfs(Arc<BashkitVfsIO>),
+}
+
+/// Query materialisation caps applied before values are cloned into Bashkit-owned memory.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct QueryLimits {
+    pub max_rows: usize,
+    pub max_value_bytes: usize,
+    pub max_result_bytes: usize,
 }
 
 /// Outcome of executing a single SQL statement.
@@ -164,13 +172,14 @@ impl SqliteEngine {
         &self,
         sql: &str,
         deadline: Deadline,
-        max_rows: usize,
+        limits: QueryLimits,
     ) -> EngineResult<StatementOutcome> {
         let mut stmt = self.conn.prepare(sql).map_err(turso_msg)?;
         let mut outcome = StatementOutcome::default();
         for idx in 0..stmt.num_columns() {
             outcome.columns.push(stmt.get_column_name(idx).to_string());
         }
+        let mut result_bytes = 0usize;
         loop {
             if deadline.expired() {
                 stmt.interrupt();
@@ -179,12 +188,32 @@ impl SqliteEngine {
             match stmt.step().map_err(turso_msg)? {
                 StepResult::Row => {
                     let next_row = outcome.rows.len() + 1;
-                    if next_row > max_rows {
+                    if next_row > limits.max_rows {
                         return Err(format!(
-                            "result set exceeds row cap ({next_row} > {max_rows})"
+                            "result set exceeds row cap ({next_row} > {})",
+                            limits.max_rows
                         ));
                     }
                     if let Some(row) = stmt.row() {
+                        let mut row_bytes = 0usize;
+                        for idx in 0..stmt.num_columns() {
+                            let value_bytes = Self::value_size_bytes(row.get_value(idx));
+                            if value_bytes > limits.max_value_bytes {
+                                return Err(format!(
+                                    "result value exceeds byte cap ({value_bytes} > {})",
+                                    limits.max_value_bytes
+                                ));
+                            }
+                            row_bytes = row_bytes.saturating_add(value_bytes);
+                        }
+                        let next_result_bytes = result_bytes.saturating_add(row_bytes);
+                        if next_result_bytes > limits.max_result_bytes {
+                            return Err(format!(
+                                "result set exceeds byte cap ({next_result_bytes} > {})",
+                                limits.max_result_bytes
+                            ));
+                        }
+                        result_bytes = next_result_bytes;
                         let values: Vec<Value> = (0..stmt.num_columns())
                             .map(|idx| row.get_value(idx).clone())
                             .collect();
@@ -202,6 +231,15 @@ impl SqliteEngine {
         }
         outcome.changes = self.conn.changes();
         Ok(outcome)
+    }
+
+    fn value_size_bytes(value: &Value) -> usize {
+        match value {
+            Value::Null => 0,
+            Value::Numeric(Numeric::Integer(_)) | Value::Numeric(Numeric::Float(_)) => 8,
+            Value::Text(text) => text.as_str().len(),
+            Value::Blob(bytes) => bytes.len(),
+        }
     }
 
     fn io_step(&self) -> EngineResult<()> {

--- a/crates/bashkit/src/builtins/sqlite/mod.rs
+++ b/crates/bashkit/src/builtins/sqlite/mod.rs
@@ -21,6 +21,8 @@
 //! Limits enforced (see [`SqliteLimits`]):
 //! - SQL script length capped at `max_script_bytes` (4 MiB default).
 //! - Per-result-set row count capped at `max_rows_per_query` (1M default).
+//! - Per-cell, raw result, and rendered-output bytes capped before values can
+//!   grow beyond the builtin's memory budget.
 //! - Per-database file size capped at `max_db_bytes` (256 MiB default).
 //! - Wall-clock budget per invocation at `max_duration` (30 s default; pass
 //!   [`std::time::Duration::ZERO`] to opt out).
@@ -46,7 +48,7 @@ use crate::interpreter::ExecResult;
 
 use super::{Builtin, Context, check_help_version, resolve_path};
 use dot_commands::{DotError, DotOutcome};
-use engine::SqliteEngine;
+use engine::{QueryLimits, SqliteEngine};
 use formatter::{OutputMode, OutputOpts, render};
 use parser::Stmt;
 
@@ -57,6 +59,14 @@ const SQLITE_OPT_IN_ENV: &str = "BASHKIT_ALLOW_INPROCESS_SQLITE";
 const DEFAULT_MAX_SCRIPT_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 /// Default cap on rows materialised per query, beyond which the query aborts.
 const DEFAULT_MAX_ROWS_PER_QUERY: usize = 1_000_000;
+/// Default cap on one returned SQLite value before Bashkit clones/renders it.
+const DEFAULT_MAX_VALUE_BYTES: usize = 8 * 1024 * 1024; // 8 MiB
+/// Default cap on raw result values materialised for one SQL statement.
+/// Equal to the per-value cap so hex/blob rendering remains bounded by
+/// `max_output_bytes` under the default limits.
+const DEFAULT_MAX_RESULT_BYTES: usize = 8 * 1024 * 1024; // 8 MiB
+/// Default cap on rendered stdout produced by one sqlite invocation.
+const DEFAULT_MAX_OUTPUT_BYTES: usize = 32 * 1024 * 1024; // 32 MiB
 /// Default cap on the size of a single database file when loaded from VFS.
 const DEFAULT_MAX_DB_BYTES: usize = 256 * 1024 * 1024; // 256 MiB
 /// Default per-script wall-clock cap. Each individual statement is checked
@@ -127,6 +137,12 @@ pub struct SqliteLimits {
     pub max_script_bytes: usize,
     /// Maximum rows materialised per query before aborting.
     pub max_rows_per_query: usize,
+    /// Maximum bytes allowed in one returned SQLite value before cloning it.
+    pub max_value_bytes: usize,
+    /// Maximum raw bytes materialised across one query result.
+    pub max_result_bytes: usize,
+    /// Maximum rendered stdout bytes produced by one sqlite invocation.
+    pub max_output_bytes: usize,
     /// Maximum database file size loadable from the VFS.
     pub max_db_bytes: usize,
     /// Wall-clock budget for the whole invocation (every statement shares
@@ -152,6 +168,9 @@ impl Default for SqliteLimits {
         Self {
             max_script_bytes: DEFAULT_MAX_SCRIPT_BYTES,
             max_rows_per_query: DEFAULT_MAX_ROWS_PER_QUERY,
+            max_value_bytes: DEFAULT_MAX_VALUE_BYTES,
+            max_result_bytes: DEFAULT_MAX_RESULT_BYTES,
+            max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
             max_db_bytes: DEFAULT_MAX_DB_BYTES,
             max_duration: DEFAULT_MAX_DURATION,
             max_statements: DEFAULT_MAX_STATEMENTS,
@@ -175,6 +194,24 @@ impl SqliteLimits {
     #[must_use]
     pub fn max_rows_per_query(mut self, n: usize) -> Self {
         self.max_rows_per_query = n;
+        self
+    }
+    /// Set max bytes for one returned SQLite value.
+    #[must_use]
+    pub fn max_value_bytes(mut self, n: usize) -> Self {
+        self.max_value_bytes = n;
+        self
+    }
+    /// Set max raw bytes materialised across one query result.
+    #[must_use]
+    pub fn max_result_bytes(mut self, n: usize) -> Self {
+        self.max_result_bytes = n;
+        self
+    }
+    /// Set max rendered stdout bytes for one sqlite invocation.
+    #[must_use]
+    pub fn max_output_bytes(mut self, n: usize) -> Self {
+        self.max_output_bytes = n;
         self
     }
     /// Set max DB file bytes.
@@ -725,21 +762,18 @@ async fn run_statements(
             Stmt::Sql(sql) => {
                 check_sql_policy(&sql, limits)?;
                 let outcome = engine
-                    .execute(&sql, deadline, limits.max_rows_per_query)
+                    .execute(&sql, deadline, query_limits(limits))
                     .map_err(|e| sanitize(&e))?;
                 let rendered = render(&outcome.columns, &outcome.rows, opts);
-                stdout.push_str(&rendered);
+                push_stdout_bounded(stdout, &rendered, limits.max_output_bytes)?;
             }
             Stmt::Dot(line) => {
-                let result = dot_commands::dispatch(
-                    &line,
-                    engine,
-                    opts,
-                    deadline,
-                    limits.max_rows_per_query,
-                );
+                let result =
+                    dot_commands::dispatch(&line, engine, opts, deadline, query_limits(limits));
                 match result {
-                    Ok(DotOutcome::Stdout(s)) => stdout.push_str(&s),
+                    Ok(DotOutcome::Stdout(s)) => {
+                        push_stdout_bounded(stdout, &s, limits.max_output_bytes)?;
+                    }
                     Ok(DotOutcome::Configured) => {}
                     Ok(DotOutcome::Quit) => return Ok(()),
                     Ok(DotOutcome::Read(p)) => {
@@ -795,6 +829,27 @@ async fn run_statements(
 ///   sandbox-safe way to express it today.
 /// * `PRAGMA <name>` is rejected when `<name>` (case-insensitive) is in
 ///   `limits.pragma_deny`. Defaults are listed in [`DEFAULT_PRAGMA_DENY`].
+fn query_limits(limits: &SqliteLimits) -> QueryLimits {
+    QueryLimits {
+        max_rows: limits.max_rows_per_query,
+        max_value_bytes: limits.max_value_bytes,
+        max_result_bytes: limits.max_result_bytes,
+    }
+}
+
+fn push_stdout_bounded(
+    stdout: &mut String,
+    chunk: &str,
+    max: usize,
+) -> std::result::Result<(), String> {
+    let next = stdout.len().saturating_add(chunk.len());
+    if next > max {
+        return Err(format!("sqlite output exceeds byte cap ({next} > {max})"));
+    }
+    stdout.push_str(chunk);
+    Ok(())
+}
+
 fn check_sql_policy(sql: &str, limits: &SqliteLimits) -> std::result::Result<(), String> {
     match parser::leading_keyword(sql).as_deref() {
         Some("ATTACH") | Some("DETACH") => {

--- a/crates/bashkit/src/builtins/sqlite/tests.rs
+++ b/crates/bashkit/src/builtins/sqlite/tests.rs
@@ -518,11 +518,75 @@ async fn dump_data_respects_row_cap() {
     );
 }
 
+#[tokio::test]
+async fn value_byte_cap_rejects_large_cell_before_rendering() {
+    let limits = SqliteLimits::default()
+        .max_value_bytes(8)
+        .max_result_bytes(1024)
+        .max_output_bytes(1024)
+        .max_duration(std::time::Duration::ZERO);
+    let r = run_with_limits(&[":memory:", "SELECT randomblob(16)"], None, limits).await;
+    assert_eq!(r.exit_code, 1);
+    assert_eq!(r.stdout, "");
+    assert!(
+        r.stderr.contains("result value exceeds byte cap (16 > 8)"),
+        "stderr was: {}",
+        r.stderr
+    );
+}
+
+#[tokio::test]
+async fn result_byte_cap_rejects_many_small_cells_before_rendering() {
+    let limits = SqliteLimits::default()
+        .max_value_bytes(16)
+        .max_result_bytes(12)
+        .max_output_bytes(1024)
+        .max_duration(std::time::Duration::ZERO);
+    let r = run_with_limits(
+        &[":memory:", "SELECT 'abcdef' UNION ALL SELECT 'ghijklmn'"],
+        None,
+        limits,
+    )
+    .await;
+    assert_eq!(r.exit_code, 1);
+    assert_eq!(r.stdout, "");
+    assert!(
+        r.stderr.contains("result set exceeds byte cap (14 > 12)"),
+        "stderr was: {}",
+        r.stderr
+    );
+}
+
+#[tokio::test]
+async fn rendered_output_cap_rejects_hex_expansion() {
+    let limits = SqliteLimits::default()
+        .max_value_bytes(16)
+        .max_result_bytes(16)
+        .max_output_bytes(10)
+        .max_duration(std::time::Duration::ZERO);
+    let r = run_with_limits(
+        &[":memory:", "-json", "SELECT randomblob(8) AS b"],
+        None,
+        limits,
+    )
+    .await;
+    assert_eq!(r.exit_code, 1);
+    assert_eq!(r.stdout, "");
+    assert!(
+        r.stderr.contains("sqlite output exceeds byte cap"),
+        "stderr was: {}",
+        r.stderr
+    );
+}
+
 #[test]
 fn limits_builder_round_trips() {
     let l = SqliteLimits::default()
         .max_script_bytes(1024)
         .max_rows_per_query(10)
+        .max_value_bytes(64)
+        .max_result_bytes(512)
+        .max_output_bytes(1024)
         .max_db_bytes(2048)
         .max_duration(std::time::Duration::from_secs(7))
         .max_statements(42)
@@ -530,6 +594,9 @@ fn limits_builder_round_trips() {
         .pragma_deny(["foo", "BAR"]);
     assert_eq!(l.max_script_bytes, 1024);
     assert_eq!(l.max_rows_per_query, 10);
+    assert_eq!(l.max_value_bytes, 64);
+    assert_eq!(l.max_result_bytes, 512);
+    assert_eq!(l.max_output_bytes, 1024);
     assert_eq!(l.max_db_bytes, 2048);
     assert_eq!(l.max_duration, std::time::Duration::from_secs(7));
     assert_eq!(l.max_statements, 42);


### PR DESCRIPTION
### Motivation
- The sqlite builtin materialised complete query results and rendered them into an unbounded String before row limits were enforced, allowing a single large TEXT/BLOB cell (or rendered JSON/blob hex expansion) to exhaust process memory. 

### Description
- Add per-value, per-result, and rendered-output byte caps to `SqliteLimits` with sensible defaults and builder setters (`max_value_bytes`, `max_result_bytes`, `max_output_bytes`).
- Introduce `QueryLimits` and enforce row/value/result caps inside `engine::execute` before cloning `Value`s into Bashkit-owned memory, aborting with a clear error when a cap is exceeded.
- Bound rendered stdout appends via `push_stdout_bounded` and pass `QueryLimits` through dot-command paths so `.dump`, `.tables`, `.schema`, and other outputs cannot grow unbounded.
- Add regression tests covering a large single cell, aggregated result-byte growth, and JSON/blob hex-expansion hitting the output cap, and update unit tests to use the new limits plumbing. 

### Testing
- Ran `cargo test --features sqlite -p bashkit --lib sqlite:: -- --nocapture` and all sqlite-related unit tests passed (103 passed, 0 failed). 
- Ran `cargo fmt --all -- --check` and `cargo clippy --features sqlite -p bashkit --lib -- -D warnings` and both checks passed. 
- Added targeted regression tests (value/result/output byte caps) which passed under the sqlite feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9031d3e8832bbdb94a3dfc72c1df)