### PR TITLE
fix(js): restore BashTool VFS compatibility APIs

### DIFF
--- a/crates/bashkit-js/__test__/ai-adapters.spec.ts
+++ b/crates/bashkit-js/__test__/ai-adapters.spec.ts
@@ -30,6 +30,20 @@ test("ai: files created via execute are readable via bash.readFile", async (t) =
   t.is(adapter.bash.readFile("/y.txt"), "created");
 });
 
+test("ai: direct VFS mkdir/remove APIs share adapter state", async (t) => {
+  const adapter = aiSdkBashTool();
+  adapter.bash.mkdir("/compat/nested", true);
+  adapter.bash.writeFile("/compat/nested/file.txt", "ok");
+  const result = await adapter.tools.bash.execute({
+    commands: "cat /compat/nested/file.txt",
+  });
+  t.is(result, "ok");
+
+  adapter.bash.remove("/compat", true);
+  const removed = await adapter.bash.execute("test ! -e /compat");
+  t.is(removed.exitCode, 0);
+});
+
 // --- Anthropic SDK adapter ---------------------------------------------------
 
 test("anthropic: files option is readable via handler", async (t) => {
@@ -65,6 +79,23 @@ test("anthropic: files created via handler are readable via bash.readFile", asyn
     input: { commands: "echo -n created > /y.txt" },
   });
   t.is(adapter.bash.readFile("/y.txt"), "created");
+});
+
+test("anthropic: direct VFS mkdir/remove APIs share adapter state", async (t) => {
+  const adapter = anthropicBashTool();
+  adapter.bash.mkdir("/compat/nested", true);
+  adapter.bash.writeFile("/compat/nested/file.txt", "ok");
+  const result = await adapter.handler({
+    type: "tool_use",
+    id: "t4",
+    name: "bash",
+    input: { commands: "cat /compat/nested/file.txt" },
+  });
+  t.is(result.content, "ok");
+
+  adapter.bash.remove("/compat", true);
+  const removed = await adapter.bash.execute("test ! -e /compat");
+  t.is(removed.exitCode, 0);
 });
 
 // --- OpenAI SDK adapter ------------------------------------------------------
@@ -107,6 +138,25 @@ test("openai: files created via handler are readable via bash.readFile", async (
     },
   });
   t.is(adapter.bash.readFile("/y.txt"), "created");
+});
+
+test("openai: direct VFS mkdir/remove APIs share adapter state", async (t) => {
+  const adapter = openAiBashTool();
+  adapter.bash.mkdir("/compat/nested", true);
+  adapter.bash.writeFile("/compat/nested/file.txt", "ok");
+  const result = await adapter.handler({
+    id: "c4",
+    type: "function",
+    function: {
+      name: "bash",
+      arguments: JSON.stringify({ commands: "cat /compat/nested/file.txt" }),
+    },
+  });
+  t.is(result.content, "ok");
+
+  adapter.bash.remove("/compat", true);
+  const removed = await adapter.bash.execute("test ! -e /compat");
+  t.is(removed.exitCode, 0);
 });
 
 // ============================================================================

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -1386,6 +1386,16 @@ export class BashTool {
     this.native.writeFile(path, content);
   }
 
+  /** Create a directory. If recursive is true, creates parents as needed. */
+  mkdir(path: string, recursive?: boolean): void {
+    this.native.mkdir(path, recursive);
+  }
+
+  /** Remove a file or directory. If recursive is true, removes contents. */
+  remove(path: string, recursive?: boolean): void {
+    this.native.remove(path, recursive);
+  }
+
   /** Get metadata for a path (fileType, size, mode, timestamps). */
   stat(path: string): {
     fileType: string;


### PR DESCRIPTION
### Motivation
- Restore backward-compatible direct VFS APIs that callers previously accessed on the adapter `bash` handle to avoid runtime `TypeError` when consuming AI adapters.
- Preserve the single shared interpreter instance used by AI adapters while re-exposing the helper methods callers relied on (mkdir/remove).

### Description
- Add `mkdir(path: string, recursive?: boolean)` and `remove(path: string, recursive?: boolean)` passthrough methods to `BashTool` so the tool exposes the same direct VFS helpers as `Bash` (file: `crates/bashkit-js/wrapper.ts`).
- Add regression tests that exercise VFS compatibility for the three AI adapters (Vercel AI, Anthropic, OpenAI) verifying `adapter.bash.mkdir(...)`, `writeFile`, `handler/execute`, and `adapter.bash.remove(...)` share state (file: `crates/bashkit-js/__test__/ai-adapters.spec.ts`).
- Apply Prettier formatting to the modified files to match repository style.

### Testing
- Ran TypeScript checks with `pnpm --dir crates/bashkit-js run type-check`, result: success (no `tsc` errors).
- Ran unit tests in the JS crate with `pnpm --dir crates/bashkit-js exec ava __test__/ai-adapters.spec.ts`, result: all tests passed (22 tests passed), and the three new adapter compatibility tests also pass when run individually (`--match '*direct VFS mkdir/remove*'` -> 3 tests passed).
- Built native bindings and JS artifacts with `pnpm --dir crates/bashkit-js run build:napi` and `pnpm --dir crates/bashkit-js run build:cjs && pnpm --dir crates/bashkit-js run build:ts`, result: success.
- Ran linter/format checks with `pnpm --dir crates/bashkit-js run lint` / `prettier --check`, result: formatting fixed and linter completed (warnings present but no blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adcd38832b956e7a0c432dbde6)