### PR TITLE
fix(history): persist history clear immediately

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -5380,7 +5380,7 @@ impl Interpreter {
                 }
             };
 
-            self.apply_builtin_side_effects(&result);
+            self.apply_builtin_side_effects(&result).await;
 
             // Sync successful export operands into env so subprocess isolation can see them.
             // Keep syncing even if export returned nonzero for other args (bash-compatible).
@@ -7480,7 +7480,7 @@ impl Interpreter {
     }
 
     /// Process structured side effects from builtin execution.
-    fn apply_builtin_side_effects(&mut self, result: &ExecResult) {
+    async fn apply_builtin_side_effects(&mut self, result: &ExecResult) {
         // Builtins that mutate SHOPT_* directly via `ctx.variables` (e.g. the
         // `set -e` / `set +u` paths in the `set` builtin) don't update the
         // cached `flags` bitfield. Resync once after every builtin so the
@@ -7532,6 +7532,8 @@ impl Interpreter {
                 }
                 builtins::BuiltinSideEffect::ClearHistory => {
                     self.history.clear();
+                    // Persist immediately so `history -c` is a same-exec sanitization boundary.
+                    self.save_history().await;
                 }
                 builtins::BuiltinSideEffect::SetLastExitCode(code) => {
                     self.last_exit_code = *code;

--- a/crates/bashkit/tests/integration/history_tests.rs
+++ b/crates/bashkit/tests/integration/history_tests.rs
@@ -57,6 +57,39 @@ async fn history_clear() {
 }
 
 #[tokio::test]
+async fn history_clear_persists_before_next_command() {
+    use std::sync::Arc;
+
+    let fs: Arc<dyn FileSystem> = Arc::new(bashkit::InMemoryFs::new());
+    let history_path = std::path::Path::new("/home/user/.bash_history");
+    fs.mkdir(std::path::Path::new("/home/user"), true)
+        .await
+        .unwrap();
+    fs.write_file(
+        history_path,
+        b"1700000000|0|10|/home/user|echo SECRET_TOKEN_123\n",
+    )
+    .await
+    .unwrap();
+
+    let mut bash = Bash::builder()
+        .fs(Arc::clone(&fs))
+        .history_file(history_path)
+        .build();
+
+    let result = bash
+        .exec("history -c\ncat /home/user/.bash_history")
+        .await
+        .unwrap();
+
+    assert!(
+        !result.stdout.contains("SECRET_TOKEN_123"),
+        "history -c must wipe persisted history before later commands can read it: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
 async fn history_grep() {
     let mut bash = Bash::new();
     bash.exec("echo hello").await.unwrap();


### PR DESCRIPTION
### Motivation

- `history -c` previously emitted only a `ClearHistory` side effect that cleared in-memory history but did not persist the cleared state, leaving the VFS history file readable later in the same exec.  
- That allowed same-exec reads (or failures/timeouts) to leak prior persisted commands (potentially secrets) despite `history -c` being invoked.

### Description

- Make `apply_builtin_side_effects` asynchronous and `await` it after builtin execution so side-effects may perform async VFS operations.  
- When handling `BuiltinSideEffect::ClearHistory` clear `self.history` and call `self.save_history().await` to immediately persist the cleared state.  
- Add an integration regression test `history_clear_persists_before_next_command` that pre-populates a VFS history file, runs `history -c` then `cat` in the same script, and asserts the old content is not exposed.

### Testing

- Ran `cargo fmt --check` which passed.  
- Ran the new focused test `cargo test -p bashkit --test integration history_clear_persists_before_next_command -- --nocapture` which passed.  
- Ran the integration history suite `cargo test -p bashkit --test integration history_tests:: -- --nocapture` which passed.  
- Ran `cargo clippy -p bashkit --test integration -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad9374832ba56b68a9564cc18f)