### PR TITLE
fix(fs): reject live self mounts

### DIFF
--- a/crates/bashkit/src/fs/mountable.rs
+++ b/crates/bashkit/src/fs/mountable.rs
@@ -223,6 +223,15 @@ impl MountableFs {
     /// # }
     /// ```
     pub fn mount(&self, path: impl AsRef<Path>, fs: Arc<dyn FileSystem>) -> Result<()> {
+        // THREAT[TM-DOS-058]: Reject direct self-mounts before they can create
+        // unbounded recursive delegation through read/write/usage traversal.
+        if std::ptr::addr_eq(
+            Arc::as_ptr(&fs).cast::<()>(),
+            self as *const Self as *const (),
+        ) {
+            return Err(IoError::other("cannot mount filesystem into itself").into());
+        }
+
         // Validate against the *input* path: the bashkit VFS is always
         // POSIX-style, so mount points must start with `/`. We use
         // `Path::has_root()` rather than `Path::is_absolute()` because the
@@ -555,6 +564,23 @@ impl FileSystemExt for MountableFs {
 mod tests {
     use super::*;
     use crate::fs::InMemoryFs;
+
+    #[test]
+    fn test_rejects_self_mount() {
+        let root = Arc::new(InMemoryFs::new());
+        let mfs = Arc::new(MountableFs::new(root));
+        let self_fs = Arc::clone(&mfs) as Arc<dyn FileSystem>;
+
+        let err = mfs
+            .mount("/", self_fs)
+            .expect_err("mounting MountableFs into itself must be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("cannot mount filesystem into itself"),
+            "unexpected error: {err}"
+        );
+    }
 
     #[tokio::test]
     async fn test_mount_and_access() {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1094,6 +1094,13 @@ impl Bash {
         vfs_path: impl AsRef<std::path::Path>,
         fs: Arc<dyn FileSystem>,
     ) -> Result<()> {
+        // THREAT[TM-DOS-058]: `Bash::fs()` exposes the live outer VFS handle;
+        // reject mounting that handle back into this Bash before any wrappers
+        // can hide pointer identity and recurse through delegated operations.
+        if Arc::ptr_eq(&self.fs, &fs) {
+            return Err(std::io::Error::other("cannot mount filesystem into itself").into());
+        }
+
         let fs: Arc<dyn FileSystem> = if self.readonly_filesystem {
             Arc::new(ReadOnlyFs::new(fs))
         } else {

--- a/crates/bashkit/tests/integration/live_mount_tests.rs
+++ b/crates/bashkit/tests/integration/live_mount_tests.rs
@@ -168,3 +168,19 @@ async fn live_mount_is_readonly_when_builder_enables_readonly_filesystem() {
         .unwrap();
     assert_ne!(result.exit_code, 0);
 }
+
+#[test]
+fn live_mount_rejects_self_mount() {
+    let bash = Bash::new();
+    let self_fs = bash.fs();
+
+    let err = bash
+        .mount("/", self_fs)
+        .expect_err("mounting Bash::fs() back into itself must be rejected");
+
+    assert!(
+        err.to_string()
+            .contains("cannot mount filesystem into itself"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service where callers can mount the interpreter's own outer `MountableFs` back into itself and cause unbounded recursion via delegated filesystem operations and usage aggregation.
- Provide a defense-in-depth check so neither `Bash::mount()` nor `MountableFs::mount()` accept the same `Arc<dyn FileSystem>` that represents the outer live VFS.

### Description
- Add a pre-check in `Bash::mount()` to reject `Arc::ptr_eq(&self.fs, &fs)` and return an error `"cannot mount filesystem into itself"` when callers attempt to mount the live outer VFS back into the interpreter.
- Add a defense-in-depth check in `MountableFs::mount()` that rejects direct self-mounts by comparing the mounted `Arc` pointer against `self` and returning the same error.
- Add a unit test in `crates/bashkit/src/fs/mountable.rs` and an integration test in `crates/bashkit/tests/integration/live_mount_tests.rs` that assert self-mount attempts fail with the expected error.

### Testing
- Ran `cargo fmt --check` and formatting passed.
- Ran the new `MountableFs` unit test via `cargo test -p bashkit fs::mountable::tests::test_rejects_self_mount` and it passed.
- Ran the live-mount integration tests via `cargo test -p bashkit live_mount_tests` and the new `live_mount_rejects_self_mount` test passed along with the suite.
- Ran `cargo clippy -p bashkit --lib --tests -- -D warnings` and the lint run completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae0270832bafaee3e0247bc912)