### PR TITLE
fix(vfs): preserve UTF-8 file decoding

### DIFF
--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -62,13 +62,16 @@ impl Builtin for Head {
                 match ctx.fs.read_file(&path).await {
                     Ok(content) => {
                         if byte_mode {
-                            // Byte mode: take first N bytes, preserve raw byte values
+                            // String-backed stdout cannot carry arbitrary raw bytes. Decode
+                            // valid UTF-8 normally, and use the Latin-1 fallback only for
+                            // non-UTF-8 device/binary data such as /dev/urandom.
                             let bytes = &content[..content.len().min(count)];
-                            let s: String = bytes.iter().map(|&b| b as char).collect();
-                            output.push_str(&s);
+                            output.push_str(&decode_file_bytes_for_path(&path, bytes));
                         } else {
-                            let text: String = content.iter().map(|&b| b as char).collect();
-                            output.push_str(&take_first_lines(&text, count));
+                            output.push_str(&take_first_lines(
+                                &decode_file_bytes_for_path(&path, &content),
+                                count,
+                            ));
                         }
                     }
                     Err(e) => {
@@ -177,6 +180,18 @@ fn parse_head_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<
     }
 
     Ok((count, byte_mode, files))
+}
+
+fn decode_file_bytes_for_path(path: &std::path::Path, bytes: &[u8]) -> String {
+    if path == std::path::Path::new("/dev/urandom") || path == std::path::Path::new("/dev/random") {
+        latin1_bytes_to_string(bytes)
+    } else {
+        String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| latin1_bytes_to_string(bytes))
+    }
+}
+
+fn latin1_bytes_to_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|&b| b as char).collect()
 }
 
 /// Take the first N bytes from text.

--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -182,11 +182,33 @@ fn parse_head_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<
     Ok((count, byte_mode, files))
 }
 
+fn normalize_vfs_path(path: &std::path::Path) -> std::path::PathBuf {
+    path.components()
+        .fold(std::path::PathBuf::new(), |mut acc, c| {
+            match c {
+                std::path::Component::ParentDir => {
+                    acc.pop();
+                    acc
+                }
+                std::path::Component::CurDir => acc,
+                c => {
+                    acc.push(c);
+                    acc
+                }
+            }
+        })
+}
+
 fn decode_file_bytes_for_path(path: &std::path::Path, bytes: &[u8]) -> String {
-    if path == std::path::Path::new("/dev/urandom") || path == std::path::Path::new("/dev/random") {
+    let normalized = normalize_vfs_path(path);
+    if normalized == std::path::Path::new("/dev/urandom")
+        || normalized == std::path::Path::new("/dev/random")
+    {
         latin1_bytes_to_string(bytes)
     } else {
-        String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| latin1_bytes_to_string(bytes))
+        std::str::from_utf8(bytes)
+            .map(str::to_owned)
+            .unwrap_or_else(|_| latin1_bytes_to_string(bytes))
     }
 }
 

--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -184,17 +184,15 @@ fn parse_head_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<
 
 fn normalize_vfs_path(path: &std::path::Path) -> std::path::PathBuf {
     path.components()
-        .fold(std::path::PathBuf::new(), |mut acc, c| {
-            match c {
-                std::path::Component::ParentDir => {
-                    acc.pop();
-                    acc
-                }
-                std::path::Component::CurDir => acc,
-                c => {
-                    acc.push(c);
-                    acc
-                }
+        .fold(std::path::PathBuf::new(), |mut acc, c| match c {
+            std::path::Component::ParentDir => {
+                acc.pop();
+                acc
+            }
+            std::path::Component::CurDir => acc,
+            c => {
+                acc.push(c);
+                acc
             }
         })
 }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -456,11 +456,30 @@ fn command_not_found_message(name: &str, known_commands: &[&str]) -> String {
 /// byte model for random devices, and use it as a fallback for other non-UTF-8
 /// data that cannot be represented as text without replacement.
 fn decode_file_bytes(bytes: &[u8]) -> String {
-    String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| latin1_bytes_to_string(bytes))
+    std::str::from_utf8(bytes)
+        .map(str::to_owned)
+        .unwrap_or_else(|_| latin1_bytes_to_string(bytes))
+}
+
+fn normalize_vfs_path(path: &Path) -> std::path::PathBuf {
+    path.components().fold(std::path::PathBuf::new(), |mut acc, c| {
+        match c {
+            std::path::Component::ParentDir => {
+                acc.pop();
+                acc
+            }
+            std::path::Component::CurDir => acc,
+            c => {
+                acc.push(c);
+                acc
+            }
+        }
+    })
 }
 
 fn decode_file_bytes_for_path(path: &Path, bytes: &[u8]) -> String {
-    if path == Path::new("/dev/urandom") || path == Path::new("/dev/random") {
+    let normalized = normalize_vfs_path(path);
+    if normalized == Path::new("/dev/urandom") || normalized == Path::new("/dev/random") {
         latin1_bytes_to_string(bytes)
     } else {
         decode_file_bytes(bytes)

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -462,8 +462,8 @@ fn decode_file_bytes(bytes: &[u8]) -> String {
 }
 
 fn normalize_vfs_path(path: &Path) -> std::path::PathBuf {
-    path.components().fold(std::path::PathBuf::new(), |mut acc, c| {
-        match c {
+    path.components()
+        .fold(std::path::PathBuf::new(), |mut acc, c| match c {
             std::path::Component::ParentDir => {
                 acc.pop();
                 acc
@@ -473,8 +473,7 @@ fn normalize_vfs_path(path: &Path) -> std::path::PathBuf {
                 acc.push(c);
                 acc
             }
-        }
-    })
+        })
 }
 
 fn decode_file_bytes_for_path(path: &Path, bytes: &[u8]) -> String {

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -451,15 +451,28 @@ fn command_not_found_message(name: &str, known_commands: &[&str]) -> String {
     msg
 }
 
-/// Check if a path refers to /dev/null after normalization.
-/// Handles attempts to bypass via paths like `/dev/../dev/null`.
-/// Convert bytes to string preserving all byte values (Latin-1/ISO 8859-1 mapping).
-/// Each byte 0x00-0xFF maps to the corresponding Unicode code point.
-/// This avoids the lossy UTF-8 conversion that replaces bytes > 0x7F with U+FFFD.
-fn bytes_to_latin1_string(bytes: &[u8]) -> String {
+/// Decode file bytes for String-backed interpreter paths. Prefer valid UTF-8
+/// so scripts and text files keep Unicode intact; force the existing Latin-1
+/// byte model for random devices, and use it as a fallback for other non-UTF-8
+/// data that cannot be represented as text without replacement.
+fn decode_file_bytes(bytes: &[u8]) -> String {
+    String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| latin1_bytes_to_string(bytes))
+}
+
+fn decode_file_bytes_for_path(path: &Path, bytes: &[u8]) -> String {
+    if path == Path::new("/dev/urandom") || path == Path::new("/dev/random") {
+        latin1_bytes_to_string(bytes)
+    } else {
+        decode_file_bytes(bytes)
+    }
+}
+
+fn latin1_bytes_to_string(bytes: &[u8]) -> String {
     bytes.iter().map(|&b| b as char).collect()
 }
 
+/// Check if a path refers to /dev/null after normalization.
+/// Handles attempts to bypass via paths like `/dev/../dev/null`.
 fn is_dev_null(path: &Path) -> bool {
     // Normalize the path to handle .. and . components
     let mut normalized = PathBuf::new();
@@ -3923,7 +3936,7 @@ impl Interpreter {
         } else if let Some(ref file) = script_file {
             let path = self.resolve_path(file);
             match self.fs.read_file(&path).await {
-                Ok(content) => bytes_to_latin1_string(&content),
+                Ok(content) => decode_file_bytes_for_path(&path, &content),
                 Err(_) => {
                     return Ok(ExecResult::err(
                         format!("{}: {}: No such file or directory\n", shell_name, file),
@@ -4860,7 +4873,7 @@ impl Interpreter {
         for (path_str, commands) in deferred {
             let path = Path::new(&path_str);
             let stdin_data = if let Ok(bytes) = self.fs.read_file(path).await {
-                let s = bytes_to_latin1_string(&bytes);
+                let s = decode_file_bytes_for_path(path, &bytes);
                 if s.is_empty() { None } else { Some(s) }
             } else {
                 None
@@ -5266,7 +5279,7 @@ impl Interpreter {
                     let target_path = self.expand_word(&redirect.target).await?;
                     let path = self.resolve_path(&target_path);
                     let content = self.fs.read_file(&path).await?;
-                    let text = bytes_to_latin1_string(&content);
+                    let text = decode_file_bytes_for_path(&path, &content);
                     let fd = redirect.fd.or(resolved_fd_var);
                     if let Some(fd) = fd {
                         self.ensure_persistent_fd_capacity(fd)?;
@@ -5803,7 +5816,7 @@ impl Interpreter {
 
         // Read file content
         let content = match self.fs.read_file(&path).await {
-            Ok(c) => bytes_to_latin1_string(&c),
+            Ok(c) => decode_file_bytes_for_path(&path, &c),
             Err(_) => {
                 return Ok(ExecResult::err(
                     format!("bash: {}: No such file or directory", name),
@@ -5878,7 +5891,7 @@ impl Interpreter {
                     continue;
                 }
                 if let Ok(content) = self.fs.read_file(&candidate).await {
-                    let script_text = bytes_to_latin1_string(&content);
+                    let script_text = decode_file_bytes_for_path(&candidate, &content);
                     let resolved = candidate.to_string_lossy();
                     let result = self
                         .execute_script_content(&resolved, &script_text, args, stdin, redirects)
@@ -6041,7 +6054,7 @@ impl Interpreter {
         let content = if filename.contains('/') {
             let path = self.resolve_path(filename);
             match self.fs.read_file(&path).await {
-                Ok(c) => bytes_to_latin1_string(&c),
+                Ok(c) => decode_file_bytes_for_path(&path, &c),
                 Err(_) => {
                     return Ok(ExecResult::err(
                         format!("source: {}: No such file or directory", filename),
@@ -6064,7 +6077,7 @@ impl Interpreter {
                 }
                 let candidate = PathBuf::from(dir).join(filename);
                 if let Ok(c) = self.fs.read_file(&candidate).await {
-                    found = Some(bytes_to_latin1_string(&c));
+                    found = Some(decode_file_bytes_for_path(&candidate, &c));
                     break;
                 }
             }
@@ -6072,7 +6085,7 @@ impl Interpreter {
             if found.is_none() {
                 let path = self.resolve_path(filename);
                 if let Ok(c) = self.fs.read_file(&path).await {
-                    found = Some(bytes_to_latin1_string(&c));
+                    found = Some(decode_file_bytes_for_path(&path, &c));
                 }
             }
             match found {
@@ -7522,7 +7535,7 @@ impl Interpreter {
                         )));
                     } else {
                         let content = self.fs.read_file(&path).await?;
-                        stdin = Some(bytes_to_latin1_string(&content));
+                        stdin = Some(decode_file_bytes_for_path(&path, &content));
                     }
                 }
                 RedirectKind::HereString => {

--- a/crates/bashkit/tests/integration/urandom_tests.rs
+++ b/crates/bashkit/tests/integration/urandom_tests.rs
@@ -62,3 +62,39 @@ async fn urandom_tr_filter_alphanumeric() {
         output
     );
 }
+
+/// Regression: valid UTF-8 file contents must not be decoded as Latin-1 mojibake.
+#[tokio::test]
+async fn utf8_file_reads_do_not_mojibake() {
+    use std::path::Path;
+
+    let mut bash = Bash::new();
+    let fs = bash.fs();
+    fs.write_file(Path::new("/tmp/utf8.txt"), "café\n".as_bytes())
+        .await
+        .unwrap();
+
+    let result = bash.exec("cat < /tmp/utf8.txt").await.unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "café\n");
+
+    let result = bash.exec("head -n 1 /tmp/utf8.txt").await.unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "café\n");
+}
+
+/// Regression: UTF-8 shell script files should parse their non-ASCII literals intact.
+#[tokio::test]
+async fn utf8_script_file_decodes_as_utf8() {
+    use std::path::Path;
+
+    let mut bash = Bash::new();
+    let fs = bash.fs();
+    fs.write_file(Path::new("/tmp/script.sh"), "echo café\n".as_bytes())
+        .await
+        .unwrap();
+
+    let result = bash.exec("bash /tmp/script.sh").await.unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "café\n");
+}


### PR DESCRIPTION
### Motivation
- Recent Latin-1 byte→char mapping avoided U+FFFD but corrupted valid UTF‑8 file contents and still did not preserve raw bytes when Strings were re-encoded. 
- Need to preserve current `/dev/urandom` behavior for random-byte pipelines while restoring correct UTF‑8 handling for scripts, text files and redirects.

### Description
- Prefer decoding file bytes with `String::from_utf8(...)` and only fall back to a Latin‑1 1:1 byte→char mapping when the bytes are not valid UTF‑8. 
- Keep `/dev/urandom` and `/dev/random` on the Latin‑1 path so random-byte pipelines (e.g. `tr ... < /dev/urandom | head -c`) keep working and do not introduce U+FFFD. 
- Replace the old helper with `decode_file_bytes`, `decode_file_bytes_for_path`, and `latin1_bytes_to_string`, and wire `decode_file_bytes_for_path` into interpreter file-read paths, input redirection, process-substitutions, `source`/`.` execution, and `head` builtin file reads. 
- Add regression tests ensuring UTF‑8 files and UTF‑8 script files are decoded intact (`utf8_file_reads_do_not_mojibake`, `utf8_script_file_decodes_as_utf8`) and update `head` to use the new helper for both byte and line modes.

### Testing
- Ran `cargo fmt --check` and formatting checks passed. 
- Ran the integration test for the urandom suite with `cargo test -p bashkit --test integration urandom_tests -- --nocapture` and all tests passed. 
- Ran head/tail unit tests with `cargo test -p bashkit builtins::headtail::tests -- --nocapture` and all tests passed. 
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` and the linter passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251aeb44c832ba5f2966a3e819c2a)