### PR TITLE
fix(ci): add --ignore-scripts to pnpm add in publish-js.yml

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -199,7 +199,7 @@ jobs:
         shell: bash
         run: |
           echo '{"type":"module","private":true}' > package.json
-          pnpm add openai ai @ai-sdk/openai @langchain/core @langchain/langgraph @langchain/openai zod
+          pnpm add --ignore-scripts openai ai @ai-sdk/openai @langchain/core @langchain/langgraph @langchain/openai zod
           rm -rf node_modules/@everruns/bashkit
           mkdir -p node_modules/@everruns
           if [ "$RUNNER_OS" = "Windows" ]; then
@@ -323,7 +323,7 @@ jobs:
       - name: Install AI SDK dependencies and re-link
         run: |
           echo '{"type":"module","private":true}' > package.json
-          pnpm add openai ai @ai-sdk/openai @langchain/core @langchain/langgraph @langchain/openai zod
+          pnpm add --ignore-scripts openai ai @ai-sdk/openai @langchain/core @langchain/langgraph @langchain/openai zod
           rm -rf node_modules/@everruns/bashkit
           mkdir -p node_modules/@everruns
           ln -s ${{ github.workspace }}/crates/bashkit-js node_modules/@everruns/bashkit


### PR DESCRIPTION
## Summary

- Release test jobs (`test-js-macos-windows`, `test-js-linux`) create an ad-hoc `package.json` and run `pnpm add` without a lockfile to install AI SDK dependencies
- These installs happen immediately before the `OPENAI_API_KEY` is fetched from Doppler; a newly malicious dependency could run a lifecycle script (`postinstall`, `prepare`, etc.) that injects code to exfiltrate the key during the AI examples run
- Added `--ignore-scripts` to both `pnpm add` calls to prevent install-time lifecycle script execution

## Test plan

- [ ] Verify AI examples still work after `--ignore-scripts` (these packages don't require install scripts for their runtime functionality)

Closes #1852

---
_Generated by [Claude Code](https://claude.ai/code/session_013DdKMwgJy1nd4VLpqN9F8B)_