### PR TITLE
fix(ci): pin publish-js.yml action refs to immutable commit SHAs

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -57,27 +57,27 @@ jobs:
           #   build: pnpm exec napi build --platform --release --target wasm32-wasip1-threads && pnpm run build:cjs && pnpm run build:ts
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.33.0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: crates/bashkit-js/pnpm-lock.yaml
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -98,7 +98,7 @@ jobs:
         working-directory: crates/bashkit-js
 
       - name: Upload native binding
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: js-bindings-${{ matrix.settings.target }}
           path: |
@@ -109,7 +109,7 @@ jobs:
       # Upload generated JS stubs from one build (they're identical across targets)
       - if: ${{ matrix.settings.target == 'x86_64-unknown-linux-gnu' }}
         name: Upload JS stubs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: js-stubs
           path: |
@@ -147,15 +147,15 @@ jobs:
         node: ["20", "22", "24"]
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.33.0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -167,13 +167,13 @@ jobs:
         working-directory: crates/bashkit-js
 
       - name: Download native binding
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: js-bindings-${{ matrix.settings.target }}
           path: crates/bashkit-js
 
       - name: Download JS stubs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: js-stubs
           path: crates/bashkit-js
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install Doppler CLI
         if: steps.doppler.outputs.available == 'true'
-        uses: dopplerhq/cli-action@v4
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
@@ -251,15 +251,15 @@ jobs:
         node: ["20", "22", "24"]
     runs-on: ${{ contains(matrix.target, 'aarch64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.33.0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -288,13 +288,13 @@ jobs:
         working-directory: crates/bashkit-js
 
       - name: Download native binding
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: js-bindings-${{ matrix.target }}
           path: crates/bashkit-js
 
       - name: Download JS stubs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: js-stubs
           path: crates/bashkit-js
@@ -334,7 +334,7 @@ jobs:
 
       - name: Install Doppler CLI
         if: steps.doppler.outputs.available == 'true'
-        uses: dopplerhq/cli-action@v4
+        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
@@ -359,13 +359,13 @@ jobs:
   #   needs: [build-js]
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
   #     - name: Setup pnpm
-  #       uses: pnpm/action-setup@v6
+  #       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
   #       with:
   #         version: 10.33.0
   #     - name: Setup node
-  #       uses: actions/setup-node@v6
+  #       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
   #       with:
   #         node-version: 24
   #         cache: pnpm
@@ -374,12 +374,12 @@ jobs:
   #       run: pnpm install --frozen-lockfile --cpu wasm32
   #       working-directory: crates/bashkit-js
   #     - name: Download native binding
-  #       uses: actions/download-artifact@v8
+  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
   #       with:
   #         name: js-bindings-wasm32-wasip1-threads
   #         path: crates/bashkit-js
   #     - name: Download JS stubs
-  #       uses: actions/download-artifact@v8
+  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
   #       with:
   #         name: js-stubs
   #         path: crates/bashkit-js
@@ -406,7 +406,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Verify publish source is on main
         run: |
@@ -419,12 +419,12 @@ jobs:
           echo "Publish source verified on origin/main: $SOURCE_SHA"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10.33.0
 
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -436,14 +436,14 @@ jobs:
         working-directory: crates/bashkit-js
 
       - name: Download all native bindings
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: js-bindings-*
           merge-multiple: true
           path: crates/bashkit-js
 
       - name: Download JS stubs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: js-stubs
           path: crates/bashkit-js


### PR DESCRIPTION
## Summary

- `publish-js.yml` uses mutable tags for all third-party actions across `build-js`, `test-js-macos-windows`, `test-js-linux`, and `release-js` jobs
- A compromised or retagged action can execute code in jobs that later receive `DOPPLER_TOKEN`/`OPENAI_API_KEY` and `NPM_TOKEN`
- Pinned all actions to the same full commit SHAs used in `ci.yml`, `fuzz.yml`, and `coverage.yml`

## Actions pinned (29 substitutions across 4 jobs)

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v6 | `df4cb1c0` |
| `pnpm/action-setup` | v6 | `0e279bb9` |
| `actions/setup-node` | v6 | `48b55a01` |
| `dtolnay/rust-toolchain` | 1.95.0 | `e0818162` |
| `actions/cache` | v5 | `27d5ce7f` |
| `actions/upload-artifact` | v7 | `043fb46d` |
| `actions/download-artifact` | v8 | `3e5f45b2` |
| `dopplerhq/cli-action` | v4 | `4819d808` |

## Test plan

- [ ] Verify workflow runs cleanly after pinning

Closes #1851

---
_Generated by [Claude Code](https://claude.ai/code/session_013DdKMwgJy1nd4VLpqN9F8B)_