### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-02
+
+### Highlights
+
+- **Pyodide/Emscripten (wasm32) Python wheel** — a reduced-feature `wasm32-unknown-emscripten` Python wheel now ships, enabling the embedded Python builtin in browser/wasm hosts ([#1811](https://github.com/everruns/bashkit/pull/1811)).
+- **Broad resource-safety hardening sweep** — fuel/budget enforcement and memory caps across the interpreter, parser, `rg`, `sqlite`, snapshot, and expansion paths (arithmetic expansion bounds, coproc/process-substitution budgets, heredoc reinjection fuel, brace-step overflow, compound-array limits, replacement-growth caps, sqlite result memory cap).
+- **JS BashTool snapshot authentication** plus keyed snapshot APIs and snapshot counter/byte-accounting fixes for correct resume.
+- Benches snapshot site page and CI hardening for the release/publish workflows.
+
+### What's Changed
+
+* chore(ci): pin Pyodide wheel toolchain and document browser verification ([#1843](https://github.com/everruns/bashkit/pull/1843)) by @chaliy
+* fix(js): authenticate BashTool snapshots ([#1838](https://github.com/everruns/bashkit/pull/1838)) by @chaliy
+* fix(interpreter): bound arithmetic variable expansion ([#1828](https://github.com/everruns/bashkit/pull/1828)) by @chaliy
+* fix(streaming): clear output callback on cancellation by @chaliy
+* fix(snapshot): account function source bytes by @chaliy
+* fix(awk): reject chained range patterns by @chaliy
+* fix(snapshot): preserve counters on resume by @chaliy
+* fix(sqlite): cap result memory growth by @chaliy
+* fix(sqlite): invalidate engine cache on snapshot restore by @chaliy
+* fix(scripted-tool): isolate extension invocation traces by @chaliy
+* fix(tool_def): bound parsed array flag inputs by @chaliy
+* fix(rg): cap replacement expansion by @chaliy
+* fix(rg): stream summary scans to avoid eager line allocation by @chaliy
+* fix(parser): charge heredoc reinjection to parser fuel by @chaliy
+* fix(ci): scope Doppler token to secret fetch steps by @chaliy
+* fix(interpreter): prevent brace step overflow by @chaliy
+* fix(parser): enforce coproc parser limits by @chaliy
+* fix(limits): enforce budgets for local compound arrays by @chaliy
+* fix(interpreter): scope deferred process substitutions by @chaliy
+* fix(interpreter): gate allexport env updates by @chaliy
+* fix(interpreter): cap word-split array assignments by @chaliy
+* fix(ci): validate CLI release tag input by @chaliy
+* fix(interpreter): avoid IFS nameref recursion by @chaliy
+* fix(js): expose keyed snapshot APIs by @chaliy
+* fix(interpreter): clear transient stdin after timeouts by @chaliy
+* fix(ci): verify release publish refs by @chaliy
+* fix(parser): debit nested process substitution budgets by @chaliy
+* fix(expansion): cap per-element replacement growth by @chaliy
+* fix(rg): bound ignore rule resource use by @chaliy
+* fix(ci): use integration test binary for cat/tac spec tests in drift workflow by @chaliy
+* feat(python): add Pyodide/Emscripten (wasm32) wheel ([#1811](https://github.com/everruns/bashkit/pull/1811)) by @chaliy
+* chore(deps): bump the rust-dependencies group with 3 updates by @dependabot
+* fix(interpreter): preserve legacy nameref targets ([#1810](https://github.com/everruns/bashkit/pull/1810)) by @chaliy
+* feat(site): add benches snapshot page ([#1789](https://github.com/everruns/bashkit/pull/1789)) by @chaliy
+* chore(python): bump monty to v0.0.18 ([#1809](https://github.com/everruns/bashkit/pull/1809)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.8.0...v0.9.0
+
 ## [0.8.0] - 2026-05-28
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 license = "MIT"
 authors = ["Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.8.0", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.9.0", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",


### PR DESCRIPTION
## Release v0.9.0

Minor release covering 35 commits since v0.8.0.

### Highlights

- **Pyodide/Emscripten (wasm32) Python wheel** — a reduced-feature `wasm32-unknown-emscripten` Python wheel now ships, enabling the embedded Python builtin in browser/wasm hosts ([#1811](https://github.com/everruns/bashkit/pull/1811)).
- **Broad resource-safety hardening sweep** — fuel/budget enforcement and memory caps across the interpreter, parser, `rg`, `sqlite`, snapshot, and expansion paths (arithmetic expansion bounds, coproc/process-substitution budgets, heredoc reinjection fuel, brace-step overflow, compound-array limits, replacement-growth caps, sqlite result memory cap).
- **JS BashTool snapshot authentication** plus keyed snapshot APIs and snapshot counter/byte-accounting fixes for correct resume.
- Benches snapshot site page and CI hardening for the release/publish workflows.

### Version bump

- Workspace `Cargo.toml`: `0.8.0` → `0.9.0`
- `crates/bashkit-cli/Cargo.toml` path-dep pin → `0.9.0`
- `crates/bashkit-js/package.json` → `0.9.0`
- `Cargo.lock` regenerated

### Publish-readiness report

- `cargo fmt --check` — pass
- `cargo clippy --workspace --features http_client,ssh,sqlite --all-targets` — pass (no warnings)
- `cargo publish --dry-run -p bashkit` — **pass** after replicating the `publish.yml` git-dep strip (monty is a git-only dep, stripped at publish time); packaging completed, upload aborted by dry-run as expected.
- `cargo publish --dry-run -p bashkit-cli` — packaging succeeded; version resolution against crates.io defers to publish-time (bashkit `0.9.0` must land on crates.io first, which CI publishes in dependency order). This is the normal chicken-and-egg and matches prior releases.
- **Version sync**: all manifests read `0.9.0`; `0.9.0` > latest published `0.8.0` on crates.io / PyPI / npm.

### What's Changed

See [CHANGELOG.md](https://github.com/everruns/bashkit/blob/claude/hopeful-heisenberg-NLFgZ/CHANGELOG.md) for the full list.

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.8.0...v0.9.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01BksyW8fAESKzvUuMfJ44dY)_