### PR TITLE
fix(ci): verify publish source is on main before running code with secrets in publish-js.yml

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -25,11 +25,35 @@ env:
 
 jobs:
   # ============================================================================
+  # Verify the publish source is on main before running any repo code
+  # with secrets. Manual dispatch and release events can target arbitrary
+  # refs; this gate ensures all subsequent jobs see trusted code.
+  # ============================================================================
+  verify-source:
+    name: Verify publish source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify publish source is reachable from main
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          SOURCE_SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$SOURCE_SHA" origin/main; then
+            echo "Error: publish source $SOURCE_SHA is not reachable from origin/main"
+            exit 1
+          fi
+          echo "Publish source verified on origin/main: $SOURCE_SHA"
+
+  # ============================================================================
   # Build native bindings for each platform
   # ============================================================================
   build-js:
     name: Build JS - ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
+    needs: [verify-source]
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- `publish-js.yml` can be triggered by `workflow_dispatch` targeting any ref; the only source verification was in the final `release-js` job — after `test-js-macos-windows` and `test-js-linux` already ran repository code with `DOPPLER_TOKEN`/`OPENAI_API_KEY`
- Added a `verify-source` job that checks `HEAD` is reachable from `origin/main` before any code builds or tests run
- `build-js` now `needs: [verify-source]`, so all downstream test and publish jobs are blocked until source is verified

## Test plan

- [ ] Verify the workflow runs cleanly (verify-source passes, build proceeds)
- [ ] Verify a dispatch from a non-main ref would fail at verify-source before any secrets are exposed

Closes #1850

---
_Generated by [Claude Code](https://claude.ai/code/session_013DdKMwgJy1nd4VLpqN9F8B)_