### PR TITLE
fix(interpreter): reset trap guard between exec calls

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1655,6 +1655,10 @@ impl Interpreter {
     pub fn reset_transient_state(&mut self) {
         self.traps_mut().clear();
         self.last_exit_code = 0;
+        // THREAT[TM-DOS-035/057]: A timeout can drop execution while a trap
+        // handler is awaited; clear the re-entrancy guard before each exec so
+        // one cancelled script cannot suppress traps in the next script.
+        self.in_trap = false;
         self.deferred_proc_subs.clear();
         self.pending_fd_capture_depth = 0;
         self.pending_fd_output.clear();

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -3207,6 +3207,26 @@ mod tests {
         assert_eq!(file.stdout, "PUBLIC_FROM_EXEC3\n");
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_timed_out_debug_trap_does_not_suppress_next_exec_debug_trap() {
+        let limits = ExecutionLimits::new().timeout(std::time::Duration::from_millis(1));
+        let mut bash = Bash::builder().limits(limits).build();
+
+        let timed_out = bash
+            .exec("trap 'sleep 10' DEBUG; echo should-not-run")
+            .await;
+        assert!(matches!(
+            timed_out,
+            Err(Error::ResourceLimit(LimitExceeded::Timeout(_)))
+        ));
+
+        let result = bash
+            .exec("count=0; trap '((count++))' DEBUG; echo body; trap - DEBUG; echo $count")
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "body\n2\n");
+    }
+
     #[tokio::test]
     async fn test_pipeline_three_commands() {
         let mut bash = Bash::new();


### PR DESCRIPTION
### Motivation

- A timeout that cancels a running trap handler could drop the awaiting future before the `in_trap` guard is cleared, leaving `in_trap` stuck true and causing subsequent `exec` calls to silently skip `DEBUG`/`ERR` traps. 
- The change aims to make per-exec transient state reset cancellation-safe by ensuring the re-entrancy guard cannot persist across top-level `exec` calls.

### Description

- Clear the trap re-entrancy guard by setting `self.in_trap = false` inside `Interpreter::reset_transient_state()` so a previously-timed-out trap cannot suppress traps in later `exec` calls (`crates/bashkit/src/interpreter/mod.rs`).
- Add a regression test `test_timed_out_debug_trap_does_not_suppress_next_exec_debug_trap` that times out inside a `DEBUG` trap and verifies a freshly-installed `DEBUG` trap fires on the next `exec` (`crates/bashkit/src/lib.rs`).

### Testing

- Ran `cargo test -p bashkit test_timed_out_debug_trap_does_not_suppress_next_exec_debug_trap --lib --no-default-features` and the test passed.
- Ran `cargo test -p bashkit test_debug_trap --lib --no-default-features` and `cargo test -p bashkit test_timed_out_bash_c_does_not_leak_stdin_to_next_exec --lib --no-default-features` and both passed.
- Ran `cargo fmt --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224736e7a4832b8f88ddd4f7523330)