### PR TITLE
fix(rg): honor `--` delimiter when checking help/version flags

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -289,6 +289,7 @@ pub(crate) fn check_help_version(
 ) -> Option<ExecResult> {
     for arg in args {
         match arg.as_str() {
+            "--" => break,
             "--help" => return Some(ExecResult::ok(help_text.to_string())),
             "--version" => {
                 if let Some(ver) = version {
@@ -1105,6 +1106,13 @@ mod tests {
     fn check_help_version_stops_at_non_flag() {
         let args = vec!["file.txt".to_string(), "--help".to_string()];
         let r = check_help_version(&args, "usage\n", None);
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn check_help_version_stops_at_option_delimiter() {
+        let args = vec!["--".to_string(), "--help".to_string()];
+        let r = check_help_version(&args, "usage\n", Some("v1"));
         assert!(r.is_none());
     }
 

--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4845,6 +4845,12 @@ fn rg_option_takes_value(arg: &str) -> bool {
     )
 }
 
+fn rg_arg_before_delimiter(args: &[String], needle: &str) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == needle)
+}
+
 fn rg_generate_kind(args: &[String]) -> Result<Option<String>> {
     let mut i = 0;
     while i < args.len() {
@@ -4989,16 +4995,16 @@ impl Builtin for Rg {
             "  -g, --glob GLOB\tinclude/exclude paths by glob (!GLOB excludes)\n",
             "  -g, --glob GLOB\tinclude/exclude paths by glob (!GLOB excludes)\n  --iglob GLOB\tcase-insensitive include/exclude path glob\n  --glob-case-insensitive\tmake -g/--glob rules case-insensitive\n  --no-glob-case-insensitive\tdisable case-insensitive -g/--glob rules\n",
         );
-        if ctx.args.iter().any(|arg| arg == "-h") {
+        if rg_arg_before_delimiter(ctx.args, "-h") {
             return Ok(ExecResult::ok(help_text));
         }
-        if ctx.args.iter().any(|arg| arg == "-V") {
+        if rg_arg_before_delimiter(ctx.args, "-V") {
             return Ok(ExecResult::ok("rg (bashkit) 0.1\n".to_string()));
         }
         if let Some(r) = super::check_help_version(ctx.args, &help_text, Some("rg (bashkit) 0.1")) {
             return Ok(r);
         }
-        if ctx.args.iter().any(|arg| arg == "--pcre2-version") {
+        if rg_arg_before_delimiter(ctx.args, "--pcre2-version") {
             return Ok(ExecResult::ok(
                 "PCRE2 10.45 is available (JIT is available)\n".to_string(),
             ));
@@ -6862,6 +6868,10 @@ mod tests {
     ];
 
     const DIFF_DASH_PATTERN_FILES: &[(&str, &[u8])] = &[("/proj/dash.txt", b"-needle\nneedle\n")];
+    const DIFF_DASH_FLAG_FILES: &[(&str, &[u8])] = &[(
+        "/proj/dash-flags.txt",
+        b"-h\n-V\n--help\n--version\n--pcre2-version\nneedle\n",
+    )];
 
     const DIFF_PCRE2_FILES: &[(&str, &[u8])] = &[(
         "/proj/pcre.txt",
@@ -7409,6 +7419,46 @@ mod tests {
             args: &["--", "-needle", "proj/dash.txt"],
             stdin: None,
             files: DIFF_DASH_PATTERN_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "dash delimiter treats short help as pattern",
+            args: &["--", "-h", "proj/dash-flags.txt"],
+            stdin: None,
+            files: DIFF_DASH_FLAG_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "dash delimiter treats short version as pattern",
+            args: &["--", "-V", "proj/dash-flags.txt"],
+            stdin: None,
+            files: DIFF_DASH_FLAG_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "dash delimiter treats long help as pattern",
+            args: &["--", "--help", "proj/dash-flags.txt"],
+            stdin: None,
+            files: DIFF_DASH_FLAG_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "dash delimiter treats long version as pattern",
+            args: &["--", "--version", "proj/dash-flags.txt"],
+            stdin: None,
+            files: DIFF_DASH_FLAG_FILES,
+            cwd: "/",
+            output: RgDiffOutput::Exact,
+        },
+        RgDiffCase {
+            name: "dash delimiter treats pcre2 version as pattern",
+            args: &["--", "--pcre2-version", "proj/dash-flags.txt"],
+            stdin: None,
+            files: DIFF_DASH_FLAG_FILES,
             cwd: "/",
             output: RgDiffOutput::Exact,
         },


### PR DESCRIPTION
### Motivation
- Fix correctness: arguments after the `--` option delimiter must be treated as positional values and not consumed as help/version flags by early shortcut checks in `rg`.
- Ensure parity with real `rg` where `rg -- --help` searches for the literal string `--help` rather than printing help.

### Description
- Stop shared `check_help_version` scanning when `--` is seen by adding a `"--" => break` case in `check_help_version` in `crates/bashkit/src/builtins/mod.rs`.
- Add a helper `rg_arg_before_delimiter(args, needle)` in `crates/bashkit/src/builtins/rg/mod.rs` that searches only up to the `--` delimiter and use it to replace `ctx.args.iter().any(...)` checks for `-h`, `-V`, and `--pcre2-version` so those shortcuts are only honored if they appear before `--`.
- Add unit test `check_help_version_stops_at_option_delimiter` and extend the `rg` differential test matrix with cases that assert dash-prefixed tokens (`-h`, `-V`, `--help`, `--version`, `--pcre2-version`) after `--` are treated as positional patterns/paths.

### Testing
- Ran `cargo fmt --check` (succeeded).
- Ran `cargo test -p bashkit check_help_version_stops_at_option_delimiter` (unit test passed).
- Ran `cargo test -p bashkit builtins::rg::tests::diff_rg_matches_real_rg_cases` (rg differential tests executed and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc44bc832b9e919552c21e42f2)