### PR TITLE
fix(interpreter): reset fd3 capture state across execs

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1642,13 +1642,17 @@ impl Interpreter {
 
     /// THREAT[TM-ISO-005/006/007]: Reset per-exec transient state.
     /// Called by Bash::exec() before each top-level execution to prevent
-    /// traps, exit code, `set` options, and transient stdin from leaking across calls.
+    /// traps, exit code, `set` options, transient stdin, and fd3+ redirect
+    /// capture buffers from leaking across calls.
     /// `shopt` options (expand_aliases, extglob, etc.) are intentionally
     /// preserved — they are persistent session configuration.
     pub fn reset_transient_state(&mut self) {
         self.traps_mut().clear();
         self.last_exit_code = 0;
         self.deferred_proc_subs.clear();
+        self.pending_fd_capture_depth = 0;
+        self.pending_fd_output.clear();
+        self.pending_fd_targets.clear();
         for var in Self::SET_OPTION_VARS {
             self.vars_mut().remove(*var);
             if let Some(bit) = BashFlags::from_shopt_name(var) {
@@ -2394,11 +2398,12 @@ impl Interpreter {
                     if capture_pending_fd {
                         self.pending_fd_capture_depth += 1;
                     }
-                    let result = self.execute_compound(compound).await?;
+                    let result = self.execute_compound(compound).await;
                     if capture_pending_fd {
                         self.pending_fd_capture_depth =
                             self.pending_fd_capture_depth.saturating_sub(1);
                     }
+                    let result = result?;
 
                     // Restore callback before applying redirections
                     if let Some(cb) = saved_callback {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -3183,6 +3183,30 @@ mod tests {
         assert_eq!(result.stdout, "");
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_timed_out_fd3_capture_does_not_leak_to_next_exec() {
+        let limits = ExecutionLimits::new().timeout(std::time::Duration::from_millis(1));
+        let mut bash = Bash::builder().limits(limits).build();
+
+        let timed_out = bash.exec("{ sleep 10; } 3>&1 > /tmp/poison.txt").await;
+        assert!(matches!(
+            timed_out,
+            Err(Error::ResourceLimit(LimitExceeded::Timeout(_)))
+        ));
+
+        let hidden = bash.exec("echo SECRET_FROM_EXEC2 1>&3").await.unwrap();
+        assert_eq!(hidden.stdout, "");
+
+        let routed = bash
+            .exec("echo PUBLIC_FROM_EXEC3 2>&1 > /tmp/public.txt")
+            .await
+            .unwrap();
+        assert_eq!(routed.stdout, "");
+
+        let file = bash.exec("cat /tmp/public.txt").await.unwrap();
+        assert_eq!(file.stdout, "PUBLIC_FROM_EXEC3\n");
+    }
+
     #[tokio::test]
     async fn test_pipeline_three_commands() {
         let mut bash = Bash::new();


### PR DESCRIPTION
### Motivation
- Prevent fd3+ pending output from being retained across `Bash::exec()` boundaries and replayed into unrelated later commands. 
- Make the fd3+ capture depth unwind-safe so timeouts/errors in compound execution cannot leave the interpreter in a capture state. 
- Add a regression test that reproduces the timeout/drop reuse case to prevent future regressions. 

### Description
- Reset `pending_fd_capture_depth`, `pending_fd_output`, and `pending_fd_targets` in `Interpreter::reset_transient_state()` so fd3+ capture state is cleared at each exec. 
- Make compound execution error-safe by awaiting `self.execute_compound(compound).await` without `?`, decrementing `pending_fd_capture_depth` if set, then propagating the error with `let result = result?;`. 
- Add a new timeout regression test `test_timed_out_fd3_capture_does_not_leak_to_next_exec` to `crates/bashkit/src/lib.rs` that exercises a timed-out mixed dup+file redirection and verifies no fd3 leak on subsequent exec. 

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo test -p bashkit test_timed_out_fd3_capture_does_not_leak_to_next_exec -- --nocapture` which passed. 
- Ran `cargo test -p bashkit test_fd3_redirect_pattern -- --nocapture` and `cargo test -p bashkit test_fd3_pending_output_not_leaked_across_commands -- --nocapture` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae15f8832ba81b0d6fd9521293)