### PR TITLE
fix(find): honor -print0, support negated -type, and fail on dangling -not

### DIFF
--- a/crates/bashkit/src/builtins/ls/find.rs
+++ b/crates/bashkit/src/builtins/ls/find.rs
@@ -19,6 +19,7 @@ pub(super) struct FindOptions {
     pub(super) max_depth: Option<usize>,
     pub(super) min_depth: Option<usize>,
     pub(super) printf_format: Option<String>,
+    pub(super) print0: bool,
     /// -exec/-execdir command template (args before \; or +)
     pub(super) exec_args: Vec<String>,
     /// true if -exec uses + (batch mode), false for \; (per-file mode)
@@ -27,6 +28,8 @@ pub(super) struct FindOptions {
     pub(super) negate_name: bool,
     /// Negate the -path predicate
     pub(super) negate_path: bool,
+    /// Negate the -type predicate
+    pub(super) negate_type: bool,
 }
 
 /// The find builtin - search for files.
@@ -58,10 +61,12 @@ pub(super) fn parse_find_args(
         max_depth: None,
         min_depth: None,
         printf_format: None,
+        print0: false,
         exec_args: Vec::new(),
         exec_batch: false,
         negate_name: false,
         negate_path: false,
+        negate_type: false,
     };
     let mut negate_next = false;
 
@@ -107,7 +112,13 @@ pub(super) fn parse_find_args(
                 }
                 let t = &args[i];
                 match t.as_str() {
-                    "f" | "d" | "l" => opts.type_filter = Some(t.chars().next().unwrap()),
+                    "f" | "d" | "l" => {
+                        opts.type_filter = Some(t.chars().next().unwrap());
+                        if negate_next {
+                            opts.negate_type = true;
+                            negate_next = false;
+                        }
+                    }
                     _ => {
                         return Err(ExecResult::err(format!("find: unknown type '{}'\n", t), 1));
                     }
@@ -149,8 +160,11 @@ pub(super) fn parse_find_args(
                     }
                 }
             }
-            "-print" | "-print0" => {
+            "-print" => {
                 // Default action, ignore
+            }
+            "-print0" => {
+                opts.print0 = true;
             }
             "-printf" => {
                 i += 1;
@@ -193,6 +207,13 @@ pub(super) fn parse_find_args(
         i += 1;
     }
 
+    if negate_next {
+        return Err(ExecResult::err(
+            "find: missing predicate after '-not'\n".to_string(),
+            1,
+        ));
+    }
+
     if paths.is_empty() {
         paths.push(".".to_string());
     }
@@ -223,10 +244,12 @@ async fn collect_find_plan_data(
         max_depth: opts.max_depth,
         min_depth: opts.min_depth,
         printf_format: None, // Don't format, just collect paths
+        print0: false,
         exec_args: Vec::new(),
         exec_batch: false,
         negate_name: opts.negate_name,
         negate_path: opts.negate_path,
+        negate_type: opts.negate_type,
     };
     let mut output = String::new();
     for path_str in search_paths {
@@ -409,9 +432,18 @@ fn find_recursive<'a>(
 
         // Check type filter
         let type_matches = match opts.type_filter {
-            Some('f') => metadata.file_type.is_file(),
-            Some('d') => metadata.file_type.is_dir(),
-            Some('l') => metadata.file_type.is_symlink(),
+            Some('f') => {
+                let m = metadata.file_type.is_file();
+                if opts.negate_type { !m } else { m }
+            }
+            Some('d') => {
+                let m = metadata.file_type.is_dir();
+                if opts.negate_type { !m } else { m }
+            }
+            Some('l') => {
+                let m = metadata.file_type.is_symlink();
+                if opts.negate_type { !m } else { m }
+            }
             _ => true,
         };
 
@@ -445,7 +477,7 @@ fn find_recursive<'a>(
                 output.push_str(&find_printf_format(fmt, display_path, &metadata));
             } else {
                 output.push_str(display_path);
-                output.push('\n');
+                output.push(if opts.print0 { '\0' } else { '\n' });
             }
         }
 

--- a/crates/bashkit/tests/integration/find_multi_path_tests.rs
+++ b/crates/bashkit/tests/integration/find_multi_path_tests.rs
@@ -173,3 +173,73 @@ async fn find_exec_with_missing_path_preserves_error_and_exec_output() {
         result.stderr
     );
 }
+
+#[tokio::test]
+async fn find_print0_uses_nul_delimiters() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/find_print0 && touch /tmp/find_print0/a.txt /tmp/find_print0/b.txt")
+        .await
+        .unwrap();
+
+    let result = bash
+        .exec("find /tmp/find_print0 -type f -print0")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.stdout.contains('\0'),
+        "Expected NUL-delimited output, got: {:?}",
+        result.stdout
+    );
+    assert!(
+        !result.stdout.contains('\n'),
+        "-print0 must not emit newline-delimited output: {:?}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn find_not_negates_type_predicate() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/find_not_type/subdir && touch /tmp/find_not_type/file.txt")
+        .await
+        .unwrap();
+
+    let result = bash
+        .exec("find /tmp/find_not_type -not -type f | sort")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(
+        result.stdout.contains("/tmp/find_not_type/subdir"),
+        "Expected directories in negated type output, got: {:?}",
+        result.stdout
+    );
+    assert!(
+        !result.stdout.contains("/tmp/find_not_type/file.txt"),
+        "Negated -type f must exclude files, got: {:?}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn find_dangling_not_fails_closed() {
+    let mut bash = Bash::builder().build();
+
+    bash.exec("mkdir -p /tmp/find_dangling_not && touch /tmp/find_dangling_not/file.txt")
+        .await
+        .unwrap();
+
+    let result = bash.exec("find /tmp/find_dangling_not -not").await.unwrap();
+
+    assert_ne!(result.exit_code, 0);
+    assert!(
+        result.stderr.contains("missing predicate after '-not'"),
+        "Expected fail-closed diagnostic, got: {:?}",
+        result.stderr
+    );
+}


### PR DESCRIPTION
### Motivation
- Close a fail-open compatibility gap where `-print0`, `-not`/`!` and negated `-type` were parsed but ignored, causing scripts relying on exact `find` semantics to get incorrect results.
- Ensure `find` behavior is predictable for callers that depend on NUL-delimited output, negation, and error-on-missing-predicate semantics.

### Description
- Added `print0` and `negate_type` to `FindOptions` and updated `parse_find_args` to set these when `-print0`, `-not`/`!` and `-type` with preceding negation are used, and to return an error on a dangling `-not` predicate (missing operand).
- Updated `find_recursive` to honor `opts.print0` when emitting paths and to apply `opts.negate_type` when evaluating `-type` predicates.
- Ensured `collect_find_plan_data` constructs a temporary `FindOptions` preserving negation flags and default `print0=false` for planning.
- Added regression integration tests in `crates/bashkit/tests/integration/find_multi_path_tests.rs` for `-print0`, negated `-type`, and a dangling `-not` case.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p bashkit --test integration find_ -- --nocapture` and the targeted integration tests passed (15 passed, 0 failed).
- Ran `cargo clippy -p bashkit --test integration -- -D warnings` and it completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae1604832bb012deb779689ad0)