### PR TITLE
fix(fs): enforce POSIX mount path prefixes

### DIFF
--- a/crates/bashkit/src/fs/mountable.rs
+++ b/crates/bashkit/src/fs/mountable.rs
@@ -26,7 +26,7 @@ use std::io::ErrorKind;
 /// The bashkit VFS is always POSIX-style on every host, so we cannot use the
 /// platform-aware predicate.
 fn is_posix_absolute(path: &Path) -> bool {
-    path.has_root()
+    path.as_os_str().as_encoded_bytes().starts_with(b"/")
 }
 
 /// Filesystem with Unix-style mount points.
@@ -233,10 +233,9 @@ impl MountableFs {
         }
 
         // Validate against the *input* path: the bashkit VFS is always
-        // POSIX-style, so mount points must start with `/`. We use
-        // `Path::has_root()` rather than `Path::is_absolute()` because the
-        // latter requires a drive prefix on Windows and rejects `/foo`,
-        // which would silently break Windows hosts.
+        // POSIX-style, so mount points must start with `/`. Use a raw
+        // slash-prefix check, not platform-aware Path predicates: on Windows,
+        // rooted drive/UNC paths are not valid VFS mount points.
         if !is_posix_absolute(path.as_ref()) {
             return Err(IoError::other("mount path must be absolute").into());
         }
@@ -725,6 +724,13 @@ mod tests {
     }
 
     #[test]
+    fn test_is_posix_absolute_rejects_windows_rooted_paths() {
+        assert!(!is_posix_absolute(Path::new(r"C:\workspace")));
+        assert!(!is_posix_absolute(Path::new(r"\workspace")));
+        assert!(!is_posix_absolute(Path::new(r"\\server\share\workspace")));
+    }
+
+    #[test]
     fn test_mount_accepts_posix_absolute_path_on_any_host() {
         // Regression: mount("/workspace", ...) must succeed on Windows.
         // Before the `has_root` switch, `Path::is_absolute` rejected POSIX
@@ -735,6 +741,19 @@ mod tests {
         let mfs = MountableFs::new(root);
         mfs.mount("/workspace", mounted.clone()).unwrap();
         mfs.mount("/data/sub", mounted).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_mount_rejects_windows_rooted_path() {
+        let root = Arc::new(InMemoryFs::new());
+        let mounted = Arc::new(InMemoryFs::new());
+
+        let mfs = MountableFs::new(root);
+        let err = mfs.mount(r"C:\workspace", mounted).unwrap_err();
+        assert!(
+            err.to_string().contains("absolute"),
+            "expected 'absolute' in error, got: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- The VFS mount-point contract requires POSIX-style absolute paths that start with `/`, but the helper `is_posix_absolute` used `Path::has_root()`, which is platform-aware and accepts Windows drive/UNC roots on Windows.
- That allowed non-POSIX Windows-rooted strings (e.g. `C:\…`, UNC paths) to pass mount validation, violating the documented POSIX-only policy and risking incorrect configuration.

### Description
- Replace `is_posix_absolute` implementation to perform a raw POSIX-leading-slash check using `path.as_os_str().as_encoded_bytes().starts_with(b"/")` to avoid platform-aware `Path` predicates.
- Update the mount validation comment to document why a raw slash-prefix check is required for the POSIX VFS semantics.
- Add regression tests `test_is_posix_absolute_rejects_windows_rooted_paths` and `test_mount_rejects_windows_rooted_path` to ensure Windows-rooted forms are rejected while preserving `/workspace` acceptance.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran targeted unit tests with `cargo test -p bashkit fs::mountable::tests:: --no-default-features` and the affected tests passed (all mountable tests passed locally).
- Verified the new `is_posix_absolute` and mount rejection tests (`test_is_posix_absolute_rejects_windows_rooted_paths` and `test_mount_rejects_windows_rooted_path`) succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae2af8832b9bce434f17145837)