### PR TITLE
fix(rg): contain followed symlink targets

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3524,6 +3524,7 @@ impl RgDisplayHint {
 async fn resolve_rg_symlink_target(
     fs: &dyn crate::fs::FileSystem,
     link_path: &Path,
+    containment_root: &Path,
 ) -> Option<(PathBuf, crate::fs::Metadata)> {
     let target = fs.read_link(link_path).await.ok()?;
     let resolved = if target.is_absolute() {
@@ -3531,6 +3532,11 @@ async fn resolve_rg_symlink_target(
     } else {
         crate::fs::normalize_path(&link_path.parent().unwrap_or(Path::new("/")).join(target))
     };
+    // rg may emulate ripgrep's -L behavior only inside the requested VFS search root;
+    // rejecting escapes preserves TM-ESC-002's inert-symlink sandbox boundary.
+    if !resolved.starts_with(containment_root) {
+        return None;
+    }
     let metadata = fs.stat(&resolved).await.ok()?;
     Some((resolved, metadata))
 }
@@ -3542,7 +3548,8 @@ async fn resolve_rg_explicit_path(
 ) -> Option<(PathBuf, crate::fs::Metadata)> {
     let meta = fs.stat(path).await.ok()?;
     if meta.file_type.is_symlink() && follow_symlinks {
-        resolve_rg_symlink_target(fs, path).await
+        let containment_root = path.parent().unwrap_or(Path::new("/"));
+        resolve_rg_symlink_target(fs, path, containment_root).await
     } else {
         Some((path.to_path_buf(), meta))
     }
@@ -3599,7 +3606,7 @@ async fn collect_rg_files_recursive(
                 let (entry_actual_path, entry_metadata) =
                     if entry.metadata.file_type.is_symlink() && opts.follow_symlinks {
                         let Some((target, target_meta)) =
-                            resolve_rg_symlink_target(fs, &actual_path).await
+                            resolve_rg_symlink_target(fs, &actual_path, &item.actual_root).await
                         else {
                             continue;
                         };
@@ -7333,15 +7340,53 @@ mod tests {
         assert!(err.contains("ratio exceeds"));
     }
 
+    #[tokio::test]
+    async fn rg_follow_rejects_recursive_symlink_escape() {
+        let result = run_rg_fixture_with_cwd(
+            &["-L", "needle", "workspace"],
+            None,
+            &[
+                ("/workspace/public.txt", b"needle public\n"),
+                ("/secret/flag.txt", b"needle secret\n"),
+            ],
+            &[
+                ("/workspace/flag.txt", "../secret/flag.txt"),
+                ("/workspace/flagdir", "../secret"),
+            ],
+            "/",
+        )
+        .await;
+
+        assert!(result.stdout.contains("workspace/public.txt"));
+        assert!(!result.stdout.contains("secret"));
+        assert!(!result.stdout.contains("flag.txt"));
+        assert!(!result.stdout.contains("flagdir"));
+    }
+
+    #[tokio::test]
+    async fn rg_follow_rejects_explicit_symlink_escape() {
+        let result = run_rg_fixture_with_cwd(
+            &["-L", "needle", "workspace/flag.txt"],
+            None,
+            &[("/secret/flag.txt", b"needle secret\n")],
+            &[("/workspace/flag.txt", "../secret/flag.txt")],
+            "/",
+        )
+        .await;
+
+        assert!(!result.stdout.contains("secret"));
+        assert!(!result.stdout.contains("flag.txt"));
+    }
+
     const DIFF_SYMLINK_FILES: &[(&str, &[u8])] = &[
-        ("/targets/file.txt", b"needle\n"),
-        ("/targets/dir/nested.txt", b"needle\n"),
+        ("/proj/targets/file.txt", b"needle\n"),
+        ("/proj/targets/dir/nested.txt", b"needle\n"),
         ("/proj/plain.txt", b"needle\n"),
     ];
 
     const DIFF_SYMLINKS: &[(&str, &str)] = &[
-        ("/proj/link.txt", "../targets/file.txt"),
-        ("/proj/linkdir", "../targets/dir"),
+        ("/proj/link.txt", "targets/file.txt"),
+        ("/proj/linkdir", "targets/dir"),
     ];
 
     const RG_SYMLINK_DIFF_CASES: &[RgSymlinkDiffCase] = &[


### PR DESCRIPTION
### Motivation
- Close a symlink-escape confidentiality gap where `rg` dereferenced symlink targets and read files outside the intended VFS/search root, violating the repository's inert-symlink threat model (TM-ESC-002).

### Description
- Add containment checks to symlink resolution by changing `resolve_rg_symlink_target` to accept a `containment_root` and reject targets that do not `starts_with` that root.
- Apply containment to explicit-path dereference (`resolve_rg_explicit_path`) using the path parent as the containment root and to recursive walks by passing `item.actual_root` for each entry.
- Update symlink differential test fixtures paths so tests exercise in-root behavior and add two regression tests (`rg_follow_rejects_recursive_symlink_escape` and `rg_follow_rejects_explicit_symlink_escape`) that assert `-L` does not allow escaping the search root.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran targeted unit tests: `cargo test -p bashkit --lib rg_follow_rejects -- --nocapture` and the new async tests passed (`ok`).
- Ran differential symlink test driver `cargo test -p bashkit --lib diff_rg_matches_real_rg_symlink_cases -- --nocapture` which reported the external-ripgrep check and returned `ok` (differential cases are skipped when the pinned ripgrep is not present). 
- Ran `cargo clippy -p bashkit --lib -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc6034832b9da6719f7a64d387)