### PR TITLE
fix(interpreter): honor errexit for final and-or failures

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4533,8 +4533,15 @@ impl Interpreter {
                     exit_code = result.exit_code;
                     self.last_exit_code = exit_code;
                     control_flow = result.control_flow;
+                    let followed_by_conditional_op =
+                        list.rest.get(i + 1).is_some_and(|(op, cmd)| {
+                            !Self::is_empty_sentinel(cmd)
+                                && matches!(op, ListOperator::And | ListOperator::Or)
+                        });
+                    // Bash suppresses errexit for AND-OR list elements except the
+                    // command following the final &&/|| operator.
                     exit_code_from_conditional_context =
-                        current_is_conditional || result.errexit_suppressed;
+                        followed_by_conditional_op || result.errexit_suppressed;
 
                     // If command signaled control flow, return immediately
                     if control_flow != ControlFlow::None {
@@ -4547,24 +4554,19 @@ impl Interpreter {
                         });
                     }
 
-                    // ERR trap: fire on non-zero exit after semicolon commands
-                    if exit_code != 0 && !current_is_conditional {
+                    // ERR trap follows the same AND-OR suppression as errexit.
+                    if exit_code != 0 && !exit_code_from_conditional_context {
                         self.run_err_trap(&mut stdout, &mut stderr).await;
                     }
                 }
             }
         }
 
-        let last_nonempty_op_is_conditional = list
-            .rest
-            .iter()
-            .rev()
-            .find(|(_, cmd)| !Self::is_empty_sentinel(cmd))
-            .is_some_and(|(op, _)| matches!(op, ListOperator::And | ListOperator::Or));
-
-        // Final errexit check for the last command
+        // Final errexit check for the last command. A non-zero status only
+        // remains suppressed when it was carried from a short-circuited or
+        // non-final AND-OR list element; a failing final &&/|| command exits.
         let should_final_errexit_check =
-            self.is_errexit_enabled() && exit_code != 0 && !last_nonempty_op_is_conditional;
+            self.is_errexit_enabled() && exit_code != 0 && !exit_code_from_conditional_context;
 
         if should_final_errexit_check {
             return Ok(ExecResult {
@@ -4581,7 +4583,7 @@ impl Interpreter {
             stderr,
             exit_code,
             control_flow: ControlFlow::None,
-            errexit_suppressed: last_nonempty_op_is_conditional && exit_code != 0,
+            errexit_suppressed: exit_code_from_conditional_context && exit_code != 0,
             ..Default::default()
         })
     }

--- a/crates/bashkit/tests/integration/set_e_and_or_tests.rs
+++ b/crates/bashkit/tests/integration/set_e_and_or_tests.rs
@@ -219,6 +219,31 @@ echo "result: ${result}"
     );
 }
 
+/// set -e: final failing command in && list inside a loop must exit.
+#[tokio::test]
+async fn set_e_exits_on_final_and_failure_in_for_loop() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+for i in 1; do
+    true && false
+done
+echo "SHOULD NOT APPEAR"
+"#,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !result.stdout.contains("SHOULD NOT APPEAR"),
+        "errexit should stop after final && command fails: exit_code={}, stdout={:?}, stderr={:?}",
+        result.exit_code,
+        result.stdout,
+        result.stderr
+    );
+}
+
 /// set -e should still exit on non-AND-OR failures
 #[tokio::test]
 async fn set_e_exits_on_plain_failure() {


### PR DESCRIPTION
### Motivation
- Correct bash semantics: `set -e` must not be suppressed when the final command of an `&&`/`||` list fails, but prior implementation marked any non-zero AND-OR list as suppressed and let outer compound commands continue.

### Description
- In `execute_list` compute whether the current element is followed by a conditional operator (`followed_by_conditional_op`) and use that to decide conditional-context suppression.
- Replace the previous coarse `last_nonempty_op_is_conditional` logic with `exit_code_from_conditional_context` and use it for ERR-trap checks, final `errexit` decision, and the returned `errexit_suppressed` flag.
- Ensure final failing `&&`/`||` commands will trigger `set -e`/ERR behavior while still suppressing errexit for short-circuited/non-final conditional elements.
- Add an integration test `set_e_exits_on_final_and_failure_in_for_loop` in `crates/bashkit/tests/integration/set_e_and_or_tests.rs` to cover the regression (`for i in 1; do true && false; done; echo ...`).

### Testing
- Ran `cargo test -p bashkit --test integration set_e_and_or_tests` and the integration suite covering the changed behavior completed with all tests passing (including the new regression test). 
- Ran the targeted tests `set_e_exits_on_final_and_failure_in_for_loop` and `set_e_and_chain_at_end_of_for_body` individually and both passed. 
- Ran `cargo fmt --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258ddb638832bb8169e044777930d)