### PR TITLE
fix(interpreter): clear BASH_SOURCE transient state

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1693,6 +1693,11 @@ impl Interpreter {
         self.pending_fd_capture_depth = 0;
         self.pending_fd_output.clear();
         self.pending_fd_targets.clear();
+        // Top-level timeouts drop the interpreter future at await points, so
+        // BASH_SOURCE cleanup after script execution may not run. Reset both
+        // the private stack and public array before reusing the Bash instance.
+        self.bash_source_stack.clear();
+        self.arrays_mut().remove("BASH_SOURCE");
         for var in Self::SET_OPTION_VARS {
             self.vars_mut().remove(*var);
             if let Some(bit) = BashFlags::from_shopt_name(var) {

--- a/crates/bashkit/tests/integration/bash_source_tests.rs
+++ b/crates/bashkit/tests/integration/bash_source_tests.rs
@@ -1,7 +1,8 @@
 //! Tests for BASH_SOURCE array variable
 
-use bashkit::Bash;
+use bashkit::{Bash, ExecutionLimits};
 use std::path::Path;
+use std::time::Duration;
 
 /// BASH_SOURCE[0] is set when executing a script by path
 #[tokio::test]
@@ -112,4 +113,29 @@ async fn bash_source_guard_sourced() {
 
     let result = bash.exec("source /guard.sh").await.unwrap();
     assert_eq!(result.stdout.trim(), "sourced");
+}
+
+/// Timed-out child bash execution must not leak BASH_SOURCE into later exec calls.
+#[tokio::test]
+async fn bash_source_cleared_after_timed_out_child_bash_script() {
+    let mut bash = Bash::builder()
+        .limits(ExecutionLimits::new().timeout(Duration::from_millis(50)))
+        .build();
+    let fs = bash.fs();
+    fs.write_file(Path::new("/hang.sh"), b"#!/bin/bash\nsleep 1")
+        .await
+        .unwrap();
+    fs.chmod(Path::new("/hang.sh"), 0o755).await.unwrap();
+
+    let timeout_result = bash.exec("bash /hang.sh").await;
+    assert!(
+        timeout_result.is_err(),
+        "child script should hit execution timeout"
+    );
+
+    let result = bash
+        .exec("echo \"source=${BASH_SOURCE[0]}\"")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "source=");
 }


### PR DESCRIPTION
### Motivation
- Timed-out top-level execution can cancel the interpreter future while a child `bash /path/script.sh` is awaiting, skipping the post-await cleanup and leaving stale entries in the internal `bash_source_stack` and public `BASH_SOURCE` array.
- Stale `BASH_SOURCE` entries allow information leakage / state-contamination across `exec()` calls within the same `Bash` instance when timeouts occur.

### Description
- Clear the internal `bash_source_stack` and remove the public `BASH_SOURCE` array during the per-exec reset by updating `Interpreter::reset_transient_state()` to call `self.bash_source_stack.clear()` and `self.arrays_mut().remove("BASH_SOURCE")` before other transient resets.
- Add a regression integration test `bash_source_cleared_after_timed_out_child_bash_script` that sets a short `ExecutionLimits::timeout`, runs `bash /hang.sh` (which sleeps past the timeout) and then asserts a subsequent `exec("echo \"source=${BASH_SOURCE[0]}\"")` yields an empty `BASH_SOURCE[0]`.
- Update the test imports to use `ExecutionLimits` and `Duration` for the new timeout-based test.

### Testing
- Ran `cargo test -p bashkit --test integration bash_source_cleared_after_timed_out_child_bash_script -- --nocapture`, which passed.
- Ran `cargo test -p bashkit --test integration bash_source_tests -- --nocapture`, which passed (all `bash_source` tests including the new regression passed).
- Ran `cargo fmt --check`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adfd5c832ba6e63666ae5beabb)