### PR TITLE
fix(sqlite): strip BOM before policy parsing

### DIFF
--- a/crates/bashkit/src/builtins/sqlite/parser.rs
+++ b/crates/bashkit/src/builtins/sqlite/parser.rs
@@ -139,6 +139,12 @@ pub(super) fn strip_leading_noise(sql: &str) -> &str {
     let bytes = sql.as_bytes();
     let mut i = 0;
     loop {
+        // SQLite accepts one UTF-8 BOM before the first token; strip it so
+        // policy checks see the same leading keyword as the engine.
+        if i == 0 && bytes.starts_with(b"\xEF\xBB\xBF") {
+            i = 3;
+            continue;
+        }
         // ASCII whitespace
         while i < bytes.len() && bytes[i].is_ascii_whitespace() {
             i += 1;
@@ -455,6 +461,10 @@ mod tests {
             Some("ATTACH".into())
         );
         assert_eq!(leading_keyword("/* hi */ DETACH y"), Some("DETACH".into()));
+        assert_eq!(
+            leading_keyword("\u{feff}ATTACH 'x' AS y"),
+            Some("ATTACH".into())
+        );
     }
 
     #[test]
@@ -484,6 +494,10 @@ mod tests {
             Some("cache_size".into())
         );
         assert_eq!(
+            pragma_name("PRAGMA main . cache_size = -1024"),
+            Some("cache_size".into())
+        );
+        assert_eq!(
             pragma_name("pragma temp.user_version"),
             Some("user_version".into())
         );
@@ -491,6 +505,10 @@ mod tests {
 
     #[test]
     fn pragma_name_handles_quoted_schema_qualified_names() {
+        assert_eq!(
+            pragma_name("PRAGMA \"cache_size\" = -1024"),
+            Some("cache_size".into())
+        );
         assert_eq!(
             pragma_name("PRAGMA main.\"cache_size\" = -1024"),
             Some("cache_size".into())
@@ -513,6 +531,10 @@ mod tests {
         );
         assert_eq!(
             pragma_name("PRAGMA/**/cache_size"),
+            Some("cache_size".into())
+        );
+        assert_eq!(
+            pragma_name("PRAGMA /*x*/ cache_size"),
             Some("cache_size".into())
         );
     }

--- a/crates/bashkit/src/builtins/sqlite/tests.rs
+++ b/crates/bashkit/src/builtins/sqlite/tests.rs
@@ -670,6 +670,20 @@ async fn detach_statement_blocked() {
 }
 
 #[tokio::test]
+async fn attach_blocked_with_leading_bom() {
+    let r = run(
+        &[
+            ":memory:",
+            "\u{feff}ATTACH DATABASE '/tmp/other.db' AS other",
+        ],
+        None,
+    )
+    .await;
+    assert_eq!(r.exit_code, 1, "stderr: {}", r.stderr);
+    assert!(r.stderr.contains("ATTACH/DETACH is not supported"));
+}
+
+#[tokio::test]
 async fn attach_blocked_even_with_leading_comment() {
     // The argv parser rejects values that begin with `-`, so a leading
     // line-comment would fail in arg parsing rather than in the policy.
@@ -744,9 +758,13 @@ async fn pragma_schema_qualified_match() {
     // deny list — otherwise the policy is trivial to bypass.
     for sql in [
         "PRAGMA main.cache_size = 100",
+        "PRAGMA main . cache_size = 100",
         "PRAGMA main.\"cache_size\" = 100",
+        "PRAGMA \"cache_size\" = 100",
         "PRAGMA temp.[cache_size]",
         "PRAGMA main.`cache_size`",
+        "PRAGMA/**/cache_size = 100",
+        "PRAGMA /*x*/ cache_size = 100",
     ] {
         let r = run(&[":memory:", sql], None).await;
         assert_eq!(r.exit_code, 1, "{sql} stderr: {}", r.stderr);


### PR DESCRIPTION
### Motivation

- Prevent BOM-prefixed SQL from bypassing the sqlite policy sniffer so leading `ATTACH`/`DETACH`/`VACUUM` keywords are detected the same way SQLite does.
- Add regression coverage for alternate SQLite-valid PRAGMA forms that operators might use to disguise denied names (schema spacing, quoted names, and comments).

### Description

- Strip a leading UTF‑8 BOM in `strip_leading_noise` so policy tokenisation sees the same first token as the engine (`crates/bashkit/src/builtins/sqlite/parser.rs`).
- Add parser unit-test assertions for BOM-prefixed leading keyword detection and for schema spacing, quoted PRAGMA names, and comment-disguised PRAGMAs (`crates/bashkit/src/builtins/sqlite/parser.rs`).
- Add an async builtin test that verifies a BOM-prefixed `ATTACH` is blocked and extend the `PRAGMA cache_size` deny-list regression set with disguised variants (`crates/bashkit/src/builtins/sqlite/tests.rs`).

### Testing

- Ran `cargo fmt --check` which passed.
- Ran the sqlite parser unit tests (`--features sqlite -p bashkit --lib` for the parser module) and all parser tests passed (19 passed, 0 failed).
- Ran the sqlite builtin unit tests (`--features sqlite -p bashkit --lib` for builtin tests) and the sqlite test suite passed (58 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae4c98832bb24de7ee35e0ea17)