### PR TITLE
fix(builtins): enforce head byte limit for utf8 stdin

### DIFF
--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -180,11 +180,26 @@ fn parse_head_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<
 }
 
 /// Take the first N bytes from text.
-/// Uses char-level truncation so that Latin-1 encoded binary data
-/// (e.g. from /dev/urandom where each byte maps to one char) is
-/// counted correctly — each char represents one original byte.
+///
+/// Bashkit keeps ordinary command output as UTF-8 strings, but binary device
+/// input is represented as Latin-1 chars so `/dev/urandom` pipelines keep one
+/// char per original byte. Treat only binary-looking Latin-1 as char-counted;
+/// normal UTF-8 stdin must never emit more than `head -c N` bytes.
 fn take_first_bytes(text: &str, n: usize) -> String {
-    text.chars().take(n).collect()
+    if looks_like_latin1_binary(text) {
+        return text.chars().take(n).collect();
+    }
+
+    let mut end = text.len().min(n);
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].to_string()
+}
+
+fn looks_like_latin1_binary(text: &str) -> bool {
+    text.chars()
+        .any(|c| matches!(c, '\0'..='\x08' | '\x0b'..='\x0c' | '\x0e'..='\x1f' | '\x7f'..='\u{9f}'))
 }
 
 /// Parse arguments for tail command, including +N "from start" syntax.
@@ -352,6 +367,29 @@ mod tests {
         let result = run_head(&["-2"], Some(input)).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "a\nb\n");
+    }
+
+    #[tokio::test]
+    async fn test_head_c_multibyte_stdin_respects_byte_limit() {
+        let result = run_head(&["-c", "1"], Some("éX")).await;
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.stdout.len() <= 1,
+            "head -c 1 must not emit more than 1 byte for UTF-8 stdin"
+        );
+
+        let result = run_head(&["-c", "2"], Some("éX")).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "é");
+        assert_eq!(result.stdout.len(), 2);
+    }
+
+    #[test]
+    fn test_head_c_preserves_latin1_binary_byte_model() {
+        let input = "A\0éZ";
+        let output = take_first_bytes(input, 3);
+        assert_eq!(output.chars().count(), 3);
+        assert_eq!(output, "A\0é");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `head -c N` was implemented using `chars().take(n)`, which counts Unicode scalar values and can emit more than N UTF-8 bytes for multibyte characters.
- This broke byte-mode semantics for ordinary UTF-8 stdin while the Latin-1 representation for `/dev/urandom` pipelines must still map one byte→one char.
- The change restores exact byte-truncation for normal UTF-8 input while keeping the Latin-1 binary-device behavior intact.

### Description
- Replace the naive `take_first_bytes` implementation in `crates/bashkit/src/builtins/headtail.rs` with a function that detects binary-looking Latin-1 input and only uses char-counting for that case via a new `looks_like_latin1_binary` helper.
- For ordinary UTF-8 stdin, truncate by bytes without cutting a UTF-8 codepoint by backing up to the previous `is_char_boundary` before slicing.
- Add unit tests `test_head_c_multibyte_stdin_respects_byte_limit` and `test_head_c_preserves_latin1_binary_byte_model` to cover UTF-8 and Latin-1/binary cases.

### Testing
- Ran `cargo test -p bashkit test_head_c` and the new unit tests passed.
- Ran integration/unit tests exercising `/dev/urandom` behavior: `cargo test -p bashkit urandom_head_char_count`, `cargo test -p bashkit urandom_pipe_into_head_c_produces_data`, and `cargo test -p bashkit urandom_tr_filter_alphanumeric`, all of which passed.
- Ran formatting check `cargo fmt --check`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae4394832ba8d861cbe353ddbf)