### PR TITLE
Preserve per-part quoting for mixed words so unquoted portions still split/glob

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -8923,6 +8923,51 @@ impl Interpreter {
                 }
             }
 
+            let has_mixed_part_quotes =
+                word.part_quoted.iter().any(|q| *q) && word.part_quoted.iter().any(|q| !*q);
+            if has_mixed_part_quotes {
+                let mut fields = vec![String::new()];
+                for (idx, part) in word.parts.iter().enumerate() {
+                    let part_is_quoted = word.part_quoted.get(idx).copied().unwrap_or(word.quoted);
+                    let part_has_expansion = matches!(
+                        part,
+                        WordPart::Variable(_)
+                            | WordPart::CommandSubstitution(_)
+                            | WordPart::ArithmeticExpansion(_)
+                            | WordPart::ParameterExpansion { .. }
+                            | WordPart::ArrayAccess { .. }
+                    );
+                    let value = if idx > 0
+                        && let WordPart::Literal(s) = part
+                    {
+                        s.clone()
+                    } else {
+                        let single = Word {
+                            parts: vec![part.clone()],
+                            quoted: part_is_quoted,
+                            has_unquoted_glob: false,
+                            part_quoted: vec![part_is_quoted],
+                        };
+                        self.expand_word(&single).await?
+                    };
+
+                    if part_has_expansion && !part_is_quoted {
+                        let split = self.ifs_split(&value);
+                        if let Some((first, rest)) = split.split_first() {
+                            if let Some(current) = fields.last_mut() {
+                                current.push_str(first);
+                            }
+                            for field in rest {
+                                fields.push(field.clone());
+                            }
+                        }
+                    } else if let Some(current) = fields.last_mut() {
+                        current.push_str(&value);
+                    }
+                }
+                return Ok(fields);
+            }
+
             // For other words, expand to a single field then apply IFS word splitting
             // when the word is unquoted and contains an expansion.
             // Per POSIX, unquoted variable/command/arithmetic expansion results undergo
@@ -14449,6 +14494,18 @@ cat /tmp/test_fd_leak.txt"#,
         assert_eq!(result.exit_code, 0);
         let lines: Vec<&str> = result.stdout.lines().collect();
         assert_eq!(lines, vec!["count:1", "arg1:a b csuffix", "arg2:<none>"]);
+    }
+
+    // Regression: only unquoted expansion parts in mixed words undergo IFS splitting.
+    #[tokio::test]
+    async fn test_mixed_quote_unquoted_prefix_var_still_splits() {
+        let result = run_script(
+            r#"a="x y"; b="q r"; set -- $a"$b"; echo "count:$#"; echo "arg1:$1"; echo "arg2:$2""#,
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["count:2", "arg1:x", "arg2:yq r"]);
     }
 
     /// Issue #1184: input process substitution temp files must be cleaned up

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -8962,7 +8962,14 @@ impl Interpreter {
                             }
                         }
                     } else if let Some(current) = fields.last_mut() {
-                        current.push_str(&value);
+                        // Quoted expansion results must not undergo brace/glob expansion
+                        // when an unquoted glob is elsewhere in the word. Escape special
+                        // chars so that expand_braces/expand_glob_item treat them as literals.
+                        if part_is_quoted && part_has_expansion && word.has_unquoted_glob {
+                            current.push_str(&Self::quote_expansion_for_quoted_glob(&value));
+                        } else {
+                            current.push_str(&value);
+                        }
                     }
                 }
                 return Ok(fields);

--- a/crates/bashkit/src/parser/ast.rs
+++ b/crates/bashkit/src/parser/ast.rs
@@ -263,6 +263,12 @@ pub struct Word {
     /// (`quoted == true`) but the unquoted `*` must still undergo glob
     /// expansion.
     pub has_unquoted_glob: bool,
+    /// Per-part quote flags. Needed for mixed words like `$a"$b"`: only
+    /// unquoted expansion parts undergo IFS splitting; quoted parts append
+    /// literally to adjacent fields. Empty for old/test-built words means
+    /// fall back to `quoted` for every part.
+    #[serde(default)]
+    pub part_quoted: Vec<bool>,
 }
 
 impl Word {
@@ -272,6 +278,7 @@ impl Word {
             parts: vec![WordPart::Literal(s.into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         }
     }
 
@@ -281,6 +288,7 @@ impl Word {
             parts: vec![WordPart::Literal(s.into())],
             quoted: true,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         }
     }
 }
@@ -590,6 +598,7 @@ mod tests {
             parts: vec![WordPart::Variable("HOME".into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "$HOME");
     }
@@ -600,6 +609,7 @@ mod tests {
             parts: vec![WordPart::ArithmeticExpansion("1+2".into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "$((1+2))");
     }
@@ -610,6 +620,7 @@ mod tests {
             parts: vec![WordPart::Length("var".into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${#var}");
     }
@@ -623,6 +634,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${arr[0]}");
     }
@@ -633,6 +645,7 @@ mod tests {
             parts: vec![WordPart::ArrayLength("arr".into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${#arr[@]}");
     }
@@ -643,6 +656,7 @@ mod tests {
             parts: vec![WordPart::ArrayIndices("arr".into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${!arr[@]}");
     }
@@ -657,6 +671,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var:2:3}");
     }
@@ -671,6 +686,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var:2}");
     }
@@ -685,6 +701,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${arr[@]:1:2}");
     }
@@ -699,6 +716,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${arr[@]:1}");
     }
@@ -714,6 +732,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${!ref}");
     }
@@ -724,6 +743,7 @@ mod tests {
             parts: vec![WordPart::PrefixMatch("MY_".into())],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${!MY_*}");
     }
@@ -737,6 +757,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var@Q}");
     }
@@ -750,6 +771,7 @@ mod tests {
             ],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "hello $USER");
     }
@@ -765,6 +787,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var:-fallback}");
     }
@@ -780,6 +803,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var-fallback}");
     }
@@ -795,6 +819,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var:=val}");
     }
@@ -810,6 +835,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var:+alt}");
     }
@@ -825,6 +851,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var:?msg}");
     }
@@ -841,6 +868,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var#pat}");
 
@@ -854,6 +882,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var##pat}");
 
@@ -867,6 +896,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var%pat}");
 
@@ -880,6 +910,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var%%pat}");
     }
@@ -898,6 +929,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var/old/new}");
 
@@ -913,6 +945,7 @@ mod tests {
             }],
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted: Vec::new(),
         };
         assert_eq!(format!("{w}"), "${var///old/new}");
     }
@@ -929,6 +962,7 @@ mod tests {
                 }],
                 quoted: false,
                 has_unquoted_glob: false,
+                part_quoted: Vec::new(),
             };
             assert_eq!(format!("{w}"), expected);
         };

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -411,6 +411,9 @@ impl<'a> Lexer<'a> {
                 // Word already has content (the prefix) — concatenate the quoted segment
                 let quote_char = ch;
                 self.advance();
+                if quote_char == '"' {
+                    word.push('\u{1e}');
+                }
                 while let Some(c) = self.peek_char() {
                     if c == quote_char {
                         self.advance();
@@ -464,6 +467,9 @@ impl<'a> Lexer<'a> {
                     }
                     word.push(c);
                     self.advance();
+                }
+                if quote_char == '"' {
+                    word.push('\u{1f}');
                 }
                 continue;
             } else if ch == '$' {
@@ -546,6 +552,9 @@ impl<'a> Lexer<'a> {
                 // This handles: VAR="val", date +"%Y", echo foo"bar"
                 let quote_char = ch;
                 self.advance(); // consume opening quote
+                if quote_char == '"' {
+                    word.push('\u{1e}');
+                }
                 while let Some(c) = self.peek_char() {
                     if c == quote_char {
                         self.advance(); // consume closing quote
@@ -610,6 +619,9 @@ impl<'a> Lexer<'a> {
                     word.push(c);
                     self.advance();
                 }
+                if quote_char == '"' {
+                    word.push('\u{1f}');
+                }
                 continue;
             } else if ch == '$' {
                 // Handle variable references and command substitution
@@ -618,10 +630,12 @@ impl<'a> Lexer<'a> {
                 // $'...' — ANSI-C quoting: resolve escapes at parse time
                 if self.peek_char() == Some('\'') {
                     self.advance(); // consume opening '
+                    word.push('\u{1e}');
                     Self::push_literal_with_escaped_dollar(
                         &mut word,
                         &self.read_dollar_single_quoted_content(),
                     );
+                    word.push('\u{1f}');
                     // ANSI-C quotes are single-quote semantics: quoted context.
                     has_quoted_expansion = true;
                     continue;
@@ -632,6 +646,7 @@ impl<'a> Lexer<'a> {
                     self.advance(); // consume opening "
                     // Locale quotes are double-quote semantics: quoted context.
                     has_quoted_expansion = true;
+                    word.push('\u{1e}');
                     while let Some(c) = self.peek_char() {
                         if c == '"' {
                             self.advance();
@@ -715,6 +730,7 @@ impl<'a> Lexer<'a> {
                         word.push(c);
                         self.advance();
                     }
+                    word.push('\u{1f}');
                     continue;
                 }
 
@@ -1024,10 +1040,10 @@ impl<'a> Lexer<'a> {
         // Any quoting makes the whole token literal.
         self.read_continuation_into(&mut content);
 
-        // Single-quoted strings are literal - no variable expansion.
-        // Decode NUL escape sentinels from continued double-quoted segments
-        // before returning a token that bypasses parse_word().
-        // Only allocate when the sentinel is actually present (common case: none).
+        // Single-quoted strings are literal - no variable expansion. Quote-boundary
+        // markers are only for parsed mixed words; LiteralWord keeps contents raw.
+        // Also decode any NUL escape sentinels from continued double-quoted segments.
+        content.retain(|ch| ch != '\u{1e}' && ch != '\u{1f}');
         Some(Token::LiteralWord(if content.contains('\x00') {
             Self::decode_nul_escape_sentinel(&content)
         } else {
@@ -1042,6 +1058,7 @@ impl<'a> Lexer<'a> {
             match self.peek_char() {
                 Some('\'') => {
                     self.advance(); // opening '
+                    content.push('\u{1e}');
                     while let Some(ch) = self.peek_char() {
                         if ch == '\'' {
                             self.advance(); // closing '
@@ -1050,9 +1067,11 @@ impl<'a> Lexer<'a> {
                         content.push(ch);
                         self.advance();
                     }
+                    content.push('\u{1f}');
                 }
                 Some('"') => {
                     self.advance(); // opening "
+                    content.push('\u{1e}');
                     while let Some(ch) = self.peek_char() {
                         if ch == '"' {
                             self.advance(); // closing "
@@ -1083,6 +1102,7 @@ impl<'a> Lexer<'a> {
                         content.push(ch);
                         self.advance();
                     }
+                    content.push('\u{1f}');
                 }
                 Some('$') => {
                     // Check for $'...' ANSI-C quoting in continuation
@@ -1091,10 +1111,12 @@ impl<'a> Lexer<'a> {
                     if lookahead.next() == Some('\'') {
                         self.advance(); // consume $
                         self.advance(); // consume opening '
+                        content.push('\u{1e}');
                         Self::push_literal_with_escaped_dollar(
                             content,
                             &self.read_dollar_single_quoted_content(),
                         );
+                        content.push('\u{1f}');
                     } else {
                         content.push('$');
                         self.advance();
@@ -1364,6 +1386,10 @@ impl<'a> Lexer<'a> {
         if let Some(ch) = self.peek_char()
             && (self.is_word_char(ch) || ch == '\'' || ch == '"' || ch == '$')
         {
+            let original = std::mem::take(&mut content);
+            content.push('\u{1e}');
+            content.push_str(&original);
+            content.push('\u{1f}');
             let before_len = content.len();
             self.read_continuation_into(&mut content);
             let has_glob = content[before_len..]

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -854,6 +854,7 @@ impl<'a> Parser<'a> {
                             parts: vec![WordPart::Literal(w.clone())],
                             quoted: true,
                             has_unquoted_glob: false,
+                            part_quoted: Vec::new(),
                         });
                         self.advance();
                     }
@@ -955,6 +956,7 @@ impl<'a> Parser<'a> {
                         parts: vec![WordPart::Literal(w.clone())],
                         quoted: true,
                         has_unquoted_glob: false,
+                        part_quoted: Vec::new(),
                     });
                     self.advance();
                 }
@@ -1538,6 +1540,7 @@ impl<'a> Parser<'a> {
                             parts: vec![WordPart::Literal(w_clone)],
                             quoted: true,
                             has_unquoted_glob: false,
+                            part_quoted: Vec::new(),
                         }
                     } else {
                         let mut parsed = self.parse_word(w_clone);
@@ -2061,6 +2064,7 @@ impl<'a> Parser<'a> {
                             parts: vec![WordPart::Literal(elem_clone)],
                             quoted: true,
                             has_unquoted_glob: false,
+                            part_quoted: Vec::new(),
                         }
                     } else if matches!(
                         &self.current_token,
@@ -2159,6 +2163,7 @@ impl<'a> Parser<'a> {
                 parts: vec![WordPart::Literal(inner.to_string())],
                 quoted: true,
                 has_unquoted_glob: false,
+                part_quoted: Vec::new(),
             }
         } else {
             self.parse_word(value_str)
@@ -2456,6 +2461,7 @@ impl<'a> Parser<'a> {
                                 parts: vec![WordPart::Literal(w)],
                                 quoted: true,
                                 has_unquoted_glob: false,
+                                part_quoted: Vec::new(),
                             }
                         } else {
                             let mut word = self.parse_word(w);
@@ -2476,6 +2482,7 @@ impl<'a> Parser<'a> {
                             parts: vec![WordPart::Literal(w)],
                             quoted: true,
                             has_unquoted_glob: false,
+                            part_quoted: Vec::new(),
                         }
                     } else {
                         let mut word = self.parse_word(w);
@@ -2720,6 +2727,7 @@ impl<'a> Parser<'a> {
                     parts: vec![WordPart::Literal(w.clone())],
                     quoted: true,
                     has_unquoted_glob: false,
+                    part_quoted: Vec::new(),
                 };
                 self.advance();
                 Ok(word)
@@ -2828,6 +2836,7 @@ impl<'a> Parser<'a> {
                     parts: vec![WordPart::ProcessSubstitution { commands, is_input }],
                     quoted: false,
                     has_unquoted_glob: false,
+                    part_quoted: Vec::new(),
                 })
             }
             _ => Err(self.error("expected word")),
@@ -2857,6 +2866,7 @@ impl<'a> Parser<'a> {
                 parts: vec![WordPart::Literal(w.clone())],
                 quoted: true,
                 has_unquoted_glob: false,
+                part_quoted: Vec::new(),
             }),
             _ => None,
         }
@@ -2889,8 +2899,16 @@ impl<'a> Parser<'a> {
     /// Parse a word string into a Word with proper parts (variables, literals)
     fn parse_word(&self, s: String) -> Word {
         let mut parts = Vec::new();
+        let mut part_quoted = Vec::new();
         let mut chars = s.chars().peekable();
         let mut current = String::new();
+        let mut in_quoted_segment = false;
+        macro_rules! push_part {
+            ($part:expr) => {{
+                parts.push($part);
+                part_quoted.push(in_quoted_segment);
+            }};
+        }
 
         while let Some(ch) = chars.next() {
             if ch == '\x00' {
@@ -2898,10 +2916,14 @@ impl<'a> Parser<'a> {
                 if let Some(literal_ch) = chars.next() {
                     current.push(literal_ch);
                 }
+            } else if ch == '\u{1e}' {
+                in_quoted_segment = true;
+            } else if ch == '\u{1f}' {
+                in_quoted_segment = false;
             } else if ch == '$' {
                 // Flush current literal
                 if !current.is_empty() {
-                    parts.push(WordPart::Literal(std::mem::take(&mut current)));
+                    push_part!(WordPart::Literal(std::mem::take(&mut current)));
                 }
 
                 // Check for $'...' - ANSI-C quoting
@@ -2933,7 +2955,7 @@ impl<'a> Parser<'a> {
                             ansi.push(c);
                         }
                     }
-                    parts.push(WordPart::Literal(ansi));
+                    push_part!(WordPart::Literal(ansi));
                 } else if chars.peek() == Some(&'(') {
                     // Check for $( - command substitution or arithmetic
                     chars.next(); // consume first '('
@@ -2961,7 +2983,7 @@ impl<'a> Parser<'a> {
                         if expr.ends_with(')') {
                             expr.pop();
                         }
-                        parts.push(WordPart::ArithmeticExpansion(expr));
+                        push_part!(WordPart::ArithmeticExpansion(expr));
                     } else {
                         // Command substitution $(...)
                         let mut cmd_str = String::new();
@@ -2986,7 +3008,7 @@ impl<'a> Parser<'a> {
                         let inner_parser =
                             Parser::with_limits(&cmd_str, remaining_depth, self.fuel);
                         if let Ok(script) = inner_parser.parse() {
-                            parts.push(WordPart::CommandSubstitution(script.commands));
+                            push_part!(WordPart::CommandSubstitution(script.commands));
                         }
                     }
                 } else if chars.peek() == Some(&'{') {
@@ -3019,17 +3041,17 @@ impl<'a> Parser<'a> {
                                 chars.next();
                             }
                             if index == "@" || index == "*" {
-                                parts.push(WordPart::ArrayLength(var_name));
+                                push_part!(WordPart::ArrayLength(var_name));
                             } else {
                                 // ${#arr[n]} - length of element (same as ${#arr[n]})
-                                parts.push(WordPart::Length(format!("{}[{}]", var_name, index)));
+                                push_part!(WordPart::Length(format!("{}[{}]", var_name, index)));
                             }
                         } else {
                             // Consume closing }
                             if chars.peek() == Some(&'}') {
                                 chars.next();
                             }
-                            parts.push(WordPart::Length(var_name));
+                            push_part!(WordPart::Length(var_name));
                         }
                     } else if chars.peek() == Some(&'!') {
                         // Check for ${!arr[@]} or ${!arr[*]} - array indices
@@ -3067,15 +3089,15 @@ impl<'a> Parser<'a> {
                                 chars.next();
                             }
                             if index == "@" || index == "*" {
-                                parts.push(WordPart::ArrayIndices(var_name));
+                                push_part!(WordPart::ArrayIndices(var_name));
                             } else {
                                 // ${!arr[n]} - not standard, treat as variable
-                                parts.push(WordPart::Variable(format!("!{}[{}]", var_name, index)));
+                                push_part!(WordPart::Variable(format!("!{}[{}]", var_name, index)));
                             }
                         } else if chars.peek() == Some(&'}') {
                             // ${!var} - indirect expansion (no operator)
                             chars.next(); // consume '}'
-                            parts.push(WordPart::IndirectExpansion {
+                            push_part!(WordPart::IndirectExpansion {
                                 name: var_name,
                                 operator: None,
                                 operand: String::new(),
@@ -3099,7 +3121,7 @@ impl<'a> Parser<'a> {
                                     '?' => ParameterOp::Error,
                                     _ => unreachable!(),
                                 };
-                                parts.push(WordPart::IndirectExpansion {
+                                push_part!(WordPart::IndirectExpansion {
                                     name: var_name,
                                     operator: Some(operator),
                                     operand,
@@ -3115,7 +3137,7 @@ impl<'a> Parser<'a> {
                                     }
                                     suffix.push(chars.next().unwrap());
                                 }
-                                parts.push(WordPart::Variable(format!("!{}{}", var_name, suffix)));
+                                push_part!(WordPart::Variable(format!("!{}{}", var_name, suffix)));
                             }
                         } else if matches!(
                             chars.peek(),
@@ -3131,7 +3153,7 @@ impl<'a> Parser<'a> {
                                 '?' => ParameterOp::Error,
                                 _ => unreachable!(),
                             };
-                            parts.push(WordPart::IndirectExpansion {
+                            push_part!(WordPart::IndirectExpansion {
                                 name: var_name,
                                 operator: Some(operator),
                                 operand,
@@ -3151,9 +3173,9 @@ impl<'a> Parser<'a> {
                             if suffix.ends_with('*') || suffix.ends_with('@') {
                                 let full_prefix =
                                     format!("{}{}", var_name, &suffix[..suffix.len() - 1]);
-                                parts.push(WordPart::PrefixMatch(full_prefix));
+                                push_part!(WordPart::PrefixMatch(full_prefix));
                             } else {
-                                parts.push(WordPart::Variable(format!("!{}{}", var_name, suffix)));
+                                push_part!(WordPart::Variable(format!("!{}{}", var_name, suffix)));
                             }
                         }
                     } else {
@@ -3237,7 +3259,7 @@ impl<'a> Parser<'a> {
                                             '?' => ParameterOp::Error,
                                             _ => unreachable!(),
                                         };
-                                        parts.push(WordPart::ParameterExpansion {
+                                        push_part!(WordPart::ParameterExpansion {
                                             name: arr_name,
                                             operator,
                                             operand,
@@ -3269,7 +3291,7 @@ impl<'a> Parser<'a> {
                                         if chars.peek() == Some(&'}') {
                                             chars.next();
                                         }
-                                        parts.push(WordPart::ArraySlice {
+                                        push_part!(WordPart::ArraySlice {
                                             name: var_name,
                                             offset,
                                             length,
@@ -3287,7 +3309,7 @@ impl<'a> Parser<'a> {
                                         '?' => ParameterOp::Error,
                                         _ => unreachable!(),
                                     };
-                                    parts.push(WordPart::ParameterExpansion {
+                                    push_part!(WordPart::ParameterExpansion {
                                         name: arr_name,
                                         operator,
                                         operand,
@@ -3298,13 +3320,13 @@ impl<'a> Parser<'a> {
                                     if chars.peek() == Some(&'}') {
                                         chars.next();
                                     }
-                                    parts.push(WordPart::ArrayAccess {
+                                    push_part!(WordPart::ArrayAccess {
                                         name: var_name,
                                         index,
                                     });
                                 }
                             } else {
-                                parts.push(WordPart::ArrayAccess {
+                                push_part!(WordPart::ArrayAccess {
                                     name: var_name,
                                     index,
                                 });
@@ -3325,7 +3347,7 @@ impl<'a> Parser<'a> {
                                                 '?' => ParameterOp::Error,
                                                 _ => unreachable!(),
                                             };
-                                            parts.push(WordPart::ParameterExpansion {
+                                            push_part!(WordPart::ParameterExpansion {
                                                 name: var_name,
                                                 operator,
                                                 operand,
@@ -3357,7 +3379,7 @@ impl<'a> Parser<'a> {
                                             if chars.peek() == Some(&'}') {
                                                 chars.next();
                                             }
-                                            parts.push(WordPart::Substring {
+                                            push_part!(WordPart::Substring {
                                                 name: var_name,
                                                 offset,
                                                 length,
@@ -3376,7 +3398,7 @@ impl<'a> Parser<'a> {
                                         '?' => ParameterOp::Error,
                                         _ => unreachable!(),
                                     };
-                                    parts.push(WordPart::ParameterExpansion {
+                                    push_part!(WordPart::ParameterExpansion {
                                         name: var_name,
                                         operator,
                                         operand,
@@ -3388,7 +3410,7 @@ impl<'a> Parser<'a> {
                                     if chars.peek() == Some(&'#') {
                                         chars.next();
                                         let op = self.read_brace_operand(&mut chars);
-                                        parts.push(WordPart::ParameterExpansion {
+                                        push_part!(WordPart::ParameterExpansion {
                                             name: var_name,
                                             operator: ParameterOp::RemovePrefixLong,
                                             operand: op,
@@ -3396,7 +3418,7 @@ impl<'a> Parser<'a> {
                                         });
                                     } else {
                                         let op = self.read_brace_operand(&mut chars);
-                                        parts.push(WordPart::ParameterExpansion {
+                                        push_part!(WordPart::ParameterExpansion {
                                             name: var_name,
                                             operator: ParameterOp::RemovePrefixShort,
                                             operand: op,
@@ -3409,7 +3431,7 @@ impl<'a> Parser<'a> {
                                     if chars.peek() == Some(&'%') {
                                         chars.next();
                                         let op = self.read_brace_operand(&mut chars);
-                                        parts.push(WordPart::ParameterExpansion {
+                                        push_part!(WordPart::ParameterExpansion {
                                             name: var_name,
                                             operator: ParameterOp::RemoveSuffixLong,
                                             operand: op,
@@ -3417,7 +3439,7 @@ impl<'a> Parser<'a> {
                                         });
                                     } else {
                                         let op = self.read_brace_operand(&mut chars);
-                                        parts.push(WordPart::ParameterExpansion {
+                                        push_part!(WordPart::ParameterExpansion {
                                             name: var_name,
                                             operator: ParameterOp::RemoveSuffixShort,
                                             operand: op,
@@ -3478,7 +3500,7 @@ impl<'a> Parser<'a> {
                                             replacement,
                                         }
                                     };
-                                    parts.push(WordPart::ParameterExpansion {
+                                    push_part!(WordPart::ParameterExpansion {
                                         name: var_name,
                                         operator: op,
                                         operand: String::new(),
@@ -3496,7 +3518,7 @@ impl<'a> Parser<'a> {
                                     if chars.peek() == Some(&'}') {
                                         chars.next();
                                     }
-                                    parts.push(WordPart::ParameterExpansion {
+                                    push_part!(WordPart::ParameterExpansion {
                                         name: var_name,
                                         operator: op,
                                         operand: String::new(),
@@ -3514,7 +3536,7 @@ impl<'a> Parser<'a> {
                                     if chars.peek() == Some(&'}') {
                                         chars.next();
                                     }
-                                    parts.push(WordPart::ParameterExpansion {
+                                    push_part!(WordPart::ParameterExpansion {
                                         name: var_name,
                                         operator: op,
                                         operand: String::new(),
@@ -3528,7 +3550,7 @@ impl<'a> Parser<'a> {
                                         if chars.peek() == Some(&'}') {
                                             chars.next();
                                         }
-                                        parts.push(WordPart::Transformation {
+                                        push_part!(WordPart::Transformation {
                                             name: var_name,
                                             operator: op,
                                         });
@@ -3536,13 +3558,13 @@ impl<'a> Parser<'a> {
                                         if chars.peek() == Some(&'}') {
                                             chars.next();
                                         }
-                                        parts.push(WordPart::Variable(var_name));
+                                        push_part!(WordPart::Variable(var_name));
                                     }
                                 }
                                 '}' => {
                                     chars.next();
                                     if !var_name.is_empty() {
-                                        parts.push(WordPart::Variable(var_name));
+                                        push_part!(WordPart::Variable(var_name));
                                     }
                                 }
                                 _ => {
@@ -3554,18 +3576,18 @@ impl<'a> Parser<'a> {
                                         chars.next();
                                     }
                                     if !var_name.is_empty() {
-                                        parts.push(WordPart::Variable(var_name));
+                                        push_part!(WordPart::Variable(var_name));
                                     }
                                 }
                             }
                         } else if !var_name.is_empty() {
-                            parts.push(WordPart::Variable(var_name));
+                            push_part!(WordPart::Variable(var_name));
                         }
                     }
                 } else if let Some(&c) = chars.peek() {
                     // Check for special single-character variables ($?, $#, $@, $*, $!, $$, $-, $0-$9)
                     if matches!(c, '?' | '#' | '@' | '*' | '!' | '$' | '-') || c.is_ascii_digit() {
-                        parts.push(WordPart::Variable(chars.next().unwrap().to_string()));
+                        push_part!(WordPart::Variable(chars.next().unwrap().to_string()));
                     } else {
                         // $VAR format
                         let mut var_name = String::new();
@@ -3577,7 +3599,7 @@ impl<'a> Parser<'a> {
                             }
                         }
                         if !var_name.is_empty() {
-                            parts.push(WordPart::Variable(var_name));
+                            push_part!(WordPart::Variable(var_name));
                         } else {
                             // Just a literal $
                             current.push('$');
@@ -3594,18 +3616,19 @@ impl<'a> Parser<'a> {
 
         // Flush remaining literal
         if !current.is_empty() {
-            parts.push(WordPart::Literal(current));
+            push_part!(WordPart::Literal(current));
         }
 
         // If no parts, create an empty literal
         if parts.is_empty() {
-            parts.push(WordPart::Literal(String::new()));
+            push_part!(WordPart::Literal(String::new()));
         }
 
         Word {
             parts,
             quoted: false,
             has_unquoted_glob: false,
+            part_quoted,
         }
     }
 


### PR DESCRIPTION
### Motivation

- A prior change promoted any word containing a double-quoted expansion to `QuotedWord`, which incorrectly applied quoted semantics to the entire mixed word and suppressed IFS splitting/globbing for unquoted portions (regression vs. bash semantics).
- The intent is to fix the original `date +"$fmt"` splitting bug without over-applying quoting to the whole word; only quoted segments should suppress splitting/globbing.

### Description

- Lexer: emit lightweight quote-boundary sentinels around concatenated quoted segments instead of marking the whole token as `QuotedWord`, and strip those markers for `LiteralWord` output; preserve `QuotedGlobWord` path when appropriate (`crates/bashkit/src/parser/lexer.rs`).
- AST: add `part_quoted: Vec<bool>` to `Word` so each `WordPart` carries whether it originated inside a quoted segment (`crates/bashkit/src/parser/ast.rs`).
- Parser: record per-part quote flags when converting lexer token strings into `Word` parts via a `push_part!` helper and the `in_quoted_segment` state (`crates/bashkit/src/parser/mod.rs`).
- Interpreter: update `expand_word_to_fields` to handle mixed quoted/unquoted parts by expanding each part individually and applying IFS splitting only to unquoted expansion parts while still concatenating quoted parts and preserving unquoted glob expansion (`crates/bashkit/src/interpreter/mod.rs`).
- Add a targeted unit test that asserts unquoted expansion parts in mixed words still undergo IFS splitting (`test_mixed_quote_unquoted_prefix_var_still_splits`) and preserved existing tests for `date +

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ada8e0832b96e6cfa651de2b71)