### PR TITLE
fix(python): bound lazy file provider materialization

### DIFF
--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -24,7 +24,7 @@ use bashkit::{
     Bash, BashTool as RustBashTool, Builtin, BuiltinContext, BuiltinRegistry,
     DirEntry as FsDirEntry, ExcType, ExecResult as RustExecResult, ExecutionExtensions,
     ExecutionLimits, ExtFunctionResult, FileSystem, FileSystemExt, FileType as FsFileType,
-    InMemoryFs, Metadata as FsMetadata, MontyException, MontyObject, NetworkAllowlist,
+    FsLimits, InMemoryFs, Metadata as FsMetadata, MontyException, MontyObject, NetworkAllowlist,
     OutputCallback as RustOutputCallback, OverlayFs, PosixFs, PythonExternalFnHandler,
     PythonLimits, ScriptedTool as RustScriptedTool, ShellStateView as RustShellStateView,
     SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
@@ -36,7 +36,7 @@ use pyo3::prelude::*;
 use pyo3::sync::PyOnceLock;
 use pyo3::types::{
     PyBytes, PyCapsule, PyCapsuleMethods, PyDict, PyFloat, PyFrozenSet, PyInt, PyList, PyModule,
-    PySet, PyTuple,
+    PySet, PyString, PyTuple,
 };
 // pyo3-async-runtimes bridges Rust futures to a Python asyncio loop; it hard-pulls
 // multi-threaded tokio + mio sockets, which do not build on wasm. The async
@@ -696,27 +696,42 @@ impl PythonLazyFilesFs {
             return Ok(());
         };
 
+        // THREAT[TM-DOS-FFI]: Lazy Python file providers are host callbacks
+        // reachable from sandboxed reads; cap returned bytes before copying into
+        // Rust-owned VFS data, then keep the provider retryable if VFS write fails.
         let loaded = Python::attach(|py| -> std::result::Result<Vec<u8>, String> {
             let value = provider.bind(py).call0().map_err(|e| e.to_string())?;
-            let text = value.extract::<String>().map_err(|_| {
+            let text = value.cast::<PyString>().map_err(|_| {
                 format!(
                     "{PY_FILE_PROVIDER_TYPE_ERROR_PREFIX}file provider for '{}' must return str",
                     normalized.display()
                 )
             })?;
-            Ok(text.into_bytes())
+            let text = text.to_str().map_err(|e| e.to_string())?;
+            let content_size = text.len();
+            let max_file_size = FsLimits::default().max_file_size as usize;
+            if content_size > max_file_size {
+                return Err(format!(
+                    "file size limit exceeded: {} bytes > {} bytes",
+                    content_size, max_file_size
+                ));
+            }
+            Ok(text.as_bytes().to_vec())
         });
 
-        match loaded {
-            Ok(content) => {
-                self.overlay.write_file(&normalized, &content).await?;
-                Ok(())
-            }
+        let content = match loaded {
+            Ok(content) => content,
             Err(message) => {
                 self.providers.write().unwrap().insert(normalized, provider);
-                Err(std::io::Error::other(message).into())
+                return Err(std::io::Error::other(message).into());
             }
+        };
+
+        if let Err(err) = self.overlay.write_file(&normalized, &content).await {
+            self.providers.write().unwrap().insert(normalized, provider);
+            return Err(err);
         }
+        Ok(())
     }
 
     fn remove_provider_paths(&self, path: &Path, recursive: bool) {

--- a/crates/bashkit-python/tests/_bashkit_categories.py
+++ b/crates/bashkit-python/tests/_bashkit_categories.py
@@ -300,6 +300,25 @@ def test_bash_files_dict_callable_errors_and_invalid_returns_raise():
         bash.read_file("/config/invalid.txt")
 
 
+def test_bash_files_dict_callable_large_return_is_limited_and_retryable():
+    state = {"large": True, "calls": 0}
+
+    def load_file():
+        state["calls"] += 1
+        if state["large"]:
+            return "x" * 10_000_001
+        return "ok"
+
+    bash = Bash(files={"/config/lazy.txt": load_file})
+
+    with pytest.raises(Exception, match="file size limit exceeded"):
+        bash.read_file("/config/lazy.txt")
+
+    state["large"] = False
+    assert bash.read_file("/config/lazy.txt") == "ok"
+    assert state["calls"] == 2
+
+
 def test_bash_mounts_readonly_by_default(tmp_path):
     (tmp_path / "data.txt").write_text("original\n")
     bash = Bash(mounts=[{"host_path": str(tmp_path), "vfs_path": "/data"}])

--- a/crates/bashkit-python/tests/test_vfs.py
+++ b/crates/bashkit-python/tests/test_vfs.py
@@ -14,6 +14,7 @@ _NAMES = (
     "test_bash_files_dict",
     "test_bash_files_dict_callables_are_lazy_and_cached",
     "test_bash_files_dict_callable_errors_and_invalid_returns_raise",
+    "test_bash_files_dict_callable_large_return_is_limited_and_retryable",
     "test_bash_mounts_readonly_by_default",
     "test_bash_mounts_writable",
     "test_bash_live_mount_preserves_state_and_unmounts",


### PR DESCRIPTION
### Motivation
- Callable-backed VFS files were materialized synchronously by calling the Python provider and converting the full `str` into Rust bytes before the overlay enforced `FsLimits`, allowing unbounded memory use or blocking the runtime. 
- The provider was removed from the provider map before write, so a successful provider plus failed overlay write left the VFS with an empty placeholder and no retryable provider.

### Description
- Cap callable-provider output size during materialization by checking against `FsLimits::default().max_file_size` and returning an error if exceeded to prevent unbounded host allocation. 
- Use `PyString` + `to_str()` to extract text safely and produce `Vec<u8>` only after the size check, and reinsert the provider on conversion or write failures so reads can retry. 
- Import `FsLimits` and `PyString` and adjust `PythonLazyFilesFs::materialize_if_needed()` to perform these checks and reinsertion logic. 
- Add a regression test `test_bash_files_dict_callable_large_return_is_limited_and_retryable` and register it in the VFS test shard to cover oversized returns and retry behavior.

### Testing
- Ran `cargo check -p bashkit-python` which completed successfully. 
- Ran formatting/lint checks with `cargo fmt --check`, `uvx ruff check crates/bashkit-python`, and `uvx ruff format --check crates/bashkit-python`, all passing. 
- Built and installed the Python extension with `./.venv/bin/python -m maturin develop -m crates/bashkit-python/Cargo.toml` which succeeded. 
- Ran the Python VFS tests with `./.venv/bin/python -m pytest crates/bashkit-python/tests/test_vfs.py` and the suite passed (`25 passed`, warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adf1bc832badf3e49e8d482168)