### PR TITLE
fix(fuzz): exercise template renderer in template_fuzz

### DIFF
--- a/crates/bashkit/fuzz/fuzz_targets/template_fuzz.rs
+++ b/crates/bashkit/fuzz/fuzz_targets/template_fuzz.rs
@@ -12,6 +12,10 @@
 
 use libfuzzer_sys::fuzz_target;
 
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 fuzz_target!(|data: &[u8]| {
     // Only process valid UTF-8
     if let Ok(input) = std::str::from_utf8(data) {
@@ -55,27 +59,24 @@ fuzz_target!(|data: &[u8]| {
                 )
                 .build();
 
-            // Test 1: render template with JSON data via stdin
+            let quoted_json = shell_quote(json_data);
+            let quoted_template = shell_quote(template);
+
+            // Test 1: write JSON to the VFS path consumed by -d, then pipe template via stdin.
             let script = format!(
-                "echo '{}' | template -d /dev/stdin '{}'",
-                json_data.replace('\'', "'\\''"),
-                template.replace('\'', "'\\''"),
+                "printf %s {quoted_json} > /tmp/template-data.json; printf %s {quoted_template} | template -d /tmp/template-data.json"
             );
             bashkit::testing::fuzz_exec(&mut bash, &script, "template_fuzz", &[]).await;
 
             // Test 2: render template with --strict mode
             let script2 = format!(
-                "echo '{}' | template --strict -d /dev/stdin '{}'",
-                json_data.replace('\'', "'\\''"),
-                template.replace('\'', "'\\''"),
+                "printf %s {quoted_json} > /tmp/template-data.json; printf %s {quoted_template} | template --strict -d /tmp/template-data.json"
             );
             bashkit::testing::fuzz_exec(&mut bash, &script2, "template_fuzz", &[]).await;
 
             // Test 3: render template with -e (HTML escape) flag
             let script3 = format!(
-                "echo '{}' | template -e -d /dev/stdin '{}'",
-                json_data.replace('\'', "'\\''"),
-                template.replace('\'', "'\\''"),
+                "printf %s {quoted_json} > /tmp/template-data.json; printf %s {quoted_template} | template -e -d /tmp/template-data.json"
             );
             bashkit::testing::fuzz_exec(&mut bash, &script3, "template_fuzz", &[]).await;
         });


### PR DESCRIPTION
### Motivation
- The `template_fuzz` harness previously passed `-d /dev/stdin` while also piping JSON to the process stdin, but the `template` builtin reads `-d` from the VFS and `/dev/stdin` is not present in the in-memory FS, so the fuzz target never reached the renderer.

### Description
- Update `crates/bashkit/fuzz/fuzz_targets/template_fuzz.rs` to write the fuzzed JSON into a real VFS path (`/tmp/template-data.json`) and pass that path to `-d` so the builtin loads JSON from the VFS.
- Pipe the fuzzed template text into the builtin stdin instead of passing it as a positional template file, ensuring the renderer is exercised; apply to default, `--strict`, and `-e` variants.
- Add a `shell_quote` helper to safely embed fuzzed JSON and template payloads into the generated shell `printf` commands.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo check --manifest-path crates/bashkit/fuzz/Cargo.toml --offline` which passed.
- Executed the fuzz harness with `cargo run --manifest-path crates/bashkit/fuzz/Cargo.toml --bin template_fuzz -- -runs=1` which completed and observed the target run (no crashes), indicating the harness now executes the template builtin code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae61a0832b8595442dc0019c90)