### PR TITLE
fix(ci): pin publish.yml action refs to immutable commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,11 @@ jobs:
   publish-bashkit:
     name: Publish bashkit
     runs-on: ubuntu-latest
+    environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Verify publish source is on main
         run: |
@@ -30,7 +33,7 @@ jobs:
           echo "Publish source verified on origin/main: $SOURCE_SHA"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Verify version matches tag
         env:
@@ -93,11 +96,14 @@ jobs:
     name: Publish bashkit-cli
     runs-on: ubuntu-latest
     needs: publish-bashkit
+    environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Wait for crates.io index update
         run: sleep 30
@@ -125,7 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-bashkit, publish-bashkit-cli]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Wait for crates.io propagation
         run: sleep 60


### PR DESCRIPTION
## Summary

- Pin `actions/checkout@v6` and `dtolnay/rust-toolchain@1.95.0` to full commit SHAs in all three jobs of `publish.yml`
- Add `environment: release` to both crates-publishing jobs (`publish-bashkit`, `publish-bashkit-cli`) to gate them behind a protected GitHub environment before `CARGO_REGISTRY_TOKEN` is consumed
- Add `persist-credentials: false` to all checkout steps to prevent the `GITHUB_TOKEN` from leaking into subsequent steps

## Test plan

- [ ] Validate `publish.yml` YAML parses correctly (`ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml")'`)
- [ ] Confirm no mutable action tags remain in `publish.yml`
- [ ] CI green on this PR

Closes #1854

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqKVq1pCK9JHhdLUcNLM1x)_