### PR TITLE
fix(rg): honor rgignore precedence over gitignore

### DIFF
--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -3295,6 +3295,29 @@ async fn load_local_ignore_rules(
         return Ok(());
     }
 
+    // Ignore evaluation is last-match-wins, so load lower-precedence files first.
+    if !opts.no_ignore_vcs && (!opts.require_git || has_git_dir_in_ancestors(fs, dir, root).await) {
+        if !opts.no_ignore_exclude {
+            load_optional_ignore_file_with_rule_base(
+                fs,
+                &dir.join(".git/info/exclude"),
+                dir,
+                opts.ignore_file_case_insensitive,
+                inherited_rule_count,
+                rules,
+            )
+            .await?;
+        }
+        load_optional_ignore_file_with_rule_base(
+            fs,
+            &dir.join(".gitignore"),
+            dir,
+            opts.ignore_file_case_insensitive,
+            inherited_rule_count,
+            rules,
+        )
+        .await?;
+    }
     if !opts.no_ignore_dot {
         load_optional_ignore_file_with_rule_base(
             fs,
@@ -3314,28 +3337,6 @@ async fn load_local_ignore_rules(
             rules,
         )
         .await?;
-    }
-    if !opts.no_ignore_vcs && (!opts.require_git || has_git_dir_in_ancestors(fs, dir, root).await) {
-        load_optional_ignore_file_with_rule_base(
-            fs,
-            &dir.join(".gitignore"),
-            dir,
-            opts.ignore_file_case_insensitive,
-            inherited_rule_count,
-            rules,
-        )
-        .await?;
-        if !opts.no_ignore_exclude {
-            load_optional_ignore_file_with_rule_base(
-                fs,
-                &dir.join(".git/info/exclude"),
-                dir,
-                opts.ignore_file_case_insensitive,
-                inherited_rule_count,
-                rules,
-            )
-            .await?;
-        }
     }
     Ok(())
 }
@@ -13080,6 +13081,31 @@ mod tests {
         assert!(no_vcs.stdout.contains("a.log"));
         assert!(!no_vcs.stdout.contains("src/ignored.txt"));
         assert!(!no_vcs.stdout.contains("rgonly.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_rg_rgignore_overrides_gitignore_conflicts() {
+        let rgignore_ignores_files: &[(&str, &[u8])] = &[
+            ("/proj/.git/config", b"[core]\n"),
+            ("/proj/.gitignore", b"!secret.txt\n"),
+            ("/proj/.rgignore", b"secret.txt\n"),
+            ("/proj/public.txt", b"needle\n"),
+            ("/proj/secret.txt", b"needle\n"),
+        ];
+        let ignored = run_rg(&["--files", "/proj"], None, rgignore_ignores_files).await;
+        assert_eq!(ignored.exit_code, 0);
+        assert!(ignored.stdout.contains("public.txt"));
+        assert!(!ignored.stdout.contains("secret.txt"));
+
+        let rgignore_unignores_files: &[(&str, &[u8])] = &[
+            ("/proj/.git/config", b"[core]\n"),
+            ("/proj/.gitignore", b"secret.txt\n"),
+            ("/proj/.rgignore", b"!secret.txt\n"),
+            ("/proj/secret.txt", b"needle\n"),
+        ];
+        let unignored = run_rg(&["--files", "/proj"], None, rgignore_unignores_files).await;
+        assert_eq!(unignored.exit_code, 0);
+        assert!(unignored.stdout.contains("secret.txt"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Ripgrep-style ignore evaluation is last-match-wins, but local ignore files were loaded in an order that let `.gitignore` override newly-supported `.rgignore` rules, causing incorrect search results.

### Description
- Reorder local ignore-file loading in `crates/bashkit/src/builtins/rg/mod.rs` so VCS ignore files (`.git/info/exclude`, `.gitignore`) are appended before dot-ignore files (`.ignore`, `.rgignore`) so higher-precedence `.rgignore` rules are applied last.
- Add a regression test `test_rg_rgignore_overrides_gitignore_conflicts` covering both ignore and unignore conflict directions between `.rgignore` and `.gitignore`.
- Keep existing behavior and limits; change is limited to `load_local_ignore_rules` rule collection order and tests.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p bashkit test_rg_rgignore_overrides_gitignore_conflicts --lib --no-default-features` which passed.
- Ran `cargo test -p bashkit test_rg_ignore_files_and_disable_flags --lib --no-default-features` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258db93a0832ba4b80094400389dd)