### PR TITLE
fix(trace): clear events after failed exec

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2085,14 +2085,28 @@ impl Interpreter {
         // THREAT[TM-DOS-059]: Increment session-level exec call counter and
         // check session limits before starting execution.
         self.counters.tick_exec_call();
-        self.counters
+        let result = match self
+            .counters
             .check_session_limits(&self.session_limits)
-            .map_err(|e| crate::error::Error::Execution(e.to_string()))?;
+            .map_err(|e| crate::error::Error::Execution(e.to_string()))
+        {
+            Ok(()) => {
+                let result = self.execute_script_body(script, true, true).await;
+                // Script boundary cleanup: background jobs are scoped to a single exec()
+                // call, so they cannot accumulate across long-lived sessions.
+                let _ = self.jobs.lock().await.wait_all_results().await;
+                result
+            }
+            Err(e) => Err(e),
+        };
 
-        let result = self.execute_script_body(script, true, true).await;
-        // Script boundary cleanup: background jobs are scoped to a single exec()
-        // call, so they cannot accumulate across long-lived sessions.
-        let _ = self.jobs.lock().await.wait_all_results().await;
+        if result.is_err() {
+            // THREAT[TM-INF-019]: Trace events are per exec() result data.
+            // Error paths have no ExecResult to carry them, so discard them before
+            // a reused Bash instance can expose stale events to the next caller.
+            let _ = self.trace.take_events();
+        }
+
         result
     }
 

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -4086,6 +4086,30 @@ mod trace_events {
     }
 
     #[tokio::test]
+    async fn trace_failed_exec_does_not_leak_events_to_next_exec() {
+        let mut bash = Bash::builder().trace_mode(TraceMode::Full).build();
+
+        let failed = bash.exec(r#"grep -E "(" tenant-a-private-arg"#).await;
+        assert!(failed.is_err(), "invalid regex should fail execution");
+
+        let r = bash.exec("echo tenant-b").await.unwrap();
+        assert_eq!(r.exit_code, 0);
+
+        for event in &r.events {
+            if let TraceEventDetails::CommandStart { command, argv, .. } = &event.details {
+                assert_ne!(
+                    command, "grep",
+                    "stale failed command leaked into next exec"
+                );
+                assert!(
+                    argv.iter().all(|arg| !arg.contains("tenant-a-private-arg")),
+                    "stale failed argv leaked into next exec: {argv:?}" // debug-ok: assert context only
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn trace_redacted_scrubs_env_secrets() {
         let mut bash = Bash::builder().trace_mode(TraceMode::Redacted).build();
         // printf with env-style key=value argument containing a secret suffix


### PR DESCRIPTION
### Motivation
- Traced `CommandStart` events were appended to a per-interpreter collector but only drained on the normal-success return path, allowing stale events from a failed execution to be observed by a subsequent successful `exec()` on the same `Bash` instance. 
- This leak can disclose command names/argv (including sensitive arguments) in `TraceMode::Redacted`/`Full` for long-lived interpreters, so events must be discarded on error paths.

### Description
- Update `Interpreter::execute` to treat `check_session_limits` + `execute_script_body` as a single `result` and call `self.trace.take_events()` when `result.is_err()` to discard per-exec events on failure. 
- Add an integration regression test `trace_failed_exec_does_not_leak_events_to_next_exec` in `crates/bashkit/tests/integration/threat_model_tests.rs` that triggers a failing traced command (`grep -E` with invalid regex) followed by a successful `echo` and asserts no stale `grep` events or private argv leak. 
- Change is localized and preserves existing successful-path behavior where `ExecResult.events` still contains collected events.

### Testing
- Ran `cargo fmt --check` and formatting passed. 
- Ran the new regression test with `cargo test -p bashkit --test integration trace_failed_exec_does_not_leak_events_to_next_exec -- --nocapture` and it passed. 
- Ran the integration trace suite with `cargo test -p bashkit --test integration trace_events` and all trace-related tests passed. 
- Ran `cargo clippy -p bashkit --test integration -- -D warnings` and no clippy warnings remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adfa04832b94e9c6e49c55a512)