### PR TITLE
fix(interpreter): clear BASH_SOURCE after cancelled exec

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1600,6 +1600,11 @@ impl Interpreter {
     /// Check if errexit (set -e) is enabled.
     /// Sync the internal bash_source_stack to the BASH_SOURCE indexed array.
     fn update_bash_source(&mut self) {
+        if self.bash_source_stack.is_empty() {
+            self.arrays_mut().remove("BASH_SOURCE");
+            return;
+        }
+
         let arr: HashMap<usize, String> = self
             .bash_source_stack
             .iter()
@@ -1757,10 +1762,12 @@ impl Interpreter {
             }
         }
         self.pipeline_stdin = None;
+        self.bash_source_stack.clear();
+        self.arrays_mut().remove("BASH_SOURCE");
     }
 
-    pub(crate) fn clear_transient_stdin(&mut self) {
-        self.pipeline_stdin = None;
+    pub(crate) fn clear_cancelled_execution_state(&mut self) {
+        self.reconcile_cancelled_execution_state(0, 0, 0, None);
     }
 
     fn clear_pending_fd_redirect_state(&mut self) {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -863,7 +863,7 @@ impl Bash {
             match tokio::time::timeout(execution_timeout, self.interpreter.execute(&ast)).await {
                 Ok(r) => r,
                 Err(_elapsed) => {
-                    self.interpreter.clear_transient_stdin();
+                    self.interpreter.clear_cancelled_execution_state();
                     Err(Error::ResourceLimit(LimitExceeded::Timeout(
                         execution_timeout,
                     )))

--- a/crates/bashkit/tests/integration/bash_source_tests.rs
+++ b/crates/bashkit/tests/integration/bash_source_tests.rs
@@ -139,3 +139,28 @@ async fn bash_source_cleared_after_timed_out_child_bash_script() {
         .unwrap();
     assert_eq!(result.stdout.trim(), "source=");
 }
+
+/// BASH_SOURCE is cleared after a timed-out sourced function call
+#[tokio::test(start_paused = true)]
+async fn bash_source_cleared_after_timeout_in_sourced_function() {
+    let limits = bashkit::ExecutionLimits::new().timeout(std::time::Duration::from_millis(1));
+    let mut bash = Bash::builder().limits(limits).build();
+    let fs = bash.fs();
+    fs.write_file(Path::new("/leak.sh"), b"leakme() { sleep 10; }\nleakme\n")
+        .await
+        .unwrap();
+
+    let timed_out = bash.exec("source /leak.sh").await;
+    assert!(matches!(
+        timed_out,
+        Err(bashkit::Error::ResourceLimit(
+            bashkit::LimitExceeded::Timeout(_)
+        ))
+    ));
+
+    let result = bash
+        .exec(r#"echo "len=${#BASH_SOURCE[@]} first=${BASH_SOURCE[0]}""#)
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "len=0 first=");
+}


### PR DESCRIPTION
### Motivation
- A function-call or sourced-file execution could push entries onto `bash_source_stack` and then return early on error or timeout before popping them, leaving stale `BASH_SOURCE` array entries visible to later `exec()` calls and allowing session-level state leakage. 
- Per-exec transient reset did not clear `bash_source_stack` or the public `BASH_SOURCE` indexed array, so aborted executions could accumulate stale source paths across `Bash::exec` calls.

### Description
- Make `update_bash_source()` remove the `BASH_SOURCE` array when the internal `bash_source_stack` is empty so the public array is not left stale. 
- Clear `bash_source_stack` and remove the `BASH_SOURCE` array in `reset_transient_state()` so transient source state is reset between top-level `exec()` calls. 
- Add `clear_cancelled_execution_state()` which calls `reconcile_cancelled_execution_state(0, 0, None)` and use it from the top-level timeout handler in `Bash::exec()` to reconcile interpreter stacks and restore `FUNCNAME`, `pipeline_stdin`, counters and `BASH_SOURCE` after a cancelled/timeout execution. 
- Add a regression integration test `bash_source_cleared_after_timeout_in_sourced_function` that reproduces the timed-out sourced-function leak and verifies `BASH_SOURCE` is cleared (`len=0 first=`).

### Testing
- Ran the regression integration test with `cargo test -p bashkit --test integration bash_source_cleared_after_timeout_in_sourced_function -- --nocapture`, which passed. 
- Ran the full BASH_SOURCE integration suite with `cargo test -p bashkit --test integration bash_source_tests -- --nocapture`, which passed. 
- Ran library/unit tests and static checks via `cargo test -p bashkit --lib`, `cargo clippy -p bashkit --all-targets -- -D warnings`, and `cargo fmt --check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adb048832bb17df54b55b5a56e)