### PR TITLE
fix(parser): ignore subscript equals in array appends

### DIFF
--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -1987,10 +1987,49 @@ impl<'a> Parser<'a> {
         s
     }
 
+    /// Find the assignment operator, ignoring `=` characters inside array subscripts.
+    fn assignment_operator_pos(word: &str) -> Option<usize> {
+        let mut bracket_depth = 0usize;
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+        let mut escaped = false;
+
+        for (pos, c) in word.char_indices() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            if bracket_depth > 0 && c == '\\' {
+                escaped = true;
+                continue;
+            }
+
+            match c {
+                '\'' if bracket_depth > 0 && !in_double_quote => {
+                    in_single_quote = !in_single_quote;
+                }
+                '"' if bracket_depth > 0 && !in_single_quote => {
+                    in_double_quote = !in_double_quote;
+                }
+                '[' if !in_single_quote && !in_double_quote => {
+                    bracket_depth += 1;
+                }
+                ']' if bracket_depth > 0 && !in_single_quote && !in_double_quote => {
+                    bracket_depth -= 1;
+                }
+                '=' if bracket_depth == 0 => return Some(pos),
+                _ => {}
+            }
+        }
+
+        None
+    }
+
     /// Check if a word is an assignment (NAME=value, NAME+=value, or NAME[index]=value)
     /// Returns (name, optional_index, value, is_append)
     fn is_assignment(word: &str) -> Option<(&str, Option<&str>, &str, bool)> {
-        let eq_pos = word.find('=')?;
+        let eq_pos = Self::assignment_operator_pos(word)?;
         let mut lhs = &word[..eq_pos];
         let is_append = lhs.ends_with('+');
         if is_append {
@@ -4024,6 +4063,42 @@ mod tests {
         assert!(!cmd.assignments[0].append);
         match &cmd.assignments[0].value {
             AssignmentValue::Scalar(word) => assert_eq!(word.to_string(), "a+=b"),
+            AssignmentValue::Array(_) => panic!("expected scalar assignment"),
+        }
+    }
+
+    #[test]
+    fn test_array_append_assignment_with_equal_in_subscript_parses_as_assignment() {
+        let parser = Parser::new("arr[i=0]+=x");
+        let script = parser.parse().expect("script should parse");
+        let cmd = match &script.commands[0] {
+            Command::Simple(cmd) => cmd,
+            other => panic!("expected simple command, got: {other:?}"),
+        };
+        assert_eq!(cmd.assignments.len(), 1);
+        assert_eq!(cmd.assignments[0].name, "arr");
+        assert_eq!(cmd.assignments[0].index.as_deref(), Some("i=0"));
+        assert!(cmd.assignments[0].append);
+        match &cmd.assignments[0].value {
+            AssignmentValue::Scalar(word) => assert_eq!(word.to_string(), "x"),
+            AssignmentValue::Array(_) => panic!("expected scalar assignment"),
+        }
+    }
+
+    #[test]
+    fn test_assoc_append_assignment_with_equal_in_subscript_parses_as_assignment() {
+        let parser = Parser::new("assoc[key=value]+=x");
+        let script = parser.parse().expect("script should parse");
+        let cmd = match &script.commands[0] {
+            Command::Simple(cmd) => cmd,
+            other => panic!("expected simple command, got: {other:?}"),
+        };
+        assert_eq!(cmd.assignments.len(), 1);
+        assert_eq!(cmd.assignments[0].name, "assoc");
+        assert_eq!(cmd.assignments[0].index.as_deref(), Some("key=value"));
+        assert!(cmd.assignments[0].append);
+        match &cmd.assignments[0].value {
+            AssignmentValue::Scalar(word) => assert_eq!(word.to_string(), "x"),
             AssignmentValue::Array(_) => panic!("expected scalar assignment"),
         }
     }


### PR DESCRIPTION
### Motivation
- A previous change split on the first `=` which misclassified words like `arr[i=0]+=x` because the `=` inside the subscript was chosen as the assignment operator. This broke array/assoc append parsing while fixing `VAR=a+=b` scalar case.
- The parser must locate the assignment operator only when it appears outside array subscripts so both scalar and array append forms remain compatible with Bash semantics.

### Description
- Add `assignment_operator_pos` which scans a word for `=` while ignoring `=` characters inside `[...]`, respecting nested single/double quotes and backslash escapes inside subscripts.
- Update `is_assignment` to use `assignment_operator_pos` instead of `word.find('=')`, preserving `+=` append detection on the full LHS and leaving `value` intact.
- Keep existing identifier validation and array-subscript extraction logic unchanged after the adjusted split.
- Add unit tests `test_array_append_assignment_with_equal_in_subscript_parses_as_assignment` and `test_assoc_append_assignment_with_equal_in_subscript_parses_as_assignment` that assert `arr[i=0]+=x` and `assoc[key=value]+=x` parse as append assignments, and ensure existing `VAR=a+=b` regression remains covered.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p bashkit assignment_with_equal_in_subscript_parses_as_assignment` and the new array/assoc append tests passed.
- Ran `cargo test -p bashkit plus_equal` (existing plus-equal regression test) and it passed; all invoked unit tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae362c832ba26781ef32407be8)