### PR TITLE
fix(bc): cap scale precision

### DIFF
--- a/crates/bashkit/src/builtins/bc.rs
+++ b/crates/bashkit/src/builtins/bc.rs
@@ -9,6 +9,10 @@ use super::{Builtin, Context};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
+// Security cap: Rust's formatter panics above its precision limit, and lower
+// huge values still let tiny untrusted bc programs allocate excessive output.
+const MAX_SCALE: u32 = 1024;
+
 /// The bc builtin - arbitrary-precision calculator.
 ///
 /// Usage: echo "expression" | bc [-l]
@@ -109,6 +113,9 @@ impl BcState {
             let val: u32 = val_str
                 .parse()
                 .map_err(|_| format!("parse error: {}", val_str))?;
+            if val > MAX_SCALE {
+                return Err(format!("scale too large: maximum is {}", MAX_SCALE));
+            }
             self.scale = val;
             return Ok(None);
         }
@@ -592,6 +599,14 @@ mod tests {
     async fn bc_financial_calc() {
         let result = run_bc("scale=2; 100.50 * 1.0825\n", &[]).await;
         assert_eq!(result.stdout, "108.79\n");
+    }
+
+    #[tokio::test]
+    async fn bc_rejects_excessive_scale() {
+        let result = run_bc("scale=65536; 1\n", &[]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("scale too large"));
+        assert_eq!(result.stdout, "");
     }
 
     // ==================== comparisons ====================


### PR DESCRIPTION
### Motivation

- The `bc` builtin accepted unbounded `scale=` values which could trigger a formatting panic or excessive output allocation when used as precision in `format!`.

### Description

- Add a builtin-specific cap `const MAX_SCALE: u32 = 1024` in `crates/bashkit/src/builtins/bc.rs` to limit decimal precision.
- Validate parsed `scale=` in `BcState::execute_statement` and return a user-facing error when `val > MAX_SCALE` instead of storing the value.
- Add a regression test `bc_rejects_excessive_scale` that asserts `scale=65536; 1` fails with a `scale too large` error.
- Preserve existing behavior for normal scale values and other `bc` functionality.

### Testing

- Ran `cargo test -p bashkit builtins::bc::tests::bc_rejects_excessive_scale --lib` and the new test passed (ok).
- Ran `cargo test -p bashkit builtins::bc::tests --lib` and the `bc` test suite passed (22 tests, all ok).
- Ran `cargo fmt --check` and `cargo test -p bashkit builtins::tests::no_debug_fmt_in_builtin_source --lib` which both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad9cb8832b82d68fed3e5c575e)