### PR TITLE
fix(examples): avoid provider symlink clobber

### DIFF
--- a/crates/bashkit/tests/integration/harness_example_tests.rs
+++ b/crates/bashkit/tests/integration/harness_example_tests.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::Path;
 use std::process::Command;
 
@@ -60,6 +60,63 @@ fn harness_example_installs_non_streaming_openai_override() {
     assert!(
         !override_body.contains("--stream"),
         "override should suppress harness streaming autodetection"
+    );
+}
+
+#[test]
+fn harness_example_does_not_follow_preexisting_provider_symlink() {
+    let temp = tempfile::tempdir().unwrap();
+    let harness_dir = temp.path().join("harness");
+    let work_dir = temp.path().join("work");
+    let providers_dir = work_dir.join(".harness/providers");
+    let target_file = temp.path().join("target.txt");
+    let fake_bashkit = temp.path().join("fake-bashkit");
+
+    fs::create_dir_all(harness_dir.join("bin")).unwrap();
+    fs::create_dir_all(&providers_dir).unwrap();
+    fs::write(&target_file, "victim data").unwrap();
+    let mut perms = fs::metadata(&target_file).unwrap().permissions();
+    perms.set_mode(0o600);
+    fs::set_permissions(&target_file, perms).unwrap();
+    symlink(&target_file, providers_dir.join("openai")).unwrap();
+
+    write_executable(
+        &fake_bashkit,
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\n' ok\n",
+    );
+
+    let output = Command::new("bash")
+        .arg(example_script())
+        .env("BASHKIT", &fake_bashkit)
+        .env("HARNESS_DIR", &harness_dir)
+        .env("WORK_DIR", &work_dir)
+        .env("OPENAI_API_KEY", "dummy")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert_eq!(fs::read_to_string(&target_file).unwrap(), "victim data");
+    assert_eq!(
+        fs::metadata(&target_file).unwrap().permissions().mode() & 0o777,
+        0o600
+    );
+    let override_path = providers_dir.join("openai");
+    assert!(
+        !fs::symlink_metadata(&override_path)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert!(
+        fs::read_to_string(override_path)
+            .unwrap()
+            .contains("exec /harness/plugins/openai/providers/openai \"$@\"")
     );
 }
 

--- a/examples/harness-openai-joke.sh
+++ b/examples/harness-openai-joke.sh
@@ -19,6 +19,10 @@
 # Decision: allow non-git HARNESS_DIR fixtures. Tests inject a minimal directory
 # tree instead of a cloned repo, so only repin when HARNESS_DIR is a git checkout.
 #
+# Decision: install the provider override through a mktemp + rename path. The
+# default work directory lives under /tmp, so never follow a pre-existing
+# providers/openai symlink while writing or chmoding the override.
+#
 # Prerequisites:
 #   - cargo build -p bashkit-cli --features realfs
 #   - OPENAI_API_KEY set in environment
@@ -39,7 +43,7 @@ if [[ ! -x "$BASHKIT" ]]; then
 fi
 
 HARNESS_DIR="${HARNESS_DIR:-/tmp/harness}"
-WORK_DIR="${WORK_DIR:-/tmp/harness-work}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/harness-work.XXXXXX")}"
 HARNESS_HOME="${HARNESS_HOME:-${WORK_DIR}/.harness}"
 HARNESS_REF="${HARNESS_REF:-fcfc0687daa7f28e2355a3ccdb6bafee2a4e8ddb}"
 
@@ -54,12 +58,15 @@ fi
 
 mkdir -p "${HARNESS_HOME}/sessions" "${HARNESS_HOME}/providers"
 
-cat > "${HARNESS_HOME}/providers/openai" <<'EOF'
+provider_override="${HARNESS_HOME}/providers/openai"
+provider_tmp="$(mktemp "${HARNESS_HOME}/providers/openai.XXXXXX")"
+cat > "${provider_tmp}" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 exec /harness/plugins/openai/providers/openai "$@"
 EOF
-chmod +x "${HARNESS_HOME}/providers/openai"
+chmod +x "${provider_tmp}"
+mv -f -- "${provider_tmp}" "${provider_override}"
 
 : "${OPENAI_API_KEY:?OPENAI_API_KEY must be set}"
 


### PR DESCRIPTION
### Motivation

- `examples/harness-openai-joke.sh` wrote `${HARNESS_HOME}/providers/openai` into a predictable `/tmp` location and could follow a pre-existing symlink, allowing local file clobber when the example is run.
- The example's intent is to install a non-streaming provider override for harness without introducing local file-safety risks.

### Description

- Change default `WORK_DIR` to a unique temporary directory using `mktemp -d` so defaults under `/tmp` are not predictable (`examples/harness-openai-joke.sh`).
- Write the provider override via a temp file (`mktemp`), `chmod` the temp file, then `mv -f --` it into `${HARNESS_HOME}/providers/openai` to avoid following preexisting symlinks (`examples/harness-openai-joke.sh`).
- Add a regression test `harness_example_does_not_follow_preexisting_provider_symlink` that pre-creates `.harness/providers/openai` as a symlink and verifies the symlink target's contents and permissions remain unchanged while the override becomes a regular file (`crates/bashkit/tests/integration/harness_example_tests.rs`).
- Import `symlink` in the test module and keep the existing behavioral tests intact.

### Testing

- Ran `cargo test -q -p bashkit --test integration harness_example -- --nocapture`, all integration tests passed (`4 passed; 0 failed`).
- Ran `cargo fmt --check` and `git diff --check`, both reported clean results.
- Manual smoke: executed the example with a fake `BASHKIT` (`OPENAI_API_KEY=dummy BASHKIT=<fake> HARNESS_DIR=<tmp>/harness bash examples/harness-openai-joke.sh`) and observed expected `ok` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dbd5d4832b933f7d637bc0184a)