### PR TITLE
fix(alias): preserve mixed quoted glob reparse

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6303,127 +6303,176 @@ impl Interpreter {
             return format!("{}", word);
         }
 
-        let mut out = String::from("\"");
-        for part in &word.parts {
-            match part {
-                WordPart::Literal(s) => {
-                    for ch in s.chars() {
-                        if matches!(ch, '\\' | '"' | '$' | '`') {
-                            out.push('\\');
-                        }
-                        out.push(ch);
+        if word.has_unquoted_glob {
+            // Keep glob metacharacters outside quotes while quoting expansions.
+            // Wrapping the whole word would erase the QuotedGlobWord boundary.
+            let mut out = String::new();
+            for part in &word.parts {
+                match part {
+                    WordPart::Literal(s) => Self::push_alias_reparse_literal(&mut out, s, true),
+                    _ => {
+                        out.push('"');
+                        Self::push_alias_reparse_word_part(&mut out, part);
+                        out.push('"');
                     }
-                }
-                WordPart::Variable(name) => out.push_str(&format!("${}", name)),
-                WordPart::CommandSubstitution(cmd) => out.push_str(&format!("$({:?})", cmd)),
-                WordPart::ArithmeticExpansion(expr) => out.push_str(&format!("$(({}))", expr)),
-                WordPart::ParameterExpansion {
-                    name,
-                    operator,
-                    operand,
-                    colon_variant,
-                } => match operator {
-                    ParameterOp::UseDefault => {
-                        let c = if *colon_variant { ":" } else { "" };
-                        out.push_str(&format!("${{{}{}-{}}}", name, c, operand));
-                    }
-                    ParameterOp::AssignDefault => {
-                        let c = if *colon_variant { ":" } else { "" };
-                        out.push_str(&format!("${{{}{}={}}}", name, c, operand));
-                    }
-                    ParameterOp::UseReplacement => {
-                        let c = if *colon_variant { ":" } else { "" };
-                        out.push_str(&format!("${{{}{}+{}}}", name, c, operand));
-                    }
-                    ParameterOp::Error => {
-                        let c = if *colon_variant { ":" } else { "" };
-                        out.push_str(&format!("${{{}{}?{}}}", name, c, operand));
-                    }
-                    ParameterOp::RemovePrefixShort => {
-                        out.push_str(&format!("${{{}#{}}}", name, operand))
-                    }
-                    ParameterOp::RemovePrefixLong => {
-                        out.push_str(&format!("${{{}##{}}}", name, operand))
-                    }
-                    ParameterOp::RemoveSuffixShort => {
-                        out.push_str(&format!("${{{}%{}}}", name, operand))
-                    }
-                    ParameterOp::RemoveSuffixLong => {
-                        out.push_str(&format!("${{{}%%{}}}", name, operand))
-                    }
-                    ParameterOp::ReplaceFirst {
-                        pattern,
-                        replacement,
-                    } => out.push_str(&format!("${{{}/{}/{}}}", name, pattern, replacement)),
-                    ParameterOp::ReplaceAll {
-                        pattern,
-                        replacement,
-                    } => out.push_str(&format!("${{{}//{}/{}}}", name, pattern, replacement)),
-                    ParameterOp::UpperFirst => out.push_str(&format!("${{{}^}}", name)),
-                    ParameterOp::UpperAll => out.push_str(&format!("${{{}^^}}", name)),
-                    ParameterOp::LowerFirst => out.push_str(&format!("${{{},}}", name)),
-                    ParameterOp::LowerAll => out.push_str(&format!("${{{},,}}", name)),
-                },
-                WordPart::Length(name) => out.push_str(&format!("${{#{}}}", name)),
-                WordPart::ArrayAccess { name, index } => {
-                    out.push_str(&format!("${{{}[{}]}}", name, index))
-                }
-                WordPart::ArrayLength(name) => out.push_str(&format!("${{#{}[@]}}", name)),
-                WordPart::ArrayIndices(name) => out.push_str(&format!("${{!{}[@]}}", name)),
-                WordPart::Substring {
-                    name,
-                    offset,
-                    length,
-                } => {
-                    if let Some(len) = length {
-                        out.push_str(&format!("${{{}:{}:{}}}", name, offset, len));
-                    } else {
-                        out.push_str(&format!("${{{}:{}}}", name, offset));
-                    }
-                }
-                WordPart::ArraySlice {
-                    name,
-                    offset,
-                    length,
-                } => {
-                    if let Some(len) = length {
-                        out.push_str(&format!("${{{}[@]:{}:{}}}", name, offset, len));
-                    } else {
-                        out.push_str(&format!("${{{}[@]:{}}}", name, offset));
-                    }
-                }
-                WordPart::IndirectExpansion {
-                    name,
-                    operator,
-                    operand,
-                    colon_variant,
-                } => {
-                    if let Some(op) = operator {
-                        let c = if *colon_variant { ":" } else { "" };
-                        let op_char = match op {
-                            ParameterOp::UseDefault => "-",
-                            ParameterOp::AssignDefault => "=",
-                            ParameterOp::UseReplacement => "+",
-                            ParameterOp::Error => "?",
-                            _ => "",
-                        };
-                        out.push_str(&format!("${{!{}{}{}{}}}", name, c, op_char, operand));
-                    } else {
-                        out.push_str(&format!("${{!{}}}", name));
-                    }
-                }
-                WordPart::PrefixMatch(prefix) => out.push_str(&format!("${{!{}*}}", prefix)),
-                WordPart::ProcessSubstitution { commands, is_input } => {
-                    let prefix = if *is_input { "<" } else { ">" };
-                    out.push_str(&format!("{}({:?})", prefix, commands));
-                }
-                WordPart::Transformation { name, operator } => {
-                    out.push_str(&format!("${{{}@{}}}", name, operator));
                 }
             }
+            return out;
+        }
+
+        let mut out = String::from("\"");
+        for part in &word.parts {
+            Self::push_alias_reparse_word_part(&mut out, part);
         }
         out.push('"');
         out
+    }
+
+    fn push_alias_reparse_literal(out: &mut String, s: &str, preserve_glob: bool) {
+        for ch in s.chars() {
+            if preserve_glob && matches!(ch, '*' | '?' | '[' | ']') {
+                out.push(ch);
+                continue;
+            }
+            if preserve_glob {
+                match ch {
+                    'a'..='z'
+                    | 'A'..='Z'
+                    | '0'..='9'
+                    | '_'
+                    | '-'
+                    | '.'
+                    | '/'
+                    | ':'
+                    | ','
+                    | '+'
+                    | '='
+                    | '%'
+                    | '@' => out.push(ch),
+                    _ => {
+                        out.push('\\');
+                        out.push(ch);
+                    }
+                }
+            } else {
+                if matches!(ch, '\\' | '"' | '$' | '`') {
+                    out.push('\\');
+                }
+                out.push(ch);
+            }
+        }
+    }
+
+    fn push_alias_reparse_word_part(out: &mut String, part: &WordPart) {
+        match part {
+            WordPart::Literal(s) => Self::push_alias_reparse_literal(out, s, false),
+            WordPart::Variable(name) => out.push_str(&format!("${}", name)),
+            WordPart::CommandSubstitution(cmd) => out.push_str(&format!("$({:?})", cmd)),
+            WordPart::ArithmeticExpansion(expr) => out.push_str(&format!("$(({}))", expr)),
+            WordPart::ParameterExpansion {
+                name,
+                operator,
+                operand,
+                colon_variant,
+            } => match operator {
+                ParameterOp::UseDefault => {
+                    let c = if *colon_variant { ":" } else { "" };
+                    out.push_str(&format!("${{{}{}-{}}}", name, c, operand));
+                }
+                ParameterOp::AssignDefault => {
+                    let c = if *colon_variant { ":" } else { "" };
+                    out.push_str(&format!("${{{}{}={}}}", name, c, operand));
+                }
+                ParameterOp::UseReplacement => {
+                    let c = if *colon_variant { ":" } else { "" };
+                    out.push_str(&format!("${{{}{}+{}}}", name, c, operand));
+                }
+                ParameterOp::Error => {
+                    let c = if *colon_variant { ":" } else { "" };
+                    out.push_str(&format!("${{{}{}?{}}}", name, c, operand));
+                }
+                ParameterOp::RemovePrefixShort => {
+                    out.push_str(&format!("${{{}#{}}}", name, operand))
+                }
+                ParameterOp::RemovePrefixLong => {
+                    out.push_str(&format!("${{{}##{}}}", name, operand))
+                }
+                ParameterOp::RemoveSuffixShort => {
+                    out.push_str(&format!("${{{}%{}}}", name, operand))
+                }
+                ParameterOp::RemoveSuffixLong => {
+                    out.push_str(&format!("${{{}%%{}}}", name, operand))
+                }
+                ParameterOp::ReplaceFirst {
+                    pattern,
+                    replacement,
+                } => out.push_str(&format!("${{{}/{}/{}}}", name, pattern, replacement)),
+                ParameterOp::ReplaceAll {
+                    pattern,
+                    replacement,
+                } => out.push_str(&format!("${{{}//{}/{}}}", name, pattern, replacement)),
+                ParameterOp::UpperFirst => out.push_str(&format!("${{{}^}}", name)),
+                ParameterOp::UpperAll => out.push_str(&format!("${{{}^^}}", name)),
+                ParameterOp::LowerFirst => out.push_str(&format!("${{{},}}", name)),
+                ParameterOp::LowerAll => out.push_str(&format!("${{{},,}}", name)),
+            },
+            WordPart::Length(name) => out.push_str(&format!("${{#{}}}", name)),
+            WordPart::ArrayAccess { name, index } => {
+                out.push_str(&format!("${{{}[{}]}}", name, index))
+            }
+            WordPart::ArrayLength(name) => out.push_str(&format!("${{#{}[@]}}", name)),
+            WordPart::ArrayIndices(name) => out.push_str(&format!("${{!{}[@]}}", name)),
+            WordPart::Substring {
+                name,
+                offset,
+                length,
+            } => {
+                if let Some(len) = length {
+                    out.push_str(&format!("${{{}:{}:{}}}", name, offset, len));
+                } else {
+                    out.push_str(&format!("${{{}:{}}}", name, offset));
+                }
+            }
+            WordPart::ArraySlice {
+                name,
+                offset,
+                length,
+            } => {
+                if let Some(len) = length {
+                    out.push_str(&format!("${{{}[@]:{}:{}}}", name, offset, len));
+                } else {
+                    out.push_str(&format!("${{{}[@]:{}}}", name, offset));
+                }
+            }
+            WordPart::IndirectExpansion {
+                name,
+                operator,
+                operand,
+                colon_variant,
+            } => {
+                if let Some(op) = operator {
+                    let c = if *colon_variant { ":" } else { "" };
+                    let op_char = match op {
+                        ParameterOp::UseDefault => "-",
+                        ParameterOp::AssignDefault => "=",
+                        ParameterOp::UseReplacement => "+",
+                        ParameterOp::Error => "?",
+                        _ => "",
+                    };
+                    out.push_str(&format!("${{!{}{}{}{}}}", name, c, op_char, operand));
+                } else {
+                    out.push_str(&format!("${{!{}}}", name));
+                }
+            }
+            WordPart::PrefixMatch(prefix) => out.push_str(&format!("${{!{}*}}", prefix)),
+            WordPart::ProcessSubstitution { commands, is_input } => {
+                let prefix = if *is_input { "<" } else { ">" };
+                out.push_str(&format!("{}({:?})", prefix, commands));
+            }
+            WordPart::Transformation { name, operator } => {
+                out.push_str(&format!("${{{}@{}}}", name, operator));
+            }
+        }
     }
 
     /// Execute a shell function call with call frame management.

--- a/crates/bashkit/tests/spec_cases/bash/alias.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/alias.test.sh
@@ -190,3 +190,16 @@ cat "$file"
 ### expect
 ok
 ### end
+
+### alias_preserves_mixed_quoted_glob_arg
+# Alias reparse must keep unquoted glob portions outside quotes.
+
+shopt -s expand_aliases
+mkdir d
+printf 'data\n' > d/a.txt
+dir=d
+alias show='printf "<%s>\n" '
+show "$dir"/*.txt
+### expect
+<d/a.txt>
+### end


### PR DESCRIPTION
### Motivation
- Fix a correctness regression where alias reparse wrapped an entire quoted word in `"..."`, erasing the quoted/unquoted boundary and dropping `has_unquoted_glob` so patterns like `"$dir"/*.txt` stopped globbing.
- Ensure alias expansion preserves quoted literalness while still allowing unquoted glob metacharacters to be expanded as originally parsed.

### Description
- Update `format_word_for_alias_reparse` to detect `word.has_unquoted_glob` and emit a representation that keeps glob metacharacters unquoted while quoting expansion parts.
- Add serialization helpers `push_alias_reparse_literal` and `push_alias_reparse_word_part` to centralize escaping/quoting rules and retain variable/expansion syntax intact during reparse.
- Add a bash spec regression `alias_preserves_mixed_quoted_glob_arg` in `crates/bashkit/tests/spec_cases/bash/alias.test.sh` that verifies `show "$dir"/*.txt` expands to matching files under alias reparse.

### Testing
- Ran the integration spec suite with `cargo test -p bashkit --test integration spec_tests::bash_spec_tests -- --nocapture` and the bash spec summary was `Total: 2053 | Passed: 2028 | Failed: 0 | Skipped: 25` (pass rate 100.0%).
- Ran formatter and static checks with `cargo fmt --check` and `git diff --check`, both returned clean results.
- Ran lints with `cargo clippy -p bashkit --test integration -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258db72c8832ba5620e98e7fa5a74)