### PR TITLE
fix(builtins): gate jq command metadata

### DIFF
--- a/crates/bashkit/src/builtins/compgen.rs
+++ b/crates/bashkit/src/builtins/compgen.rs
@@ -26,7 +26,7 @@ const BUILTIN_COMMANDS: &[&str] = &[
     "clear", "column", "comm", "compgen", "continue", "cp", "curl", "cut", "date", "declare", "df",
     "diff", "dirname", "dirs", "dotenv", "du", "echo", "env", "envsubst", "eval", "exit", "expand",
     "export", "expr", "false", "find", "fold", "grep", "gunzip", "gzip", "head", "hexdump",
-    "history", "hostname", "iconv", "id", "jq", "json", "join", "kill", "ln", "local", "log", "ls",
+    "history", "hostname", "iconv", "id", "json", "join", "kill", "ln", "local", "log", "ls",
     "mkdir", "mktemp", "mv", "nl", "od", "paste", "popd", "printenv", "printf", "pushd", "pwd",
     "read", "readlink", "readonly", "realpath", "retry", "return", "rev", "rm", "rmdir", "sed",
     "semver", "seq", "set", "shift", "shopt", "shuf", "sleep", "sort", "source", "split", "stat",
@@ -153,6 +153,11 @@ impl Builtin for Compgen {
                     completions.push(cmd.to_string());
                 }
             }
+            #[cfg(feature = "jq")]
+            if "jq".starts_with(pfx) {
+                completions.push("jq".to_string());
+            }
+
             // Functions from shell context
             if let Some(ref shell) = ctx.shell {
                 for name in shell.functions.keys() {
@@ -299,6 +304,13 @@ mod tests {
         let r = run(&["-c", "--", "ec"], None, None).await;
         assert_eq!(r.exit_code, 0);
         assert!(r.stdout.contains("echo\n"));
+    }
+
+    #[tokio::test]
+    async fn test_jq_completion_matches_enabled_feature() {
+        let r = run(&["-c", "--", "jq"], None, None).await;
+        assert_eq!(r.exit_code == 0, cfg!(feature = "jq"));
+        assert_eq!(r.stdout.contains("jq\n"), cfg!(feature = "jq"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/help.rs
+++ b/crates/bashkit/src/builtins/help.rs
@@ -220,6 +220,7 @@ const BUILTINS: &[CmdInfo] = &[
         usage: "wc [-lwc] [FILE...]",
         description: "Count lines/words/bytes",
     },
+    #[cfg(feature = "jq")]
     CmdInfo {
         name: "jq",
         category: "text",
@@ -539,6 +540,12 @@ mod tests {
         assert!(result.stdout.contains("echo"));
         assert!(result.stdout.contains("grep"));
         assert!(result.stdout.contains("mkdir"));
+    }
+
+    #[tokio::test]
+    async fn test_jq_help_matches_enabled_feature() {
+        let result = run_help(&["jq"]).await;
+        assert_eq!(result.exit_code == 0, cfg!(feature = "jq"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -27,7 +27,7 @@
 //! | Flow control | `true`, `false`, `exit`, `return`, `break`, `continue`, `test`, `[`, `assert` |
 //! | Variables | `export`, `set`, `unset`, `local`, `shift`, `source`, `.`, `eval`, `readonly`, `times`, `declare`, `typeset`, `let`, `dotenv`, `envsubst` |
 //! | Shell | `bash`, `sh` (virtual re-invocation), `:`, `trap`, `caller`, `getopts`, `shopt`, `alias`, `unalias`, `compgen`, `fc`, `help` |
-//! | Text processing | `grep`, `rg`, `sed`, `awk`, `jq`, `head`, `tail`, `sort`, `uniq`, `cut`, `tr`, `wc`, `paste`, `column`, `diff`, `comm`, `strings`, `tac`, `rev`, `seq`, `expr`, `fold`, `expand`, `unexpand`, `join`, `split`, `iconv`, `template` |
+//! | Text processing | `grep`, `rg`, `sed`, `awk`, `jq` (with `jq` feature), `head`, `tail`, `sort`, `uniq`, `cut`, `tr`, `wc`, `paste`, `column`, `diff`, `comm`, `strings`, `tac`, `rev`, `seq`, `expr`, `fold`, `expand`, `unexpand`, `join`, `split`, `iconv`, `template` |
 //! | File operations | `mkdir`, `mktemp`, `mkfifo`, `rm`, `cp`, `mv`, `touch`, `chmod`, `chown`, `ln`, `rmdir`, `realpath`, `readlink`, `glob`, `patch` |
 //! | File inspection | `file`, `stat`, `less` |
 //! | Archives | `tar`, `gzip`, `gunzip`, `zip`, `unzip` |

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -248,9 +248,26 @@ mod duration_millis {
 }
 
 /// List of built-in commands (organized by category)
+#[cfg(feature = "jq")]
 const BUILTINS: &str = "\
 echo printf cat read \
 grep sed awk jq head tail sort uniq cut tr wc nl paste column comm diff strings tac rev \
+cd pwd ls find mkdir mktemp rm rmdir cp mv touch chmod chown ln \
+file stat less tar gzip gunzip du df \
+test [ true false exit return break continue \
+export set unset local shift source eval declare typeset readonly shopt getopts \
+sleep date seq expr yes wait timeout xargs tee watch \
+basename dirname realpath \
+pushd popd dirs \
+whoami hostname uname id env printenv history \
+curl wget \
+od xxd hexdump base64 \
+kill";
+
+#[cfg(not(feature = "jq"))]
+const BUILTINS: &str = "\
+echo printf cat read \
+grep sed awk head tail sort uniq cut tr wc nl paste column comm diff strings tac rev \
 cd pwd ls find mkdir mktemp rm rmdir cp mv touch chmod chown ln \
 file stat less tar gzip gunzip du df \
 test [ true false exit return break continue \
@@ -1398,6 +1415,12 @@ mod tests {
         assert!(tool.help().contains("## Parameters"));
         assert!(tool.system_prompt().starts_with("bashkit:"));
         assert_eq!(tool.version(), VERSION);
+    }
+
+    #[test]
+    fn test_jq_help_matches_enabled_feature() {
+        let helptext = BashTool::default().help();
+        assert_eq!(helptext.contains("awk jq head"), cfg!(feature = "jq"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- A refactor made the `jq` builtin optional via a `jq` feature but the public metadata, discovery, and tests still advertised/assumed `jq` was always present, causing incorrect tooling prompts and failing runtime commands in no-`jq` builds. 
- The intent is to avoid misleading LLM/tool integrations and callers by ensuring help, completion, and BashTool metadata reflect whether `jq` is actually compiled into the build.

### Description
- Gate `BashTool` builtins list in `crates/bashkit/src/tool.rs` so the advertised `BUILTINS` string includes `jq` only when `#[cfg(feature = "jq")]`, and add a `#[cfg(not(feature = "jq"))]` variant that omits `jq`.
- Gate `help` metadata in `crates/bashkit/src/builtins/help.rs` by wrapping the `CmdInfo` entry for `jq` with `#[cfg(feature = "jq")]` so `help jq` is present only when compiled.
- Update `crates/bashkit/src/builtins/compgen.rs` to stop unconditionally advertising `jq` in the hardcoded builtin list and add a `#[cfg(feature = "jq")]` runtime completion branch so `compgen -c jq` appears only when the feature is enabled.
- Clarify top-level Rustdoc in `crates/bashkit/src/lib.rs` to note `jq` requires the `jq` feature, and add small unit tests in `tool.rs`, `help.rs`, and `compgen.rs` that assert help/completion visibility matches `cfg!(feature = "jq")`.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo test -p bashkit --no-default-features test_jq` to validate no-`jq` behavior and the added assertions, which passed.
- Ran `cargo test -p bashkit --features jq test_jq` to validate `jq`-enabled behavior, which passed.
- Existing unit/integration tests that depend on `jq` remain gated by the feature and all executed test runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adaf2c832ba1fd2890b19728c3)