### PR TITLE
fix(ci): pin fuzz.yml actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,16 +29,16 @@ jobs:
         target: [parser_fuzz, lexer_fuzz, arithmetic_fuzz, glob_fuzz]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
 
       - name: Cache fuzz corpus
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: crates/bashkit/fuzz/corpus
           key: fuzz-corpus-${{ matrix.target }}-${{ github.sha }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: fuzz-crashes-${{ matrix.target }}
           path: |


### PR DESCRIPTION
Closes #1861

Pin all remote actions in `fuzz.yml` to reviewed full-length commit SHAs.

A compromised or retargeted fuzz workflow action could execute arbitrary code on scheduled or manually dispatched runners.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164vJwkbxaxphDKUbafJF7J)_