### PR TITLE
chore(ci): pin site workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -38,9 +38,9 @@ jobs:
     name: Docs Routes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
       - name: Verify docs route metadata
@@ -54,13 +54,13 @@ jobs:
     name: Site Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.11.1
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: pnpm


### PR DESCRIPTION
## Summary

- Pins all `uses:` action refs in `.github/workflows/site.yml` from mutable tags to immutable commit SHAs
- Keeps the original tag as a comment for readability
- Actions pinned: `actions/checkout`, `actions/setup-node`, `pnpm/action-setup`

## Test plan

- [ ] CI passes on this PR
- [ ] All pinned SHAs verified against current tag refs via `gh api`

Closes #1865