### PR TITLE
fix(coreutils-port): reject shadowable `value_parser!` macros

### DIFF
--- a/crates/bashkit-coreutils-port/src/args.rs
+++ b/crates/bashkit-coreutils-port/src/args.rs
@@ -867,12 +867,13 @@ fn path_ends_with_command_new(func: &Expr) -> bool {
 }
 
 fn validate_allowed_command_builder_macro(mac: &syn::Macro) -> Result<()> {
+    // Only fully qualified trusted builder macros may cross this boundary:
+    // unqualified macros can be shadowed by copied uutils modules before codegen.
     let segs = path_segments(&mac.path);
     if matches!(segs.as_slice(), [env] if env == "env") {
         return validate_env_macro(mac);
     }
-    if matches!(segs.as_slice(), [value_parser] if value_parser == "value_parser")
-        || matches!(segs.as_slice(), [clap, value_parser] if clap == "clap" && value_parser == "value_parser")
+    if matches!(segs.as_slice(), [clap, value_parser] if clap == "clap" && value_parser == "value_parser")
     {
         return validate_value_parser_macro(mac);
     }
@@ -1358,6 +1359,34 @@ pub fn uu_app() -> clap::Command {
         let msg = format!("{err:#}");
         assert!(
             msg.contains("value_parser! in command builder must not contain a nested macro"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_unqualified_value_parser_macro() {
+        let (_tmp, uutils) = fixture(&[
+            (
+                "src/uu/cat/src/cat.rs",
+                r#"
+mod options {
+    pub static FILE: &str = "file";
+}
+
+pub fn uu_app() -> clap::Command {
+    Command::new("cat").arg(
+        Arg::new(options::FILE).value_parser(value_parser!(std::ffi::OsString)),
+    )
+}
+"#,
+            ),
+            ("src/uu/cat/locales/en-US.ftl", ""),
+        ]);
+
+        let err = run(&uutils, "cat", "poc").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("macro is not allowed in command builder"),
             "got: {msg}"
         );
     }


### PR DESCRIPTION
### Motivation
- Prevent untrusted/copy-pasted `mod options` from shadowing an unqualified `value_parser!` macro and thereby executing host-side code during generated `*_command()` construction. 

### Description
- Tighten `validate_allowed_command_builder_macro` in `crates/bashkit-coreutils-port/src/args.rs` to only accept fully-qualified `clap::value_parser!` and `env!` usages, removing the previous allowance for unqualified `value_parser!` paths. 
- Add a clarifying comment above the macro validator about rejecting unqualified/shadowable macros. 
- Add regression test `rejects_unqualified_value_parser_macro` to assert that unqualified `value_parser!(...)` is rejected by the validator.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p bashkit-coreutils-port` and all unit tests passed (37 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad6b48832b927112bdfcd0fee6)