### PR TITLE
fix(typescript): cap VM timeout by Bash deadline

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -389,6 +389,33 @@ pub struct ExecutionExtensions {
     values: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
 }
 
+/// Per-exec wall-clock deadline for builtins with synchronous VM sections.
+#[derive(Debug, Clone)]
+pub(crate) struct ExecutionDeadline {
+    started_at: std::time::Instant,
+    timeout: std::time::Duration,
+}
+
+impl ExecutionDeadline {
+    /// Create a deadline anchored at the start of `Bash::exec*`.
+    pub(crate) fn new(timeout: std::time::Duration) -> Self {
+        Self {
+            started_at: std::time::Instant::now(),
+            timeout,
+        }
+    }
+
+    /// Remaining budget; never returns zero so downstream VM timers stay active.
+    pub(crate) fn remaining(&self) -> std::time::Duration {
+        let remaining = self.timeout.saturating_sub(self.started_at.elapsed());
+        if remaining.is_zero() {
+            std::time::Duration::from_millis(1)
+        } else {
+            remaining
+        }
+    }
+}
+
 impl ExecutionExtensions {
     /// Create an empty execution extension bag.
     pub fn new() -> Self {

--- a/crates/bashkit/src/builtins/typescript.rs
+++ b/crates/bashkit/src/builtins/typescript.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use zapcode_core::{ResourceLimits, RunResult, Value, VmState, ZapcodeRun};
 
-use super::{Builtin, Context, Extension, resolve_path};
+use super::{Builtin, Context, ExecutionDeadline, Extension, resolve_path};
 use crate::error::Result;
 use crate::fs::FileSystem;
 use crate::interpreter::ExecResult;
@@ -398,6 +398,14 @@ impl TypeScript {
         self.external_fns = Some(TypeScriptExternalFns { names, handler });
         self
     }
+
+    fn effective_limits(&self, deadline: Option<&ExecutionDeadline>) -> TypeScriptLimits {
+        let mut limits = self.limits.clone();
+        if let Some(deadline) = deadline {
+            limits.max_duration = limits.max_duration.min(deadline.remaining());
+        }
+        limits
+    }
 }
 
 impl Default for TypeScript {
@@ -628,11 +636,13 @@ impl Builtin for TypeScript {
             ));
         };
 
+        let limits = self.effective_limits(ctx.execution_extension::<ExecutionDeadline>());
+
         run_typescript(
             &code,
             ctx.fs.clone(),
             ctx.cwd,
-            &self.limits,
+            &limits,
             self.external_fns.as_ref(),
         )
         .await

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -660,9 +660,11 @@ impl Bash {
         script: &str,
         mut extensions: ExecutionExtensions,
     ) -> Result<ExecResult> {
-        // Expose active execution limits to builtins that need to honor
-        // per-execution sandbox settings.
-        let _ = extensions.insert(self.interpreter.limits().clone());
+        // Expose active execution limits and deadline to builtins that need to
+        // honor per-execution sandbox settings inside synchronous VM sections.
+        let active_limits = self.interpreter.limits().clone();
+        let _ = extensions.insert(active_limits.clone());
+        let _ = extensions.insert(builtins::ExecutionDeadline::new(active_limits.timeout));
         #[cfg(feature = "python")]
         let _ = extensions.insert(builtins::PythonInprocessOptIn(self.python_inprocess_opt_in));
         #[cfg(feature = "sqlite")]

--- a/crates/bashkit/tests/integration/typescript_security_tests.rs
+++ b/crates/bashkit/tests/integration/typescript_security_tests.rs
@@ -199,6 +199,29 @@ mod blackbox_resource_exhaustion {
         assert_ne!(r.exit_code, 0, "string bomb should be limited");
     }
 
+    /// TM-DOS-057: Bash execution timeout caps TypeScript VM timeout.
+    #[tokio::test]
+    async fn threat_ts_honors_bash_execution_timeout() {
+        let mut bash = Bash::builder()
+            .limits(ExecutionLimits::new().timeout(Duration::from_millis(100)))
+            .typescript_with_limits(
+                TypeScriptLimits::default().max_duration(Duration::from_millis(1500)),
+            )
+            .build();
+
+        let start = std::time::Instant::now();
+        let result = bash.exec(r#"ts -c "while (true) {}""#).await;
+        let elapsed = start.elapsed();
+
+        if let Ok(r) = result {
+            assert_ne!(r.exit_code, 0, "infinite loop should not succeed");
+        }
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "TypeScript VM must be capped by Bash timeout, elapsed: {elapsed:?}"
+        );
+    }
+
     /// Generous limits should succeed for normal code
     #[tokio::test]
     async fn normal_code_within_limits() {


### PR DESCRIPTION
### Motivation
- ZapCode's synchronous VM execution could block Tokio's timeout, letting TypeScript code run longer than the host `ExecutionLimits::timeout` and weakening the per-exec resource boundary.
- Ensure TypeScript's internal time limit is never larger than the remaining Bash execution budget so short Bash deadlines still bound CPU-bound TS code.

### Description
- Add `ExecutionDeadline` (per-exec wall-clock deadline) to `builtins::ExecutionExtensions` to expose remaining Bash execution budget to builtins with synchronous VM sections (`crates/bashkit/src/builtins/mod.rs`).
- Insert active `ExecutionLimits` and an `ExecutionDeadline` into per-execution extensions in `Bash::exec_with_extensions()` so builtins can read the deadline (`crates/bashkit/src/lib.rs`).
- In the TypeScript builtin, compute effective ZapCode limits that cap `max_duration` by the deadline's remaining budget via a new `effective_limits()` helper and use those limits before invoking the synchronous VM (`crates/bashkit/src/builtins/typescript.rs`).
- Add a regression integration test that runs `ts -c "while (true) {}"` with a Bash timeout shorter than the TypeScript default to assert the overall execution is bounded by the Bash deadline (`crates/bashkit/tests/integration/typescript_security_tests.rs`).

### Testing
- `cargo fmt --check` — passed.
- `cargo clippy --features typescript -p bashkit --all-targets -- -D warnings` — passed.
- Targeted test: `cargo test --features typescript -p bashkit threat_ts_honors_bash_execution_timeout -- --nocapture` — passed.
- Full typescript-enabled test suite: `cargo test --features typescript -p bashkit` — ran and passed (no failures for the tested target).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad7464832b8c02b595fb0b1584)