### PR TITLE
fix(parser): decode escaped-dollar sentinel in literal continuations

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1024,8 +1024,12 @@ impl<'a> Lexer<'a> {
         // Any quoting makes the whole token literal.
         self.read_continuation_into(&mut content);
 
-        // Single-quoted strings are literal - no variable expansion
-        Some(Token::LiteralWord(content))
+        // Single-quoted strings are literal - no variable expansion.
+        // Decode lexer-only escaped-dollar sentinels from continued segments
+        // before returning a token that bypasses parse_word().
+        Some(Token::LiteralWord(Self::decode_escaped_dollar_sentinel(
+            &content,
+        )))
     }
 
     /// After a closing quote, read any adjacent quoted or unquoted word chars
@@ -1221,6 +1225,24 @@ impl<'a> Lexer<'a> {
             }
             dst.push(ch);
         }
+    }
+
+    /// Decode lexer-only escaped-dollar sentinels for literal-token paths.
+    fn decode_escaped_dollar_sentinel(segment: &str) -> String {
+        let mut decoded = String::with_capacity(segment.len());
+        let mut chars = segment.chars();
+
+        while let Some(ch) = chars.next() {
+            if ch == '\x00' {
+                if let Some(literal_ch) = chars.next() {
+                    decoded.push(literal_ch);
+                }
+            } else {
+                decoded.push(ch);
+            }
+        }
+
+        decoded
     }
 
     fn read_double_quoted_string(&mut self) -> Option<Token> {
@@ -1972,6 +1994,17 @@ mod tests {
         assert_eq!(
             lexer.next_token(),
             Some(Token::Word("foo\x00$(id)".to_string()))
+        );
+        assert_eq!(lexer.next_token(), None);
+    }
+
+    #[test]
+    fn test_single_quoted_word_continuation_decodes_escaped_dollar() {
+        let mut lexer = Lexer::new(r#"echo 'x'"\$HOME""#);
+        assert_eq!(lexer.next_token(), Some(Token::Word("echo".to_string())));
+        assert_eq!(
+            lexer.next_token(),
+            Some(Token::LiteralWord("x$HOME".to_string()))
         );
         assert_eq!(lexer.next_token(), None);
     }

--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1025,11 +1025,14 @@ impl<'a> Lexer<'a> {
         self.read_continuation_into(&mut content);
 
         // Single-quoted strings are literal - no variable expansion.
-        // Decode lexer-only escaped-dollar sentinels from continued segments
+        // Decode NUL escape sentinels from continued double-quoted segments
         // before returning a token that bypasses parse_word().
-        Some(Token::LiteralWord(Self::decode_escaped_dollar_sentinel(
-            &content,
-        )))
+        // Only allocate when the sentinel is actually present (common case: none).
+        Some(Token::LiteralWord(if content.contains('\x00') {
+            Self::decode_nul_escape_sentinel(&content)
+        } else {
+            content
+        }))
     }
 
     /// After a closing quote, read any adjacent quoted or unquoted word chars
@@ -1227,8 +1230,9 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Decode lexer-only escaped-dollar sentinels for literal-token paths.
-    fn decode_escaped_dollar_sentinel(segment: &str) -> String {
+    /// Decode NUL-based escape sentinels: each `\x00` followed by a char is
+    /// collapsed to that char. Used for literal-token paths that bypass `parse_word()`.
+    fn decode_nul_escape_sentinel(segment: &str) -> String {
         let mut decoded = String::with_capacity(segment.len());
         let mut chars = segment.chars();
 

--- a/crates/bashkit/tests/spec_cases/bash/quote.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/quote.test.sh
@@ -108,6 +108,13 @@ echo "\$ \\ \\ \p \q"
 $ \ \ \p \q
 ### end
 
+### quote_backslash_dollar_after_single_quote
+# Escaped dollar in a double-quoted continuation remains literal, without leaking sentinels
+printf '<%s>\n' 'x'"\$HOME"
+### expect
+<x$HOME>
+### end
+
 ### quote_no_c_escape_in_double
 # C-style backslash escapes NOT special in double quotes
 echo "\a \b"


### PR DESCRIPTION
### Motivation
- Prevent the internal NUL sentinel used to mark escaped `$` in double-quoted segments from leaking into `LiteralWord` tokens when a single-quoted segment is followed by a double-quoted continuation (e.g., `'x'"\$HOME"`).

### Description
- Decode lexer-only escaped-dollar sentinels in `read_single_quoted_string()` before returning `Token::LiteralWord` by adding `decode_escaped_dollar_sentinel()` and using it on the continued content.
- Implement `decode_escaped_dollar_sentinel(segment: &str) -> String` which consumes `\x00` sentinels and emits the following literal char.
- Add a lexer unit test `test_single_quoted_word_continuation_decodes_escaped_dollar` and a bash spec case in `crates/bashkit/tests/spec_cases/bash/quote.test.sh` to cover `'x'"\$HOME"`.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran unit tests `cargo test -p bashkit parser::lexer::tests::test_single_quoted_word_continuation_decodes_escaped_dollar` and `cargo test -p bashkit parser::lexer::tests::test_variable_words` which both passed.
- Ran the bash spec integration `cargo test -p bashkit --test integration spec_tests::bash_spec_tests -- --nocapture` which passed (Total: 2053 | Passed: 2028 | Failed: 0 | Skipped: 25).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251addde8832b8aa5616b06735b10)