### PR TITLE
fix(streaming): enforce stdout/stderr caps for live callbacks

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -951,6 +951,10 @@ pub struct Interpreter {
     /// Monotonic counter incremented each time output is emitted via callback.
     /// Used to detect whether sub-calls already emitted output, preventing duplicates.
     output_emit_count: u64,
+    /// Bytes already delivered to streaming output callbacks for this execution.
+    /// Mirrors ExecResult caps so live consumers cannot bypass output limits.
+    output_stream_stdout_bytes: usize,
+    output_stream_stderr_bytes: usize,
     /// Pending nounset (set -u) error message, consumed by execute_command.
     nounset_error: Option<String>,
     /// Trap handlers: signal/event name -> command string. Arc-wrapped for CoW subshell snapshots.
@@ -1392,6 +1396,8 @@ impl Interpreter {
                 builtins::ExecutionExtensions::new(),
             ))),
             output_emit_count: 0,
+            output_stream_stdout_bytes: 0,
+            output_stream_stderr_bytes: 0,
             nounset_error: None,
             traps: Arc::new(HashMap::new()),
             pipestatus: Vec::new(),
@@ -2010,12 +2016,16 @@ impl Interpreter {
     pub fn set_output_callback(&mut self, callback: OutputCallback) {
         self.output_callback = Some(callback);
         self.output_emit_count = 0;
+        self.output_stream_stdout_bytes = 0;
+        self.output_stream_stderr_bytes = 0;
     }
 
     /// Clear the output callback.
     pub fn clear_output_callback(&mut self) {
         self.output_callback = None;
         self.output_emit_count = 0;
+        self.output_stream_stdout_bytes = 0;
+        self.output_stream_stderr_bytes = 0;
     }
 
     /// Emit output via the callback if set, and if sub-calls didn't already emit.
@@ -2032,12 +2042,26 @@ impl Interpreter {
         if self.output_emit_count != emit_count_before {
             return false;
         }
-        if stdout.is_empty() && stderr.is_empty() {
+
+        let stdout_remaining = self
+            .limits
+            .max_stdout_bytes
+            .saturating_sub(self.output_stream_stdout_bytes);
+        let stderr_remaining = self
+            .limits
+            .max_stderr_bytes
+            .saturating_sub(self.output_stream_stderr_bytes);
+        let stdout_chunk = Self::utf8_prefix_at_most(stdout, stdout_remaining);
+        let stderr_chunk = Self::utf8_prefix_at_most(stderr, stderr_remaining);
+        if stdout_chunk.is_empty() && stderr_chunk.is_empty() {
             return false;
         }
+
         if let Some(ref mut cb) = self.output_callback {
-            cb(stdout, stderr);
+            cb(stdout_chunk, stderr_chunk);
             self.output_emit_count += 1;
+            self.output_stream_stdout_bytes += stdout_chunk.len();
+            self.output_stream_stderr_bytes += stderr_chunk.len();
         }
         true
     }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -6498,6 +6498,45 @@ echo missing fi"#,
     }
 
     #[tokio::test]
+    async fn test_exec_streaming_respects_stdout_stderr_limits() {
+        let stdout_chunks = Arc::new(Mutex::new(Vec::new()));
+        let stderr_chunks = Arc::new(Mutex::new(Vec::new()));
+        let so = stdout_chunks.clone();
+        let se = stderr_chunks.clone();
+        let mut bash = Bash::builder()
+            .limits(
+                ExecutionLimits::new()
+                    .max_stdout_bytes(10)
+                    .max_stderr_bytes(8),
+            )
+            .build();
+
+        let result = bash
+            .exec_streaming(
+                "echo hello; echo world; echo err1 >&2; echo err2 >&2",
+                Box::new(move |stdout, stderr| {
+                    if !stdout.is_empty() {
+                        so.lock().unwrap().push(stdout.to_string());
+                    }
+                    if !stderr.is_empty() {
+                        se.lock().unwrap().push(stderr.to_string());
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.stdout, "hello\nworl");
+        assert_eq!(result.stderr, "err1\nerr");
+        assert!(result.stdout_truncated);
+        assert!(result.stderr_truncated);
+        let streamed_stdout: String = stdout_chunks.lock().unwrap().iter().cloned().collect();
+        let streamed_stderr: String = stderr_chunks.lock().unwrap().iter().cloned().collect();
+        assert_eq!(streamed_stdout, result.stdout);
+        assert_eq!(streamed_stderr, result.stderr);
+    }
+
+    #[tokio::test]
     async fn test_streaming_equivalence_for_loop() {
         assert_streaming_equivalence("for i in 1 2 3; do echo $i; done").await;
     }


### PR DESCRIPTION
### Motivation

- The JS `onOutput` / `exec_streaming` path forwarded raw stdout/stderr chunks to hosts before the interpreter applied `max_stdout_bytes`/`max_stderr_bytes`, letting live consumers see more data than the final `ExecResult` (bypassing resource caps).

### Description

- Track per-execution streamed byte counts with two new fields `output_stream_stdout_bytes` and `output_stream_stderr_bytes` in `Interpreter` and initialize/reset them when a streaming callback is installed/cleared. (`crates/bashkit/src/interpreter/mod.rs`)
- Clamp each streaming callback invocation to the remaining bytes allowed by `max_stdout_bytes`/`max_stderr_bytes` using `utf8_prefix_at_most` so UTF‑8 boundaries are preserved, and update the streamed-byte counters after delivery. (`maybe_emit_output` in `crates/bashkit/src/interpreter/mod.rs`)
- Add a regression unit test `test_exec_streaming_respects_stdout_stderr_limits` that asserts streamed chunks reassemble to the capped final `ExecResult` and that truncation flags are set. (`crates/bashkit/src/lib.rs`)

### Testing

- Ran `cargo fmt --check` (passed).
- Ran targeted unit tests: `cargo test -p bashkit test_exec_streaming_respects_stdout_stderr_limits` (passed) and `cargo test -p bashkit exec_streaming` (passed).
- Ran broader test slices: `cargo test -p bashkit output_truncation` and `cargo test -p bashkit --lib` (all exercised tests passed; full `bashkit` lib tests show green in this run).
- Verified `cargo check -p bashkit-js` (passed) and `git diff --check` (no whitespace/diff-check issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae2474832bab8dd3cb28b1432a)