### PR TITLE
fix(awk): reject chained range patterns

### DIFF
--- a/crates/bashkit/src/builtins/awk/parser.rs
+++ b/crates/bashkit/src/builtins/awk/parser.rs
@@ -261,6 +261,37 @@ impl<'a> AwkParser<'a> {
     }
 
     fn parse_pattern(&mut self) -> Result<Option<AwkPattern>> {
+        let Some(first_pat) = self.parse_single_pattern()? else {
+            return Ok(None);
+        };
+
+        self.skip_whitespace();
+        if self.pos >= self.input.len() || self.current_char().unwrap() != ',' {
+            return Ok(Some(first_pat));
+        }
+
+        // THREAT[TM-DOS-027]: awk ranges contain exactly two operands. Do not
+        // recursively parse comma chains (`1,1,1,...`) because attacker-sized
+        // chains can exhaust the host stack before runtime limits apply.
+        self.pos += 1; // consume ','
+        let second_pat = self
+            .parse_single_pattern()?
+            .ok_or_else(|| Error::Execution("awk: expected second pattern in range".to_string()))?;
+
+        self.skip_whitespace();
+        if self.pos < self.input.len() && self.current_char().unwrap() == ',' {
+            return Err(Error::Execution(
+                "awk: unexpected ',' after range pattern".to_string(),
+            ));
+        }
+
+        Ok(Some(AwkPattern::Range(
+            Box::new(first_pat),
+            Box::new(second_pat),
+        )))
+    }
+
+    fn parse_single_pattern(&mut self) -> Result<Option<AwkPattern>> {
         self.skip_whitespace();
 
         if self.pos >= self.input.len() {
@@ -269,36 +300,13 @@ impl<'a> AwkParser<'a> {
 
         let c = self.current_char().unwrap();
 
-        // Check for regex pattern
-        let first: Option<AwkPattern> = if c == '/' {
-            Some(self.parse_regex_pattern()?)
+        if c == '/' {
+            Ok(Some(self.parse_regex_pattern()?))
         } else if c == '{' {
-            // Check for opening brace (no pattern)
-            return Ok(None);
-        } else {
-            // Expression pattern
-            let expr = self.parse_expression()?;
-            Some(AwkPattern::Expression(expr))
-        };
-
-        // Check for range pattern: pattern1 , pattern2
-        if let Some(first_pat) = first {
-            self.skip_whitespace();
-            if self.pos < self.input.len() && self.current_char().unwrap() == ',' {
-                self.pos += 1; // consume ','
-                let second = self.parse_pattern()?;
-                let second_pat = second.ok_or_else(|| {
-                    Error::Execution("awk: expected second pattern in range".to_string())
-                })?;
-                Ok(Some(AwkPattern::Range(
-                    Box::new(first_pat),
-                    Box::new(second_pat),
-                )))
-            } else {
-                Ok(Some(first_pat))
-            }
-        } else {
             Ok(None)
+        } else {
+            let expr = self.parse_expression()?;
+            Ok(Some(AwkPattern::Expression(expr)))
         }
     }
 

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -221,6 +221,22 @@ fn test_awk_parser_depth_limit_unary() {
     );
 }
 
+/// TM-DOS-027: Range patterns must not recursively parse comma chains.
+#[test]
+fn test_awk_parser_rejects_chained_range_pattern() {
+    let operands = std::iter::repeat_n("1", 150).collect::<Vec<_>>().join(",");
+    let program = format!("{operands}{{print}}");
+
+    let mut parser = AwkParser::new(&program);
+    let result = parser.parse();
+    assert!(result.is_err(), "comma-chained ranges must be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("unexpected ',' after range pattern"),
+        "error should mention unexpected comma after range: {err}"
+    );
+}
+
 /// TM-DOS-027: Moderate nesting within limit still works
 #[test]
 fn test_awk_parser_moderate_nesting_ok() {


### PR DESCRIPTION
### Motivation
- The `Awk` range parser previously called `parse_pattern()` recursively for the second operand, allowing inputs like `1,1,1,1,...{print}` to create one stack frame per comma and risk stack exhaustion and process abort (TM-DOS-027 availability issue). 

### Description
- Replace recursive range parsing with a non-recursive two-operand parse by adding `parse_single_pattern()` and having `parse_pattern()` explicitly parse exactly two operands for `/start/,/end/` ranges in `crates/bashkit/src/builtins/awk/parser.rs`.
- Reject any additional comma after the second operand with a clear `awk: unexpected ',' after range pattern` error to prevent comma-chained parsing abuse.
- Add a regression unit test `test_awk_parser_rejects_chained_range_pattern` in `crates/bashkit/src/builtins/awk/tests.rs` that constructs a long comma chain and asserts the parser rejects it.

### Testing
- Ran formatting check with `cargo fmt --check`, which passed.
- Ran unit/parser tests with `cargo test -p bashkit awk_parser`, which passed and included the new `test_awk_parser_rejects_chained_range_pattern` test.
- Ran integration range tests with `cargo test -p bashkit awk_range_pattern`, which passed (existing 8 range tests unaffected).
- All automated tests above completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9bba9754832bbbb52266ce87f22b)