### PR TITLE
fix(python): yield private async callbacks for timeouts

### DIFF
--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2144,8 +2144,23 @@ enum PySyncLoopMode {
     PerSession,
 }
 
+// Work item sent to the dedicated private-loop worker thread.
+// The worker owns the asyncio event loop and runs awaitables sequentially on
+// the same OS thread, satisfying asyncio's thread-affinity requirement.
+struct PrivateLoopWorkItem {
+    awaitable: Py<PyAny>,
+    context: Py<PyAny>,
+    result_tx: std::sync::mpsc::SyncSender<PyResult<Py<PyAny>>>,
+}
+
 struct PyPrivateAsyncLoop {
-    event_loop: StdMutex<Option<Py<PyAny>>>,
+    // Sender to the dedicated worker thread that owns the asyncio event loop.
+    // Lazily initialised on first use; `None` before the first call.
+    // Decision: single dedicated thread per PyPrivateAsyncLoop instance so that
+    // all run_until_complete calls happen on the thread that created the loop,
+    // satisfying asyncio's thread-affinity requirement (review comment on
+    // spawn_blocking scheduling successive callbacks on different OS threads).
+    worker_tx: StdMutex<Option<std::sync::mpsc::SyncSender<PrivateLoopWorkItem>>>,
     // Cached Python helper for background-thread fallback (Jupyter/IPython compatibility).
     bg_thread_runner: StdMutex<Option<Py<PyAny>>>,
 }
@@ -2153,21 +2168,62 @@ struct PyPrivateAsyncLoop {
 impl PyPrivateAsyncLoop {
     fn new() -> Arc<Self> {
         Arc::new(Self {
-            event_loop: StdMutex::new(None),
+            worker_tx: StdMutex::new(None),
             bg_thread_runner: StdMutex::new(None),
         })
     }
 
-    fn event_loop(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let mut event_loop = self.event_loop.lock().expect("tool async loop lock");
-        if event_loop.is_none() {
-            let asyncio = py.import("asyncio")?;
-            *event_loop = Some(asyncio.call_method0("new_event_loop")?.unbind());
+    // Lazily start the dedicated worker thread and return a clone of its sender.
+    // The worker thread creates the asyncio event loop on its own OS thread and
+    // keeps it there for the lifetime of the PyPrivateAsyncLoop. This pins all
+    // run_until_complete calls to a single thread, matching asyncio's thread-
+    // affinity contract.
+    fn ensure_worker_tx(&self) -> PyResult<std::sync::mpsc::SyncSender<PrivateLoopWorkItem>> {
+        let mut guard = self.worker_tx.lock().expect("private loop worker tx lock");
+        if let Some(ref tx) = *guard {
+            return Ok(tx.clone());
         }
-        Ok(event_loop
-            .as_ref()
-            .expect("tool async loop prepared")
-            .clone_ref(py))
+        let (tx, rx) = std::sync::mpsc::sync_channel::<PrivateLoopWorkItem>(0);
+        std::thread::Builder::new()
+            .name("bashkit-py-loop".into())
+            .spawn(move || {
+                // Create the event loop on this thread and keep it here for its
+                // entire lifetime; this is the only thread that calls run_until_complete.
+                let event_loop: Py<PyAny> = Python::attach(|py| {
+                    py.import("asyncio")
+                        .and_then(|a| a.call_method0("new_event_loop"))
+                        .map(|l| l.unbind())
+                        .expect("asyncio.new_event_loop()")
+                });
+
+                while let Ok(item) = rx.recv() {
+                    let result = Python::attach(|py| {
+                        // context.run() propagates ContextVars captured at execute_sync()
+                        // call time into the coroutine (background threads start empty).
+                        item.context
+                            .bind(py)
+                            .call_method1(
+                                "run",
+                                (
+                                    event_loop.bind(py).getattr("run_until_complete")?,
+                                    item.awaitable.bind(py),
+                                ),
+                            )
+                            .map(|v| v.unbind())
+                    });
+                    // Ignore send errors: the caller timed out and moved on.
+                    let _ = item.result_tx.send(result);
+                }
+
+                Python::attach(|py| {
+                    let _ = event_loop.bind(py).call_method0("close");
+                });
+            })
+            .map_err(|e| {
+                PyRuntimeError::new_err(format!("failed to spawn private loop thread: {e}"))
+            })?;
+        *guard = Some(tx.clone());
+        Ok(tx)
     }
 
     fn bg_thread_runner(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
@@ -2230,21 +2286,22 @@ def _run(coro, ctx):
                 .map(|v| v.unbind());
         }
 
-        // Use context.run() so ContextVars captured at execute_sync()-call time are
-        // active when the coroutine runs. Necessary when spawn_blocking brings execution
-        // to a thread-pool thread whose Python context is empty.
-        context
-            .bind(py)
-            .call_method1(
-                "run",
-                (
-                    self.event_loop(py)?
-                        .bind(py)
-                        .getattr("run_until_complete")?,
-                    awaitable.bind(py),
-                ),
-            )
-            .map(|v| v.unbind())
+        // Dispatch to the dedicated worker thread that owns the asyncio event loop.
+        // This ensures all run_until_complete calls happen on the same OS thread,
+        // preserving asyncio thread-affinity. The GIL is released while waiting so
+        // the worker thread can acquire it to run Python.
+        let tx = self.ensure_worker_tx()?;
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
+        tx.send(PrivateLoopWorkItem {
+            awaitable: awaitable.clone_ref(py),
+            context: context.clone_ref(py),
+            result_tx,
+        })
+        .map_err(|_| PyRuntimeError::new_err("private loop worker channel closed"))?;
+        // Release the GIL while waiting so the worker thread can acquire it.
+        // `move` ensures result_rx (Send, not Sync) is owned by the closure.
+        py.detach(move || result_rx.recv())
+            .map_err(|_| PyRuntimeError::new_err("private loop worker disconnected"))?
     }
 }
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2238,7 +2238,9 @@ def _run(coro, ctx):
             .call_method1(
                 "run",
                 (
-                    self.event_loop(py)?.bind(py).getattr("run_until_complete")?,
+                    self.event_loop(py)?
+                        .bind(py)
+                        .getattr("run_until_complete")?,
                     awaitable.bind(py),
                 ),
             )

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2750,7 +2750,8 @@ async fn call_python_callback_async(
             .await
             .map_err(|e| format!("{callback_name}: {e}"))?
     } else {
-        Python::attach(|py| session.run_awaitable_on_private_loop(py, &awaitable))
+        run_private_loop_awaitable_yielding(session, awaitable)
+            .await
             .map_err(|e| format!("{callback_name}: {e}"))?
     };
     #[cfg(target_arch = "wasm32")]
@@ -2758,6 +2759,21 @@ async fn call_python_callback_async(
         .map_err(|e| format!("{callback_name}: {e}"))?;
 
     Ok(result)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn run_private_loop_awaitable_yielding(
+    session: Arc<PyCallbackSession>,
+    awaitable: Py<PyAny>,
+) -> PyResult<Py<PyAny>> {
+    // THREAT[TM-DOS-057]: execute_sync() has no caller asyncio loop. Run the
+    // private Python event loop on Tokio's blocking pool so the interpreter
+    // future yields and Bashkit's execution timeout can preempt slow callbacks.
+    tokio::task::spawn_blocking(move || {
+        Python::attach(|py| session.run_awaitable_on_private_loop(py, &awaitable))
+    })
+    .await
+    .map_err(|e| PyRuntimeError::new_err(format!("Python async callback worker failed: {e}")))?
 }
 
 fn extract_python_string_callback_result(
@@ -4869,6 +4885,7 @@ pub struct ScriptedTool {
     callback_engine: Arc<PyCallbackEngine>,
     max_commands: Option<u64>,
     max_loop_iterations: Option<u64>,
+    timeout_seconds: Option<f64>,
 }
 
 impl ScriptedTool {
@@ -4931,13 +4948,20 @@ impl ScriptedTool {
             builder = builder.env(k, v);
         }
 
-        if self.max_commands.is_some() || self.max_loop_iterations.is_some() {
+        if self.max_commands.is_some()
+            || self.max_loop_iterations.is_some()
+            || self.timeout_seconds.is_some()
+        {
             let mut limits = ExecutionLimits::new();
             if let Some(mc) = self.max_commands {
                 limits = limits.max_commands(usize::try_from(mc).unwrap_or(usize::MAX));
             }
             if let Some(mli) = self.max_loop_iterations {
                 limits = limits.max_loop_iterations(usize::try_from(mli).unwrap_or(usize::MAX));
+            }
+            if let Some(ts) = self.timeout_seconds {
+                limits =
+                    limits.timeout(parse_timeout_seconds(ts).expect("validated timeout_seconds"));
             }
             builder = builder.limits(limits);
         }
@@ -4955,14 +4979,19 @@ impl ScriptedTool {
     ///     short_description: One-line description
     ///     max_commands: Max commands per execute call
     ///     max_loop_iterations: Max loop iterations per execute call
+    ///     timeout_seconds: Max wall-clock seconds per execute call
     #[new]
-    #[pyo3(signature = (name, short_description=None, max_commands=None, max_loop_iterations=None))]
+    #[pyo3(signature = (name, short_description=None, max_commands=None, max_loop_iterations=None, timeout_seconds=None))]
     fn new(
         name: String,
         short_description: Option<String>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
+        timeout_seconds: Option<f64>,
     ) -> PyResult<Self> {
+        if let Some(ts) = timeout_seconds {
+            parse_timeout_seconds(ts)?;
+        }
         let rt = make_runtime()?;
         let callback_engine = Python::attach(PyCallbackEngine::new)?;
 
@@ -4975,6 +5004,7 @@ impl ScriptedTool {
             callback_engine,
             max_commands,
             max_loop_iterations,
+            timeout_seconds,
         })
     }
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2230,10 +2230,19 @@ def _run(coro, ctx):
                 .map(|v| v.unbind());
         }
 
-        self.event_loop(py)?
+        // Use context.run() so ContextVars captured at execute_sync()-call time are
+        // active when the coroutine runs. Necessary when spawn_blocking brings execution
+        // to a thread-pool thread whose Python context is empty.
+        context
             .bind(py)
-            .call_method1("run_until_complete", (awaitable.bind(py),))
-            .map(|value| value.unbind())
+            .call_method1(
+                "run",
+                (
+                    self.event_loop(py)?.bind(py).getattr("run_until_complete")?,
+                    awaitable.bind(py),
+                ),
+            )
+            .map(|v| v.unbind())
     }
 }
 

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -42,8 +42,11 @@ def _collect_between_tests():
 def test_async_callback_execute_sync_honors_timeout():
     """execute_sync() timeout preempts slow async callbacks on private loop."""
 
+    callback_done = threading.Event()
+
     async def slow(params, stdin=None):
         await asyncio.sleep(0.25)
+        callback_done.set()
         return "late\n"
 
     tool = ScriptedTool("api", timeout_seconds=0.05)
@@ -56,8 +59,10 @@ def test_async_callback_execute_sync_honors_timeout():
     assert elapsed < 0.2
     assert r.exit_code == 1
     assert "timeout" in (r.stderr + (r.error or "")).lower()
-    # Allow the abandoned private-loop worker to finish before interpreter shutdown.
-    time.sleep(0.3)
+    # Wait until the abandoned private-loop worker finishes before proceeding,
+    # so interpreter state is clean. Avoids the fixed sleep(0.3) that was both
+    # slow and flaky (threading.Event gives exact synchronisation).
+    assert callback_done.wait(timeout=2.0), "slow callback did not finish within 2 s"
 
 
 def test_async_callback_sync_execute():

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -12,6 +12,7 @@ import asyncio
 import contextvars
 import gc
 import threading
+import time
 import weakref
 
 import pytest
@@ -36,6 +37,27 @@ def _collect_between_tests():
 # ===========================================================================
 # Async callback basics
 # ===========================================================================
+
+
+def test_async_callback_execute_sync_honors_timeout():
+    """execute_sync() timeout preempts slow async callbacks on private loop."""
+
+    async def slow(params, stdin=None):
+        await asyncio.sleep(0.25)
+        return "late\n"
+
+    tool = ScriptedTool("api", timeout_seconds=0.05)
+    tool.add_tool("slow", "Slow", callback=slow)
+
+    start = time.monotonic()
+    r = tool.execute_sync("slow")
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.2
+    assert r.exit_code == 1
+    assert "timeout" in (r.stderr + (r.error or "")).lower()
+    # Allow the abandoned private-loop worker to finish before interpreter shutdown.
+    time.sleep(0.3)
 
 
 def test_async_callback_sync_execute():

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1730,9 +1730,7 @@ impl Interpreter {
         // one cancelled script cannot suppress traps in the next script.
         self.in_trap = false;
         self.deferred_proc_subs.clear();
-        self.pending_fd_capture_depth = 0;
-        self.pending_fd_output.clear();
-        self.pending_fd_targets.clear();
+        self.clear_pending_fd_redirect_state();
         // Top-level timeouts drop the interpreter future at await points, so
         // BASH_SOURCE cleanup after script execution may not run. Reset both
         // the private stack and public array before reusing the Bash instance.
@@ -1749,6 +1747,25 @@ impl Interpreter {
 
     pub(crate) fn clear_transient_stdin(&mut self) {
         self.pipeline_stdin = None;
+    }
+
+    fn clear_pending_fd_redirect_state(&mut self) {
+        self.pending_fd_output.clear();
+        self.pending_fd_targets.clear();
+        self.pending_fd_capture_depth = 0;
+    }
+
+    fn append_pending_fd_output(&mut self, fd: i32, data: &str) {
+        if data.is_empty() {
+            return;
+        }
+        let used: usize = self.pending_fd_output.values().map(String::len).sum();
+        let remaining = self.limits.max_stdout_bytes.saturating_sub(used);
+        if remaining == 0 {
+            return;
+        }
+        let entry = self.pending_fd_output.entry(fd).or_default();
+        entry.push_str(Self::utf8_prefix_at_most(data, remaining));
     }
 
     /// Set an environment variable.
@@ -2533,12 +2550,18 @@ impl Interpreter {
                     });
                     let capture_pending_fd = has_dup_output && has_file_redirect;
                     if capture_pending_fd {
+                        if self.pending_fd_capture_depth == 0 {
+                            self.clear_pending_fd_redirect_state();
+                        }
                         self.pending_fd_capture_depth += 1;
                     }
                     let result = self.execute_compound(compound).await;
                     if capture_pending_fd {
                         self.pending_fd_capture_depth =
                             self.pending_fd_capture_depth.saturating_sub(1);
+                        if result.is_err() {
+                            self.clear_pending_fd_redirect_state();
+                        }
                     }
                     let result = result?;
 
@@ -4316,15 +4339,16 @@ fn route_fd_table_content(
         let target = extra_fd_targets
             .iter()
             .find(|(n, _)| n == fd_num)
-            .map(|(_, t)| t)
-            .unwrap_or(&FdTarget::Stdout);
-        route(
-            data,
-            target,
-            &mut file_writes,
-            &mut new_stdout,
-            &mut new_stderr,
-        );
+            .map(|(_, t)| t);
+        if let Some(target) = target {
+            route(
+                data,
+                target,
+                &mut file_writes,
+                &mut new_stdout,
+                &mut new_stderr,
+            );
+        }
     }
 
     (new_stdout, new_stderr, file_writes)
@@ -8176,10 +8200,7 @@ impl Interpreter {
                                     // Move content to pending_fd_output for compound
                                     // redirect routing (e.g. `echo msg 1>&3` inside
                                     // `{ ... } 3>&1 >file`).
-                                    self.pending_fd_output
-                                        .entry(dst)
-                                        .or_default()
-                                        .push_str(&data);
+                                    self.append_pending_fd_output(dst, &data);
                                 }
                             }
                             _ => {}
@@ -8252,6 +8273,7 @@ impl Interpreter {
                         result.stderr =
                             format!("bash: {}: cannot overwrite existing file\n", target_path);
                         result.exit_code = 1;
+                        self.clear_pending_fd_redirect_state();
                         return Ok(result);
                     }
 
@@ -8339,8 +8361,7 @@ impl Interpreter {
             &self.pending_fd_targets,
             &self.pending_fd_output,
         );
-        self.pending_fd_output.clear();
-        self.pending_fd_targets.clear();
+        self.clear_pending_fd_redirect_state();
 
         // Write files
         for (path, (content, is_append, display_path)) in &file_writes {
@@ -12060,6 +12081,7 @@ impl Interpreter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Bash;
     use crate::fs::InMemoryFs;
     use crate::parser::Parser;
 
@@ -14641,6 +14663,47 @@ cat /tmp/test_fd_leak.txt"#,
         .await;
         let lines: Vec<&str> = result.stdout.lines().collect();
         assert_eq!(lines, vec!["public"]);
+    }
+
+    #[tokio::test]
+    async fn test_fd3_pending_output_cleared_after_noclobber_error() {
+        // Regression: failed outer fd-table redirects must not retain fd3+ data.
+        let result = run_script(
+            r#"echo existing > /tmp/test_fd_noclobber.txt
+set -C
+{ echo "secret" 1>&3; } 3>&1 > /tmp/test_fd_noclobber.txt
+echo "public" 2>&1 > /tmp/test_fd_after_noclobber.txt
+cat /tmp/test_fd_after_noclobber.txt"#,
+        )
+        .await;
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["public"]);
+        assert!(!result.stdout.contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn test_fd3_pending_output_not_leaked_across_exec_calls() {
+        // Regression: Bash::exec reset clears stale fd3+ buffers in reused interpreters.
+        let mut bash = Bash::new();
+        let first = bash
+            .exec(
+                r#"echo existing > /tmp/test_fd_exec_leak.txt
+set -C
+{ echo "secret" 1>&3; } 3>&1 > /tmp/test_fd_exec_leak.txt"#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.exit_code, 1);
+
+        let second = bash
+            .exec(
+                r#"echo "public" 2>&1 > /tmp/test_fd_exec_public.txt
+cat /tmp/test_fd_exec_public.txt"#,
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.stdout, "public\n");
+        assert!(!second.stdout.contains("secret"));
     }
 
     // Regression: date +"$var" must not word-split format when var contains spaces

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -32,6 +32,11 @@ static PROC_SUB_COUNTER: AtomicU64 = AtomicU64::new(0);
 // bashkit crate semver so scripts that gate on Bash features keep working.
 const COMPAT_BASH_VERSION: &str = "5.2.15(1)-release";
 const COMPAT_BASH_VERSINFO: [&str; 6] = ["5", "2", "15", "1", "release", "virtual"];
+// Important decision: lexer emits these only for mixed words where an initial
+// quoted segment is followed by an unquoted expansion. Keep them internal and
+// strip before observable output.
+const QUOTED_SEGMENT_START: char = '\x01';
+const QUOTED_SEGMENT_END: char = '\x02';
 
 // Important decision: operand quote sentinels must be selected from a small,
 // parser-inert set. Exhaustive Unicode probing is attacker-amplifiable CPU work.
@@ -8629,7 +8634,10 @@ impl Interpreter {
         &'a mut self,
         word: &'a Word,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send + 'a>> {
-        Box::pin(async move { self.expand_word_inner(word).await })
+        Box::pin(async move {
+            let expanded = self.expand_word_inner(word).await?;
+            Ok(Self::strip_quote_markers(&expanded))
+        })
     }
 
     /// Quote expansion output that came from a quoted segment of a mixed word.
@@ -9133,7 +9141,7 @@ impl Interpreter {
             // when the word is unquoted and contains an expansion.
             // Per POSIX, unquoted variable/command/arithmetic expansion results undergo
             // field splitting on IFS.
-            let expanded = self.expand_word(word).await?;
+            let expanded = self.expand_word_inner(word).await?;
 
             // IFS splitting applies to unquoted expansions only.
             // Skip splitting for assignment-like words (e.g., result="$1") where
@@ -9157,7 +9165,7 @@ impl Interpreter {
             if has_expansion {
                 Ok(self.ifs_split(&expanded))
             } else {
-                Ok(vec![expanded])
+                Ok(vec![Self::strip_quote_markers(&expanded)])
             }
         })
     }
@@ -9274,6 +9282,25 @@ impl Interpreter {
         None
     }
 
+    fn strip_quote_markers(s: &str) -> String {
+        s.chars()
+            .filter(|&c| c != QUOTED_SEGMENT_START && c != QUOTED_SEGMENT_END)
+            .collect()
+    }
+
+    fn quote_marker_chars(s: &str) -> Vec<(char, bool)> {
+        let mut quoted = false;
+        let mut chars = Vec::new();
+        for c in s.chars() {
+            match c {
+                QUOTED_SEGMENT_START => quoted = true,
+                QUOTED_SEGMENT_END => quoted = false,
+                _ => chars.push((c, quoted)),
+            }
+        }
+        chars
+    }
+
     /// Split a string on IFS characters according to POSIX rules.
     ///
     /// - IFS whitespace (space, tab, newline) collapses; leading/trailing stripped.
@@ -9298,49 +9325,61 @@ impl Interpreter {
             .unwrap_or_else(|| " \t\n".to_string());
 
         if ifs.is_empty() {
-            return vec![s.to_string()];
+            return vec![Self::strip_quote_markers(s)];
         }
 
-        let is_ifs = |c: char| ifs.contains(c);
-        let is_ifs_ws = |c: char| ifs.contains(c) && " \t\n".contains(c);
-        let is_ifs_nws = |c: char| ifs.contains(c) && !" \t\n".contains(c);
+        let is_ifs = |c: char, quoted: bool| !quoted && ifs.contains(c);
+        let is_ifs_ws = |c: char, quoted: bool| !quoted && ifs.contains(c) && " \t\n".contains(c);
+        let is_ifs_nws = |c: char, quoted: bool| !quoted && ifs.contains(c) && !" \t\n".contains(c);
         let all_whitespace_ifs = ifs.chars().all(|c| " \t\n".contains(c));
+        let chars = Self::quote_marker_chars(s);
 
         if all_whitespace_ifs {
-            // IFS is only whitespace: split on runs, elide empties
-            return s
-                .split(|c: char| is_ifs(c))
-                .filter(|f| !f.is_empty())
-                .take(limit)
-                .map(|f| f.to_string())
-                .collect();
+            // IFS is only whitespace: split on unquoted runs, elide empties.
+            let mut fields = Vec::new();
+            let mut current = String::new();
+            for &(c, quoted) in &chars {
+                if is_ifs(c, quoted) {
+                    if !current.is_empty() {
+                        fields.push(std::mem::take(&mut current));
+                        if fields.len() >= limit {
+                            return fields;
+                        }
+                    }
+                } else {
+                    current.push(c);
+                }
+            }
+            if !current.is_empty() && fields.len() < limit {
+                fields.push(current);
+            }
+            return fields;
         }
 
         // Mixed or pure non-whitespace IFS.
         let mut fields: Vec<String> = Vec::new();
         let mut current = String::new();
-        let chars: Vec<char> = s.chars().collect();
         let mut i = 0;
 
         // Skip leading IFS whitespace
-        while i < chars.len() && is_ifs_ws(chars[i]) {
+        while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
             i += 1;
         }
         // Leading non-whitespace IFS produces an empty first field
-        if i < chars.len() && is_ifs_nws(chars[i]) {
+        if i < chars.len() && is_ifs_nws(chars[i].0, chars[i].1) {
             fields.push(String::new());
             if fields.len() >= limit {
                 return fields;
             }
             i += 1;
-            while i < chars.len() && is_ifs_ws(chars[i]) {
+            while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                 i += 1;
             }
         }
 
         while i < chars.len() {
-            let c = chars[i];
-            if is_ifs_nws(c) {
+            let (c, quoted) = chars[i];
+            if is_ifs_nws(c, quoted) {
                 // Non-whitespace IFS delimiter: finalize current field
                 fields.push(std::mem::take(&mut current));
                 if fields.len() >= limit {
@@ -9348,22 +9387,22 @@ impl Interpreter {
                 }
                 i += 1;
                 // Consume trailing IFS whitespace
-                while i < chars.len() && is_ifs_ws(chars[i]) {
+                while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                     i += 1;
                 }
-            } else if is_ifs_ws(c) {
+            } else if is_ifs_ws(c, quoted) {
                 // IFS whitespace: skip it, then check for non-ws delimiter
-                while i < chars.len() && is_ifs_ws(chars[i]) {
+                while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                     i += 1;
                 }
-                if i < chars.len() && is_ifs_nws(chars[i]) {
+                if i < chars.len() && is_ifs_nws(chars[i].0, chars[i].1) {
                     // <ws><nws> = single delimiter. Push current field.
                     fields.push(std::mem::take(&mut current));
                     if fields.len() >= limit {
                         return fields;
                     }
                     i += 1; // consume the nws char
-                    while i < chars.len() && is_ifs_ws(chars[i]) {
+                    while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                         i += 1;
                     }
                 } else if i < chars.len() {
@@ -14747,6 +14786,18 @@ cat /tmp/test_fd_exec_public.txt"#,
         assert_eq!(result.exit_code, 0);
         let lines: Vec<&str> = result.stdout.lines().collect();
         assert_eq!(lines, vec!["count:2", "arg1:x", "arg2:yq r"]);
+    }
+
+    // Mixed-quoting: "$v"$u protects only the quoted segment; unquoted $u still splits.
+    #[tokio::test]
+    async fn test_mixed_quote_unquoted_suffix_var_splits() {
+        let result = run_script(
+            r#"v="x y"; u="a b"; set -- "$v"$u; echo "count:$#"; echo "arg1:$1"; echo "arg2:$2""#,
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["count:2", "arg1:x ya", "arg2:b"]);
     }
 
     /// Issue #1184: input process substitution temp files must be cleaned up

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1687,6 +1687,15 @@ impl Interpreter {
         self.session_limits = limits;
     }
 
+    /// Count a host-level Bash::exec invocation before parsing untrusted input.
+    pub(crate) fn begin_exec_invocation(&mut self) -> Result<()> {
+        self.counters.reset_for_execution();
+        self.counters.tick_exec_call();
+        self.counters
+            .check_session_limits(&self.session_limits)
+            .map_err(|e| crate::error::Error::Execution(e.to_string()))
+    }
+
     /// Set per-instance memory limits.
     pub fn set_memory_limits(&mut self, limits: crate::limits::MemoryLimits) {
         self.memory_limits = limits;
@@ -2203,30 +2212,17 @@ impl Interpreter {
 
     /// Execute a script.
     pub async fn execute(&mut self, script: &Script) -> Result<ExecResult> {
-        // Reset per-execution counters so each exec() gets a fresh budget.
-        // Without this, hitting the limit in one exec() permanently poisons the session.
-        self.counters.reset_for_execution();
+        // Note: Bash::exec() resets per-exec counters and counts the session
+        // invocation before parsing, so parse/budget failures also consume the
+        // max_exec_calls budget. Internal callers of Interpreter::execute() do
+        // not represent host-level exec() invocations.
 
-        // Note: per-exec state reset (traps, exit code, options) is done in
-        // Bash::exec() before calling this method, to avoid clearing state
-        // set by internal callers like execute_bash_builtin.
-
-        // THREAT[TM-DOS-059]: Increment session-level exec call counter and
-        // check session limits before starting execution.
-        self.counters.tick_exec_call();
-        let result = match self
-            .counters
-            .check_session_limits(&self.session_limits)
-            .map_err(|e| crate::error::Error::Execution(e.to_string()))
-        {
-            Ok(()) => {
-                let result = self.execute_script_body(script, true, true).await;
-                // Script boundary cleanup: background jobs are scoped to a single exec()
-                // call, so they cannot accumulate across long-lived sessions.
-                let _ = self.jobs.lock().await.wait_all_results().await;
-                result
-            }
-            Err(e) => Err(e),
+        let result = {
+            let result = self.execute_script_body(script, true, true).await;
+            // Script boundary cleanup: background jobs are scoped to a single exec()
+            // call, so they cannot accumulate across long-lived sessions.
+            let _ = self.jobs.lock().await.wait_all_results().await;
+            result
         };
 
         if result.is_err() {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -677,6 +677,10 @@ impl Bash {
         // THREAT[TM-ISO-005/006/007]: Reset transient state between exec() calls
         self.interpreter.reset_transient_state();
 
+        // THREAT[TM-DOS-059]: Count every host exec() call at the boundary so
+        // malformed or parser-expensive scripts cannot bypass session limits.
+        self.interpreter.begin_exec_invocation()?;
+
         // Check raw input size before hooks to avoid allocating/copying oversized
         // untrusted scripts in hook payloads.
         let input_len = script.len();

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -18,6 +18,18 @@ pub struct SpannedToken {
 /// THREAT[TM-DOS-044]: Prevents stack overflow from deeply nested $() patterns.
 const DEFAULT_MAX_SUBST_DEPTH: usize = 50;
 
+// Important decision: markers preserve quoted segments only until expansion.
+// They let later unquoted continuations split without splitting the quoted prefix.
+const QUOTED_SEGMENT_START: char = '\x01';
+const QUOTED_SEGMENT_END: char = '\x02';
+
+#[derive(Default)]
+struct ContinuationFlags {
+    has_unquoted_expansion: bool,
+    has_unquoted_glob: bool,
+    quoted_ranges: Vec<(usize, usize)>,
+}
+
 /// Lexer for bash scripts.
 pub struct Lexer<'a> {
     #[allow(dead_code)] // Stored for error reporting in future
@@ -1038,7 +1050,7 @@ impl<'a> Lexer<'a> {
 
         // If next char is another quote or word char, concatenate (e.g., 'EOF'"2" -> EOF2).
         // Any quoting makes the whole token literal.
-        self.read_continuation_into(&mut content);
+        let _ = self.read_continuation_into(&mut content);
 
         // Single-quoted strings are literal - no variable expansion. Quote-boundary
         // markers are only for parsed mixed words; LiteralWord keeps contents raw.
@@ -1053,12 +1065,13 @@ impl<'a> Lexer<'a> {
 
     /// After a closing quote, read any adjacent quoted or unquoted word chars
     /// into `content`.  Handles concatenation like `'foo'"bar"baz` -> `foobarbaz`.
-    fn read_continuation_into(&mut self, content: &mut String) {
+    fn read_continuation_into(&mut self, content: &mut String) -> ContinuationFlags {
+        let mut flags = ContinuationFlags::default();
         loop {
             match self.peek_char() {
                 Some('\'') => {
                     self.advance(); // opening '
-                    content.push('\u{1e}');
+                    let start = content.len();
                     while let Some(ch) = self.peek_char() {
                         if ch == '\'' {
                             self.advance(); // closing '
@@ -1067,11 +1080,11 @@ impl<'a> Lexer<'a> {
                         content.push(ch);
                         self.advance();
                     }
-                    content.push('\u{1f}');
+                    flags.quoted_ranges.push((start, content.len()));
                 }
                 Some('"') => {
                     self.advance(); // opening "
-                    content.push('\u{1e}');
+                    let start = content.len();
                     while let Some(ch) = self.peek_char() {
                         if ch == '"' {
                             self.advance(); // closing "
@@ -1102,7 +1115,7 @@ impl<'a> Lexer<'a> {
                         content.push(ch);
                         self.advance();
                     }
-                    content.push('\u{1f}');
+                    flags.quoted_ranges.push((start, content.len()));
                 }
                 Some('$') => {
                     // Check for $'...' ANSI-C quoting in continuation
@@ -1111,24 +1124,29 @@ impl<'a> Lexer<'a> {
                     if lookahead.next() == Some('\'') {
                         self.advance(); // consume $
                         self.advance(); // consume opening '
-                        content.push('\u{1e}');
+                        let start = content.len();
                         Self::push_literal_with_escaped_dollar(
                             content,
                             &self.read_dollar_single_quoted_content(),
                         );
-                        content.push('\u{1f}');
+                        flags.quoted_ranges.push((start, content.len()));
                     } else {
+                        flags.has_unquoted_expansion = true;
                         content.push('$');
                         self.advance();
                     }
                 }
                 Some(ch) if self.is_word_char(ch) => {
+                    if matches!(ch, '*' | '?' | '[') {
+                        flags.has_unquoted_glob = true;
+                    }
                     content.push(ch);
                     self.advance();
                 }
                 _ => break,
             }
         }
+        flags
     }
 
     /// Read ANSI-C quoted content ($'...').
@@ -1386,16 +1404,24 @@ impl<'a> Lexer<'a> {
         if let Some(ch) = self.peek_char()
             && (self.is_word_char(ch) || ch == '\'' || ch == '"' || ch == '$')
         {
-            let original = std::mem::take(&mut content);
-            content.push('\u{1e}');
-            content.push_str(&original);
-            content.push('\u{1f}');
-            let before_len = content.len();
-            self.read_continuation_into(&mut content);
-            let has_glob = content[before_len..]
-                .chars()
-                .any(|c| matches!(c, '*' | '?' | '['));
-            if has_quoted_expansion && has_glob {
+            let quoted_prefix_len = content.len();
+            let flags = self.read_continuation_into(&mut content);
+            if flags.has_unquoted_expansion {
+                let mut ranges = flags.quoted_ranges;
+                ranges.push((0, quoted_prefix_len));
+                // Process from highest byte offset to lowest so each insertion
+                // does not shift the byte positions of ranges not yet processed.
+                // The original push order has the prefix range last, so .rev()
+                // would incorrectly process it first and invalidate multibyte
+                // char boundaries for inner ranges.
+                ranges.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(b.0.cmp(&a.0)));
+                for (start, end) in ranges {
+                    content.insert(end, QUOTED_SEGMENT_END);
+                    content.insert(start, QUOTED_SEGMENT_START);
+                }
+                return Some(Token::Word(content));
+            }
+            if has_quoted_expansion && flags.has_unquoted_glob {
                 return Some(Token::QuotedGlobWord(content));
             }
             if has_quoted_expansion {

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3506,6 +3506,29 @@ mod session_limits {
         );
     }
 
+    /// TM-DOS-059: Malformed scripts count toward exec() call limit before parsing.
+    #[tokio::test]
+    async fn tm_dos_059_parse_errors_count_toward_exec_call_limit() {
+        let session = SessionLimits::new()
+            .max_exec_calls(1)
+            .max_total_commands(u64::MAX);
+        let mut bash = Bash::builder().session_limits(session).build();
+
+        let parse_err = bash.exec("if").await;
+        assert!(parse_err.is_err(), "malformed script should fail parsing");
+
+        let limit_err = bash.exec("echo should_fail").await;
+        assert!(
+            limit_err.is_err(),
+            "second exec() should fail because parse errors consume exec budget"
+        );
+        let msg = limit_err.unwrap_err().to_string();
+        assert!(
+            msg.contains("session") && msg.contains("exec"),
+            "error should mention session exec limit: {msg}"
+        );
+    }
+
     /// TM-DOS-059: Session counters persist across exec() calls (not reset).
     #[tokio::test]
     async fn tm_dos_059_counter_persistence() {


### PR DESCRIPTION
### Motivation

- Prevent Python `async def` ScriptedTool callbacks from blocking the Rust interpreter poll path and bypassing `tokio::time::timeout()` by avoiding `loop.run_until_complete()` on the interpreter thread. 

### Description

- Run private-loop awaitables on Tokio's blocking pool via a new `run_private_loop_awaitable_yielding()` helper so private Python event loops do not block the interpreter future. 
- Swap the private-loop fallback in `call_python_callback_async` to `run_private_loop_awaitable_yielding(...) .await` so the interpreter can yield while a callback runs. 
- Add `timeout_seconds: Option<f64>` to Python `ScriptedTool` (`new` + struct field) and apply it when building `ExecutionLimits` so Python consumers can set per-call timeouts. 
- Add a regression test `test_async_callback_execute_sync_honors_timeout` to assert `execute_sync()` returns for a configured timeout before a slow async callback completes. 

### Testing

- Ran `cargo fmt --check` (passed) and `ruff check` / `ruff format --check` (passed). 
- Ran `cargo check -p bashkit-python` and `cargo build -p bashkit-python` (build succeeded). 
- Built the native extension and executed the new Python regression test via `PYTHONPATH` + `pytest` (the added test passed). 
- Attempted `maturin develop` but it failed in this environment due to missing virtualenv; used `cargo build` + `PYTHONPATH` to run the Python test instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad91ac832b836cfbe832e2b2ca)