### PR TITLE
fix(interpreter): suppress streaming for captured EXIT traps

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4105,6 +4105,16 @@ impl Interpreter {
         self.execute_command_sequence_impl(commands, false).await
     }
 
+    /// Execute commands whose stdout is captured by command substitution.
+    /// Streaming callbacks must stay suspended so hidden capture output cannot
+    /// leak to observers before it is assigned or otherwise consumed.
+    async fn execute_capture_only_sequence(&mut self, commands: &[Command]) -> Result<ExecResult> {
+        let saved_callback = self.output_callback.take();
+        let result = self.execute_command_sequence(commands).await;
+        self.output_callback = saved_callback;
+        result
+    }
+
     /// Execute a sequence of commands with optional errexit checking
     async fn execute_command_sequence_impl(
         &mut self,
@@ -8122,7 +8132,9 @@ impl Interpreter {
                     self.limits.max_parser_operations,
                 )
                 .parse()
-                && let Ok(trap_result) = self.execute_command_sequence(&trap_script.commands).await
+                && let Ok(trap_result) = self
+                    .execute_capture_only_sequence(&trap_script.commands)
+                    .await
             {
                 stdout.push_str(&trap_result.stdout);
             }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -6539,6 +6539,12 @@ echo missing fi"#,
     }
 
     #[tokio::test]
+    async fn test_streaming_equivalence_command_substitution_exit_trap() {
+        assert_streaming_equivalence("secret=$(trap 'echo TOKEN' EXIT); trap - EXIT; echo ok")
+            .await;
+    }
+
+    #[tokio::test]
     async fn test_max_memory_caps_string_growth() {
         let mut bash = Bash::builder()
             .max_memory(1024)


### PR DESCRIPTION
### Motivation
- EXIT traps set inside command substitutions could be executed via the normal emitting path and their stdout forwarded to `exec_streaming` callbacks, leaking data that should remain captured by the substitution.

### Description
- Add `execute_capture_only_sequence(&mut self, commands)` which temporarily removes the interpreter `output_callback` while running a command sequence so its stdout/stderr are not emitted to streaming observers.
- Route command-substitution `EXIT` trap execution through `execute_capture_only_sequence` so trap output is appended to the captured substitution result but not streamed.
- Add a regression test `test_streaming_equivalence_command_substitution_exit_trap` that asserts streamed chunks reassemble exactly to final stdout for `secret=$(trap 'echo TOKEN' EXIT); trap - EXIT; echo ok`.

### Testing
- Ran `cargo fmt` / `cargo fmt --check` with no formatting failures.
- Ran `cargo test -p bashkit test_streaming_equivalence_command_substitution_exit_trap` and `cargo test -p bashkit test_streaming_equivalence_subshell`, both tests passed.
- Ran focused unit test runs for the modified area and observed no regressions in the targeted streaming-equivalence checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adf8a4832babfdb7494471fe77)