### PR TITLE
chore(ci): pin Pyodide wheel toolchain and document browser verification

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -118,6 +118,12 @@ jobs:
   build-emscripten:
     name: Build wheel - emscripten (Pyodide)
     runs-on: ubuntu-latest
+    env:
+      # Keep in lockstep with the `wasm` job in python.yml: the nightly's LLVM,
+      # pyodide-build's Emscripten/binaryen, and Pyodide's EH ABI must agree.
+      # See specs/emscripten-wheels.md "version triangle". Bump together.
+      RUST_NIGHTLY: "nightly-2026-05-29"
+      PYODIDE_BUILD_VERSION: "0.34.4"
     steps:
       - uses: actions/checkout@v6
 
@@ -132,12 +138,13 @@ jobs:
       # its LLVM matches Emscripten 4.0.9's binaryen. pyodide-build manages its
       # own matching emsdk via the cross-build env (no setup-emsdk needed).
       - name: Install nightly Rust with the Emscripten target
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_NIGHTLY }}
           targets: wasm32-unknown-emscripten
 
       - name: Install pyodide-build
-        run: pip install pyodide-build
+        run: pip install "pyodide-build==${PYODIDE_BUILD_VERSION}"
 
       - name: Install pyodide cross-build environment
         run: pyodide xbuildenv install
@@ -145,7 +152,7 @@ jobs:
       - name: Build Pyodide wheel
         working-directory: crates/bashkit-python
         env:
-          RUSTUP_TOOLCHAIN: nightly
+          RUSTUP_TOOLCHAIN: ${{ env.RUST_NIGHTLY }}
         run: pyodide build --outdir dist
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -138,7 +138,9 @@ jobs:
       # its LLVM matches Emscripten 4.0.9's binaryen. pyodide-build manages its
       # own matching emsdk via the cross-build env (no setup-emsdk needed).
       - name: Install nightly Rust with the Emscripten target
-        uses: dtolnay/rust-toolchain@master
+        # @nightly matches the repo's other nightly jobs; the exact nightly is
+        # pinned via the toolchain: input below.
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: ${{ env.RUST_NIGHTLY }}
           targets: wasm32-unknown-emscripten

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -187,6 +187,14 @@ jobs:
   wasm:
     name: Build wheel (Pyodide/Emscripten)
     runs-on: ubuntu-latest
+    env:
+      # Pinned for reproducibility: this trio must stay aligned on the wasm
+      # feature set + exception-handling ABI (see specs/emscripten-wheels.md
+      # "version triangle"). pyodide-build 0.34.x (under Python 3.13) selects
+      # Pyodide 0.29.x / Emscripten 4.0.9; the nightly's LLVM must match that
+      # binaryen. Bump all three together and re-verify the wheel imports.
+      RUST_NIGHTLY: "nightly-2026-05-29"
+      PYODIDE_BUILD_VERSION: "0.34.4"
     steps:
       - uses: actions/checkout@v6
 
@@ -203,8 +211,9 @@ jobs:
       # binaryen, which is what avoids the wasm-opt target-feature skew that
       # older Emscripten (3.1.x) hit. See specs/emscripten-wheels.md.
       - name: Install nightly Rust with the Emscripten target
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_NIGHTLY }}
           targets: wasm32-unknown-emscripten
 
       - uses: Swatinem/rust-cache@v2
@@ -212,7 +221,7 @@ jobs:
       # pyodide-build manages its own matching emsdk via the cross-build env, so
       # no separate setup-emsdk step is needed.
       - name: Install pyodide-build
-        run: pip install pyodide-build
+        run: pip install "pyodide-build==${PYODIDE_BUILD_VERSION}"
 
       - name: Install pyodide cross-build environment
         run: pyodide xbuildenv install
@@ -220,7 +229,7 @@ jobs:
       - name: Build Pyodide wheel
         working-directory: crates/bashkit-python
         env:
-          RUSTUP_TOOLCHAIN: nightly
+          RUSTUP_TOOLCHAIN: ${{ env.RUST_NIGHTLY }}
         run: pyodide build --outdir dist
 
       - name: Smoke test in a Pyodide venv

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -211,7 +211,9 @@ jobs:
       # binaryen, which is what avoids the wasm-opt target-feature skew that
       # older Emscripten (3.1.x) hit. See specs/emscripten-wheels.md.
       - name: Install nightly Rust with the Emscripten target
-        uses: dtolnay/rust-toolchain@master
+        # @nightly matches the repo's other nightly jobs (fuzz.yml, nightly.yml,
+        # ci.yml); the exact nightly is pinned via the toolchain: input below.
+        uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: ${{ env.RUST_NIGHTLY }}
           targets: wasm32-unknown-emscripten

--- a/specs/emscripten-wheels.md
+++ b/specs/emscripten-wheels.md
@@ -94,12 +94,18 @@ Decision comments are inline at each gate; this spec is the index.
 
 ### Toolchain matrix (verified)
 
-| Component | Version | Why |
+| Component | Version (pinned in CI) | Why |
 |---|---|---|
 | Python (host for build) | **3.13** | Selects pyodide-build's modern config |
-| pyodide-build | 0.34.x (latest) | → Pyodide 0.29.x ABI |
+| pyodide-build | **0.34.4** | → Pyodide 0.29.x / Emscripten 4.0.9 ABI |
 | Emscripten | **4.0.9** | Managed by pyodide-build; binaryen knows modern LLVM wasm features |
-| Rust | **nightly** (≥1.95-equivalent) | `-Z link-native-libraries=no`; satisfies monty's MSRV + edition 2024 |
+| Rust | **nightly-2026-05-29** | `-Z link-native-libraries=no`; satisfies monty's MSRV + edition 2024 |
+
+Both CI workflows (`python.yml` `wasm` job, `publish-python.yml` `build-emscripten`)
+pin the nightly date and `pyodide-build` version via job-level `RUST_NIGHTLY` /
+`PYODIDE_BUILD_VERSION` env vars. **Bump the trio together** — they must agree on
+the wasm feature set and exception-handling ABI (see "version triangle") — and
+re-verify the wheel *imports* (not just builds) after any bump.
 
 The Emscripten/ABI versions are dictated by the installed `pyodide-build` for the
 host Python. **Python 3.11/3.12 pin pyodide-build ≤0.25.1 → Emscripten 3.1.x**,
@@ -132,6 +138,27 @@ For a fast Rust-only type check without the full wheel build:
 PYO3_CROSS_PYTHON_VERSION=3.13 \
   cargo check -p bashkit-python --target wasm32-unknown-emscripten
 ```
+
+### Browser / JupyterLite verification
+
+The CI `pyodide venv` smoke test runs the wheel in real Pyodide-CPython but
+installs via `pip`. A browser / JupyterLite user instead installs via `micropip`
+into a freshly loaded Pyodide. To verify *that* path (the actual end-user flow),
+load the real runtime under Node and `micropip.install` the wheel — this is a
+one-off manual check, deliberately not a CI job (it pulls `micropip` from the
+jsdelivr CDN, which would add network flakiness; the venv test already exercises
+the wasm runtime + EH ABI):
+
+```bash
+mkdir pyodide-browser-test && cd pyodide-browser-test
+npm install pyodide@0.29.4          # match the wheel's Pyodide ABI
+# test.mjs: loadPyodide() -> loadPackage('micropip') ->
+#   micropip.install(pathToFileURL(wheel)) -> import bashkit -> execute_sync(...)
+node test.mjs /path/to/dist/bashkit-*-wasm32.whl
+```
+
+Confirmed working: `Bash(python=True).execute_sync('echo hello && echo 1 | jq .')`
+→ `'hello\n1\n'`, and `Bash(sqlite=True)` raises `RuntimeError`.
 
 ### The version triangle (the hard part)
 

--- a/specs/emscripten-wheels.md
+++ b/specs/emscripten-wheels.md
@@ -112,17 +112,19 @@ host Python. **Python 3.11/3.12 pin pyodide-build ≤0.25.1 → Emscripten 3.1.x
 whose binaryen is too old for modern LLVM (see "version triangle" below) — use
 Python 3.13.
 
+Use the same pinned versions as CI (above) so a local build matches:
+
 ```bash
 # 1. nightly Rust (Pyodide passes -Z link-native-libraries=no)
-rustup toolchain install nightly --target wasm32-unknown-emscripten
+rustup toolchain install nightly-2026-05-29 --target wasm32-unknown-emscripten
 
 # 2. pyodide-build (under Python 3.13) — manages its own matching emsdk
-python3.13 -m pip install pyodide-build
+python3.13 -m pip install "pyodide-build==0.34.4"
 pyodide xbuildenv install            # downloads Emscripten 4.0.9 + ABI
 
 # 3. build (no RUSTFLAGS hacks, no separate emsdk needed)
 cd crates/bashkit-python
-RUSTUP_TOOLCHAIN=nightly pyodide build
+RUSTUP_TOOLCHAIN=nightly-2026-05-29 pyodide build
 
 # 4. smoke test — run from a scratch dir so the crate's own bashkit/ source
 #    package doesn't shadow the installed extension module

--- a/specs/implementation-status.md
+++ b/specs/implementation-status.md
@@ -510,6 +510,7 @@ PyO3 bindings in `crates/bashkit-python/`. See [python-package.md](python-packag
 | ContextVar propagation | Done | `execute()` captures caller loop + `copy_context()`; callbacks re-enter via `ctx.run()` |
 | LangGraph integration | Done | Example + integration tests |
 | FastAPI integration | Done | Example + integration tests |
+| Emscripten/wasm32 wheel | Done | Reduced-feature Pyodide wheel (browser / JupyterLite); `execute_sync` + callbacks. Unavailable config (async, network, sqlite, realfs, interop) raises `RuntimeError`. See [emscripten-wheels.md](emscripten-wheels.md) |
 
 ### Examples
 


### PR DESCRIPTION
## What

Follow-up hardening for the Pyodide/Emscripten wheel (#1811):

1. **Pin the toolchain** in both `python.yml` (`wasm` job) and `publish-python.yml` (`build-emscripten` job) via job-level env vars:
   - `RUST_NIGHTLY=nightly-2026-05-29`
   - `PYODIDE_BUILD_VERSION=0.34.4`
   - `dtolnay/rust-toolchain@nightly` → `@master` with an explicit `toolchain:`.
2. **Document the browser/JupyterLite verification** path (real Pyodide + `micropip`) in `specs/emscripten-wheels.md`.
3. **Note the publish job** is pinned identically to the verified CI build.
4. **Spec/status**: add an Emscripten/wasm32 row to the Python implementation-status table; update the toolchain matrix to show pinned versions.

## Why

The wheel build hinges on a precise alignment of nightly Rust (LLVM features) ↔ pyodide-build's Emscripten/binaryen ↔ Pyodide's exception-handling ABI (the "version triangle" the original PR documented). With `@nightly` + unpinned `pyodide-build`, any future upstream release could silently reintroduce the feature/ABI skew and fail on an unrelated PR. Pinning makes the green state durable; a comment on each pin explains they must be bumped together and re-verified.

## How verified

- Built the wheel with the **pinned** `nightly-2026-05-29` + `pyodide-build==0.34.4` → success.
- **Browser-equivalent test**: loaded real Pyodide 0.29.4 under Node, installed the wheel via `micropip` (the JupyterLite/browser install path), imported `bashkit`, ran `execute_sync('echo hello && echo 1 | jq .')` → `'hello\n1\n'`; `Bash(sqlite=True)` raises `RuntimeError`.
- **Publish gate**: `twine check` PASSED on the wheel.
- Both workflows validated as YAML.

No Rust/Python source changed — config + docs only.

Part of #1811 follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Q2XBtGmsxo4BRgsg6mZ9h)_