### PR TITLE
fix(ci): restrict secret-bearing steps to push events only in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,12 +136,12 @@ jobs:
   examples:
     name: Examples
     runs-on: ubuntu-latest
-    # Fork-PR secret exfiltration guard: secrets are NOT exposed at job
-    # level here, because PR-controlled code (examples, build.rs, scripts)
-    # executes in this job. Steps that need real secrets gate on
-    # `github.event.pull_request.head.repo.fork != true` and only set the
-    # secret in their own step `env:`. See response in PR discussion;
-    # mirrors the pattern in `coverage.yml` and `js.yml`.
+    # Secret guard: only expose Doppler/API keys on push to main (trusted
+    # code). PRs — including same-repo branches — execute PR-controlled
+    # code (examples, build.rs, scripts) and must never see secrets.
+    # `github.event_name == 'push'` is the only reliable gate; the old
+    # `head.repo.fork != true` check passes for same-repo PRs and for
+    # workflow_call events where pull_request context is absent.
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -194,7 +194,7 @@ jobs:
       # steps gate on `env.DOPPLER_AVAILABLE` so this job stays green
       # in repos/forks without the secret configured.
       - name: Detect Doppler availability (trusted runs only)
-        if: github.event.pull_request.head.repo.fork != true
+        if: github.event_name == 'push'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
@@ -203,7 +203,7 @@ jobs:
           fi
 
       - name: Install Doppler CLI
-        if: github.event.pull_request.head.repo.fork != true && env.DOPPLER_AVAILABLE == 'true'
+        if: github.event_name == 'push' && env.DOPPLER_AVAILABLE == 'true'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
@@ -211,19 +211,18 @@ jobs:
       # External API dependency — don't block CI on Anthropic outages.
       # ANTHROPIC_API_KEY is sourced from Doppler (single source of truth
       # for non-GitHub secrets), so this step also requires Doppler to be
-      # available, which already implies a non-fork event.
+      # available, which already implies a push to main.
       # `--only-secrets` keeps the principle of least privilege: the
-      # PR-controlled cargo step sees ANTHROPIC_API_KEY only, not every
-      # secret in the Doppler config.
+      # step sees ANTHROPIC_API_KEY only, not every secret in Doppler.
       - name: Run LLM agent example
-        if: github.event.pull_request.head.repo.fork != true && env.DOPPLER_AVAILABLE == 'true'
+        if: github.event_name == 'push' && env.DOPPLER_AVAILABLE == 'true'
         continue-on-error: true
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --only-secrets ANTHROPIC_API_KEY -- cargo run --example agent_tool --features http_client
 
       - name: Run harness OpenAI joke example
-        if: github.event.pull_request.head.repo.fork != true && env.DOPPLER_AVAILABLE == 'true'
+        if: github.event_name == 'push' && env.DOPPLER_AVAILABLE == 'true'
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,10 +189,10 @@ jobs:
           TICKET_REF: 194b71a8bbc3771da1ce9f579395937c976bbddc
         run: bash examples/ticket-cli.sh
 
-      # Detect whether DOPPLER_TOKEN is configured. Only set on non-fork
-      # PRs/pushes; fork PRs never see the secret. Subsequent Doppler
-      # steps gate on `env.DOPPLER_AVAILABLE` so this job stays green
-      # in repos/forks without the secret configured.
+      # Detect whether DOPPLER_TOKEN is configured. Only set on push to
+      # main (trusted code); PRs — including same-repo branches — must
+      # never see the secret. Subsequent Doppler steps gate on
+      # `env.DOPPLER_AVAILABLE` so this job stays green when unconfigured.
       - name: Detect Doppler availability (trusted runs only)
         if: github.event_name == 'push'
         env:


### PR DESCRIPTION
## Summary

- Same-repo PRs and `workflow_call` events satisfy the old `github.event.pull_request.head.repo.fork != true` guard, exposing `DOPPLER_TOKEN` and API keys to PR-controlled code (examples, build scripts)
- Gate all secret-bearing steps on `github.event_name == 'push'` instead — only direct pushes to main are trusted
- Updates the job comment to explain the new invariant

## Test plan

- [ ] Verify CI passes on this PR (secret steps skip, job stays green)
- [ ] After merge, verify push to main runs the LLM/OpenAI example steps as expected

Closes #1847

---
_Generated by [Claude Code](https://claude.ai/code/session_013DdKMwgJy1nd4VLpqN9F8B)_