### PR TITLE
fix(bench): avoid predictable sqlite temp file

### DIFF
--- a/scripts/bench-sqlite.sh
+++ b/scripts/bench-sqlite.sh
@@ -3,8 +3,8 @@
 # crates/bashkit/benches/results/, next to the bench source.
 #
 # Usage:
-#   ./scripts/bench-sqlite.sh          # run + save
-#   ./scripts/bench-sqlite.sh --dry    # parse last run without re-running
+#   ./scripts/bench-sqlite.sh                  # run + save
+#   ./scripts/bench-sqlite.sh --dry OUTPUT     # parse trusted output without re-running
 set -euo pipefail
 
 RESULTS_DIR="crates/bashkit/benches/results"
@@ -15,17 +15,35 @@ CPUS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "?")
 TIMESTAMP=$(date +%s)
 MONIKER="${HOSTNAME}-${OS}-${ARCH}"
 
-OUTPUT_FILE=/tmp/criterion-sqlite-output.txt
+usage() {
+    echo "Usage: $0 [--dry TRUSTED_OUTPUT_FILE]" >&2
+}
 
-if [[ "${1:-}" != "--dry" ]]; then
+OUTPUT_FILE=""
+CLEAN_OUTPUT_FILE=0
+
+if [[ "${1:-}" == "--dry" ]]; then
+    if [[ $# -ne 2 ]]; then
+        usage
+        exit 2
+    fi
+    OUTPUT_FILE="$2"
+    if [[ -L "$OUTPUT_FILE" || ! -f "$OUTPUT_FILE" || ! -r "$OUTPUT_FILE" ]]; then
+        echo "Dry output must be a readable regular file: $OUTPUT_FILE" >&2
+        exit 1
+    fi
+    echo "Using trusted output from $OUTPUT_FILE"
+elif [[ $# -eq 0 ]]; then
+    # Security: mktemp creates a private file so tee cannot follow a pre-created /tmp symlink.
+    OUTPUT_FILE=$(mktemp "${TMPDIR:-/tmp}/criterion-sqlite-output.XXXXXX")
+    CLEAN_OUTPUT_FILE=1
+    trap 'if [[ "$CLEAN_OUTPUT_FILE" -eq 1 ]]; then rm -f "$OUTPUT_FILE"; fi' EXIT
+
     echo "Running sqlite benchmark..."
     cargo bench --bench sqlite --features sqlite 2>&1 | tee "$OUTPUT_FILE"
 else
-    if [[ ! -f "$OUTPUT_FILE" ]]; then
-        echo "No previous output found at $OUTPUT_FILE"
-        exit 1
-    fi
-    echo "Using cached output from $OUTPUT_FILE"
+    usage
+    exit 2
 fi
 
 extract_times() {


### PR DESCRIPTION
### Motivation
- The sqlite benchmark script used a fixed `/tmp` output path which allowed local symlink/file-clobber attacks when a developer ran the helper.
- Make the script safe for local/dev runs by ensuring benchmark output is written to a private, atomically-created temp file and that `--dry` requires a trusted input file.

### Description
- Replace the hard-coded `/tmp/criterion-sqlite-output.txt` with a `mktemp`-created output file for normal runs so `tee` cannot follow a pre-created symlink.
- Change `--dry` to require an explicit trusted output file and validate that the path is a readable regular file and not a symlink.
- Add a `trap` to clean the transient temp file on exit and update the usage text/comments to `--dry OUTPUT`.

### Testing
- Ran `bash -n scripts/bench-sqlite.sh` to verify syntax and it succeeded.
- Regression check using a fake `cargo` and a pre-created `/tmp/criterion-sqlite-output.txt` symlink confirmed the victim file was not clobbered (pass).
- Exercised `./scripts/bench-sqlite.sh --dry <sample-output>` to generate a results markdown and confirmed `--dry` rejects symlink inputs (both passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adde50832b99ea531b8c39b121)