### PR TITLE
fix(interpreter): scope errexit suppression

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2183,6 +2183,26 @@ impl Interpreter {
     /// Used by `execute_source` and nested shell contexts.
     /// `run_exit_trap`: whether this shell context runs its EXIT trap.
     /// `fire_exit_hook`: whether `exit` notifies host-level on_exit hooks.
+    fn suppresses_script_body_err_exit(command: &Command, result: &ExecResult) -> bool {
+        matches!(command, Command::List(_))
+            || matches!(command, Command::Pipeline(p) if p.negated)
+            || (result.errexit_suppressed
+                && matches!(
+                    command,
+                    Command::Compound(
+                        CompoundCommand::If(_)
+                            | CompoundCommand::For(_)
+                            | CompoundCommand::ArithmeticFor(_)
+                            | CompoundCommand::While(_)
+                            | CompoundCommand::Until(_)
+                            | CompoundCommand::Case(_)
+                            | CompoundCommand::Select(_)
+                            | CompoundCommand::BraceGroup(_),
+                        _
+                    )
+                ))
+    }
+
     async fn execute_script_body(
         &mut self,
         script: &Script,
@@ -2258,9 +2278,7 @@ impl Interpreter {
 
             // Run ERR trap on non-zero exit (unless in conditional chain)
             if exit_code != 0 {
-                let suppressed = matches!(command, Command::List(_))
-                    || matches!(command, Command::Pipeline(p) if p.negated)
-                    || result.errexit_suppressed;
+                let suppressed = Self::suppresses_script_body_err_exit(command, &result);
                 if !suppressed {
                     self.run_err_trap(&mut stdout, &mut stderr).await;
                 }
@@ -2269,11 +2287,11 @@ impl Interpreter {
             // errexit (set -e): stop on non-zero exit for top-level simple commands.
             // List commands handle errexit internally (with && / || chain awareness).
             // Negated pipelines (! cmd) explicitly handle the exit code.
-            // Compound commands propagate errexit_suppressed from inner AND-OR chains.
+            // Only compound commands whose own execution context ignores -e
+            // may suppress a propagated AND-OR failure here; simple function
+            // calls and subshell compounds must still make the parent exit.
             if self.is_errexit_enabled() && exit_code != 0 {
-                let suppressed = matches!(command, Command::List(_))
-                    || matches!(command, Command::Pipeline(p) if p.negated)
-                    || result.errexit_suppressed;
+                let suppressed = Self::suppresses_script_body_err_exit(command, &result);
                 if !suppressed {
                     break;
                 }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2276,7 +2276,7 @@ impl Interpreter {
                 }
             }
 
-            // Run ERR trap on non-zero exit (unless in conditional chain)
+            // Run ERR trap on non-zero exit unless suppressed by AND-OR list, negated pipeline, or compound context
             if exit_code != 0 {
                 let suppressed = Self::suppresses_script_body_err_exit(command, &result);
                 if !suppressed {

--- a/crates/bashkit/tests/integration/issue_873_test.rs
+++ b/crates/bashkit/tests/integration/issue_873_test.rs
@@ -68,3 +68,60 @@ echo "SHOULD NOT APPEAR"
         .unwrap();
     assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
 }
+
+#[tokio::test]
+async fn set_e_subshell_and_chain_failure_exits_parent() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+( false && : )
+echo "SHOULD NOT APPEAR"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1, "stdout: {}", result.stdout);
+    assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
+}
+
+#[tokio::test]
+async fn set_e_function_and_chain_failure_exits_parent() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+f() { false && :; }
+f
+echo "SHOULD NOT APPEAR"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1, "stdout: {}", result.stdout);
+    assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
+}
+
+#[tokio::test]
+async fn err_trap_runs_for_subshell_and_function_and_chain_failures() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+trap 'echo ERR' ERR
+( false && : )
+f() { false && :; }
+f
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        result.stdout.matches("ERR").count(),
+        2,
+        "stdout: {}",
+        result.stdout
+    );
+}


### PR DESCRIPTION
### Motivation
- Correct a regression that over-suppressed `set -e` and ERR traps when `ExecResult.errexit_suppressed` was present, allowing subshells and function calls to incorrectly continue after AND-OR failures.
- Ensure semantics match bash: compound loop/brace/conditional contexts may suppress propagated AND-OR failures, but subshells and simple function calls must still cause the parent to exit under `set -e`.

### Description
- Add `suppresses_script_body_err_exit(command, result)` to centralize the suppression logic and limit propagation to `Command::List`, negated pipelines, or compound commands that should ignore `-e` (If, For, ArithmeticFor, While, Until, Case, Select, BraceGroup).
- Replace the previous inline top-level checks in `execute_script_body` with calls to the new helper so simple function calls and subshells no longer get over-suppressed.
- Add regression tests in `crates/bashkit/tests/integration/issue_873_test.rs` that assert `set -e; ( false && : ); echo after` and `set -e; f(){ false && :; }; f; echo after` cause the parent to exit and that ERR traps run for subshell/function AND-OR failures.

### Testing
- Ran `cargo test -p bashkit --test integration issue_873 -- --nocapture`, tests passed (6 passed, 0 failed).
- Ran `cargo fmt --check && cargo test -p bashkit --test integration set_e_and_or -- --nocapture`, formatting check and tests passed (11 passed, 0 failed).
- Ran `cargo clippy -p bashkit --test integration -- -D warnings`, lints passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad8bc4832b977c8af1fce4cf9d)