### PR TITLE
fix(parser): split unquoted mixed-quote suffix expansions

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -32,6 +32,11 @@ static PROC_SUB_COUNTER: AtomicU64 = AtomicU64::new(0);
 // bashkit crate semver so scripts that gate on Bash features keep working.
 const COMPAT_BASH_VERSION: &str = "5.2.15(1)-release";
 const COMPAT_BASH_VERSINFO: [&str; 6] = ["5", "2", "15", "1", "release", "virtual"];
+// Important decision: lexer emits these only for mixed words where an initial
+// quoted segment is followed by an unquoted expansion. Keep them internal and
+// strip before observable output.
+const QUOTED_SEGMENT_START: char = '\x01';
+const QUOTED_SEGMENT_END: char = '\x02';
 
 // Important decision: operand quote sentinels must be selected from a small,
 // parser-inert set. Exhaustive Unicode probing is attacker-amplifiable CPU work.
@@ -8608,7 +8613,10 @@ impl Interpreter {
         &'a mut self,
         word: &'a Word,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<String>> + Send + 'a>> {
-        Box::pin(async move { self.expand_word_inner(word).await })
+        Box::pin(async move {
+            let expanded = self.expand_word_inner(word).await?;
+            Ok(Self::strip_quote_markers(&expanded))
+        })
     }
 
     /// Quote expansion output that came from a quoted segment of a mixed word.
@@ -9112,7 +9120,7 @@ impl Interpreter {
             // when the word is unquoted and contains an expansion.
             // Per POSIX, unquoted variable/command/arithmetic expansion results undergo
             // field splitting on IFS.
-            let expanded = self.expand_word(word).await?;
+            let expanded = self.expand_word_inner(word).await?;
 
             // IFS splitting applies to unquoted expansions only.
             // Skip splitting for assignment-like words (e.g., result="$1") where
@@ -9136,7 +9144,7 @@ impl Interpreter {
             if has_expansion {
                 Ok(self.ifs_split(&expanded))
             } else {
-                Ok(vec![expanded])
+                Ok(vec![Self::strip_quote_markers(&expanded)])
             }
         })
     }
@@ -9253,6 +9261,25 @@ impl Interpreter {
         None
     }
 
+    fn strip_quote_markers(s: &str) -> String {
+        s.chars()
+            .filter(|&c| c != QUOTED_SEGMENT_START && c != QUOTED_SEGMENT_END)
+            .collect()
+    }
+
+    fn quote_marker_chars(s: &str) -> Vec<(char, bool)> {
+        let mut quoted = false;
+        let mut chars = Vec::new();
+        for c in s.chars() {
+            match c {
+                QUOTED_SEGMENT_START => quoted = true,
+                QUOTED_SEGMENT_END => quoted = false,
+                _ => chars.push((c, quoted)),
+            }
+        }
+        chars
+    }
+
     /// Split a string on IFS characters according to POSIX rules.
     ///
     /// - IFS whitespace (space, tab, newline) collapses; leading/trailing stripped.
@@ -9277,49 +9304,61 @@ impl Interpreter {
             .unwrap_or_else(|| " \t\n".to_string());
 
         if ifs.is_empty() {
-            return vec![s.to_string()];
+            return vec![Self::strip_quote_markers(s)];
         }
 
-        let is_ifs = |c: char| ifs.contains(c);
-        let is_ifs_ws = |c: char| ifs.contains(c) && " \t\n".contains(c);
-        let is_ifs_nws = |c: char| ifs.contains(c) && !" \t\n".contains(c);
+        let is_ifs = |c: char, quoted: bool| !quoted && ifs.contains(c);
+        let is_ifs_ws = |c: char, quoted: bool| !quoted && ifs.contains(c) && " \t\n".contains(c);
+        let is_ifs_nws = |c: char, quoted: bool| !quoted && ifs.contains(c) && !" \t\n".contains(c);
         let all_whitespace_ifs = ifs.chars().all(|c| " \t\n".contains(c));
+        let chars = Self::quote_marker_chars(s);
 
         if all_whitespace_ifs {
-            // IFS is only whitespace: split on runs, elide empties
-            return s
-                .split(|c: char| is_ifs(c))
-                .filter(|f| !f.is_empty())
-                .take(limit)
-                .map(|f| f.to_string())
-                .collect();
+            // IFS is only whitespace: split on unquoted runs, elide empties.
+            let mut fields = Vec::new();
+            let mut current = String::new();
+            for &(c, quoted) in &chars {
+                if is_ifs(c, quoted) {
+                    if !current.is_empty() {
+                        fields.push(std::mem::take(&mut current));
+                        if fields.len() >= limit {
+                            return fields;
+                        }
+                    }
+                } else {
+                    current.push(c);
+                }
+            }
+            if !current.is_empty() && fields.len() < limit {
+                fields.push(current);
+            }
+            return fields;
         }
 
         // Mixed or pure non-whitespace IFS.
         let mut fields: Vec<String> = Vec::new();
         let mut current = String::new();
-        let chars: Vec<char> = s.chars().collect();
         let mut i = 0;
 
         // Skip leading IFS whitespace
-        while i < chars.len() && is_ifs_ws(chars[i]) {
+        while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
             i += 1;
         }
         // Leading non-whitespace IFS produces an empty first field
-        if i < chars.len() && is_ifs_nws(chars[i]) {
+        if i < chars.len() && is_ifs_nws(chars[i].0, chars[i].1) {
             fields.push(String::new());
             if fields.len() >= limit {
                 return fields;
             }
             i += 1;
-            while i < chars.len() && is_ifs_ws(chars[i]) {
+            while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                 i += 1;
             }
         }
 
         while i < chars.len() {
-            let c = chars[i];
-            if is_ifs_nws(c) {
+            let (c, quoted) = chars[i];
+            if is_ifs_nws(c, quoted) {
                 // Non-whitespace IFS delimiter: finalize current field
                 fields.push(std::mem::take(&mut current));
                 if fields.len() >= limit {
@@ -9327,22 +9366,22 @@ impl Interpreter {
                 }
                 i += 1;
                 // Consume trailing IFS whitespace
-                while i < chars.len() && is_ifs_ws(chars[i]) {
+                while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                     i += 1;
                 }
-            } else if is_ifs_ws(c) {
+            } else if is_ifs_ws(c, quoted) {
                 // IFS whitespace: skip it, then check for non-ws delimiter
-                while i < chars.len() && is_ifs_ws(chars[i]) {
+                while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                     i += 1;
                 }
-                if i < chars.len() && is_ifs_nws(chars[i]) {
+                if i < chars.len() && is_ifs_nws(chars[i].0, chars[i].1) {
                     // <ws><nws> = single delimiter. Push current field.
                     fields.push(std::mem::take(&mut current));
                     if fields.len() >= limit {
                         return fields;
                     }
                     i += 1; // consume the nws char
-                    while i < chars.len() && is_ifs_ws(chars[i]) {
+                    while i < chars.len() && is_ifs_ws(chars[i].0, chars[i].1) {
                         i += 1;
                     }
                 } else if i < chars.len() {
@@ -14684,6 +14723,18 @@ cat /tmp/test_fd_leak.txt"#,
         assert_eq!(result.exit_code, 0);
         let lines: Vec<&str> = result.stdout.lines().collect();
         assert_eq!(lines, vec!["count:2", "arg1:x", "arg2:yq r"]);
+    }
+
+    // Mixed-quoting: "$v"$u protects only the quoted segment; unquoted $u still splits.
+    #[tokio::test]
+    async fn test_mixed_quote_unquoted_suffix_var_splits() {
+        let result = run_script(
+            r#"v="x y"; u="a b"; set -- "$v"$u; echo "count:$#"; echo "arg1:$1"; echo "arg2:$2""#,
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["count:2", "arg1:x ya", "arg2:b"]);
     }
 
     /// Issue #1184: input process substitution temp files must be cleaned up

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -18,6 +18,18 @@ pub struct SpannedToken {
 /// THREAT[TM-DOS-044]: Prevents stack overflow from deeply nested $() patterns.
 const DEFAULT_MAX_SUBST_DEPTH: usize = 50;
 
+// Important decision: markers preserve quoted segments only until expansion.
+// They let later unquoted continuations split without splitting the quoted prefix.
+const QUOTED_SEGMENT_START: char = '\x01';
+const QUOTED_SEGMENT_END: char = '\x02';
+
+#[derive(Default)]
+struct ContinuationFlags {
+    has_unquoted_expansion: bool,
+    has_unquoted_glob: bool,
+    quoted_ranges: Vec<(usize, usize)>,
+}
+
 /// Lexer for bash scripts.
 pub struct Lexer<'a> {
     #[allow(dead_code)] // Stored for error reporting in future
@@ -1038,7 +1050,7 @@ impl<'a> Lexer<'a> {
 
         // If next char is another quote or word char, concatenate (e.g., 'EOF'"2" -> EOF2).
         // Any quoting makes the whole token literal.
-        self.read_continuation_into(&mut content);
+        let _ = self.read_continuation_into(&mut content);
 
         // Single-quoted strings are literal - no variable expansion. Quote-boundary
         // markers are only for parsed mixed words; LiteralWord keeps contents raw.
@@ -1053,12 +1065,13 @@ impl<'a> Lexer<'a> {
 
     /// After a closing quote, read any adjacent quoted or unquoted word chars
     /// into `content`.  Handles concatenation like `'foo'"bar"baz` -> `foobarbaz`.
-    fn read_continuation_into(&mut self, content: &mut String) {
+    fn read_continuation_into(&mut self, content: &mut String) -> ContinuationFlags {
+        let mut flags = ContinuationFlags::default();
         loop {
             match self.peek_char() {
                 Some('\'') => {
                     self.advance(); // opening '
-                    content.push('\u{1e}');
+                    let start = content.len();
                     while let Some(ch) = self.peek_char() {
                         if ch == '\'' {
                             self.advance(); // closing '
@@ -1067,11 +1080,11 @@ impl<'a> Lexer<'a> {
                         content.push(ch);
                         self.advance();
                     }
-                    content.push('\u{1f}');
+                    flags.quoted_ranges.push((start, content.len()));
                 }
                 Some('"') => {
                     self.advance(); // opening "
-                    content.push('\u{1e}');
+                    let start = content.len();
                     while let Some(ch) = self.peek_char() {
                         if ch == '"' {
                             self.advance(); // closing "
@@ -1102,7 +1115,7 @@ impl<'a> Lexer<'a> {
                         content.push(ch);
                         self.advance();
                     }
-                    content.push('\u{1f}');
+                    flags.quoted_ranges.push((start, content.len()));
                 }
                 Some('$') => {
                     // Check for $'...' ANSI-C quoting in continuation
@@ -1111,24 +1124,29 @@ impl<'a> Lexer<'a> {
                     if lookahead.next() == Some('\'') {
                         self.advance(); // consume $
                         self.advance(); // consume opening '
-                        content.push('\u{1e}');
+                        let start = content.len();
                         Self::push_literal_with_escaped_dollar(
                             content,
                             &self.read_dollar_single_quoted_content(),
                         );
-                        content.push('\u{1f}');
+                        flags.quoted_ranges.push((start, content.len()));
                     } else {
+                        flags.has_unquoted_expansion = true;
                         content.push('$');
                         self.advance();
                     }
                 }
                 Some(ch) if self.is_word_char(ch) => {
+                    if matches!(ch, '*' | '?' | '[') {
+                        flags.has_unquoted_glob = true;
+                    }
                     content.push(ch);
                     self.advance();
                 }
                 _ => break,
             }
         }
+        flags
     }
 
     /// Read ANSI-C quoted content ($'...').
@@ -1386,16 +1404,18 @@ impl<'a> Lexer<'a> {
         if let Some(ch) = self.peek_char()
             && (self.is_word_char(ch) || ch == '\'' || ch == '"' || ch == '$')
         {
-            let original = std::mem::take(&mut content);
-            content.push('\u{1e}');
-            content.push_str(&original);
-            content.push('\u{1f}');
-            let before_len = content.len();
-            self.read_continuation_into(&mut content);
-            let has_glob = content[before_len..]
-                .chars()
-                .any(|c| matches!(c, '*' | '?' | '['));
-            if has_quoted_expansion && has_glob {
+            let quoted_prefix_len = content.len();
+            let flags = self.read_continuation_into(&mut content);
+            if flags.has_unquoted_expansion {
+                let mut ranges = flags.quoted_ranges;
+                ranges.push((0, quoted_prefix_len));
+                for (start, end) in ranges.into_iter().rev() {
+                    content.insert(end, QUOTED_SEGMENT_END);
+                    content.insert(start, QUOTED_SEGMENT_START);
+                }
+                return Some(Token::Word(content));
+            }
+            if has_quoted_expansion && flags.has_unquoted_glob {
                 return Some(Token::QuotedGlobWord(content));
             }
             if has_quoted_expansion {

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1409,7 +1409,13 @@ impl<'a> Lexer<'a> {
             if flags.has_unquoted_expansion {
                 let mut ranges = flags.quoted_ranges;
                 ranges.push((0, quoted_prefix_len));
-                for (start, end) in ranges.into_iter().rev() {
+                // Process from highest byte offset to lowest so each insertion
+                // does not shift the byte positions of ranges not yet processed.
+                // The original push order has the prefix range last, so .rev()
+                // would incorrectly process it first and invalidate multibyte
+                // char boundaries for inner ranges.
+                ranges.sort_unstable_by(|a, b| b.1.cmp(&a.1).then(b.0.cmp(&a.0)));
+                for (start, end) in ranges {
                     content.insert(end, QUOTED_SEGMENT_END);
                     content.insert(start, QUOTED_SEGMENT_START);
                 }


### PR DESCRIPTION
### Motivation
- A recent lexer change marked an entire mixed quoted+unquoted word as quoted when the initial quoted segment contained an expansion, which prevented later unquoted expansions from undergoing POSIX IFS splitting.
- The goal is to preserve IFS-suppression for quoted segments while allowing unquoted continuations (including unquoted `$` expansions) to split and perform glob expansion as in bash.

### Description
- Track continuation-level metadata in the lexer by adding `ContinuationFlags` and recording `quoted_ranges` and `has_unquoted_expansion` in `read_continuation_into` in `crates/bashkit/src/parser/lexer.rs` so the lexer knows which subranges were quoted vs unquoted.
- Emit internal markers (`QUOTED_SEGMENT_START`/`QUOTED_SEGMENT_END`) around quoted ranges only when an unquoted expansion follows, and return `Token::Word` for mixed words that need later unquoted splitting, preserving per-segment quoting information.
- Teach the interpreter to ignore these internal markers in normal output by adding `strip_quote_markers` and to perform IFS splitting while treating characters inside marker-delimited quoted regions as protected in `crates/bashkit/src/interpreter/mod.rs`.
- Replace previous wholesale `QuotedWord` behavior with the new per-segment approach, and add a regression test `test_mixed_quote_unquoted_suffix_var_splits` to ensure `"$v"$u` yields the quoted prefix protected while the unquoted `$u` is still IFS-split.

### Testing
- Ran `cargo fmt --check` and it succeeded.
- Ran unit tests for the mixed-quote area with `cargo test -p bashkit mixed_quote -- --nocapture` and the new/related tests passed.
- Ran `cargo test -p bashkit test_glob_with_quoted_prefix -- --nocapture` and it passed to verify glob behavior remains correct.
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` and it passed (no warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc2c7c832b8fd057497cb24dfa)