### PR TITLE
fix(interpreter): avoid quadratic invalid bracket glob scans

### DIFF
--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -165,6 +165,10 @@ impl Interpreter {
         }
 
         let extglob = self.is_extglob();
+        // THREAT[TM-DOS-039]: Once the remaining pattern has no closing bracket,
+        // every `[` is literal. Cache that state so an unmatched suffix is scanned
+        // at most once instead of from every subsequent `[` start.
+        let mut no_more_bracket_closes = !pattern.contains(']');
 
         // Check for extglob at the start of pattern
         if extglob && pattern.len() >= 2 {
@@ -244,6 +248,17 @@ impl Interpreter {
                     }
                 }
                 (Some('['), Some(v)) => {
+                    if no_more_bracket_closes || !pattern_chars.clone().any(|c| c == ']') {
+                        no_more_bracket_closes = true;
+                        pattern_chars.next();
+                        if v == '[' {
+                            value_chars.next();
+                        } else {
+                            return false;
+                        }
+                        continue;
+                    }
+
                     // Save state before consuming '[' — if bracket expr is
                     // invalid (e.g. "[]"), we fall back to literal '[' match.
                     let saved_pattern = pattern_chars.clone();
@@ -832,5 +847,37 @@ impl Interpreter {
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::fs::{FileSystem, InMemoryFs};
+
+    use super::Interpreter;
+
+    fn interp() -> Interpreter {
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        Interpreter::new(fs)
+    }
+
+    #[test]
+    fn unmatched_bracket_run_matches_literals() {
+        let interp = interp();
+        let brackets = "[".repeat(65_536);
+
+        assert!(interp.pattern_matches(&brackets, &brackets));
+        assert!(!interp.pattern_matches(&format!("{brackets}x"), &brackets));
+    }
+
+    #[test]
+    fn invalid_and_valid_bracket_patterns_still_match() {
+        let interp = interp();
+
+        assert!(interp.pattern_matches("[]", "[]"));
+        assert!(interp.pattern_matches("[", "["));
+        assert!(interp.pattern_matches("a", "[a]"));
     }
 }


### PR DESCRIPTION
### Motivation
- Invalid bracket fallback reparsed the remaining suffix from every `[` start, producing O(N^2) work for patterns consisting of repeated `[` characters and enabling a CPU DoS. 
- The goal is to treat invalid/unclosed bracket expressions as literals while avoiding repeated full-tail rescans.

### Description
- Update `crates/bashkit/src/interpreter/glob.rs` to cache when the remaining pattern has no closing `]` and short-circuit bracket parsing for the unmatched suffix using a `no_more_bracket_closes` flag. 
- Preserve existing behavior: valid bracket classes still parsed by `match_bracket_expr` and invalid bracket expressions are treated as literal `[` when appropriate. 
- Add unit tests in the same file to cover a long run of `[` characters and to assert existing invalid/valid bracket behaviors (`[]`, `[`, `[a]`).

### Testing
- Ran unit tests with `cargo test -p bashkit interpreter::glob::tests` and the new tests `unmatched_bracket_run_matches_literals` and `invalid_and_valid_bracket_patterns_still_match`, all of which passed. 
- Ran formatting check with `cargo fmt --check` which succeeded. 
- Per-file `git diff --check` reported no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251aecc2c832b98ec8d2be228c57b)