### PR TITLE
fix(tests): target consolidated integration harness

### DIFF
--- a/.github/workflows/coreutils-args-drift.yml
+++ b/.github/workflows/coreutils-args-drift.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Run cat/tac spec tests
         working-directory: bashkit
-        run: cargo test -p bashkit --test integration bash_spec_tests
+        run: cargo test -p bashkit --test integration -- spec_tests::bash_spec_tests
 
       # Body-drift gate: rebuild the matching uutils binaries from the
       # *same* tree the args codegen ran against, then run the
@@ -193,7 +193,7 @@ jobs:
         working-directory: bashkit
         env:
           BASHKIT_RUN_COREUTILS_DIFF: '1'
-        run: cargo test -p bashkit --test coreutils_differential_tests
+        run: cargo test -p bashkit --test integration -- coreutils_differential_tests::
 
       - name: Capture drift patch
         id: diff

--- a/crates/bashkit/tests/integration/spec_tests.rs
+++ b/crates/bashkit/tests/integration/spec_tests.rs
@@ -1,6 +1,6 @@
 //! Spec test integration - runs all .test.sh files against Bashkit
 //!
-//! Run with: cargo test --test spec_tests
+//! Run with: cargo test --test integration -- spec_tests::
 //!
 //! Test files are in tests/spec_cases/{bash,awk,grep,sed,jq}/
 //!

--- a/justfile
+++ b/justfile
@@ -55,15 +55,15 @@ check-bash-compat-verbose:
 
 # Generate comprehensive compatibility report
 compat-report:
-    cargo test --test spec_tests -- compatibility_report --ignored --nocapture
+    cargo test --test integration -- spec_tests::bash_comparison_tests --ignored --nocapture
 
 # Run differential fuzzing tests (grammar-based proptest)
 fuzz-diff:
-    cargo test --test proptest_differential -- --nocapture
+    cargo test --test integration -- proptest_differential:: --nocapture
 
 # Run differential fuzzing with more iterations
 fuzz-diff-deep:
-    PROPTEST_CASES=500 cargo test --test proptest_differential -- --nocapture
+    PROPTEST_CASES=500 cargo test --test integration -- proptest_differential:: --nocapture
 
 # Clean build artifacts
 clean:

--- a/scripts/update-spec-expected.sh
+++ b/scripts/update-spec-expected.sh
@@ -15,7 +15,7 @@
 # 3. Or add ### bash_diff marker if the difference is intentional
 #
 # This is a wrapper around:
-# cargo test --test spec_tests -- bash_comparison_tests --ignored
+# cargo test --test integration -- spec_tests::bash_comparison_tests --ignored
 
 set -euo pipefail
 
@@ -62,9 +62,9 @@ echo "Checking spec tests against real bash..."
 echo ""
 
 if $VERBOSE; then
-    cargo test --test spec_tests -- bash_comparison_tests --ignored --nocapture 2>&1
+    cargo test --test integration -- spec_tests::bash_comparison_tests --ignored --nocapture 2>&1
 else
-    cargo test --test spec_tests -- bash_comparison_tests --ignored 2>&1
+    cargo test --test integration -- spec_tests::bash_comparison_tests --ignored 2>&1
 fi
 
 exit_code=$?


### PR DESCRIPTION
### Motivation
- Integration tests were consolidated into a single `integration` test binary, which removed standalone Cargo test targets like `spec_tests`, `proptest_differential`, and `coreutils_differential_tests`, breaking CI and developer recipes that still invoked those targets.
- Update all scripts and workflows to call the consolidated `integration` target with module filters so tooling and CI continue to run the same test modules without reintroducing separate binaries.

### Description
- Replace old standalone invocations with module-filtered calls to the consolidated harness, e.g. ``--test spec_tests`` → ``--test integration -- spec_tests::...`` and ``--test proptest_differential`` → ``--test integration -- proptest_differential::``.
- Patch `.github/workflows/coreutils-args-drift.yml` to run `spec_tests::bash_spec_tests` and `coreutils_differential_tests::` via the `integration` binary.
- Update developer `justfile` recipes to run `spec_tests::bash_comparison_tests` and `proptest_differential::` through `integration`.
- Update `scripts/update-spec-expected.sh` wrapper and doc comment to target `integration` with `spec_tests::bash_comparison_tests` and refresh the `spec_tests` module usage comment in `crates/bashkit/tests/integration/spec_tests.rs`.

### Testing
- Ran `cargo test -p bashkit --features http_client,ssh,sqlite --test integration --no-run` which completed successfully.
- Listed integration modules with `cargo test -p bashkit --test integration -- --list | rg '^(spec_tests::(bash_spec_tests|bash_comparison_tests)|proptest_differential::|coreutils_differential_tests::)'` and verified expected modules are present.
- Verified no remaining stale invocations using search commands against `.github/workflows`, `justfile`, and `scripts` and confirmed replacements removed the old targets.
- Ran `cargo fmt --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251aded8c832b9b1aed9360debaf3)