### PR TITLE
fix(strings): preserve dash-prefixed filenames

### DIFF
--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -55,13 +55,13 @@ fn parse_strings_args(
         } else if p.flag("-a") {
             // Default behavior, ignore
         } else if let Some(arg) = p.current() {
-            if arg != "-" && arg.starts_with('-') {
-                // Try parsing as -NUM shorthand
-                if let Some(rest) = arg.strip_prefix('-')
-                    && let Ok(n) = rest.parse::<usize>()
-                {
-                    opts.min_length = n;
-                }
+            if let Some(rest) = arg.strip_prefix('-')
+                && !rest.is_empty()
+                && rest.chars().all(|c| c.is_ascii_digit())
+            {
+                opts.min_length = rest
+                    .parse()
+                    .map_err(|_| format!("strings: invalid minimum string length: '{}'", rest))?;
                 p.advance();
             } else if let Some(file) = p.positional() {
                 files.push(file.to_string());
@@ -301,6 +301,14 @@ mod tests {
         let result = run_strings_with_fs(&["-8", "/test.bin"], &[("/test.bin", data)]).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "longest-string\n");
+    }
+
+    #[tokio::test]
+    async fn test_strings_dash_prefixed_filename() {
+        let data = b"dash-file\0";
+        let result = run_strings_with_fs(&["-data.bin"], &[("/-data.bin", data)]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "dash-file\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Fix a regression that consumed any dash-prefixed argument (e.g. `-data.bin`) and dropped it instead of treating it as a positional filename while preserving the `-NUM` shorthand behavior.

### Description
- Restrict `-NUM` shorthand parsing in `crates/bashkit/src/builtins/strings.rs` to arguments whose suffix is non-empty and entirely ASCII digits, and parse that suffix into `min_length` only in that case.
- Let nonnumeric dash-prefixed arguments fall through to `p.positional()` so filenames beginning with `-` are accepted.
- Add a regression unit test `test_strings_dash_prefixed_filename` to ensure a filename like `-data.bin` is handled as a file while keeping the existing `-NUM` shorthand test.

### Testing
- Ran `cargo fmt --check`, which succeeded.
- Ran the new unit test `test_strings_dash_prefixed_filename` and the existing shorthand test `test_strings_min_length_shorthand`, both of which passed.
- Ran the crate string test group (`strings` builtin tests) and observed all related tests pass (15 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adaf20832bb0929b4ebdc56088)