### PR TITLE
fix(interpreter): respect parentheses in conditional precedence

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2926,6 +2926,97 @@ impl Interpreter {
         })
     }
 
+    fn conditional_word_literal(word: &Word) -> Option<&str> {
+        if word.parts.len() == 1
+            && let WordPart::Literal(s) = &word.parts[0]
+        {
+            return Some(s);
+        }
+        None
+    }
+
+    fn conditional_words_wrapped(words: &[Word]) -> bool {
+        if words.len() < 2
+            || Self::conditional_word_literal(&words[0]) != Some("(")
+            || Self::conditional_word_literal(&words[words.len() - 1]) != Some(")")
+        {
+            return false;
+        }
+
+        let mut depth = 0usize;
+        for (i, word) in words.iter().enumerate() {
+            match Self::conditional_word_literal(word) {
+                Some("(") => depth += 1,
+                Some(")") => {
+                    let Some(next_depth) = depth.checked_sub(1) else {
+                        return false;
+                    };
+                    depth = next_depth;
+                    if depth == 0 && i < words.len() - 1 {
+                        return false;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        depth == 0
+    }
+
+    fn conditional_args_wrapped(args: &[String]) -> bool {
+        if args.len() < 2
+            || args.first().map(|s| s.as_str()) != Some("(")
+            || args.last().map(|s| s.as_str()) != Some(")")
+        {
+            return false;
+        }
+
+        let mut depth = 0usize;
+        for (i, arg) in args.iter().enumerate() {
+            match arg.as_str() {
+                "(" => depth += 1,
+                ")" => {
+                    let Some(next_depth) = depth.checked_sub(1) else {
+                        return false;
+                    };
+                    depth = next_depth;
+                    if depth == 0 && i < args.len() - 1 {
+                        return false;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        depth == 0
+    }
+
+    fn find_top_level_conditional_word_operator(words: &[Word], op: &str) -> Option<usize> {
+        let mut depth = 0usize;
+        for i in (0..words.len()).rev() {
+            match Self::conditional_word_literal(&words[i]) {
+                Some(")") => depth += 1,
+                Some("(") => depth = depth.saturating_sub(1),
+                Some(found) if found == op && depth == 0 && i > 0 => return Some(i),
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn find_top_level_conditional_arg_operator(args: &[String], op: &str) -> Option<usize> {
+        let mut depth = 0usize;
+        for i in (0..args.len()).rev() {
+            match args[i].as_str() {
+                ")" => depth += 1,
+                "(" => depth = depth.saturating_sub(1),
+                found if found == op && depth == 0 && i > 0 => return Some(i),
+                _ => {}
+            }
+        }
+        None
+    }
+
     /// Evaluate [[ ]] from raw words with lazy expansion for short-circuit.
     fn evaluate_conditional_words<'a>(
         &'a mut self,
@@ -2936,48 +3027,32 @@ impl Interpreter {
                 return Ok(false);
             }
 
-            // Helper: get literal text of a word (for operators like &&, ||, !, (, ))
-            let word_literal = |w: &Word| -> Option<String> {
-                if w.parts.len() == 1
-                    && let WordPart::Literal(s) = &w.parts[0]
-                {
-                    return Some(s.clone());
-                }
-                None
-            };
-
             // Handle negation
-            if word_literal(&words[0]).as_deref() == Some("!") {
+            if Self::conditional_word_literal(&words[0]) == Some("!") {
                 return Ok(!self.evaluate_conditional_words(&words[1..]).await?);
             }
 
-            // Handle parentheses
-            if word_literal(&words[0]).as_deref() == Some("(")
-                && word_literal(&words[words.len() - 1]).as_deref() == Some(")")
-            {
+            // Handle parentheses only when they wrap the whole expression.
+            if Self::conditional_words_wrapped(words) {
                 return self
                     .evaluate_conditional_words(&words[1..words.len() - 1])
                     .await;
             }
 
-            // Look for || (lowest precedence), then && — scan right to left
-            for i in (0..words.len()).rev() {
-                if word_literal(&words[i]).as_deref() == Some("||") && i > 0 {
-                    let left = self.evaluate_conditional_words(&words[..i]).await?;
-                    if left {
-                        return Ok(true); // short-circuit: skip right side
-                    }
-                    return self.evaluate_conditional_words(&words[i + 1..]).await;
+            // Look for || (lowest precedence), then && — only at current paren depth.
+            if let Some(i) = Self::find_top_level_conditional_word_operator(words, "||") {
+                let left = self.evaluate_conditional_words(&words[..i]).await?;
+                if left {
+                    return Ok(true); // short-circuit: skip right side
                 }
+                return self.evaluate_conditional_words(&words[i + 1..]).await;
             }
-            for i in (0..words.len()).rev() {
-                if word_literal(&words[i]).as_deref() == Some("&&") && i > 0 {
-                    let left = self.evaluate_conditional_words(&words[..i]).await?;
-                    if !left {
-                        return Ok(false); // short-circuit: skip right side
-                    }
-                    return self.evaluate_conditional_words(&words[i + 1..]).await;
+            if let Some(i) = Self::find_top_level_conditional_word_operator(words, "&&") {
+                let left = self.evaluate_conditional_words(&words[..i]).await?;
+                if !left {
+                    return Ok(false); // short-circuit: skip right side
                 }
+                return self.evaluate_conditional_words(&words[i + 1..]).await;
             }
 
             // Leaf: expand words and evaluate as a simple condition
@@ -3004,26 +3079,19 @@ impl Interpreter {
                 return !self.evaluate_conditional(&args[1..]).await;
             }
 
-            // Handle parentheses
-            if args.first().map(|s| s.as_str()) == Some("(")
-                && args.last().map(|s| s.as_str()) == Some(")")
-            {
+            // Handle parentheses only when they wrap the whole expression.
+            if Self::conditional_args_wrapped(args) {
                 return self.evaluate_conditional(&args[1..args.len() - 1]).await;
             }
 
-            // Look for logical operators: || has lowest precedence, then &&.
-            // Scan for || first (split at lowest precedence first).
-            for i in (0..args.len()).rev() {
-                if args[i] == "||" && i > 0 {
-                    return self.evaluate_conditional(&args[..i]).await
-                        || self.evaluate_conditional(&args[i + 1..]).await;
-                }
+            // Look for logical operators at current paren depth: || lowest, then &&.
+            if let Some(i) = Self::find_top_level_conditional_arg_operator(args, "||") {
+                return self.evaluate_conditional(&args[..i]).await
+                    || self.evaluate_conditional(&args[i + 1..]).await;
             }
-            for i in (0..args.len()).rev() {
-                if args[i] == "&&" && i > 0 {
-                    return self.evaluate_conditional(&args[..i]).await
-                        && self.evaluate_conditional(&args[i + 1..]).await;
-                }
+            if let Some(i) = Self::find_top_level_conditional_arg_operator(args, "&&") {
+                return self.evaluate_conditional(&args[..i]).await
+                    && self.evaluate_conditional(&args[i + 1..]).await;
             }
 
             match args.len() {

--- a/crates/bashkit/tests/spec_cases/bash/conditional.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/conditional.test.sh
@@ -175,6 +175,27 @@ correct
 correct
 ### end
 
+
+### cond_parenthesized_or_outer_and_false
+# Parenthesized || must not be split before the outer &&.
+a=""
+b=""
+c="1"
+[[ ( "$a" || "$b" ) && "$c" ]] && echo wrong || echo correct
+### expect
+correct
+### end
+
+### cond_parenthesized_or_outer_and_true
+# Parenthesized || evaluates first, then the outer &&.
+a=""
+b="1"
+c="1"
+[[ ( "$a" || "$b" ) && "$c" ]] && echo correct || echo wrong
+### expect
+correct
+### end
+
 ### cond_exact_match_no_glob
 # [[ == ]] exact match with no glob chars
 [[ "hello" == "hello" ]] && echo yes || echo no


### PR DESCRIPTION
### Motivation
- A recent change split `[[ ]]` conditionals on `||` before `&&` but did not track parenthesis depth, allowing inner `||` inside parentheses to be treated as a top-level operator and producing incorrect evaluations.

### Description
- Add depth-aware helpers and only split on `||`/`&&` when the operator is at the current parenthesis depth, implemented as `find_top_level_conditional_*_operator` for both raw `Word` and expanded-`String` paths in `crates/bashkit/src/interpreter/mod.rs`.
- Tighten parenthesis stripping so outer parentheses are removed only when they wrap the entire expression, via `conditional_words_wrapped` and `conditional_args_wrapped` for `Word` and `String` code paths respectively.
- Preserve lazy short-circuit evaluation behavior while using the depth-aware operator lookup so semantics and short-circuiting remain unchanged.
- Add two bash spec tests covering `( "$a" || "$b" ) && "$c"` for both false and true scenarios in `crates/bashkit/tests/spec_cases/bash/conditional.test.sh`.

### Testing
- Ran the bash spec suite subset: `cargo test -p bashkit --test integration bash_spec_tests -- --nocapture`, which passed (spec harness reported all bash spec tests passed).
- Ran formatting and lint checks: `cargo fmt --check` and `cargo clippy -p bashkit --test integration -- -D warnings`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc0364832ba5c3d901d9cf9965)