### PR TITLE
fix(iconv): reject unsupported target suffixes

### DIFF
--- a/crates/bashkit/src/builtins/iconv.rs
+++ b/crates/bashkit/src/builtins/iconv.rs
@@ -23,13 +23,16 @@ impl BuiltinHelper for Iconv {
 
 /// Parse an encoding spec like "ascii//translit" into (encoding, translit).
 fn parse_encoding_spec(spec: &str) -> (Option<&'static str>, bool) {
-    let (name, translit) = if let Some(pos) = spec.find("//") {
+    if let Some(pos) = spec.find("//") {
         let suffix = &spec[pos + 2..];
-        (&spec[..pos], suffix.eq_ignore_ascii_case("translit"))
+        if suffix.eq_ignore_ascii_case("translit") {
+            (normalize_encoding(&spec[..pos]), true)
+        } else {
+            (None, false)
+        }
     } else {
-        (spec, false)
-    };
-    (normalize_encoding(name), translit)
+        (normalize_encoding(spec), false)
+    }
 }
 
 /// Normalize encoding name to canonical form.
@@ -445,6 +448,15 @@ mod tests {
         let r = run(&["-f", "EBCDIC", "-t", "UTF-8"], Some("hi"), None).await;
         assert_eq!(r.exit_code, 1);
         assert!(r.stderr.contains("unsupported encoding"));
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_target_encoding_suffix() {
+        for target in ["ASCII//BAD", "UTF-8//IGNORE", "ASCII//TRANSLIT//IGNORE"] {
+            let r = run(&["-f", "UTF-8", "-t", target], Some("hi"), None).await;
+            assert_eq!(r.exit_code, 1, "target should be rejected: {target}");
+            assert!(r.stderr.contains("unsupported encoding"));
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent a fail-open parsing behavior where `-t ENCODING//SUFFIX` accepted unknown suffixes (e.g. `ASCII//BAD`) by returning the normalized base encoding and proceeding.
- Ensure only the explicitly supported `//translit` suffix is accepted and other or compound suffixes are rejected as unsupported.

### Description
- Update `parse_encoding_spec` to return `(None, false)` when a `//` suffix is present but is not equal to `translit` (case-insensitive), instead of silently accepting the base encoding.
- Preserve existing behavior for plain encodings and for `//translit` which continues to set the transliteration flag.
- Add a regression test `test_unsupported_target_encoding_suffix` covering `"ASCII//BAD"`, `"UTF-8//IGNORE"`, and `"ASCII//TRANSLIT//IGNORE"` to assert these are rejected.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran the new unit test via `cargo test -p bashkit builtins::iconv::tests::test_unsupported_target_encoding_suffix -- --nocapture` which passed.
- Ran the full iconv test set via `cargo test -p bashkit builtins::iconv -- --nocapture` and all iconv tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc1bb8832b920e5393bf3d1e22)