### PR TITLE
fix(grep): stream only-matching ranges

### DIFF
--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -724,8 +724,9 @@ impl Builtin for Grep {
                 }
 
                 if opts.only_matching && !opts.invert_match {
-                    // -o mode: count each match separately
-                    for _ in matcher.find_ranges(line) {
+                    // -o mode: count each match separately, stopping the lazy
+                    // matcher as soon as grep's early-exit conditions are met.
+                    matcher.for_each_range(line, |_| {
                         file_matched = true;
                         if !opts.files_without_matches {
                             any_match = true;
@@ -734,16 +735,18 @@ impl Builtin for Grep {
                         total_matches += 1;
 
                         if opts.files_with_matches || opts.files_without_matches || opts.quiet {
-                            break;
+                            return false;
                         }
 
                         if let Some(max) = opts.max_count
                             && total_matches >= max
                         {
                             max_reached = true;
-                            break;
+                            return false;
                         }
-                    }
+
+                        true
+                    });
                     if (opts.files_with_matches || opts.files_without_matches) && file_matched {
                         break;
                     }
@@ -827,14 +830,15 @@ impl Builtin for Grep {
                 }
             } else if !opts.quiet {
                 if opts.only_matching && !opts.invert_match {
-                    // -o mode: output each match
+                    // -o mode: output each match lazily so -m can stop before
+                    // materializing every match range on dense inputs.
                     let mut o_matches = 0usize;
                     for (line_num, line) in lines.iter().enumerate() {
-                        for (start, end) in matcher.find_ranges(line) {
+                        matcher.for_each_range(line, |(start, end)| {
                             if let Some(max) = opts.max_count
                                 && o_matches >= max
                             {
-                                break;
+                                return false;
                             }
                             if show_filename {
                                 output.push_str(filename);
@@ -849,7 +853,8 @@ impl Builtin for Grep {
                             output.push_str(&line[start..end]);
                             output.push('\n');
                             o_matches += 1;
-                        }
+                            true
+                        });
                         if let Some(max) = opts.max_count
                             && o_matches >= max
                         {
@@ -1215,6 +1220,15 @@ mod tests {
             .unwrap();
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "o\no\no\no\n");
+    }
+
+    #[tokio::test]
+    async fn test_grep_only_matching_max_count_stops_on_first_dense_match() {
+        let haystack = "x".repeat(100_000);
+        let result = run_grep(&["-om1", "."], Some(&haystack)).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "x\n");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/search_common.rs
+++ b/crates/bashkit/src/builtins/search_common.rs
@@ -57,19 +57,30 @@ impl Matcher {
         }
     }
 
-    /// Byte ranges `(start, end)` of all non-overlapping matches, left to
-    /// right. Slice `text[start..end]` to recover the matched substring.
-    pub(crate) fn find_ranges(&self, text: &str) -> Vec<(usize, usize)> {
+    /// Visit non-overlapping match byte ranges left to right.
+    ///
+    /// The callback returns `false` to stop scanning immediately. Keep this
+    /// lazy so grep early exits (`-m`, `-q`, `-l`, `-L`) bound work and memory
+    /// even for dense `-o` matches on large single-line files.
+    pub(crate) fn for_each_range(&self, text: &str, mut visit: impl FnMut((usize, usize)) -> bool) {
         match self {
-            Matcher::Standard(re) => re.find_iter(text).map(|m| (m.start(), m.end())).collect(),
-            // `find_iter` yields `Result<Match, _>`; `flatten` drops the Err
-            // arm (backtrack-limit / internal errors) — same "no match" policy
-            // as `is_match`.
-            Matcher::Fancy(re) => re
-                .find_iter(text)
-                .flatten()
-                .map(|m| (m.start(), m.end()))
-                .collect(),
+            Matcher::Standard(re) => {
+                for m in re.find_iter(text) {
+                    if !visit((m.start(), m.end())) {
+                        break;
+                    }
+                }
+            }
+            // `find_iter` yields `Result<Match, _>`; `Err` arms
+            // (backtrack-limit / internal errors) keep the same "no match"
+            // policy as `is_match` by not calling the visitor.
+            Matcher::Fancy(re) => {
+                for m in re.find_iter(text).flatten() {
+                    if !visit((m.start(), m.end())) {
+                        break;
+                    }
+                }
+            }
         }
     }
 }
@@ -131,4 +142,22 @@ pub(crate) fn parse_numeric_flag_arg(
             cmd_name, flag_name, num_str
         ))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_each_range_stops_when_visitor_returns_false() {
+        let matcher = Matcher::Standard(build_regex(".").unwrap());
+        let mut visited = 0usize;
+
+        matcher.for_each_range(&"x".repeat(100_000), |_| {
+            visited += 1;
+            false
+        });
+
+        assert_eq!(visited, 1);
+    }
 }


### PR DESCRIPTION
### Motivation
- A previous change made `Matcher::find_ranges()` return a `Vec` of all matches, which forces eager allocation for dense single-line inputs and allows `grep -o` to be used for resource exhaustion despite `-m`/`-q`/`-l` limits. 
- The intent is to restore lazy scanning so grep's early-exit options bound CPU/memory even when a line contains many matches. 

### Description
- Add a lazy visitor API `Matcher::for_each_range(&self, text: &str, visit: impl FnMut((usize,usize)) -> bool)` in `crates/bashkit/src/builtins/search_common.rs` that iterates matches left-to-right and stops when the visitor returns `false`. 
- Replace eager `matcher.find_ranges(...)` callers in `crates/bashkit/src/builtins/grep.rs` (counting and `-o` output paths) with `matcher.for_each_range(...)` and return `false` from the visitor to enforce existing early-exit semantics (`-m`, `-q`, `-l`, `-L`). 
- Add regression tests: a unit test for early-stop behavior of `for_each_range` and a `grep` test that verifies `grep -om1 .` on a dense input stops after the first match. 

### Testing
- Ran `cargo test -p bashkit for_each_range_stops_when_visitor_returns_false` which passed. 
- Ran the new grep regression test `cargo test -p bashkit test_grep_only_matching_max_count_stops_on_first_dense_match` which passed. 
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224371de8c832b8d0d731794e2a374)