### PR TITLE
fix(fs): allow snapshot restores at file count limit

### DIFF
--- a/crates/bashkit/src/fs/limits.rs
+++ b/crates/bashkit/src/fs/limits.rs
@@ -334,6 +334,17 @@ impl FsLimits {
         Ok(())
     }
 
+    /// Check if a restored snapshot's final file count exceeds the limit.
+    pub fn check_final_file_count(&self, count: u64) -> Result<(), FsLimitExceeded> {
+        if count > self.max_file_count {
+            return Err(FsLimitExceeded::FileCount {
+                current: count,
+                limit: self.max_file_count,
+            });
+        }
+        Ok(())
+    }
+
     /// Check if adding a directory would exceed the directory count limit.
     pub fn check_dir_count(&self, current: u64) -> Result<(), FsLimitExceeded> {
         if current >= self.max_dir_count {

--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -732,7 +732,7 @@ impl InMemoryFs {
             return Err(IoError::other("snapshot total bytes exceed limit").into());
         }
         self.limits
-            .check_file_count(file_count)
+            .check_final_file_count(file_count)
             .map_err(|e| IoError::other(e.to_string()))?;
 
         let mut entries = self.entries.write().unwrap();
@@ -2146,6 +2146,72 @@ mod tests {
         let err = limited.restore(&snapshot);
         assert!(err.is_err(), "restore must report the limit violation");
         assert!(!limited.exists(Path::new("/tmp/huge.bin")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_restore_allows_exact_file_count_limit() {
+        // InMemoryFs starts with 3 device files. Add 2 user files so the
+        // snapshot's final file count exactly matches the configured limit.
+        let source = InMemoryFs::new();
+        source
+            .write_file(Path::new("/tmp/one.txt"), b"one")
+            .await
+            .unwrap();
+        source
+            .write_file(Path::new("/tmp/two.txt"), b"two")
+            .await
+            .unwrap();
+        let snapshot = source.snapshot();
+
+        let limited = InMemoryFs::with_limits(FsLimits::new().max_file_count(5));
+        limited
+            .write_file(Path::new("/tmp/stale.txt"), b"stale")
+            .await
+            .unwrap();
+
+        limited
+            .restore(&snapshot)
+            .expect("exact-limit snapshots should restore successfully");
+
+        assert!(!limited.exists(Path::new("/tmp/stale.txt")).await.unwrap());
+        assert_eq!(
+            limited.read_file(Path::new("/tmp/one.txt")).await.unwrap(),
+            b"one"
+        );
+        assert_eq!(
+            limited.read_file(Path::new("/tmp/two.txt")).await.unwrap(),
+            b"two"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restore_rejects_over_file_count_limit() {
+        let source = InMemoryFs::new();
+        for name in ["one", "two", "three"] {
+            source
+                .write_file(Path::new(&format!("/tmp/{name}.txt")), name.as_bytes())
+                .await
+                .unwrap();
+        }
+        let snapshot = source.snapshot();
+
+        let limited = InMemoryFs::with_limits(FsLimits::new().max_file_count(5));
+        limited
+            .write_file(Path::new("/tmp/stale.txt"), b"stale")
+            .await
+            .unwrap();
+
+        let err = limited.restore(&snapshot);
+
+        assert!(err.is_err(), "over-limit snapshots must fail closed");
+        assert_eq!(
+            limited
+                .read_file(Path::new("/tmp/stale.txt"))
+                .await
+                .unwrap(),
+            b"stale"
+        );
+        assert!(!limited.exists(Path::new("/tmp/three.txt")).await.unwrap());
     }
 
     /// THREAT[TM-DOS-034]: Verify append_file uses single write lock,


### PR DESCRIPTION
### Motivation

- `InMemoryFs::restore()` used the pre-add helper `check_file_count()` to validate the snapshot's final file count, which rejected snapshots where `file_count == max_file_count` and left the old VFS intact (silent no-op), breaking tenant isolation.

### Description

- Add `FsLimits::check_final_file_count()` that rejects only when `count > max_file_count`, preserving `check_file_count()` semantics for write paths.
- Use `check_final_file_count()` in `InMemoryFs::restore()` instead of `check_file_count()` so exact-limit snapshots are accepted and applied.
- Add regression tests: `test_restore_allows_exact_file_count_limit` and `test_restore_rejects_over_file_count_limit` that verify exact-limit restores succeed and over-limit restores fail closed.
- Files changed: `crates/bashkit/src/fs/limits.rs`, `crates/bashkit/src/fs/memory.rs`.

### Testing

- Ran `cargo fmt --check` (passed).
- Ran targeted unit tests: `fs::memory::tests::test_restore_allows_exact_file_count_limit`, `fs::memory::tests::test_restore_rejects_over_file_count_limit`, and `fs::memory::tests::test_restore_respects_file_size_limit` (all passed).
- Verified that the new tests exercise both exact-limit acceptance and over-limit rejection and that restore no longer silently leaves stale files when snapshot is valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae5310832bbd19716d34056ca5)