### PR TITLE
fix(ci): pin cli-binaries.yml actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/cli-binaries.yml
+++ b/.github/workflows/cli-binaries.yml
@@ -34,7 +34,7 @@ jobs:
           fi
           echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ steps.validate.outputs.tag }}
           fetch-depth: 0
@@ -84,18 +84,18 @@ jobs:
             archive: bashkit-x86_64-unknown-linux-gnu.tar.gz
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ needs.validate-tag.outputs.tag }}
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "cli-${{ matrix.target }}"
 
@@ -209,7 +209,7 @@ jobs:
           cat bashkit.rb
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v4
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
 
       - name: Push formula to homebrew-tap
         env:


### PR DESCRIPTION
Closes #1858

Pin all remote actions in `cli-binaries.yml` to reviewed full-length commit SHAs.

The release-binary workflow builds/uploads artifacts and fetches the Homebrew tap PAT via `DOPPLER_TOKEN`. Mutable action tags could inject code that tampers with published binaries or steals credentials.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164vJwkbxaxphDKUbafJF7J)_