### PR TITLE
fix(examples): enforce timeout parameter in bashkit-pi bash tool

### DIFF
--- a/examples/bashkit-pi/bashkit-extension.ts
+++ b/examples/bashkit-pi/bashkit-extension.ts
@@ -93,7 +93,13 @@ export default function (pi: any) {
 			_toolCallId: string,
 			params: { command: string; timeout?: number },
 		) {
-			const result = bash.executeSync(params.command);
+			// Convert caller-supplied seconds to milliseconds for AbortSignal.
+			// If no timeout is given, execute unbounded (subject to Bash instance limits).
+			const signal =
+				params.timeout != null
+					? AbortSignal.timeout(params.timeout * 1000)
+					: undefined;
+			const result = bash.executeSync(params.command, { signal });
 			let output = "";
 			if (result.stdout) output += result.stdout;
 			if (result.stderr) output += result.stderr;


### PR DESCRIPTION
## Summary

- The bash tool in `examples/bashkit-pi/bashkit-extension.ts` exposed a `timeout` parameter in its schema but never used it — `executeSync` was always called without any timeout bound.
- Fix: convert `params.timeout` (seconds) to milliseconds and pass it as an `AbortSignal` via `AbortSignal.timeout(ms)` to `executeSync`, which accepts `{ signal }` in its `ExecuteOptions`.
- When no timeout is provided the behavior is unchanged (unbounded, subject to `Bash` instance limits).

## Test plan

- [ ] Verify the extension loads without errors: `cd examples/bashkit-pi && pnpm install`
- [ ] Confirm that a command with a short timeout (e.g. `timeout: 1` with `sleep 5`) is cancelled after ~1 s
- [ ] Confirm that a command without a timeout still runs normally

Closes #1870