### PR TITLE
fix(ci): pin coreutils-args-drift.yml actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/coreutils-args-drift.yml
+++ b/.github/workflows/coreutils-args-drift.yml
@@ -45,7 +45,7 @@ jobs:
       utils: ${{ steps.regen.outputs.utils }}
     steps:
       - name: Checkout bashkit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: bashkit
           persist-credentials: false
@@ -57,7 +57,7 @@ jobs:
         uses: ./bashkit/.github/actions/free-disk-space
 
       - name: Checkout uutils/coreutils
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: uutils/coreutils
           path: uutils
@@ -67,11 +67,11 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: bashkit
 
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload drift patch
         if: steps.diff.outputs.drifted == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coreutils-drift-patch
           path: ${{ runner.temp }}/coreutils-drift.patch
@@ -229,13 +229,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout bashkit
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: bashkit
           persist-credentials: false
 
       - name: Download drift patch
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coreutils-drift-patch
           path: ${{ runner.temp }}/coreutils-drift


### PR DESCRIPTION
Closes #1859

Pin all remote actions in `coreutils-args-drift.yml` to reviewed full-length commit SHAs.

This workflow has `contents: write` and `pull-requests: write` in its PR-opening job. Mutable tags could inject code that abuses those permissions or exfiltrates credentials.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164vJwkbxaxphDKUbafJF7J)_