### PR TITLE
fix(ci): verify release tag integrity before creating GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,11 @@ jobs:
       - name: Create and verify release tag
         run: |
           TAG="${{ steps.version.outputs.tag }}"
-          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
-          if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
-            TAG_SHA=$(git rev-list -n 1 "$TAG")
+          # Check remote first to avoid stale local refs
+          REMOTE_TAG_SHA=$(git ls-remote origin "refs/tags/$TAG" | awk '{print $1}')
+          if [ -n "$REMOTE_TAG_SHA" ]; then
+            git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG"
+            TAG_SHA=$(git rev-list -n 1 "refs/tags/$TAG")
             if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
               echo "Error: existing tag $TAG points to $TAG_SHA, expected $GITHUB_SHA"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,23 @@ jobs:
           echo "$NOTES" > release_notes.md
           echo "Release notes extracted for v$VERSION"
 
+      - name: Create and verify release tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git fetch --force origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
+          if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
+            TAG_SHA=$(git rev-list -n 1 "$TAG")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              echo "Error: existing tag $TAG points to $TAG_SHA, expected $GITHUB_SHA"
+              exit 1
+            fi
+            echo "Existing tag $TAG verified at $GITHUB_SHA"
+          else
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "$TAG"
+            echo "Created tag $TAG at $GITHUB_SHA"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:


### PR DESCRIPTION
## Summary

- Add a `Create and verify release tag` step immediately before `softprops/action-gh-release`
- If the tag already exists it must resolve to `$GITHUB_SHA` or the workflow fails before any release is published
- If the tag is absent it is created explicitly at `$GITHUB_SHA` before the release action runs
- The existing post-release tag verification step is kept as a redundant final check

This closes the race window described in the issue: a public release can no longer be attached to an unverified commit.

## Test plan

- [ ] Validate `release.yml` YAML parses correctly
- [ ] CI green on this PR

Closes #1856

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqKVq1pCK9JHhdLUcNLM1x)_