### PR TITLE
fix(ci): drop redundant version stanza from Homebrew formula

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -114,7 +114,6 @@ jobs:
           RELEASE_TAG: ${{ needs.validate-tag.outputs.tag }}
         run: |
           TAG="$RELEASE_TAG"
-          VERSION="${TAG#v}"
 
           # Validate checksum files exist and are non-empty
           for f in bashkit-aarch64-apple-darwin.tar.gz.sha256 \
@@ -146,7 +145,6 @@ jobs:
           class Bashkit < Formula
             desc "Virtual bash interpreter with sandboxed execution"
             homepage "${{ github.server_url }}/${{ github.repository }}"
-            version "${VERSION}"
             license "Apache-2.0"
 
             on_macos do


### PR DESCRIPTION
## What
Remove the explicit `version "${VERSION}"` stanza from the Homebrew formula generated by the `update-homebrew` job in `cli-binaries.yml`, and drop the now-unused `VERSION` assignment in the generate step.

## Why
`brew audit` fails the release with:

> Stable: `version 0.9.0` is redundant with version scanned from URL

The release download URL already encodes the tag (`.../releases/download/vX.Y.Z/bashkit-...tar.gz`), so Homebrew scans the version from the URL. Declaring `version` explicitly duplicates that and trips the audit, breaking the publish step.

## How
Let Homebrew derive the version from the URL by removing the `version` line. The `test do` block still resolves `version.to_s` to the URL-scanned version, which matches `bashkit --version`.

## Testing
- Workflow YAML validated with `yaml.safe_load`.
- Change is CI-only (no Rust/behavioral code touched), so no unit/integration tests apply. The real verification is the next release run passing `brew audit`.