### PR TITLE
fix(interpreter): reset all set short option state

### DIFF
--- a/crates/bashkit/src/builtins/vars.rs
+++ b/crates/bashkit/src/builtins/vars.rs
@@ -83,6 +83,24 @@ fn option_name_to_var(name: &str) -> Option<&'static str> {
     }
 }
 
+/// Map accepted short `set` option flags to their transient SHOPT_* variables.
+fn short_option_to_var(opt: char) -> Option<&'static str> {
+    match opt {
+        'a' => Some("SHOPT_a"),
+        'b' => Some("SHOPT_b"),
+        'e' => Some("SHOPT_e"),
+        'f' => Some("SHOPT_f"),
+        'h' => Some("SHOPT_h"),
+        'm' => Some("SHOPT_m"),
+        'n' => Some("SHOPT_n"),
+        'u' => Some("SHOPT_u"),
+        'v' => Some("SHOPT_v"),
+        'x' => Some("SHOPT_x"),
+        'C' => Some("SHOPT_C"),
+        _ => None,
+    }
+}
+
 /// All known `set -o` options with their variable names, in display order.
 const SET_O_OPTIONS: &[(&str, &str)] = &[
     ("allexport", "SHOPT_a"),
@@ -177,10 +195,22 @@ impl Builtin for Set {
                     if opt == 'o' {
                         // -o within a combined flag (e.g. -euo): next arg is option name
                         need_o_arg = true;
-                    } else {
-                        let opt_name = format!("SHOPT_{}", opt);
-                        ctx.variables
-                            .insert(opt_name, if enable { "1" } else { "0" }.to_string());
+                    } else if short_option_to_var(opt).is_none() {
+                        return Ok(ExecResult::err(
+                            format!("bash: set: -{}: invalid option\n", opt),
+                            2,
+                        ));
+                    }
+                }
+                for opt in arg.chars().skip(1) {
+                    if opt == 'o' {
+                        continue;
+                    }
+                    if let Some(opt_name) = short_option_to_var(opt) {
+                        ctx.variables.insert(
+                            opt_name.to_string(),
+                            if enable { "1" } else { "0" }.to_string(),
+                        );
                     }
                 }
                 if need_o_arg && i + 1 < ctx.args.len() {

--- a/crates/bashkit/src/builtins/vars.rs
+++ b/crates/bashkit/src/builtins/vars.rs
@@ -197,7 +197,11 @@ impl Builtin for Set {
                         need_o_arg = true;
                     } else if short_option_to_var(opt).is_none() {
                         return Ok(ExecResult::err(
-                            format!("bash: set: -{}: invalid option\n", opt),
+                            format!(
+                                "bash: set: {}{}: invalid option\n",
+                                if enable { '-' } else { '+' },
+                                opt
+                            ),
                             2,
                         ));
                     }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1663,8 +1663,11 @@ impl Interpreter {
     /// persistent session configuration and are NOT reset.
     const SET_OPTION_VARS: &'static [&'static str] = &[
         "SHOPT_a",
+        "SHOPT_b",
         "SHOPT_e",
         "SHOPT_f",
+        "SHOPT_h",
+        "SHOPT_m",
         "SHOPT_n",
         "SHOPT_u",
         "SHOPT_v",

--- a/crates/bashkit/tests/integration/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/integration/blackbox_security_tests.rs
@@ -586,6 +586,34 @@ mod finding_shell_options_leak {
             "set -e leaked across exec() calls — false aborted execution"
         );
     }
+
+    /// TM-ISO-023: all `set` short options are per-exec transient state.
+    #[tokio::test]
+    async fn set_short_flags_do_not_leak_between_exec() {
+        let mut bash = tight_bash();
+        let _ = bash.exec("set -bhm").await;
+        let result = bash.exec("echo \"$-\"").await.unwrap();
+        assert_eq!(
+            result.stdout.trim(),
+            "",
+            "set -b/-h/-m leaked across exec() calls through $-"
+        );
+    }
+
+    /// TM-ISO-023: unsupported short options must not mint persistent SHOPT_* state.
+    #[tokio::test]
+    async fn set_invalid_short_option_does_not_create_shopt_state() {
+        let mut bash = tight_bash();
+        let result = bash.exec("set -Z").await.unwrap();
+        assert_eq!(result.exit_code, 2);
+
+        let result = bash.exec("echo \"$SHOPT_Z\"").await.unwrap();
+        assert_eq!(
+            result.stdout.trim(),
+            "",
+            "invalid set option created SHOPT_Z state"
+        );
+    }
 }
 
 // =============================================================================

--- a/crates/bashkit/tests/integration/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/integration/blackbox_security_tests.rs
@@ -591,7 +591,8 @@ mod finding_shell_options_leak {
     #[tokio::test]
     async fn set_short_flags_do_not_leak_between_exec() {
         let mut bash = tight_bash();
-        let _ = bash.exec("set -bhm").await;
+        let result = bash.exec("set -bhm").await.unwrap();
+        assert_eq!(result.exit_code, 0, "set -bhm should succeed");
         let result = bash.exec("echo \"$-\"").await.unwrap();
         assert_eq!(
             result.stdout.trim(),


### PR DESCRIPTION
### Motivation
- Fix TM-ISO-023 regression where short `set` flags (e.g. `-b`, `-h`, `-m`) could create `SHOPT_*` variables that persisted across `exec()` calls.
- Ensure the `set` builtin only mints recognized short-option state and rejects unsupported short flags.
- Preserve prior intent to keep `shopt` options persistent while making `set`-level flags transient per-exec.

### Description
- Add `short_option_to_var` mapping and validate short `set` flags so unsupported flags return an error instead of creating arbitrary `SHOPT_<char>` variables (`crates/bashkit/src/builtins/vars.rs`).
- Extend the interpreter transient-reset whitelist to include `SHOPT_b`, `SHOPT_h`, and `SHOPT_m` so these short-option flags are cleared by `reset_transient_state()` (`crates/bashkit/src/interpreter/mod.rs`).
- Replace the previous unconstrained `format!("SHOPT_{}", opt)` path with the validated mapping and explicit insertion of allowed `SHOPT_*` entries (`crates/bashkit/src/builtins/vars.rs`).
- Add regression tests that assert `$-` does not observe leaked `b/h/m` flags and that invalid short options do not create persistent `SHOPT_*` state (`crates/bashkit/tests/integration/blackbox_security_tests.rs`).

### Testing
- Ran `cargo test -p bashkit --test integration finding_shell_options_leak -- --nocapture` and the new/related tests passed.
- Ran `cargo fmt --check` and formatting check passed.
- Ran `cargo test -p bashkit --lib` (unit test suite) and the library tests passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae8a54832b81cb332a197ccdd0)