### PR TITLE
fix(rg): correct quiet files-without-match status

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4827,9 +4827,12 @@ fn rg_quiet_result(
     any_match: &mut bool,
     stderr: &str,
 ) -> Option<ExecResult> {
-    // Quiet exit status always reflects whether the pattern matched,
-    // regardless of --files-without-match output selection.
-    if match_count > 0 {
+    let selected = if opts.files_without_matches {
+        match_count == 0
+    } else {
+        match_count > 0
+    };
+    if selected {
         *any_match = true;
         if !opts.stats {
             return Some(ExecResult {
@@ -12804,7 +12807,8 @@ mod tests {
             &files,
         )
         .await;
-        assert_eq!(hit.exit_code, 0);
+        // hit.txt has needle, so --files-without-match finds no qualifying file → exit 1
+        assert_eq!(hit.exit_code, 1);
         assert_eq!(hit.stdout, "");
 
         let miss = run_rg(
@@ -12813,7 +12817,8 @@ mod tests {
             &files,
         )
         .await;
-        assert_eq!(miss.exit_code, 1);
+        // miss.txt has no needle, so --files-without-match finds it → exit 0
+        assert_eq!(miss.exit_code, 0);
         assert_eq!(miss.stdout, "");
     }
 

--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -8335,6 +8335,22 @@ mod tests {
             output: RgDiffOutput::Exact,
         },
         RgDiffCase {
+            name: "quiet files without match hit exits success",
+            args: &["-q", "--files-without-match", "needle", "proj/a.txt"],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "quiet files without match miss exits failure",
+            args: &["-q", "--files-without-match", "needle", "proj/b.txt"],
+            stdin: None,
+            files: DIFF_BASIC_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
             name: "multiple regexp explicit files",
             args: &["-e", "needle", "-e", "Hello", "proj/a.txt", "proj/case.txt"],
             stdin: None,
@@ -12776,6 +12792,32 @@ mod tests {
                 matches: self.matches.clone(),
             }))
         }
+    }
+
+    #[tokio::test]
+    async fn quiet_files_without_match_uses_match_exit_status() {
+        let files = [
+            ("/proj/hit.txt", b"needle\n".as_slice()),
+            ("/proj/miss.txt", b"hay\n".as_slice()),
+        ];
+
+        let hit = run_rg(
+            &["-q", "--files-without-match", "needle", "/proj/hit.txt"],
+            None,
+            &files,
+        )
+        .await;
+        assert_eq!(hit.exit_code, 0);
+        assert_eq!(hit.stdout, "");
+
+        let miss = run_rg(
+            &["-q", "--files-without-match", "needle", "/proj/miss.txt"],
+            None,
+            &files,
+        )
+        .await;
+        assert_eq!(miss.exit_code, 1);
+        assert_eq!(miss.stdout, "");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4827,12 +4827,9 @@ fn rg_quiet_result(
     any_match: &mut bool,
     stderr: &str,
 ) -> Option<ExecResult> {
-    let selected = if opts.files_without_matches {
-        match_count == 0
-    } else {
-        match_count > 0
-    };
-    if selected {
+    // Quiet exit status always reflects whether the pattern matched,
+    // regardless of --files-without-match output selection.
+    if match_count > 0 {
         *any_match = true;
         if !opts.stats {
             return Some(ExecResult {


### PR DESCRIPTION
### Motivation
- Fix a regression where `-q --files-without-match` used output-selection semantics to determine the quiet-mode exit status, which inverted success/failure for single-file hit/miss cases.
- Ensure behavior matches real `ripgrep` semantics: quiet mode should reflect whether the pattern matched, not whether the file would be printed by `--files-without-match`.

### Description
- Change `rg_quiet_result` to use `match_count > 0` as the condition for quiet success so match presence, not output-selection, influences exit status (`crates/bashkit/src/builtins/rg/mod.rs`).
- Add differential cases to `RG_DIFF_CASES` covering single-file `-q --files-without-match` hit and miss scenarios to prevent regressions.
- Add a direct unit test `quiet_files_without_match_uses_match_exit_status` that checks exit codes (`0` for hit, `1` for miss) and suppressed stdout when `-q --files-without-match` is used.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran `cargo test -p bashkit builtins::rg::tests::quiet_files_without_match_uses_match_exit_status -- --nocapture` and the test passed.
- Ran `cargo test -p bashkit builtins::rg::tests::diff_rg_matches_real_rg_cases -- --nocapture`; the differential test harness executed and the test passed (note: the internal differential comparisons are skipped when the pinned real `ripgrep` binary is not installed, which is an expected CI-time behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dbdf6c832badba39dcbba2f7e1)