### PR TITLE
fix(read): treat adjacent mixed IFS delimiters as one sequence

### DIFF
--- a/crates/bashkit/src/builtins/read.rs
+++ b/crates/bashkit/src/builtins/read.rs
@@ -212,7 +212,8 @@ impl Builtin for Read {
                         field_start = i;
                         last_delim_was_non_ws = true;
                     } else {
-                        if field_start != i {
+                        let pushed_field = field_start != i;
+                        if pushed_field {
                             fields.push(ReadField {
                                 text: &line[field_start..i],
                                 start: field_start,
@@ -228,6 +229,26 @@ impl Builtin for Read {
                                 break;
                             }
                         }
+
+                        // IFS whitespace adjacent to a non-whitespace IFS delimiter
+                        // is one delimiter sequence, not an empty field.
+                        if pushed_field && i < line.len() {
+                            let mut next_iter = line[i..].char_indices();
+                            let (_, next_ch) = next_iter.next().expect("valid char boundary");
+                            if ifs_non_ws.contains(&next_ch) {
+                                i += next_ch.len_utf8();
+                                while i < line.len() {
+                                    let mut ws_iter = line[i..].char_indices();
+                                    let (_, ws_ch) = ws_iter.next().expect("valid char boundary");
+                                    if ifs_ws.contains(&ws_ch) {
+                                        i += ws_ch.len_utf8();
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
                         field_start = i;
                         last_delim_was_non_ws = false;
                     }
@@ -708,6 +729,28 @@ mod tests {
         assert_eq!(vars.get("A").unwrap(), "one");
         assert_eq!(vars.get("B").unwrap(), "two");
         assert_eq!(vars.get("C").unwrap(), "three");
+    }
+
+    #[tokio::test]
+    async fn read_mixed_ifs_whitespace_before_non_ws_delimiter() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let mut env = HashMap::new();
+        env.insert("IFS".to_string(), ": ".to_string());
+        let args = vec!["A".to_string(), "B".to_string(), "C".to_string()];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            Some("one : two"),
+        );
+        let result = Read.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let vars = extract_vars(&result);
+        assert_eq!(vars.get("A").unwrap(), "one");
+        assert_eq!(vars.get("B").unwrap(), "two");
+        assert_eq!(vars.get("C").unwrap(), "");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
@@ -83,6 +83,14 @@ echo "a=$a b=$b c=$c"
 a=one b=two c=three
 ### end
 
+### read_ifs_mixed_whitespace_before_non_ws_delimiter
+# IFS whitespace adjacent to a non-whitespace delimiter is one delimiter sequence
+IFS=": " read a b c <<< "one : two"
+echo "a=$a b=$b c=$c"
+### expect
+a=one b=two c=
+### end
+
 ### read_nchars
 # read -n N reads N characters
 read -n 3 var <<< "hello"


### PR DESCRIPTION
### Motivation
- Fix a Bash-compatibility regression in `read` word-splitting where `IFS` combining whitespace and non-whitespace could produce a spurious empty field when whitespace is immediately followed by a non-whitespace IFS delimiter.

### Description
- Update mixed-IFS parser in `crates/bashkit/src/builtins/read.rs` to detect when a whitespace delimiter was pushed and, if followed by a non-whitespace IFS delimiter, consume that delimiter+adjacent IFS-whitespace as a single delimiter sequence instead of emitting an empty field.
- Add a unit test `read_mixed_ifs_whitespace_before_non_ws_delimiter` in `crates/bashkit/src/builtins/read.rs` that exercises `IFS=": "` with input `one : two`.
- Add a bash spec case in `crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh` covering the same scenario.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran the focused unit tests `cargo test -p bashkit read_mixed_ifs_whitespace_before_non_ws_delimiter -- --nocapture` and `cargo test -p bashkit read_mixed_ifs_whitespace_and_non_ws -- --nocapture`, both passed.
- Ran the integration spec runner `cargo test -p bashkit --test integration bash_spec_tests -- --nocapture` which completed with all spec cases passing (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258db80a8832b906a59ac90ccf573)