### PR TITLE
fix(snapshot): preserve counters on resume

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1946,10 +1946,10 @@ impl Interpreter {
         &self.counters
     }
 
-    /// Restore session-level counters from a snapshot.
+    /// Merge session-level counters from a snapshot without lowering live usage.
     pub fn restore_session_counters(&mut self, session_commands: u64, session_exec_calls: u64) {
-        self.counters.session_commands = session_commands;
-        self.counters.session_exec_calls = session_exec_calls;
+        self.counters.session_commands = self.counters.session_commands.max(session_commands);
+        self.counters.session_exec_calls = self.counters.session_exec_calls.max(session_exec_calls);
     }
 
     /// Set an output callback for streaming output during execution.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1159,10 +1159,11 @@ impl Bash {
         (c.session_commands, c.session_exec_calls)
     }
 
-    /// Restore session-level counters to resume a session across Bash instances.
+    /// Merge session-level counters to resume a session across Bash instances.
     ///
     /// This is used by external tool hosts to persist cumulative session counters
-    /// across fresh Bash instances created per tool call.
+    /// across fresh Bash instances created per tool call. Counters are monotonic:
+    /// restoring lower values never reduces already-consumed session budget.
     pub fn restore_session_counters(&mut self, session_commands: u64, session_exec_calls: u64) {
         self.interpreter
             .restore_session_counters(session_commands, session_exec_calls);

--- a/crates/bashkit/src/snapshot.rs
+++ b/crates/bashkit/src/snapshot.rs
@@ -1,7 +1,7 @@
 // Decision: Snapshot format uses serde_json for Phase 1 (debuggable, human-readable).
 // Phase 2 can add bincode/postcard for compactness.
 // VFS contents are included by default; SnapshotOptions can opt out for shell-only restores.
-// Session counters are serialized for observability; restore paths do not trust them.
+// Session counters are serialized and restored monotonically so snapshot/resume cannot reset budgets.
 
 //! Snapshot/resume — serialize interpreter state between `exec()` calls.
 //!
@@ -335,6 +335,11 @@ impl crate::Bash {
         // Shell state cannot fail past validation, and the VFS has already
         // been restored atomically (or rejected) above.
         self.interpreter.restore_shell_state(&snap.shell);
+        // Session counters are part of session accounting. Merge them
+        // monotonically: authenticated snapshot/resume carries used budget
+        // forward, while tampered unkeyed bytes cannot lower live counters.
+        self.interpreter
+            .restore_session_counters(snap.session_commands, snap.session_exec_calls);
         Ok(())
     }
 

--- a/crates/bashkit/tests/integration/snapshot_tests.rs
+++ b/crates/bashkit/tests/integration/snapshot_tests.rs
@@ -568,6 +568,39 @@ async fn snapshot_restore_does_not_reset_session_exec_limit_with_tampered_counte
 }
 
 #[tokio::test]
+async fn keyed_snapshot_restore_carries_session_exec_budget_forward() {
+    let key = b"session-budget-hmac-key";
+    let session_limits = SessionLimits::new().max_exec_calls(2);
+    let mut bash = Bash::builder()
+        .session_limits(session_limits.clone())
+        .build();
+    bash.exec("echo first").await.unwrap();
+    let bytes = bash.snapshot_to_bytes_keyed(key).unwrap();
+
+    let mut restored = Bash::builder().session_limits(session_limits).build();
+    restored.restore_snapshot_keyed(&bytes, key).unwrap();
+    assert_eq!(restored.session_counters().1, 1);
+
+    restored.exec("echo second").await.unwrap();
+    let third = restored.exec("echo third").await;
+    assert!(
+        third.is_err(),
+        "authenticated snapshot resume must not grant a fresh exec-call budget"
+    );
+}
+
+#[tokio::test]
+async fn from_snapshot_keyed_restores_session_counters() {
+    let key = b"session-counter-hmac-key";
+    let mut bash = Bash::new();
+    bash.exec("echo first").await.unwrap();
+    let bytes = bash.snapshot_to_bytes_keyed(key).unwrap();
+
+    let restored = Bash::from_snapshot_keyed(&bytes, key).unwrap();
+    assert_eq!(restored.session_counters(), bash.session_counters());
+}
+
+#[tokio::test]
 async fn snapshot_restore_rejects_tampered_shell_state_that_exceeds_memory_limits() {
     let mut src = Bash::new();
     src.exec("x=ok").await.unwrap();


### PR DESCRIPTION
### Motivation
- Prevent fresh-instance snapshot resume from resetting session-level budgets when snapshots (including keyed/HMAC-protected ones) contain nonzero session counters.
- Keep protection against tampered/untrusted snapshot bytes lowering live counters while allowing authenticated snapshots to carry forward consumed budget.

### Description
- Merge serialized session counters during restore by calling `restore_session_counters` from `restore_snapshot_inner` after validated shell/VFS restore so counters are applied atomically with state.
- Change `Interpreter::restore_session_counters` to be monotonic (use `max`) so restoring never reduces already-consumed `session_commands` or `session_exec_calls`.
- Update public `Bash::restore_session_counters` docstring to reflect monotonic merge semantics.
- Add integration tests covering keyed (HMAC) snapshot resume: `keyed_snapshot_restore_carries_session_exec_budget_forward` and `from_snapshot_keyed_restores_session_counters` to assert authenticated resumes carry counters forward.

### Testing
- Ran the integration snapshot test binary: `cargo test -p bashkit --test integration snapshot_tests:: -- --nocapture` and all snapshot-related tests passed (`40 passed, 0 failed`).
- Ran `cargo fmt --all -- --check` to ensure formatting is clean and it passed.
- Verified the newly added snapshot integration tests execute and succeed as part of the snapshot test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b98924644832b81e4d3fbecdafeea)