### PR TITLE
fix(sort): preserve stable equal-key order

### DIFF
--- a/crates/bashkit/src/builtins/sortuniq.rs
+++ b/crates/bashkit/src/builtins/sortuniq.rs
@@ -523,8 +523,9 @@ impl Builtin for Sort {
 
         // Sort the lines
         let sort_fn = |a: &String, b: &String| -> std::cmp::Ordering {
-            if !key_specs.is_empty() {
+            let ord = if !key_specs.is_empty() {
                 // Multi-key sort: compare by each key spec in order
+                let mut result = std::cmp::Ordering::Equal;
                 for key in &key_specs {
                     let ka = extract_key_spec(a, delimiter, key);
                     let kb = extract_key_spec(b, delimiter, key);
@@ -543,28 +544,35 @@ impl Builtin for Sort {
                     };
                     let ord = if key.reverse { ord.reverse() } else { ord };
                     if ord != std::cmp::Ordering::Equal {
-                        return ord;
+                        result = ord;
+                        break;
                     }
                 }
-                // All keys equal — fall back to full-line comparison
-                a.cmp(b)
+                if result == std::cmp::Ordering::Equal && !stable {
+                    // GNU sort uses the full line as the final tie-breaker unless -s disables it.
+                    a.cmp(b)
+                } else {
+                    result
+                }
             } else {
                 // No key specs — use global flags on whole line
-                if version_sort {
-                    let ord = version_cmp(a, b);
-                    if ord == std::cmp::Ordering::Equal {
-                        a.cmp(b)
-                    } else {
-                        ord
-                    }
+                let ord = if version_sort {
+                    version_cmp(a, b)
                 } else {
-                    let ord = compare_keys(a, b, numeric, human_numeric, month_sort, fold_case);
-                    if ord == std::cmp::Ordering::Equal {
-                        a.cmp(b)
-                    } else {
-                        ord
-                    }
+                    compare_keys(a, b, numeric, human_numeric, month_sort, fold_case)
+                };
+                if ord == std::cmp::Ordering::Equal && !stable {
+                    // Without -s, equal mode-specific keys still fall back to lexical line order.
+                    a.cmp(b)
+                } else {
+                    ord
                 }
+            };
+
+            if reverse && ord != std::cmp::Ordering::Equal {
+                ord.reverse()
+            } else {
+                ord
             }
         };
 
@@ -572,10 +580,6 @@ impl Builtin for Sort {
             all_lines.sort_by(sort_fn);
         } else {
             all_lines.sort_unstable_by(sort_fn);
-        }
-
-        if reverse {
-            all_lines.reverse();
         }
 
         if unique {

--- a/crates/bashkit/src/builtins/sortuniq.rs
+++ b/crates/bashkit/src/builtins/sortuniq.rs
@@ -583,7 +583,10 @@ impl Builtin for Sort {
         }
 
         if unique {
-            all_lines.dedup();
+            // Use a HashSet so identical lines are removed even when not adjacent
+            // (can happen in stable mode when equal-key different-content lines interleave).
+            let mut seen = std::collections::HashSet::new();
+            all_lines.retain(|line| seen.insert(line.clone()));
         }
 
         let sep = if zero_terminated { "\0" } else { "\n" };

--- a/crates/bashkit/tests/spec_cases/bash/sortuniq.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/sortuniq.test.sh
@@ -146,6 +146,33 @@ b 1
 b 3
 ### end
 
+### sort_stable_equal_field_preserves_input_order
+# Stable sort preserves input order when selected field keys compare equal
+printf 'b 3\na 2\nb 1\n' | sort -s -k1,1
+### expect
+a 2
+b 3
+b 1
+### end
+
+### sort_stable_numeric_equal_preserves_input_order
+# Stable numeric sort preserves input order when numeric keys compare equal
+printf '2 beta\n1 one\n2 alpha\n' | sort -s -n
+### expect
+1 one
+2 beta
+2 alpha
+### end
+
+### sort_stable_reverse_equal_field_preserves_input_order
+# Reverse stable sort reverses key order without reversing equal-key records
+printf 'b 3\na 2\nb 1\n' | sort -s -r -k1,1
+### expect
+b 3
+b 1
+a 2
+### end
+
 ### sort_check
 # Check if input is sorted
 printf 'a\nb\nc\n' | sort -c


### PR DESCRIPTION
### Motivation
- A functional regression caused `sort -s` to reorder records with equal keys because the comparator used a full-line tie-breaker even when stable mode was requested. 
- The change restores documented stable semantics (preserve input order for equal keys) while keeping existing features (numeric/key-based comparisons, reverse, etc.).

### Description
- Update `crates/bashkit/src/builtins/sortuniq.rs` so the comparator does not fall back to a full-line comparison when `-s` (stable) is enabled, returning `Ordering::Equal` for equal keys instead. 
- Apply global reverse handling inside the comparator (per-comparison `ord.reverse()` when applicable) instead of reversing the entire sorted vector, preserving the input order of equal-key groups in stable mode. 
- Add regression spec tests in `crates/bashkit/tests/spec_cases/bash/sortuniq.test.sh` covering stable field-key equality, stable numeric-key equality, and reverse-stable behavior.

### Testing
- Ran `cargo fmt --check` and it succeeded. 
- Ran `cargo test -p bashkit --test integration bash_spec_tests -- --nocapture` and the spec integration suite passed (new regression tests exercised). 
- Ran `cargo clippy -p bashkit -- -D warnings` and it completed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adc248832b800bbf8f12777882)