### PR TITLE
fix(ci): verify pinned ripgrep archive digest

### DIFF
--- a/scripts/install-ripgrep-ci.sh
+++ b/scripts/install-ripgrep-ci.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# CI executes the installed `rg`; pin archive digests before extraction so a
+# compromised release asset or redirect cannot become CI code execution.
 version="${1:-15.1.0}"
 os="$(uname -s)"
 arch="$(uname -m)"
@@ -24,12 +26,59 @@ case "${os}:${arch}" in
     ;;
 esac
 
+case "${version}:${target}" in
+  15.1.0:x86_64-unknown-linux-musl)
+    expected_sha256="1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599"
+    ;;
+  15.1.0:aarch64-unknown-linux-gnu)
+    expected_sha256="2b661c6ef508e902f388e9098d9c4c5aca72c87b55922d94abdba830b4dc885e"
+    ;;
+  15.1.0:x86_64-apple-darwin)
+    expected_sha256="64811cb24e77cac3057d6c40b63ac9becf9082eedd54ca411b475b755d334882"
+    ;;
+  15.1.0:aarch64-apple-darwin)
+    expected_sha256="378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715"
+    ;;
+  *)
+    echo "missing pinned SHA-256 for ripgrep ${version} ${target}" >&2
+    exit 1
+    ;;
+esac
+
+sha256_file() {
+  local file="$1"
+
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+  elif command -v shasum > /dev/null 2>&1; then
+    shasum -a 256 "${file}" | awk '{print $1}'
+  else
+    echo "No SHA-256 tool found (need sha256sum or shasum)" >&2
+    exit 1
+  fi
+}
+
+verify_sha256() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(sha256_file "${file}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "SHA-256 mismatch for ${file}" >&2
+    echo "Expected: ${expected}" >&2
+    echo "Actual:   ${actual}" >&2
+    exit 1
+  fi
+}
+
 archive="ripgrep-${version}-${target}.tar.gz"
 url="https://github.com/BurntSushi/ripgrep/releases/download/${version}/${archive}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
 
 curl -fsSL "${url}" -o "${tmp}/${archive}"
+verify_sha256 "${tmp}/${archive}" "${expected_sha256}"
 tar -xzf "${tmp}/${archive}" -C "${tmp}"
 
 install_dir="${RUNNER_TOOL_CACHE:-${HOME}/.cache}/ripgrep-${version}-${target}/bin"


### PR DESCRIPTION
### Motivation
- CI helper `scripts/install-ripgrep-ci.sh` downloaded and executed a ripgrep release archive without verifying integrity, allowing a compromised release asset to execute code in CI.

### Description
- Add pinned SHA-256 digests for `ripgrep 15.1.0` per supported `version:target` combination in `scripts/install-ripgrep-ci.sh` and fail when missing.
- Add `sha256_file` and `verify_sha256` helpers that use `sha256sum` or `shasum` to compute and compare file digests.
- Verify the downloaded archive with `verify_sha256` before any `tar -xzf`, install, PATH update, or executing `rg`.
- Emit clear diagnostics and exit non-zero on mismatch or when no digest is pinned.

### Testing
- `bash -n scripts/install-ripgrep-ci.sh` — syntax check passed. (success)
- Fake-download mismatch smoke test using a fake `curl` ensured the script fails with `SHA-256 mismatch` and the malicious `rg` was not executed. (success)
- Real-install smoke test: `RUNNER_TOOL_CACHE=/tmp/... GITHUB_PATH=/tmp/... scripts/install-ripgrep-ci.sh 15.1.0` produced a valid `rg --version` output. (success)
- `shellcheck` not available in the environment so lint step was not run. (warning)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adca2c832ba3d3d5566b6618e4)