### PR TITLE
fix(vfs): enforce lazy file materialization limits

### DIFF
--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -613,6 +613,10 @@ impl InMemoryFs {
         for path in lazy_paths {
             if let Some(FsEntry::LazyFile { loader, metadata }) = entries.remove(&path) {
                 let content = loader();
+                if let Err(_err) = self.check_write_limits(&entries, &path, content.len()) {
+                    entries.insert(path, FsEntry::LazyFile { loader, metadata });
+                    continue;
+                }
                 let mut metadata = metadata;
                 metadata.size = content.len() as u64;
                 entries.insert(path, FsEntry::File { content, metadata });
@@ -633,8 +637,7 @@ impl InMemoryFs {
                     });
                 }
                 FsEntry::LazyFile { .. } => {
-                    // All lazy files were materialized above
-                    unreachable!()
+                    // Lazy files that exceed limits stay lazy and are omitted.
                 }
                 FsEntry::Directory { metadata } => {
                     files.push(VfsEntry {
@@ -1212,9 +1215,13 @@ impl FileSystem for InMemoryFs {
                 return Ok(());
             }
             Some(FsEntry::LazyFile { .. }) => {
-                // Materialize lazy file before appending
+                // Materialize lazy file before appending.
                 if let Some(FsEntry::LazyFile { loader, metadata }) = entries.remove(&path) {
                     let loaded = loader();
+                    if let Err(err) = self.check_write_limits(&entries, &path, loaded.len()) {
+                        entries.insert(path, FsEntry::LazyFile { loader, metadata });
+                        return Err(err);
+                    }
                     let mut metadata = metadata;
                     metadata.size = loaded.len() as u64;
                     entries.insert(
@@ -1262,6 +1269,9 @@ impl FileSystem for InMemoryFs {
                     ..
                 } => {
                     current_total += file_content.len() as u64;
+                }
+                FsEntry::LazyFile { metadata, .. } => {
+                    current_total += metadata.size;
                 }
                 _ => {}
             }
@@ -2423,6 +2433,39 @@ mod tests {
 
         let result = fs.read_file(Path::new("/tmp/lazy.txt")).await;
         assert!(result.is_err());
+        assert!(fs.exists(Path::new("/tmp/lazy.txt")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_lazy_file_snapshot_rejects_oversized_materialization() {
+        let limits = FsLimits::new().max_file_size(5);
+        let fs = InMemoryFs::with_limits(limits);
+        fs.add_lazy_file("/tmp/lazy.txt", 1, 0o644, Arc::new(|| b"toolarge".to_vec()));
+
+        let snapshot = fs.snapshot();
+        assert!(
+            !snapshot
+                .entries
+                .iter()
+                .any(|e| e.path == Path::new("/tmp/lazy.txt"))
+        );
+
+        let result = fs.read_file(Path::new("/tmp/lazy.txt")).await;
+        assert!(result.is_err());
+        assert!(fs.exists(Path::new("/tmp/lazy.txt")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_lazy_file_append_rejects_oversized_materialization() {
+        let limits = FsLimits::new().max_file_size(5);
+        let fs = InMemoryFs::with_limits(limits);
+        fs.add_lazy_file("/tmp/lazy.txt", 1, 0o644, Arc::new(|| b"toolarge".to_vec()));
+
+        let append_result = fs.append_file(Path::new("/tmp/lazy.txt"), b"!").await;
+        assert!(append_result.is_err());
+
+        let read_result = fs.read_file(Path::new("/tmp/lazy.txt")).await;
+        assert!(read_result.is_err());
         assert!(fs.exists(Path::new("/tmp/lazy.txt")).await.unwrap());
     }
 


### PR DESCRIPTION
### Motivation
- Prevent lazy-mounted files from bypassing `FsLimits` during materialization (read, snapshot, append) which can lead to host memory exhaustion and DoS.
- Ensure lazy entries are accounted for consistently with eager `File`/`Fifo` entries so configured quotas are respected.

### Description
- Before inserting loader output during `snapshot()`, call `check_write_limits` and, on failure, restore the entry as `LazyFile` and omit it from the snapshot instead of materializing an oversized file.
- During `append_file()`, materialize a `LazyFile` only after verifying `check_write_limits` against the loader output and preserve the lazy entry and return the quota error if the check fails.
- Include `LazyFile` metadata size hints when computing `current_total` for append total-byte accounting so append checks count lazy entries correctly.
- Add regression tests `test_lazy_file_snapshot_rejects_oversized_materialization` and `test_lazy_file_append_rejects_oversized_materialization` to cover snapshot and append materialization failure cases.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran the targeted unit tests with `cargo test -p bashkit lazy_file_` and all lazy-file related tests passed (new tests included and succeeding).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad8e00832bae0d220b2d32367f)