### PR TITLE
fix(rg): escape glob class set operators

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -2529,6 +2529,12 @@ fn glob_class_to_regex(chars: &[char], start: usize) -> Option<(String, usize)> 
             return Some((out, i + 1));
         }
         saw_member = true;
+        if c == '-' && chars.get(i + 1) == Some(&'-') && !body.is_empty() {
+            // Preserve glob range validation by avoiding Rust regex `--` set difference syntax.
+            body.push_str(r"-\-");
+            i += 2;
+            continue;
+        }
         push_glob_class_char(&mut body, c, chars.get(i + 1).copied());
         i += 1;
     }
@@ -2542,6 +2548,8 @@ fn push_glob_class_char(out: &mut String, c: char, next: Option<char>) {
         ']' => out.push_str(r"\]"),
         '^' if out.is_empty() => out.push_str(r"\^"),
         '-' if out.is_empty() || next == Some(']') => out.push_str(r"\-"),
+        '&' => out.push_str(r"\&"),
+        '~' => out.push_str(r"\~"),
         _ => out.push(c),
     }
 }
@@ -6574,6 +6582,27 @@ mod tests {
     fn glob_brace_alternation_depth_limit_does_not_expand_nested_pattern() {
         let regex = glob_to_regex_with_depth("{a,b}", RG_GLOB_MAX_BRACE_DEPTH);
         assert_eq!(regex, r"^\{a,b\}$");
+    }
+
+    #[test]
+    fn glob_bracket_classes_escape_regex_set_operator_chars() {
+        let regex =
+            build_regex_opts(&glob_to_regex("[a&&b].txt"), false).expect("valid ampersand class");
+        assert!(regex.is_match("a.txt"));
+        assert!(regex.is_match("&.txt"));
+        assert!(regex.is_match("b.txt"));
+
+        let regex =
+            build_regex_opts(&glob_to_regex("[a~~b].txt"), false).expect("valid tilde class");
+        assert!(regex.is_match("a.txt"));
+        assert!(regex.is_match("~.txt"));
+        assert!(regex.is_match("b.txt"));
+    }
+
+    #[test]
+    fn glob_bracket_classes_reject_double_hyphen_operator_ranges() {
+        assert!(RgGlobRule::parse("[a--b].txt", false, false).is_err());
+        assert!(RgTypeGlob::parse("[a--b].txt").is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Rust `regex` treats tokens like `&&`, `~~`, and `--` specially inside character classes, which caused converted glob classes (e.g. `[a&&b]`) to be interpreted incorrectly. 
- This led to incorrect `--glob`, `--type-add` and ignore/type matching behavior compared to real ripgrep and allowed patterns that ripgrep rejects. 
- The change aims to preserve real-ripgrep semantics by escaping regex set-operator characters and preserving invalid-range rejection for double-hyphen sequences.

### Description
- Escape `&` and `~` when emitting glob character-class members by updating `push_glob_class_char` in `crates/bashkit/src/builtins/rg/mod.rs`. 
- Detect a `--` sequence inside a class body in `glob_class_to_regex` and emit an escaped form to avoid Rust regex set-difference parsing so that invalid ranges remain rejected by the glob parser. 
- Add unit tests exercising `[a&&b].txt`, `[a~~b].txt`, and the invalid `[a--b].txt` cases to cover both glob and type parsing paths in the same file.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran the focused unit tests via `cargo test -p bashkit glob_bracket_classes --no-default-features` and both new tests passed. 
- Ran a local test build and unit-test run for the crate which completed with the new tests passing (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad70ec832bb05a2a9d416c9aed)