### PR TITLE
fix(interpreter): guard malformed nameref array targets

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -507,6 +507,18 @@ pub(crate) fn is_hidden_variable(name: &str) -> bool {
     is_internal_variable(name) || name.starts_with("_TTY_")
 }
 
+/// THREAT[TM-DOS-090]: Nameref targets are script-controlled. Only treat a
+/// resolved target as an embedded array element when it is exactly `name[index]`;
+/// malformed strings containing `[` must remain ordinary names, never sliced.
+fn parse_embedded_array_ref(resolved_name: &str) -> Option<(&str, &str)> {
+    let (arr_name, rest) = resolved_name.split_once('[')?;
+    let idx_part = rest.strip_suffix(']')?;
+    if !is_valid_var_name(arr_name) || idx_part.contains('[') || idx_part.contains(']') {
+        return None;
+    }
+    Some((arr_name, idx_part))
+}
+
 /// Check if a string is a valid shell variable name: `[a-zA-Z_][a-zA-Z0-9_]*`.
 ///
 /// Single canonical copy used by interpreter and builtins.
@@ -7913,12 +7925,9 @@ impl Interpreter {
     /// Expand an array access expression (`${arr[index]}`).
     fn expand_array_access_part(&self, name: &str, index: &str) -> String {
         let resolved_name = self.resolve_nameref(name);
-        let (arr_name, extra_index) = if let Some(bracket) = resolved_name.find('[') {
-            let idx_part = &resolved_name[bracket + 1..resolved_name.len() - 1];
-            (&resolved_name[..bracket], Some(idx_part.to_string()))
-        } else {
-            (resolved_name, None)
-        };
+        let (arr_name, extra_index) = parse_embedded_array_ref(resolved_name)
+            .map(|(arr_name, idx_part)| (arr_name, Some(idx_part.to_string())))
+            .unwrap_or((resolved_name, None));
 
         let mut result = String::new();
         if index == "@" || index == "*" {

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -2857,6 +2857,37 @@ echo "result=${a:-cycle_broken}"
         );
     }
 
+    /// TM-DOS-090: malformed nameref array targets must not panic expansion.
+    #[tokio::test]
+    async fn tm_dos_090_malformed_nameref_array_target_does_not_panic() {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            exec(
+                r#"
+arr=(zero one)
+declare -n elem='arr[1]'
+echo "elem=${elem[0]}"
+declare -n ref='['
+echo "before"
+echo "${ref[0]}"
+declare -n ref='a['
+echo "${ref[0]}"
+echo "after"
+"#,
+            ),
+        )
+        .await
+        .expect("malformed nameref target must not panic or hang");
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.stdout.contains("elem=one")
+                && result.stdout.contains("before")
+                && result.stdout.contains("after"),
+            "malformed nameref target should expand safely: {:?}",
+            result.stdout
+        );
+    }
+
     // --- Cross-builtin: injected markers from one builtin don't affect another ---
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent a panic when a nameref target contains malformed embedded array syntax (e.g. `declare -n ref='['`) which was being sliced unsafely. 
- Only treat a resolved nameref target as an embedded array element when it exactly matches `name[index]` to avoid untrusted-script-controlled slicing. 

### Description
- Add `parse_embedded_array_ref(resolved_name: &str) -> Option<(&str, &str)>` that validates and returns `(arr_name, idx)` only for well-formed `name[index]` patterns. 
- Replace unsafe `resolved_name[bracket + 1..resolved_name.len() - 1]` slicing in `expand_array_access_part` with a call to `parse_embedded_array_ref`, preserving existing behavior for valid `arr[index]` cases. 
- Add integration test `tm_dos_090_malformed_nameref_array_target_does_not_panic` covering valid `arr[1]` nameref behavior and malformed targets like `'['` and `a[` to ensure no panic and correct safe fallback. 

### Testing
- Ran `cargo test -p bashkit --test integration tm_dos_090_malformed_nameref_array_target_does_not_panic -- --nocapture` and the test passed. 
- Ran `cargo test -p bashkit --test integration nameref -- --nocapture` and the related nameref integration tests passed. 
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --test integration -- -D warnings` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adbc8c832b9ba8847f7eee099f)