### PR TITLE
fix(ci): restrict secret-bearing steps to push-to-main only in js.yml

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Detect Doppler availability
         id: doppler
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo "available=${{ secrets.DOPPLER_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Install Doppler CLI


### PR DESCRIPTION
## Summary

- `workflow_dispatch` lets any user with write access run the JS workflow on an unmerged branch
- The old guard `github.event_name != 'pull_request'` passes for `workflow_dispatch`, exposing `DOPPLER_TOKEN`/`OPENAI_API_KEY` to repo code on unverified refs
- Changed `Detect Doppler availability` condition to `github.event_name == 'push' && github.ref == 'refs/heads/main'` — secrets only flow on trusted pushes to main

## Test plan

- [ ] Verify JS CI passes on this PR (Doppler steps skip, job green)
- [ ] After merge, verify push to main runs AI example steps as expected

Closes #1848

---
_Generated by [Claude Code](https://claude.ai/code/session_013DdKMwgJy1nd4VLpqN9F8B)_