### PR TITLE
fix(snapshot): account function source bytes

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -779,6 +779,13 @@ fn deserialize_function_from_source(
     deserialize_function_from_source_with_limits(name, source, 100, 100_000)
 }
 
+fn function_storage_bytes(func: &FunctionDef) -> usize {
+    func.source.as_ref().map_or_else(
+        || func.span.end.offset.saturating_sub(func.span.start.offset),
+        |source| source.len(),
+    )
+}
+
 // Important decision: variable attributes (readonly/integer/lower/upper) and
 // namerefs are stored in dedicated maps rather than the `variables` HashMap with
 // `_READONLY_X` / `_INTEGER_X` / `_LOWER_X` / `_UPPER_X` / `_NAMEREF_X` keys.
@@ -1814,11 +1821,7 @@ impl Interpreter {
             ) else {
                 continue;
             };
-            let body_bytes = parsed_func
-                .span
-                .end
-                .offset
-                .saturating_sub(parsed_func.span.start.offset);
+            let body_bytes = function_storage_bytes(&parsed_func);
             if function_memory_budget
                 .check_function_insert(body_bytes, true, 0, &self.memory_limits)
                 .is_err()
@@ -1833,11 +1836,7 @@ impl Interpreter {
         self.traps = Arc::new(state.traps.clone());
         // Recompute memory budget from restored state to prevent desync
         let func_count = self.functions.len();
-        let func_bytes: usize = self
-            .functions
-            .values()
-            .map(|f| f.span.end.offset.saturating_sub(f.span.start.offset))
-            .sum();
+        let func_bytes: usize = self.functions.values().map(function_storage_bytes).sum();
         self.memory_budget = crate::limits::MemoryBudget::recompute_from_state(
             &self.variables,
             &self.arrays,
@@ -2366,18 +2365,14 @@ impl Interpreter {
                 }
                 Command::Function(func_def) => {
                     // THREAT[TM-DOS-060]: Check function count/size budget
-                    let body_bytes = func_def
-                        .span
-                        .end
-                        .offset
-                        .saturating_sub(func_def.span.start.offset);
+                    let body_bytes = function_storage_bytes(func_def);
                     let is_new = !self.functions.contains_key(&func_def.name);
                     let old_body_bytes = if is_new {
                         0
                     } else {
                         self.functions
                             .get(&func_def.name)
-                            .map(|f| f.span.end.offset.saturating_sub(f.span.start.offset))
+                            .map(function_storage_bytes)
                             .unwrap_or(0)
                     };
                     if self

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -153,7 +153,10 @@ impl<'a> Parser<'a> {
         if self.current_token.is_some() {
             self.current_span.start.offset
         } else {
-            self.input.len()
+            // Important decision: EOF keeps `current_span` on the last real token;
+            // use that token end so skipped trailing comments are not retained in
+            // persistent function source snapshots.
+            self.current_span.end.offset
         }
     }
 

--- a/crates/bashkit/tests/integration/snapshot_tests.rs
+++ b/crates/bashkit/tests/integration/snapshot_tests.rs
@@ -404,6 +404,46 @@ async fn snapshot_without_functions_skips_function_restore() {
 }
 
 #[tokio::test]
+async fn snapshot_function_source_excludes_trailing_eof_comment() {
+    let mut bash = Bash::new();
+    let trailing = "x".repeat(2048);
+    bash.exec(&format!("trimmed() {{ :; }} #{trailing}"))
+        .await
+        .unwrap();
+
+    let bytes = bash.snapshot().unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    let source = json["shell"]["functions"]["trimmed"]["source"]
+        .as_str()
+        .unwrap();
+
+    assert_eq!(source, "trimmed() { :; }");
+}
+
+#[tokio::test]
+async fn snapshot_restore_counts_source_bytes_against_function_limit() {
+    let mut src = Bash::new();
+    src.exec("large_source() { :; }").await.unwrap();
+    let bytes = src.snapshot().unwrap();
+    let mut json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    json["shell"]["functions"]["large_source"] = serde_json::json!({
+        "source": format!("large_source() {{ :; }} #{}", "x".repeat(2048))
+    });
+
+    let rewritten: Snapshot = serde_json::from_value(json).unwrap();
+    let bytes = rewritten.to_bytes().unwrap();
+    let limits = MemoryLimits::new().max_function_body_bytes(256);
+    let mut restored = Bash::builder().memory_limits(limits).build();
+    restored.restore_snapshot(&bytes).unwrap();
+
+    let result = restored
+        .exec("type large_source >/dev/null 2>&1; echo $?")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "1\n");
+}
+
+#[tokio::test]
 async fn snapshot_restore_enforces_function_limits() {
     let mut src = Bash::new();
     src.exec("a() { echo a; }; b() { echo b; }").await.unwrap();


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled trailing EOF comments from being retained in `FunctionDef.source` without charging against `MemoryLimits::max_function_body_bytes`, which allowed resource-exhaustion via many large function sources.

### Description
- Stop EOF source capture from returning `input.len()` by using `current_span.end.offset` at EOF in `Parser::current_command_end_offset` so skipped trailing comments aren't included in captured source (`crates/bashkit/src/parser/mod.rs`).
- Add `function_storage_bytes(func: &FunctionDef)` to charge stored `FunctionDef.source` bytes when present and fall back to AST `span` size for legacy cases (`crates/bashkit/src/interpreter/mod.rs`).
- Use `function_storage_bytes` when enforcing function insert/replace budgets at runtime and during snapshot restore and budget recompute so stored source is accounted for (`crates/bashkit/src/interpreter/mod.rs`).
- Add integration tests that assert trailing EOF comments are not spuriously retained and that source-only snapshot restores are charged against `max_function_body_bytes` (`crates/bashkit/tests/integration/snapshot_tests.rs`).

### Testing
- Ran targeted unit/integration tests `snapshot_function_source_excludes_trailing_eof_comment` and `snapshot_restore_counts_source_bytes_against_function_limit` and both passed.
- Ran the full snapshot integration test suite `cargo test -p bashkit --test integration snapshot_tests::` and all snapshot tests passed (40 passed, 0 failed).
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --tests -- -D warnings` as formatting/lint checks and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b996eccd0832ba7239b6240e9bde2)