### PR TITLE
fix(snapshot): saturate session counters

### DIFF
--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -409,8 +409,8 @@ impl ExecutionCounters {
             Ok(())
         });
 
-        self.commands += 1;
-        self.session_commands += 1;
+        self.commands = self.commands.saturating_add(1);
+        self.session_commands = self.session_commands.saturating_add(1);
         if self.commands > limits.max_commands {
             return Err(LimitExceeded::MaxCommands(limits.max_commands));
         }
@@ -437,7 +437,7 @@ impl ExecutionCounters {
 
     /// Increment exec call counter for session tracking.
     pub fn tick_exec_call(&mut self) {
-        self.session_exec_calls += 1;
+        self.session_exec_calls = self.session_exec_calls.saturating_add(1);
     }
 
     /// Increment loop iteration counter, returns error if limit exceeded
@@ -922,6 +922,31 @@ mod tests {
             counters.tick_command(&limits),
             Err(LimitExceeded::MaxCommands(5))
         ));
+    }
+
+    #[test]
+    fn test_command_counter_saturates_on_overflow() {
+        let limits = ExecutionLimits::new().max_commands(5);
+        let mut counters = ExecutionCounters::new();
+        counters.commands = usize::MAX;
+        counters.session_commands = u64::MAX;
+
+        assert!(matches!(
+            counters.tick_command(&limits),
+            Err(LimitExceeded::MaxCommands(5))
+        ));
+        assert_eq!(counters.commands, usize::MAX);
+        assert_eq!(counters.session_commands, u64::MAX);
+    }
+
+    #[test]
+    fn test_exec_counter_saturates_on_overflow() {
+        let mut counters = ExecutionCounters::new();
+        counters.session_exec_calls = u64::MAX;
+
+        counters.tick_exec_call();
+
+        assert_eq!(counters.session_exec_calls, u64::MAX);
     }
 
     #[test]

--- a/crates/bashkit/tests/integration/snapshot_tests.rs
+++ b/crates/bashkit/tests/integration/snapshot_tests.rs
@@ -608,6 +608,27 @@ async fn snapshot_restore_does_not_reset_session_exec_limit_with_tampered_counte
 }
 
 #[tokio::test]
+async fn snapshot_restore_extreme_exec_counter_errors_without_overflow() {
+    let session_limits = SessionLimits::new().max_exec_calls(2);
+    let mut bash = Bash::builder().session_limits(session_limits).build();
+    bash.exec("echo first").await.unwrap();
+    let bytes = bash.snapshot().unwrap();
+
+    let mut tampered_json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    tampered_json["session_exec_calls"] = serde_json::json!(u64::MAX);
+    let tampered_snapshot: Snapshot = serde_json::from_value(tampered_json).unwrap();
+    let tampered_bytes = tampered_snapshot.to_bytes().unwrap();
+
+    bash.restore_snapshot(&tampered_bytes).unwrap();
+    let result = bash.exec("echo must-not-wrap").await;
+    assert!(
+        result.is_err(),
+        "restored u64::MAX exec counter must not panic or wrap below the limit"
+    );
+    assert_eq!(bash.session_counters().1, u64::MAX);
+}
+
+#[tokio::test]
 async fn keyed_snapshot_restore_carries_session_exec_budget_forward() {
     let key = b"session-budget-hmac-key";
     let session_limits = SessionLimits::new().max_exec_calls(2);

--- a/crates/bashkit/tests/integration/snapshot_tests.rs
+++ b/crates/bashkit/tests/integration/snapshot_tests.rs
@@ -625,6 +625,11 @@ async fn snapshot_restore_extreme_exec_counter_errors_without_overflow() {
         result.is_err(),
         "restored u64::MAX exec counter must not panic or wrap below the limit"
     );
+    let err_str = result.unwrap_err().to_string();
+    assert!(
+        err_str.contains("session exec() call limit"),
+        "error must be session exec limit, got: {err_str}"
+    );
     assert_eq!(bash.session_counters().1, u64::MAX);
 }
 


### PR DESCRIPTION
### Motivation
- Restoring snapshot-provided u64 session counters could set counters to `u64::MAX` and the subsequent unchecked `+= 1` would overflow or wrap, allowing a forged snapshot to crash the process or bypass session exec-call limits. 
- Prevent overflow/wrap while preserving the intended monotonic merge semantics for authenticated snapshots.

### Description
- Use saturating increments for per-exec and session counters by replacing `+= 1` with `saturating_add(1)` in `tick_command` and `tick_exec_call` in `crates/bashkit/src/limits.rs`. 
- Add unit tests `test_command_counter_saturates_on_overflow` and `test_exec_counter_saturates_on_overflow` in `crates/bashkit/src/limits.rs` to assert counters saturate at their max values. 
- Add integration regression `snapshot_restore_extreme_exec_counter_errors_without_overflow` in `crates/bashkit/tests/integration/snapshot_tests.rs` to assert restoring `session_exec_calls = u64::MAX` does not panic or wrap and still enforces limits. 

### Testing
- Ran formatting check with `cargo fmt --all -- --check` and it passed. 
- Ran unit tests including the new saturation tests with `cargo test -p bashkit` and the new tests passed. 
- Ran snapshot integration tests with `cargo test -p bashkit --test integration snapshot_tests::` and the snapshot suite (including the new regression) passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ede9c393c832bb75cb954ee10b9d1)