### PR TITLE
fix(interpreter): restore scoped local arrays

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -12268,8 +12268,6 @@ mod tests {
             local_arrays: HashMap::new(),
             local_assoc_arrays: HashMap::new(),
             positional: Vec::new(),
-            saved_arrays: HashMap::new(),
-            saved_assoc_arrays: HashMap::new(),
         });
         let baseline_call_stack_len = interp.call_stack.len();
         let baseline_bash_source_len = interp.bash_source_stack.len();
@@ -12281,8 +12279,6 @@ mod tests {
             local_arrays: HashMap::new(),
             local_assoc_arrays: HashMap::new(),
             positional: Vec::new(),
-            saved_arrays: HashMap::new(),
-            saved_assoc_arrays: HashMap::new(),
         });
         interp.bash_source_stack.push("script.sh".to_string());
 

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -635,24 +635,12 @@ struct CallFrame {
     name: String,
     /// Local variables in this scope
     locals: HashMap<String, String>,
+    /// Indexed arrays shadowed by local declarations in this scope.
+    local_arrays: HashMap<String, Option<HashMap<usize, String>>>,
+    /// Associative arrays shadowed by local declarations in this scope.
+    local_assoc_arrays: HashMap<String, Option<HashMap<String, String>>>,
     /// Positional parameters ($1, $2, etc.)
     positional: Vec<String>,
-    /// Saved indexed array bindings shadowed by `local`.
-    saved_arrays: HashMap<String, Option<HashMap<usize, String>>>,
-    /// Saved associative array bindings shadowed by `local`.
-    saved_assoc_arrays: HashMap<String, Option<HashMap<String, String>>>,
-}
-
-impl CallFrame {
-    fn new(name: String, positional: Vec<String>) -> Self {
-        Self {
-            name,
-            locals: HashMap::new(),
-            positional,
-            saved_arrays: HashMap::new(),
-            saved_assoc_arrays: HashMap::new(),
-        }
-    }
 }
 
 /// A snapshot of shell state (variables, env, cwd, options).
@@ -4121,8 +4109,13 @@ impl Interpreter {
         self.reset_state_for_child_shell();
 
         // Push call frame, apply options, execute, restore, pop
-        self.call_stack
-            .push(CallFrame::new(name_arg, positional_args));
+        self.call_stack.push(CallFrame {
+            name: name_arg,
+            locals: HashMap::new(),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
+            positional: positional_args,
+        });
 
         let mut saved_opt_names: HashSet<&'static str> = HashSet::new();
         for (var, val) in &shell_opts {
@@ -4158,7 +4151,7 @@ impl Interpreter {
         // Restore stdin
         self.pipeline_stdin = saved_stdin;
 
-        self.call_stack.pop();
+        self.pop_call_frame();
 
         // Restore parent state — full revert of the snapshot since the child
         // is process-isolated. This also undoes OPTIND/SHOPT_* writes above.
@@ -6067,7 +6060,13 @@ impl Interpreter {
         self.nounset_error = None;
 
         // Push call frame: $0 = script name, $1..N = args
-        self.call_stack = vec![CallFrame::new(name.to_string(), args.to_vec())];
+        self.call_stack = vec![CallFrame {
+            name: name.to_string(),
+            locals: HashMap::new(),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
+            positional: args.to_vec(),
+        }];
 
         // Set up BASH_SOURCE for the subprocess
         let saved_source_stack = self.bash_source_stack.clone();
@@ -6202,8 +6201,13 @@ impl Interpreter {
             let saved = self.call_stack.last().map(|frame| frame.positional.clone());
             // Push a temporary call frame for positional params
             if self.call_stack.is_empty() {
-                self.call_stack
-                    .push(CallFrame::new(filename.clone(), source_args));
+                self.call_stack.push(CallFrame {
+                    name: filename.clone(),
+                    locals: HashMap::new(),
+                    local_arrays: HashMap::new(),
+                    local_assoc_arrays: HashMap::new(),
+                    positional: source_args,
+                });
             } else if let Some(frame) = self.call_stack.last_mut() {
                 frame.positional = source_args;
             }
@@ -6243,7 +6247,7 @@ impl Interpreter {
                 }
             } else {
                 // We pushed a frame; pop it
-                self.call_stack.pop();
+                self.pop_call_frame();
             }
         }
 
@@ -6548,22 +6552,9 @@ impl Interpreter {
         }
     }
 
-    /// Execute a shell function call with call frame management.
-    fn save_local_array_bindings(&mut self, name: &str) {
-        let saved_array = self.arrays.get(name).cloned();
-        let saved_assoc = self.assoc_arrays.get(name).cloned();
-        if let Some(frame) = self.call_stack.last_mut() {
-            let name = name.to_string();
-            frame
-                .saved_arrays
-                .entry(name.clone())
-                .or_insert(saved_array);
-            frame.saved_assoc_arrays.entry(name).or_insert(saved_assoc);
-        }
-    }
-
     fn shadow_local_array_bindings(&mut self, name: &str, keep_indexed: bool, keep_assoc: bool) {
-        self.save_local_array_bindings(name);
+        self.remember_local_array_binding(name);
+        self.remember_local_assoc_array_binding(name);
         let mut removed_entries = 0;
         if !keep_indexed {
             removed_entries += self.arrays_mut().remove(name).map_or(0, |arr| arr.len());
@@ -6579,37 +6570,6 @@ impl Interpreter {
         }
     }
 
-    fn restore_local_array_bindings(&mut self, frame: CallFrame) {
-        for (name, saved) in frame.saved_arrays {
-            let old_entries = self.arrays.get(&name).map_or(0, |arr| arr.len());
-            let new_entries = saved.as_ref().map_or(0, |arr| arr.len());
-            match saved {
-                Some(arr) => {
-                    self.arrays_mut().insert(name, arr);
-                }
-                None => {
-                    self.arrays_mut().remove(&name);
-                }
-            }
-            self.memory_budget.array_entries =
-                self.memory_budget.array_entries.saturating_sub(old_entries) + new_entries;
-        }
-        for (name, saved) in frame.saved_assoc_arrays {
-            let old_entries = self.assoc_arrays.get(&name).map_or(0, |arr| arr.len());
-            let new_entries = saved.as_ref().map_or(0, |arr| arr.len());
-            match saved {
-                Some(arr) => {
-                    self.assoc_arrays_mut().insert(name, arr);
-                }
-                None => {
-                    self.assoc_arrays_mut().remove(&name);
-                }
-            }
-            self.memory_budget.array_entries =
-                self.memory_budget.array_entries.saturating_sub(old_entries) + new_entries;
-        }
-    }
-
     async fn execute_function_call(
         &mut self,
         name: &str,
@@ -6622,7 +6582,13 @@ impl Interpreter {
         self.counters.push_function(&self.limits)?;
 
         // Push call frame with positional parameters
-        self.call_stack.push(CallFrame::new(name.to_string(), args));
+        self.call_stack.push(CallFrame {
+            name: name.to_string(),
+            locals: HashMap::new(),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
+            positional: args,
+        });
 
         // Set FUNCNAME array from call stack (index 0 = current, 1 = caller, ...)
         let funcname_arr: HashMap<usize, String> = self
@@ -6652,9 +6618,7 @@ impl Interpreter {
         self.pipeline_stdin = prev_pipeline_stdin;
 
         // Pop call frame, restore local array bindings, function counter, and BASH_SOURCE
-        if let Some(frame) = self.call_stack.pop() {
-            self.restore_local_array_bindings(frame);
-        }
+        self.pop_call_frame();
         self.counters.pop_function();
         self.bash_source_stack.pop();
         self.update_bash_source();
@@ -6734,6 +6698,7 @@ impl Interpreter {
                         self.shadow_local_array_bindings(var_name, !flags.assoc, flags.assoc);
                         let inner = &value[1..value.len() - 1];
                         let inserted = if flags.assoc {
+                            self.remember_local_assoc_array_binding(var_name);
                             let mut arr = HashMap::new();
                             let mut rest = inner.trim();
                             while let Some(bracket_start) = rest.find('[') {
@@ -6771,6 +6736,7 @@ impl Interpreter {
                             }
                             self.insert_assoc_array_checked(var_name.to_string(), arr)
                         } else {
+                            self.remember_local_array_binding(var_name);
                             let mut arr = HashMap::new();
                             for (idx, val) in inner.split_whitespace().enumerate() {
                                 arr.insert(idx, val.trim_matches('"').to_string());
@@ -6795,17 +6761,17 @@ impl Interpreter {
                     }
                 } else if !is_internal_variable(arg) {
                     if flags.assoc {
-                        self.shadow_local_array_bindings(arg, false, true);
+                        self.remember_local_assoc_array_binding(arg);
+                        if self.insert_assoc_array_checked(arg.to_string(), HashMap::new()) {
+                            self.insert_local_checked(arg.to_string(), String::new());
+                        }
                     } else if flags.array {
-                        self.shadow_local_array_bindings(arg, true, false);
+                        self.remember_local_array_binding(arg);
+                        if self.insert_array_checked(arg.to_string(), HashMap::new()) {
+                            self.insert_local_checked(arg.to_string(), String::new());
+                        }
                     } else {
-                        self.shadow_local_array_bindings(arg, false, false);
-                    }
-                    self.insert_local_checked(arg.to_string(), String::new());
-                    if flags.assoc {
-                        self.assoc_arrays_mut().entry(arg.to_string()).or_default();
-                    } else if flags.array {
-                        self.arrays_mut().entry(arg.to_string()).or_default();
+                        self.insert_local_checked(arg.to_string(), String::new());
                     }
                     if flags.integer {
                         self.add_var_attr(arg, VarAttrs::INTEGER);
@@ -7962,8 +7928,13 @@ impl Interpreter {
                     if let Some(frame) = self.call_stack.last_mut() {
                         frame.positional = new_positional.clone();
                     } else {
-                        self.call_stack
-                            .push(CallFrame::new(String::new(), new_positional.clone()));
+                        self.call_stack.push(CallFrame {
+                            name: String::new(),
+                            locals: HashMap::new(),
+                            local_arrays: HashMap::new(),
+                            local_assoc_arrays: HashMap::new(),
+                            positional: new_positional.clone(),
+                        });
                     }
                 }
                 builtins::BuiltinSideEffect::ClearHistory => {
@@ -11411,6 +11382,74 @@ impl Interpreter {
         self.env.insert(key, value);
     }
 
+    /// Pop a call frame and restore any global array bindings shadowed by `local -a/-A`.
+    fn pop_call_frame(&mut self) -> Option<CallFrame> {
+        let frame = self.call_stack.pop()?;
+        for (name, previous) in &frame.local_arrays {
+            self.restore_array_binding(name, previous.clone());
+        }
+        for (name, previous) in &frame.local_assoc_arrays {
+            self.restore_assoc_array_binding(name, previous.clone());
+        }
+        Some(frame)
+    }
+
+    /// Remember the array binding that a local indexed array declaration shadows.
+    fn remember_local_array_binding(&mut self, name: &str) {
+        let previous = self.arrays.get(name).cloned();
+        if let Some(frame) = self.call_stack.last_mut() {
+            frame
+                .local_arrays
+                .entry(name.to_string())
+                .or_insert(previous);
+        }
+    }
+
+    /// Remember the array binding that a local associative array declaration shadows.
+    fn remember_local_assoc_array_binding(&mut self, name: &str) {
+        let previous = self.assoc_arrays.get(name).cloned();
+        if let Some(frame) = self.call_stack.last_mut() {
+            frame
+                .local_assoc_arrays
+                .entry(name.to_string())
+                .or_insert(previous);
+        }
+    }
+
+    fn restore_array_binding(&mut self, name: &str, previous: Option<HashMap<usize, String>>) {
+        let old_entries = self.arrays.get(name).map_or(0, |a| a.len());
+        let new_entries = previous.as_ref().map_or(0, |a| a.len());
+        self.memory_budget.array_entries = self
+            .memory_budget
+            .array_entries
+            .saturating_sub(old_entries)
+            .saturating_add(new_entries);
+        if let Some(arr) = previous {
+            self.arrays_mut().insert(name.to_string(), arr);
+        } else {
+            self.arrays_mut().remove(name);
+        }
+    }
+
+    fn restore_assoc_array_binding(
+        &mut self,
+        name: &str,
+        previous: Option<HashMap<String, String>>,
+    ) {
+        let old_entries = self.assoc_arrays.get(name).map_or(0, |a| a.len());
+        let new_entries = previous.as_ref().map_or(0, |a| a.len());
+        self.memory_budget.array_entries = self
+            .memory_budget
+            .array_entries
+            .saturating_sub(old_entries)
+            .saturating_add(new_entries);
+        if let Some(arr) = previous {
+            self.assoc_arrays_mut().insert(name.to_string(), arr);
+        } else {
+            self.assoc_arrays_mut().remove(name);
+        }
+    }
+
     /// Insert an array with memory budget checking.
     /// Returns true if the insert succeeded.
     fn insert_array_checked(&mut self, name: String, arr: HashMap<usize, String>) -> bool {
@@ -12106,9 +12145,13 @@ mod tests {
         let mut interp = Interpreter::new(Arc::clone(&fs));
         let replacement = "a".repeat(2048);
         interp.set_variable("p".to_string(), replacement);
-        interp
-            .call_stack
-            .push(CallFrame::new("f".to_string(), vec!["x".to_string(); 6000]));
+        interp.call_stack.push(CallFrame {
+            name: "f".to_string(),
+            locals: HashMap::new(),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
+            positional: vec!["x".to_string(); 6000],
+        });
 
         let value = interp.resolve_param_expansion_name("@").1;
         let expanded = interp.apply_param_op_maybe_per_element(
@@ -12222,6 +12265,8 @@ mod tests {
         interp.call_stack.push(CallFrame {
             name: "caller".to_string(),
             locals: HashMap::new(),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
             positional: Vec::new(),
             saved_arrays: HashMap::new(),
             saved_assoc_arrays: HashMap::new(),
@@ -12233,6 +12278,8 @@ mod tests {
         interp.call_stack.push(CallFrame {
             name: "bash".to_string(),
             locals: HashMap::new(),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
             positional: Vec::new(),
             saved_arrays: HashMap::new(),
             saved_assoc_arrays: HashMap::new(),
@@ -12366,10 +12413,12 @@ mod tests {
         let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
         let mut interp = Interpreter::new(Arc::clone(&fs));
         interp.set_memory_limits(crate::limits::MemoryLimits::new().max_total_variable_bytes(20));
-        interp.call_stack.push({
-            let mut frame = CallFrame::new("f".to_string(), Vec::new());
-            frame.locals = HashMap::from([("A".to_string(), "1".to_string())]);
-            frame
+        interp.call_stack.push(CallFrame {
+            name: "f".to_string(),
+            locals: HashMap::from([("A".to_string(), "1".to_string())]),
+            local_arrays: HashMap::new(),
+            local_assoc_arrays: HashMap::new(),
+            positional: Vec::new(),
         });
         interp
             .memory_budget

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3808,6 +3808,51 @@ f
         assert_eq!(counts, vec![0, 0]);
     }
 
+    /// TM-INF-023: local compound arrays must not leak after a function returns.
+    #[tokio::test]
+    async fn tm_inf_023_function_local_arrays_do_not_leak() {
+        let mut bash = Bash::builder()
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+outer=(global value)
+declare -A outer_map=([k]=global)
+f() {
+    local -a outer=(token value)
+    local -a secret_arr=(hidden token)
+    local -A outer_map=([k]=secret)
+    local -A secret_map=([k]=hidden)
+    printf "inside_outer=%s\n" "${outer[*]}"
+    printf "inside_secret_arr=%s\n" "${secret_arr[*]}"
+    printf "inside_outer_map=%s\n" "${outer_map[*]}"
+    printf "inside_secret_map=%s\n" "${secret_map[*]}"
+}
+f
+printf "outside_outer=%s\n" "${outer[*]}"
+printf "outside_secret_arr=%s\n" "${secret_arr[*]}"
+printf "outside_outer_map=%s\n" "${outer_map[*]}"
+printf "outside_secret_map=%s\n" "${secret_map[*]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "inside_outer=token value",
+                "inside_secret_arr=hidden token",
+                "inside_outer_map=secret",
+                "inside_secret_map=hidden",
+                "outside_outer=global value",
+                "outside_secret_arr=",
+                "outside_outer_map=global",
+                "outside_secret_map=",
+            ]
+        );
+    }
+
     /// TM-DOS-060: Array entry bomb — indexed array with many entries.
     #[tokio::test]
     async fn tm_dos_060_array_entry_bomb() {


### PR DESCRIPTION
### Motivation
- The `local -a` / `local -A` compound-init path wrote elements directly into the interpreter's global `arrays`/`assoc_arrays`, causing function-local arrays to persist after return and bypass array-entry memory accounting.
- Shadowed array bindings must be tracked per-call-frame and restored on frame pop to preserve proper lexical scoping and `MemoryBudget` invariants.

### Description
- Add per-frame shadow storage: `CallFrame` now includes `local_arrays: HashMap<String, Option<HashMap<usize,String>>>` and `local_assoc_arrays: HashMap<String, Option<HashMap<String,String>>>` to record previous global bindings.
- Introduce `remember_local_array_binding` and `remember_local_assoc_array_binding` which snapshot any existing global binding before a `local -a/-A` declaration, and call them from `execute_local_builtin` for both compound and empty local array declarations.
- Add `pop_call_frame()` which restores shadowed array bindings and updates `memory_budget.array_entries`, and replace direct `call_stack.pop()` uses in function/source teardown with `pop_call_frame()`.
- Use the existing checked helpers `insert_array_checked` / `insert_assoc_array_checked` for empty local array declarations so array-entry budget is respected.
- Add an integration regression test `tm_inf_023_function_local_arrays_do_not_leak` that verifies local indexed and associative arrays are visible inside the function and absent after return.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p bashkit --test integration tm_inf_023_function_local_arrays_do_not_leak` which passed.
- Ran `cargo test -p bashkit --test integration tm_dos_060_local_compound_array_respects_budget` which passed.
- Ran `cargo test -p bashkit --lib` which completed with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc4a64832b9c5f7621314c345d)