### PR TITLE
fix(builtins): preserve read tail delimiters

### DIFF
--- a/crates/bashkit/src/builtins/read.rs
+++ b/crates/bashkit/src/builtins/read.rs
@@ -138,22 +138,48 @@ impl Builtin for Read {
             .or_else(|| ctx.env.get("IFS"))
             .map(|s| s.as_str())
             .unwrap_or(" \t\n");
-        let words: Vec<&str> = if ifs.is_empty() {
+        struct ReadField<'a> {
+            text: &'a str,
+            start: usize,
+        }
+
+        let words: Vec<ReadField<'_>> = if ifs.is_empty() {
             // Empty IFS means no word splitting
-            vec![&line]
+            vec![ReadField {
+                text: &line,
+                start: 0,
+            }]
         } else {
             let ifs_ws: Vec<char> = ifs.chars().filter(|c| " \t\n".contains(*c)).collect();
             let ifs_non_ws: Vec<char> = ifs.chars().filter(|c| !" \t\n".contains(*c)).collect();
 
             if ifs_non_ws.is_empty() {
                 // All IFS chars are whitespace: collapse runs, trim
-                line.split(|c: char| ifs.contains(c))
-                    .filter(|s| !s.is_empty())
-                    .collect()
+                let mut fields = Vec::new();
+                let mut field_start = None::<usize>;
+                for (i, ch) in line.char_indices() {
+                    if ifs.contains(ch) {
+                        if let Some(start) = field_start.take() {
+                            fields.push(ReadField {
+                                text: &line[start..i],
+                                start,
+                            });
+                        }
+                    } else if field_start.is_none() {
+                        field_start = Some(i);
+                    }
+                }
+                if let Some(start) = field_start {
+                    fields.push(ReadField {
+                        text: &line[start..],
+                        start,
+                    });
+                }
+                fields
             } else {
                 // Mixed IFS: split on all IFS chars, collapse whitespace runs,
                 // preserve empty fields for consecutive non-whitespace delimiters.
-                let mut fields: Vec<&str> = Vec::new();
+                let mut fields: Vec<ReadField<'_>> = Vec::new();
                 let mut field_start = 0usize;
                 let mut i = 0usize;
                 let mut last_delim_was_non_ws = false;
@@ -169,7 +195,10 @@ impl Builtin for Read {
                     }
 
                     if ifs_non_ws.contains(&ch) {
-                        fields.push(&line[field_start..i]);
+                        fields.push(ReadField {
+                            text: &line[field_start..i],
+                            start: field_start,
+                        });
                         i += ch_len;
                         while i < line.len() {
                             let mut ws_iter = line[i..].char_indices();
@@ -184,7 +213,10 @@ impl Builtin for Read {
                         last_delim_was_non_ws = true;
                     } else {
                         if field_start != i {
-                            fields.push(&line[field_start..i]);
+                            fields.push(ReadField {
+                                text: &line[field_start..i],
+                                start: field_start,
+                            });
                         }
                         i += ch_len;
                         while i < line.len() {
@@ -202,7 +234,10 @@ impl Builtin for Read {
                 }
 
                 if field_start < line.len() || last_delim_was_non_ws {
-                    fields.push(&line[field_start..]);
+                    fields.push(ReadField {
+                        text: &line[field_start..],
+                        start: field_start,
+                    });
                 }
                 fields
             }
@@ -218,7 +253,7 @@ impl Builtin for Read {
             let mut result = ExecResult::ok(String::new());
             result.side_effects.push(BuiltinSideEffect::SetArray {
                 name: arr_name.to_string(),
-                elements: words.iter().map(|w| w.to_string()).collect(),
+                elements: words.iter().map(|w| w.text.to_string()).collect(),
             });
             return Ok(result);
         }
@@ -238,19 +273,14 @@ impl Builtin for Read {
                 continue;
             }
             let value = if i == var_names.len() - 1 {
-                // Last variable gets all remaining words joined by first IFS char
-                let remaining: Vec<&str> = words.iter().skip(i).copied().collect();
-                let ifs_non_ws: Vec<char> = ifs.chars().filter(|c| !" \t\n".contains(*c)).collect();
-                let join_sep = if !ifs_non_ws.is_empty() {
-                    // Non-whitespace IFS: join with the first non-whitespace IFS char
-                    ifs_non_ws[0].to_string()
-                } else {
-                    // Whitespace-only IFS: join with space
-                    " ".to_string()
-                };
-                remaining.join(&join_sep)
+                // Bash gives the final variable the unsplit remaining input.
+                // Preserve original separators instead of reconstructing from IFS.
+                words
+                    .get(i)
+                    .map(|field| line[field.start..].to_string())
+                    .unwrap_or_default()
             } else if i < words.len() {
-                words[i].to_string()
+                words[i].text.to_string()
             } else {
                 // Not enough words - set to empty
                 String::new()
@@ -607,6 +637,27 @@ mod tests {
         let vars = extract_vars(&result);
         assert_eq!(vars.get("A").unwrap(), "foo");
         assert_eq!(vars.get("B").unwrap(), "bar:baz");
+    }
+
+    #[tokio::test]
+    async fn read_custom_ifs_last_var_preserves_original_delimiters() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let mut env = HashMap::new();
+        env.insert("IFS".to_string(), ",:".to_string());
+        let args = vec!["A".to_string(), "B".to_string()];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            Some("1,2:3"),
+        );
+        let result = Read.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let vars = extract_vars(&result);
+        assert_eq!(vars.get("A").unwrap(), "1");
+        assert_eq!(vars.get("B").unwrap(), "2:3");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
@@ -134,3 +134,10 @@ IFS=":"; read -ra parts <<< "a:b:c"; echo "${#parts[@]} ${parts[1]}"
 ### expect
 3 b
 ### end
+
+### read_custom_ifs_multiple_delimiters_last_var
+# Last read variable should preserve original remaining delimiters
+IFS=",:"; read -r a b <<< "1,2:3"; echo "$a|$b"
+### expect
+1|2:3
+### end


### PR DESCRIPTION
### Motivation
- A previous change reconstructed the final `read` variable by joining remaining fields with the first non-whitespace `IFS` character, which loses the original delimiters when `IFS` contains multiple non-whitespace delimiters and thus diverges from Bash semantics.
- The goal is to preserve the original remaining input for the last `read` variable so mixed custom `IFS` delimiters are not corrupted.

### Description
- Add a `ReadField` struct that tracks each split field's `text` and its `start` offset in the original `line` and produce `Vec<ReadField>` from the IFS-splitting logic instead of `Vec<&str>`.
- Update whitespace-only and mixed-IFS splitting branches to record start offsets and preserve empty fields semantics, and update `-a` (array) behavior to use `ReadField.text` for array elements.
- Assign the final `read` variable from the original remaining slice `line[field.start..]` so original separators are preserved instead of reconstructing by joining fields with an `IFS` char.
- Add a unit test `read_custom_ifs_last_var_preserves_original_delimiters` and a bash spec case `read_custom_ifs_multiple_delimiters_last_var` covering `IFS=",:"; read -r a b <<< "1,2:3"` expecting `b=2:3`.

### Testing
- Ran the targeted unit test which failed on the old logic and passes after the fix via `cargo test -p bashkit builtins::read::tests::read_custom_ifs_last_var_preserves_original_delimiters --lib`.
- Ran `cargo test` for the related `read` unit tests and the bash spec integration test `spec_tests::bash_spec_tests`, and all exercised tests passed locally.
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --lib -- -D warnings` and `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae17e0832b967d0d1c3808aa84)