### PR TITLE
fix(curl): escape multipart backslashes

### DIFF
--- a/crates/bashkit/src/builtins/curl.rs
+++ b/crates/bashkit/src/builtins/curl.rs
@@ -295,7 +295,8 @@ impl Builtin for Curl {
 }
 
 /// Sanitize a multipart field name or filename to prevent header injection.
-/// Rejects CR/LF characters (which could inject headers) and escapes double quotes.
+/// Rejects CR/LF characters (which could inject headers) and escapes quoted-string
+/// metacharacters so names cannot terminate `Content-Disposition` parameters.
 fn sanitize_multipart_name(value: &str, label: &str) -> std::result::Result<String, String> {
     if value.contains('\r') || value.contains('\n') {
         return Err(format!(
@@ -303,7 +304,15 @@ fn sanitize_multipart_name(value: &str, label: &str) -> std::result::Result<Stri
             label
         ));
     }
-    Ok(value.replace('"', "\\\""))
+
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch == '\\' || ch == '"' {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    Ok(escaped)
 }
 
 /// Execute the actual curl request when http_client feature is enabled.
@@ -1321,6 +1330,12 @@ mod tests {
             run_curl_with_stdin_and_fs(&["-d", "plain-data", "https://example.com"], None, &[])
                 .await;
         assert!(result.stderr.contains("network access not configured"));
+    }
+
+    #[test]
+    fn test_sanitize_multipart_name_escapes_backslash_before_quote() {
+        let result = sanitize_multipart_name("foo\\\"; filename=evil", "field name").unwrap();
+        assert_eq!(result, "foo\\\\\\\"; filename=evil");
     }
 
     #[cfg(feature = "http_client")]


### PR DESCRIPTION
### Motivation

- Prevent header-injection / quoted-string breakout when user-controlled multipart field names or filenames contain backslashes before quotes, which the previous sanitizer left unescaped.

### Description

- Change `sanitize_multipart_name` in `crates/bashkit/src/builtins/curl.rs` to escape both backslashes (`\`) and double quotes (`"`) when building HTTP quoted-string parameters.
- Ensure the sanitized output is used in `Content-Disposition` headers for both file and text multipart parts (same function is used at emission sites).
- Add a regression unit test `test_sanitize_multipart_name_escapes_backslash_before_quote` in `crates/bashkit/src/builtins/curl.rs` that verifies a backslash-before-quote value is escaped correctly.

### Testing

- Ran `cargo fmt --check` which passed.
- Ran the targeted unit test via `cargo test -p bashkit test_sanitize_multipart_name_escapes_backslash_before_quote` which passed.
- Ran `cargo test -p bashkit --features http_client sanitize_multipart_name` and `cargo test -p bashkit` and observed all tests pass.
- Note: this checkout had no configured upstream remote so a rebase onto `origin/main` could not be performed from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae6bf8832b96608df9b688ceda)