### PR TITLE
fix(api): clear tty state when disabled

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1481,8 +1481,11 @@ impl BashBuilder {
     ///     .build();
     /// ```
     pub fn tty(mut self, fd: u32, is_terminal: bool) -> Self {
+        let key = format!("_TTY_{}", fd);
         if is_terminal {
-            self.env.insert(format!("_TTY_{}", fd), "1".to_string());
+            self.env.insert(key, "1".to_string());
+        } else {
+            self.env.remove(&key);
         }
         self
     }

--- a/crates/bashkit/tests/integration/tty_tests.rs
+++ b/crates/bashkit/tests/integration/tty_tests.rs
@@ -44,3 +44,22 @@ async fn tty_test_builtin_bracket() {
     let result = bash.exec("[ -t 1 ] && echo yes || echo no").await.unwrap();
     assert_eq!(result.stdout.trim(), "yes");
 }
+
+/// false clears a prior builder terminal configuration
+#[tokio::test]
+async fn tty_false_clears_prior_builder_true() {
+    let mut bash = Bash::builder().tty(1, true).tty(1, false).build();
+    let result = bash
+        .exec("[[ -t 1 ]] && echo yes || echo no")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.trim(), "no");
+}
+
+/// false overrides an inherited _TTY_N environment value
+#[tokio::test]
+async fn tty_false_overrides_env_true() {
+    let mut bash = Bash::builder().env("_TTY_1", "1").tty(1, false).build();
+    let result = bash.exec("[ -t 1 ] && echo yes || echo no").await.unwrap();
+    assert_eq!(result.stdout.trim(), "no");
+}


### PR DESCRIPTION
### Motivation
- The `BashBuilder::tty(fd, is_terminal)` API is boolean but previously only set `_TTY_<fd>=1` for `true` and left prior `true` state in place for `false`, causing stale terminal detection.

### Description
- Make `BashBuilder::tty` remove the `_TTY_<fd>` env entry when `is_terminal` is `false`, preventing prior `true` settings from persisting (`crates/bashkit/src/lib.rs`).
- Add two regression tests that assert `.tty(1, true).tty(1, false)` and `.env("_TTY_1", "1").tty(1, false)` produce `false` for `[ -t 1 ]` / `[[ -t 1 ]]` (`crates/bashkit/tests/integration/tty_tests.rs`).

### Testing
- Ran `cargo fmt --check` and the integration tests via `cargo test -p bashkit --test integration tty_tests:: -- --nocapture` and `cargo test -p bashkit --test integration tty_false -- --nocapture`.
- All invoked tests passed (new regression tests included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dbcf84832b8c1dd59f186dc1ee)