### PR TITLE
fix(ci): pin js.yml action refs to immutable commit SHAs

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -37,20 +37,20 @@ jobs:
     name: TypeScript type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: pnpm
@@ -105,21 +105,21 @@ jobs:
             run: "deno run -A"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.33.0
 
       - name: Setup Node.js
         if: matrix.runtime == 'node'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.version }}
           cache: pnpm
@@ -129,7 +129,7 @@ jobs:
 
       - name: Setup Node.js (for napi build)
         if: matrix.runtime != 'node'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           cache: pnpm
@@ -139,13 +139,13 @@ jobs:
 
       - name: Setup Bun
         if: matrix.runtime == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: ${{ matrix.version }}
 
       - name: Setup Deno
         if: matrix.runtime == 'deno'
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: ${{ matrix.version }}
 
@@ -211,7 +211,7 @@ jobs:
 
       - name: Install Doppler CLI
         if: steps.doppler.outputs.available == 'true'
-        uses: dopplerhq/cli-action@v4
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `js.yml` uses mutable tags (`@v6`, `@v2`, `@1.95.0`) for all third-party actions including `dopplerhq/cli-action` which runs in a job that later exposes `DOPPLER_TOKEN`/`OPENAI_API_KEY`
- A compromised or retagged action can execute arbitrary code and steal secrets
- Pinned all actions to the same full commit SHAs already used in `ci.yml`, `nightly.yml`, and `coverage.yml`

## Actions pinned

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v6 | `df4cb1c0` |
| `dtolnay/rust-toolchain` | 1.95.0 | `e0818162` |
| `Swatinem/rust-cache` | v2 | `e18b4974` |
| `pnpm/action-setup` | v6 | `0e279bb9` |
| `actions/setup-node` | v6 | `48b55a01` |
| `oven-sh/setup-bun` | v2 | `0c5077e5` |
| `denoland/setup-deno` | v2 | `667a34cd` |
| `dopplerhq/cli-action` | v4 | `4819d808` |

## Test plan

- [ ] Verify JS CI passes on this PR

Closes #1849

---
_Generated by [Claude Code](https://claude.ai/code/session_013DdKMwgJy1nd4VLpqN9F8B)_