### PR TITLE
fix(hooks): enforce interceptor decisions

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5352,8 +5352,7 @@ impl Interpreter {
                 match plan_result {
                     Ok(Ok(Some(plan))) => {
                         let result = self.execute_builtin_plan(plan, redirects).await?;
-                        self.fire_after_tool(name, &result);
-                        return Ok(result);
+                        return Ok(self.apply_after_tool(name, result));
                     }
                     Ok(Ok(None)) => { /* fall through to normal execute() */ }
                     Ok(Err(e)) => return Err(e),
@@ -5363,8 +5362,7 @@ impl Interpreter {
                             1,
                         );
                         let result = self.apply_redirections(result, redirects).await?;
-                        self.fire_after_tool(name, &result);
-                        return Ok(result);
+                        return Ok(self.apply_after_tool(name, result));
                     }
                 }
             }
@@ -5431,21 +5429,81 @@ impl Interpreter {
             }
 
             let result = self.apply_redirections(result, redirects).await?;
-            self.fire_after_tool(name, &result);
-            Ok(result)
+            Ok(self.apply_after_tool(name, result))
         })
     }
 
-    /// Fire `after_tool` hooks if any are registered (observational).
-    fn fire_after_tool(&self, name: &str, result: &ExecResult) {
-        if !self.hooks.after_tool.is_empty() {
-            let event = crate::hooks::ToolResult {
-                name: name.to_string(),
-                stdout: result.stdout.clone(),
-                exit_code: result.exit_code,
-            };
-            self.hooks.fire_after_tool(event);
+    /// Apply `after_tool` interceptor decisions to the result returned to callers.
+    fn apply_after_tool(&self, name: &str, result: ExecResult) -> ExecResult {
+        if self.hooks.after_tool.is_empty() {
+            return result;
         }
+
+        let event = crate::hooks::ToolResult {
+            name: name.to_string(),
+            stdout: result.stdout.clone(),
+            exit_code: result.exit_code,
+        };
+        match self.hooks.fire_after_tool(event) {
+            Some(event) => ExecResult {
+                stdout: event.stdout,
+                exit_code: event.exit_code,
+                ..result
+            },
+            None => ExecResult::err(format!("bash: {name}: cancelled by after_tool hook\n"), 1),
+        }
+    }
+
+    fn is_special_builtin_name(name: &str) -> bool {
+        matches!(
+            name,
+            "exec"
+                | "local"
+                | "bash"
+                | "sh"
+                | "source"
+                | "."
+                | "eval"
+                | "command"
+                | "declare"
+                | "typeset"
+                | "let"
+                | "unset"
+                | "getopts"
+        )
+    }
+
+    async fn execute_special_builtin_with_hooks(
+        &mut self,
+        name: &str,
+        args: &[String],
+        stdin: Option<String>,
+        redirects: &[Redirect],
+    ) -> Result<ExecResult> {
+        let args = if !self.hooks.before_tool.is_empty() {
+            let event = crate::hooks::ToolEvent {
+                name: name.to_string(),
+                args: args.to_vec(),
+            };
+            match self.hooks.fire_before_tool(event) {
+                Some(modified) => std::borrow::Cow::Owned(modified.args),
+                None => {
+                    let result = ExecResult::err(
+                        format!("bash: {name}: cancelled by before_tool hook\n"),
+                        1,
+                    );
+                    return self.apply_redirections(result, redirects).await;
+                }
+            }
+        } else {
+            std::borrow::Cow::Borrowed(args)
+        };
+
+        let result = self
+            .dispatch_special_builtin(name, &args, stdin, redirects)
+            .await
+            .expect("special builtin name checked before dispatch")?;
+        Ok(self.apply_after_tool(name, result))
     }
 
     /// Dispatch an interpreter-level (special) builtin by name.
@@ -5507,11 +5565,15 @@ impl Interpreter {
             }
 
             // Interpreter-level special builtins
-            if let Some(result) = self
-                .dispatch_special_builtin(name, &args, stdin.clone(), &command.redirects)
-                .await
-            {
-                return result;
+            if Self::is_special_builtin_name(name) {
+                return self
+                    .execute_special_builtin_with_hooks(
+                        name,
+                        &args,
+                        stdin.clone(),
+                        &command.redirects,
+                    )
+                    .await;
             }
 
             // Host-registered builtins (mutable, may override baked-in builtins).

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -7266,10 +7266,9 @@ echo missing fi"#,
     }
 
     #[tokio::test]
-    async fn test_before_tool_hook_does_not_fire_for_special_builtins() {
-        // Special builtins (declare, local, etc.) dispatch through
-        // dispatch_special_builtin, not execute_registered_builtin,
-        // so before_tool should not fire for them.
+    async fn test_before_tool_hook_fires_for_special_and_registered_builtins() {
+        // Special builtins now route through execute_special_builtin_with_hooks
+        // so before_tool fires for both declare and echo.
         use std::sync::Arc;
         use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -7283,13 +7282,13 @@ echo missing fi"#,
             }))
             .build();
 
-        // declare is a special builtin — should NOT trigger before_tool
+        // declare is a special builtin — now triggers before_tool
         bash.exec("declare x=1").await.unwrap();
-        assert_eq!(count.load(Ordering::Relaxed), 0);
-
-        // echo is a registered builtin — should trigger before_tool
-        bash.exec("echo hi").await.unwrap();
         assert_eq!(count.load(Ordering::Relaxed), 1);
+
+        // echo is a registered builtin — also triggers before_tool
+        bash.exec("echo hi").await.unwrap();
+        assert_eq!(count.load(Ordering::Relaxed), 2);
     }
 
     #[cfg(feature = "http_client")]

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -912,18 +912,30 @@ impl Bash {
             }
         }
 
-        // Fire after_exec hooks
-        if let Ok(ref exec_result) = result
-            && !self.interpreter.hooks().after_exec.is_empty()
-        {
-            let output = hooks::ExecOutput {
-                script: script.to_string(),
-                stdout: exec_result.stdout.clone(),
-                stderr: exec_result.stderr.clone(),
-                exit_code: exec_result.exit_code,
-            };
-            self.interpreter.hooks().fire_after_exec(output);
-        }
+        // Fire after_exec hooks — interceptor decisions are part of the public policy API.
+        let result = if let Ok(exec_result) = result {
+            if !self.interpreter.hooks().after_exec.is_empty() {
+                let output = hooks::ExecOutput {
+                    script: script.to_string(),
+                    stdout: exec_result.stdout.clone(),
+                    stderr: exec_result.stderr.clone(),
+                    exit_code: exec_result.exit_code,
+                };
+                match self.interpreter.hooks().fire_after_exec(output) {
+                    Some(output) => Ok(ExecResult {
+                        stdout: output.stdout,
+                        stderr: output.stderr,
+                        exit_code: output.exit_code,
+                        ..exec_result
+                    }),
+                    None => Ok(ExecResult::err("cancelled by after_exec hook", 1)),
+                }
+            } else {
+                Ok(exec_result)
+            }
+        } else {
+            result
+        };
 
         // Fire on_error hooks for execution errors
         if let Err(ref e) = result
@@ -6847,6 +6859,89 @@ echo missing fi"#,
 
         bash.exec("echo hello-hooks").await.unwrap();
         assert_eq!(captured.lock().unwrap().trim(), "hello-hooks");
+    }
+
+    #[tokio::test]
+    async fn test_after_exec_hook_can_modify_output() {
+        let mut bash = Bash::builder()
+            .after_exec(Box::new(|mut output| {
+                output.stdout = output.stdout.replace("SECRET", "[redacted]");
+                output.stderr = "policy stderr\n".to_string();
+                output.exit_code = 7;
+                hooks::HookAction::Continue(output)
+            }))
+            .build();
+
+        let result = bash.exec("echo SECRET").await.unwrap();
+        assert_eq!(result.stdout, "[redacted]\n");
+        assert_eq!(result.stderr, "policy stderr\n");
+        assert_eq!(result.exit_code, 7);
+    }
+
+    #[tokio::test]
+    async fn test_after_exec_hook_can_cancel_result() {
+        let mut bash = Bash::builder()
+            .after_exec(Box::new(|_output| {
+                hooks::HookAction::Cancel("blocked".to_string())
+            }))
+            .build();
+
+        let result = bash.exec("echo SECRET").await.unwrap();
+        assert_eq!(result.stdout, "");
+        assert_eq!(result.stderr, "cancelled by after_exec hook");
+        assert_eq!(result.exit_code, 1);
+    }
+
+    #[tokio::test]
+    async fn test_before_tool_hook_can_cancel_special_builtin() {
+        let mut bash = Bash::builder()
+            .before_tool(Box::new(|event| {
+                if event.name == "source" {
+                    hooks::HookAction::Cancel("source blocked".to_string())
+                } else {
+                    hooks::HookAction::Continue(event)
+                }
+            }))
+            .build();
+
+        let result = bash.exec("source missing.sh").await.unwrap();
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("cancelled by before_tool hook"));
+    }
+
+    #[tokio::test]
+    async fn test_after_tool_hook_can_modify_builtin_result() {
+        let mut bash = Bash::builder()
+            .after_tool(Box::new(|mut result| {
+                if result.name == "echo" {
+                    result.stdout = result.stdout.replace("SECRET", "[redacted]");
+                    result.exit_code = 9;
+                }
+                hooks::HookAction::Continue(result)
+            }))
+            .build();
+
+        let result = bash.exec("echo SECRET").await.unwrap();
+        assert_eq!(result.stdout, "[redacted]\n");
+        assert_eq!(result.exit_code, 9);
+    }
+
+    #[tokio::test]
+    async fn test_after_tool_hook_can_cancel_builtin_result() {
+        let mut bash = Bash::builder()
+            .after_tool(Box::new(|result| {
+                if result.name == "echo" {
+                    hooks::HookAction::Cancel("blocked".to_string())
+                } else {
+                    hooks::HookAction::Continue(result)
+                }
+            }))
+            .build();
+
+        let result = bash.exec("echo SECRET").await.unwrap();
+        assert_eq!(result.stdout, "");
+        assert!(result.stderr.contains("cancelled by after_tool hook"));
+        assert_eq!(result.exit_code, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation

- Hooks were documented as interceptors that can modify or cancel operations, but `after_exec` return values were ignored and `before_tool`/`after_tool` were not enforced for several builtin dispatch paths, allowing policy bypass.  
- An embedding could reasonably use these hooks for redaction or command blocking, so returned/observational results must reflect hook decisions.  

### Description

- Apply `after_exec` interceptor decisions to the `Bash::exec` return value so hook-modified `stdout`, `stderr`, and `exit_code` are returned and `Cancel` becomes a cancelled `ExecResult` (see `crates/bashkit/src/lib.rs`).  
- Replace observational `fire_after_tool` usage with an `apply_after_tool` helper and call it on all builtin return paths (execution-plan path, panic/fallback, and normal execution) so `after_tool` mutations/cancellations affect the caller-visible `ExecResult` (see `crates/bashkit/src/interpreter/mod.rs`).  
- Route interpreter-level special builtins through a new `execute_special_builtin_with_hooks` flow that runs `before_tool`/`after_tool` (so `before_tool` can cancel special builtins such as `source`/`eval`/`command`).  
- Add regression unit tests covering `after_exec` mutation/cancellation, `before_tool` cancellation for special builtins, and `after_tool` mutation/cancellation, and wire changes into existing test anchors (`crates/bashkit/src/lib.rs`).  

### Testing

- Ran targeted unit tests: `cargo test -p bashkit test_after_exec_hook_observes_output -- --nocapture` and the grouped hook tests via `cargo test -p bashkit hook_can -- --nocapture`, all executed tests passed (new and existing hook-related tests passed).  
- Ran formatting and lints: `cargo fmt --check` and `cargo clippy -p bashkit --all-targets -- -D warnings` succeeded.  
- `git diff --check` was run and reported clean diff check for the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad4f4c832bbf539f4cf329e7ac)