### PR TITLE
fix(interpreter): bound explicit subshell nesting

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2556,6 +2556,7 @@ impl Interpreter {
             CompoundCommand::While(while_cmd) => self.execute_while(while_cmd).await,
             CompoundCommand::Until(until_cmd) => self.execute_until(until_cmd).await,
             CompoundCommand::Subshell(commands) => {
+                self.counters.push_subshell(&self.limits)?;
                 // Subshells run in fully isolated scope: variables, arrays,
                 // functions, cwd, traps, positional params, and options are
                 // all snapshot/restored so mutations don't leak to the parent.
@@ -2602,6 +2603,7 @@ impl Interpreter {
                 self.call_stack = saved_call_stack;
                 self.last_exit_code = saved_exit;
                 self.coproc_buffers = saved_coproc;
+                self.counters.pop_subshell();
 
                 // Consume Exit and Return control flow at subshell boundary —
                 // they only terminate the subshell, not the parent shell.
@@ -12217,6 +12219,21 @@ mod tests {
         assert!(matches!(
             err,
             crate::error::Error::ResourceLimit(crate::limits::LimitExceeded::MaxLoopIterations(2))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_nested_subshells_enforce_depth_limit() {
+        let limits = ExecutionLimits::new().max_subshell_depth(2);
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mut interp = Interpreter::new(Arc::clone(&fs));
+        interp.set_limits(limits);
+        let parser = Parser::new("( ( ( echo too-deep ) ) )");
+        let ast = parser.parse().unwrap();
+        let err = interp.execute(&ast).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::ResourceLimit(crate::limits::LimitExceeded::MaxSubshellDepth(2))
         ));
     }
 

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -93,6 +93,13 @@ pub struct ExecutionLimits {
     /// Default: 32
     pub max_subst_depth: usize,
 
+    // THREAT[TM-DOS-092]: Nested `( ... )` subshells keep saved call-stack
+    // clones and CoW state snapshots alive until unwind. Bound nesting so large
+    // positional parameters/state cannot be multiplied up to max_ast_depth.
+    /// Maximum explicit subshell nesting depth.
+    /// Default: 32
+    pub max_subshell_depth: usize,
+
     /// Maximum persistent custom file descriptors opened via `exec N>file`,
     /// `exec N<file`, or fd duplication. Standard fds 0/1/2 do not count.
     /// Default: 1024
@@ -118,6 +125,7 @@ impl Default for ExecutionLimits {
             max_stdout_bytes: 1_048_576, // 1MB
             max_stderr_bytes: 1_048_576, // 1MB
             max_subst_depth: 32,
+            max_subshell_depth: 32,
             max_file_descriptors: 1024,
             capture_final_env: false,
         }
@@ -233,6 +241,15 @@ impl ExecutionLimits {
         self
     }
 
+    /// Set maximum explicit subshell nesting depth.
+    /// Passing 0 is treated as "use default" (no-op) to prevent misconfiguration.
+    pub fn max_subshell_depth(mut self, depth: usize) -> Self {
+        if depth > 0 {
+            self.max_subshell_depth = depth;
+        }
+        self
+    }
+
     /// Set maximum persistent custom file descriptors.
     /// A value of 0 is a valid strict limit that prevents custom descriptors.
     pub fn max_file_descriptors(mut self, count: usize) -> Self {
@@ -331,6 +348,9 @@ pub struct ExecutionCounters {
     /// Current command substitution nesting depth.
     pub subst_depth: usize,
 
+    /// Current explicit subshell nesting depth.
+    pub subshell_depth: usize,
+
     // THREAT[TM-DOS-059]: Session-level cumulative counters.
     // These persist across exec() calls (never reset by reset_for_execution).
     /// Total commands across all exec() calls in this session.
@@ -353,10 +373,11 @@ impl ExecutionCounters {
         self.commands = 0;
         self.loop_iterations.clear();
         self.total_loop_iterations = 0;
-        // function_depth and subst_depth should already be 0 between exec() calls,
-        // but reset defensively to avoid stuck state
+        // function_depth/subst_depth/subshell_depth should already be 0 between
+        // exec() calls, but reset defensively to avoid stuck state.
         self.function_depth = 0;
         self.subst_depth = 0;
+        self.subshell_depth = 0;
     }
 
     /// Increment command counter, returns error if limit exceeded
@@ -522,6 +543,22 @@ impl ExecutionCounters {
     pub fn pop_subst(&mut self) {
         self.subst_depth = self.subst_depth.saturating_sub(1);
     }
+
+    /// Push explicit subshell, returns error if depth exceeded.
+    /// THREAT[TM-DOS-092]: Explicit subshells keep parent snapshots alive, so
+    /// nesting must be bounded separately from parser AST depth.
+    pub fn push_subshell(&mut self, limits: &ExecutionLimits) -> Result<(), LimitExceeded> {
+        if self.subshell_depth >= limits.max_subshell_depth {
+            return Err(LimitExceeded::MaxSubshellDepth(limits.max_subshell_depth));
+        }
+        self.subshell_depth += 1;
+        Ok(())
+    }
+
+    /// Pop explicit subshell.
+    pub fn pop_subshell(&mut self) {
+        self.subshell_depth = self.subshell_depth.saturating_sub(1);
+    }
 }
 
 /// Error returned when a resource limit is exceeded
@@ -541,6 +578,9 @@ pub enum LimitExceeded {
 
     #[error("maximum command substitution depth exceeded ({0})")]
     MaxSubstDepth(usize),
+
+    #[error("maximum subshell depth exceeded ({0})")]
+    MaxSubshellDepth(usize),
 
     #[error("maximum file descriptors exceeded ({0})")]
     MaxFileDescriptors(usize),
@@ -855,6 +895,8 @@ mod tests {
         assert_eq!(limits.max_parser_operations, 100_000);
         assert_eq!(limits.max_stdout_bytes, 1_048_576);
         assert_eq!(limits.max_stderr_bytes, 1_048_576);
+        assert_eq!(limits.max_subst_depth, 32);
+        assert_eq!(limits.max_subshell_depth, 32);
         assert!(!limits.capture_final_env);
     }
 
@@ -1008,6 +1050,22 @@ mod tests {
     }
 
     #[test]
+    fn test_subshell_depth() {
+        let limits = ExecutionLimits::new().max_subshell_depth(2);
+        let mut counters = ExecutionCounters::new();
+
+        assert!(counters.push_subshell(&limits).is_ok());
+        assert!(counters.push_subshell(&limits).is_ok());
+        assert!(matches!(
+            counters.push_subshell(&limits),
+            Err(LimitExceeded::MaxSubshellDepth(2))
+        ));
+
+        counters.pop_subshell();
+        assert!(counters.push_subshell(&limits).is_ok());
+    }
+
+    #[test]
     fn test_reset_for_execution() {
         let limits = ExecutionLimits::new().max_commands(5);
         let mut counters = ExecutionCounters::new();
@@ -1022,6 +1080,8 @@ mod tests {
         counters.loop_iterations = vec![42];
         counters.total_loop_iterations = 999;
         counters.function_depth = 3;
+        counters.subst_depth = 2;
+        counters.subshell_depth = 2;
 
         // Reset should restore all counters
         counters.reset_for_execution();
@@ -1029,6 +1089,8 @@ mod tests {
         assert!(counters.loop_iterations.is_empty());
         assert_eq!(counters.total_loop_iterations, 0);
         assert_eq!(counters.function_depth, 0);
+        assert_eq!(counters.subst_depth, 0);
+        assert_eq!(counters.subshell_depth, 0);
 
         // Should be able to tick commands again
         assert!(counters.tick_command(&limits).is_ok());
@@ -1047,6 +1109,7 @@ mod tests {
             .max_stdout_bytes(0)
             .max_stderr_bytes(0)
             .max_subst_depth(0)
+            .max_subshell_depth(0)
             .max_file_descriptors(0);
 
         assert_eq!(limits.max_commands, 0);
@@ -1059,6 +1122,7 @@ mod tests {
         assert_eq!(limits.max_stdout_bytes, 0);
         assert_eq!(limits.max_stderr_bytes, 0);
         assert_eq!(limits.max_subst_depth, 0);
+        assert_eq!(limits.max_subshell_depth, 0);
         assert_eq!(limits.max_file_descriptors, 0);
     }
 
@@ -1075,6 +1139,7 @@ mod tests {
             .max_stdout_bytes(2048)
             .max_stderr_bytes(4096)
             .max_subst_depth(8)
+            .max_subshell_depth(6)
             .max_file_descriptors(16);
 
         assert_eq!(limits.max_commands, 5);
@@ -1087,6 +1152,7 @@ mod tests {
         assert_eq!(limits.max_stdout_bytes, 2048);
         assert_eq!(limits.max_stderr_bytes, 4096);
         assert_eq!(limits.max_subst_depth, 8);
+        assert_eq!(limits.max_subshell_depth, 6);
         assert_eq!(limits.max_file_descriptors, 16);
     }
 

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -242,11 +242,9 @@ impl ExecutionLimits {
     }
 
     /// Set maximum explicit subshell nesting depth.
-    /// Passing 0 is treated as "use default" (no-op) to prevent misconfiguration.
+    /// A value of 0 is a valid strict limit that prevents explicit subshells.
     pub fn max_subshell_depth(mut self, depth: usize) -> Self {
-        if depth > 0 {
-            self.max_subshell_depth = depth;
-        }
+        self.max_subshell_depth = depth;
         self
     }
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1386,6 +1386,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-DOS-089 | Command substitution stack overflow via inlined futures | SIGABRT at ~20-30 nested $() levels | Box::pin `expand_word` and `execute_cmd_subst` to cap per-level stack — **FIXED** via #1089 |
 | ~~TM-DOS-090~~ | ~~`shuf` unbounded range/repeat materialization~~ | ~~OOM/CPU exhaustion via huge `--input-range` or `--head-count` before stdout truncation~~ | ~~Sample numeric ranges without full collection and reject output that exceeds `ExecutionLimits` before allocation~~ — `shuf_resource_tests` cover huge range `-n 1` and repeat output caps (**FIXED**) |
 | TM-DOS-091 | SQLite `.dump` cumulative output bypass | `.dump` built the full schema+rows string before checking `max_output_bytes`; an attacker controlling many tables/rows could cause memory to grow far beyond the configured output cap | `bounded_append()` helper enforces the cap after each schema line and each INSERT row; `dispatch()` receives the *remaining* budget (`max_output_bytes - stdout.len()`) from `run_statements` — **FIXED** via #1869 |
+| TM-DOS-092 | Subshell snapshot amplification | Deeply nested `( ... )` keeps CoW state snapshots and call-stack clones alive | `max_subshell_depth` counter (default 32) bounds live explicit subshell snapshots | **MITIGATED** |
 
 ### Accepted (Low Priority)
 


### PR DESCRIPTION
### Motivation
- A change made subshell execution snapshot all interpreter state, enabling nested `( ... )` to multiply live CoW snapshots and exhaust host memory (resource-amplification DoS).  
- Need a lightweight mitigation that preserves subshell isolation semantics while bounding amplification risk.  
- Add an explicit nesting cap for `( ... )` separate from `$()`/parser limits so attacker-controlled state cannot be multiplied arbitrarily.

### Description
- Add new `ExecutionLimits::max_subshell_depth` (default 32) to bound explicit `( ... )` nesting and document the threat (`TM-DOS-092`) in `specs/threat-model.md`.
- Track explicit subshell depth in `ExecutionCounters` with `subshell_depth`, and add `push_subshell` / `pop_subshell` helpers and `LimitExceeded::MaxSubshellDepth` in `crates/bashkit/src/limits.rs`.
- Enforce the subshell limit at runtime by calling `self.counters.push_subshell(&self.limits)?` before executing a `CompoundCommand::Subshell(...)` and `self.counters.pop_subshell()` after restore in `crates/bashkit/src/interpreter/mod.rs`.
- Add unit tests covering counter behavior and interpreter-level rejection: `limits::tests::test_subshell_depth` and `interpreter::tests::test_nested_subshells_enforce_depth_limit`.

### Testing
- Ran `cargo test -p bashkit limits::tests --lib` and all `limits` unit tests passed (included new `test_subshell_depth`).  
- Ran `cargo test -p bashkit --lib` targeted interpreter test `test_nested_subshells_enforce_depth_limit` and it passed after correcting test parser syntax.  
- Ran `cargo fmt --check` and `cargo check -p bashkit` with no errors.  
- The added tests assert that exceeding `max_subshell_depth` returns `LimitExceeded::MaxSubshellDepth` and that counter push/pop/reset behavior is correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc7a58832b8829d8e3792fe21e)