### PR TITLE
fix(streaming): clear output callback on cancellation

### DIFF
--- a/crates/bashkit-python/tests/test_streaming_output.py
+++ b/crates/bashkit-python/tests/test_streaming_output.py
@@ -205,3 +205,25 @@ async def test_execute_on_output_error_does_not_poison_future_calls(factory):
 
     assert result.exit_code == 0
     assert result.stdout == "after-error\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+async def test_execute_on_output_cancel_does_not_poison_future_calls(factory):
+    shell = factory()
+    chunks = []
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            shell.execute(
+                "sleep 1; echo should-not-run",
+                on_output=lambda stdout, stderr: chunks.append((stdout, stderr)),
+            ),
+            timeout=0.01,
+        )
+
+    result = await shell.execute("echo later-run")
+
+    assert result.exit_code == 0
+    assert result.stdout == "later-run\n"
+    assert chunks == []

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -547,6 +547,34 @@ fn env_opt_in_enabled(env: &HashMap<String, String>, key: &str) -> bool {
         .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
 }
 
+// Keep streaming callback cleanup cancellation-safe: Python bindings expose this
+// future to cancellable asyncio tasks, so cleanup must run from Drop.
+struct OutputCallbackGuard {
+    interpreter: *mut Interpreter,
+}
+
+// SAFETY: the guard only clears the callback through the unique Bash execution
+// borrow that created it; moving the future between executor threads does not
+// create shared access to the interpreter.
+unsafe impl Send for OutputCallbackGuard {}
+
+impl OutputCallbackGuard {
+    fn install(interpreter: &mut Interpreter, callback: OutputCallback) -> Self {
+        interpreter.set_output_callback(callback);
+        Self { interpreter }
+    }
+}
+
+impl Drop for OutputCallbackGuard {
+    fn drop(&mut self) {
+        // SAFETY: the guard is created from `&mut self.interpreter` inside a
+        // Bash execution future. That future keeps exclusive access to the same
+        // Bash until it is completed or dropped, so clearing this field here does
+        // not race with another mutable interpreter access.
+        unsafe { (*self.interpreter).clear_output_callback() };
+    }
+}
+
 /// Main entry point for Bashkit.
 ///
 /// Provides a virtual bash interpreter with an in-memory virtual filesystem.
@@ -949,10 +977,8 @@ impl Bash {
         output_callback: OutputCallback,
         extensions: ExecutionExtensions,
     ) -> Result<ExecResult> {
-        self.interpreter.set_output_callback(output_callback);
-        let result = self.exec_with_extensions(script, extensions).await;
-        self.interpreter.clear_output_callback();
-        result
+        let _guard = OutputCallbackGuard::install(&mut self.interpreter, output_callback);
+        self.exec_with_extensions(script, extensions).await
     }
 
     /// Return a shared cancellation token.
@@ -6272,6 +6298,40 @@ echo missing fi"#,
         let mut bash = Bash::new();
         let result = bash.exec("for i in a b c; do echo $i; done").await.unwrap();
         assert_eq!(result.stdout, "a\nb\nc\n");
+    }
+
+    #[tokio::test]
+    async fn test_exec_streaming_cancel_clears_callback() {
+        use std::time::Duration;
+
+        let chunks = Arc::new(Mutex::new(Vec::new()));
+        let chunks_cb = chunks.clone();
+        let mut bash = Bash::new();
+
+        let timed_out = tokio::time::timeout(
+            Duration::from_millis(10),
+            bash.exec_streaming(
+                "sleep 1; echo should-not-run",
+                Box::new(move |stdout, stderr| {
+                    chunks_cb
+                        .lock()
+                        .unwrap()
+                        .push((stdout.to_string(), stderr.to_string()));
+                }),
+            ),
+        )
+        .await;
+
+        assert!(timed_out.is_err(), "streaming execution should time out");
+
+        let result = bash.exec("echo later-run").await.unwrap();
+
+        assert_eq!(result.stdout, "later-run\n");
+        assert_eq!(
+            *chunks.lock().unwrap(),
+            Vec::<(String, String)>::new(),
+            "cancelled streaming callback must not receive later output"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent stale interpreter output callbacks from surviving if a streaming execution future is cancelled or dropped, which can leak stdout/stderr into later executions and cross-request contexts.

### Description
- Introduce an RAII guard `OutputCallbackGuard` that installs the callback via `install` and clears it in `Drop` to make cleanup cancellation-safe and robust across await points. (`crates/bashkit/src/lib.rs`)
- Mark the guard `Send` with a safety comment so it can travel across executor boundaries while still ensuring unique access to the interpreter. (`crates/bashkit/src/lib.rs`)
- Use the guard in `exec_streaming_with_extensions` so callbacks are cleared even if the streaming future is cancelled. (`crates/bashkit/src/lib.rs`)
- Add a Rust regression test `test_exec_streaming_cancel_clears_callback` proving a timed-out/cancelled streaming run does not receive later output. (`crates/bashkit/src/lib.rs`)
- Add a Python async regression `test_execute_on_output_cancel_does_not_poison_future_calls` covering `asyncio.wait_for` cancellation for both `Bash` and `BashTool`. (`crates/bashkit-python/tests/test_streaming_output.py`)

### Testing
- `cargo test -p bashkit test_exec_streaming_cancel_clears_callback --lib` — passed. 
- `VIRTUAL_ENV=$PWD/.uv-venv-bashkit PATH=$PWD/.uv-venv-bashkit/bin:$PATH uvx maturin develop --manifest-path crates/bashkit-python/Cargo.toml` and `python -m pytest crates/bashkit-python/tests/test_streaming_output.py -q` — Python tests passed (26 passed).
- `cargo clippy -p bashkit --lib -- -D warnings` — passed. 
- `cargo fmt --check` and `ruff check` / `ruff format --check` on the modified Python test file — passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9a844dbc832b85d415551731291b)