### PR TITLE
fix(interpreter): restore errexit for final list and loop failures

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2608,6 +2608,9 @@ impl Interpreter {
                 // Consume Exit and Return control flow at subshell boundary —
                 // they only terminate the subshell, not the parent shell.
                 // Return is used by ${var:?msg} error handling and nounset errors.
+                // Also clear errexit_suppressed: inner AND/OR suppression must not
+                // escape the subshell boundary and prevent the parent set -e from
+                // firing on the subshell's non-zero exit code.
                 if let Ok(ref mut res) = result {
                     match res.control_flow {
                         ControlFlow::Exit(code) | ControlFlow::Return(code) => {
@@ -2616,6 +2619,7 @@ impl Interpreter {
                         }
                         _ => {}
                     }
+                    res.errexit_suppressed = false;
                 }
 
                 result
@@ -6590,6 +6594,11 @@ impl Interpreter {
             result.exit_code = code;
             result.control_flow = ControlFlow::None;
         }
+
+        // Clear errexit_suppressed at function boundary: AND/OR suppression
+        // from inside the function must not prevent the caller's set -e from
+        // firing on the function's non-zero exit code.
+        result.errexit_suppressed = false;
 
         self.apply_redirections(result, redirects).await
     }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4531,10 +4531,6 @@ impl Interpreter {
             // POSIX `errexit` suppression applies to non-final commands in an
             // AND-OR list; the final executed command can still abort on failure.
             let current_is_conditional = matches!(op, ListOperator::And | ListOperator::Or);
-            let next_is_conditional = matches!(
-                list.rest.get(i + 1).map(|(op, _)| op),
-                Some(ListOperator::And | ListOperator::Or)
-            );
 
             // Determine if THIS command should be backgrounded.
             // A command is backgrounded when the NEXT separator is Background

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2281,20 +2281,22 @@ impl Interpreter {
 
             // Run ERR trap on non-zero exit unless suppressed by AND-OR list, negated pipeline, or compound context
             if exit_code != 0 {
+                // Lists are suppressed here because execute_list already fired
+                // the ERR trap for the failing subcommand; firing again would
+                // double-invoke the trap.
                 let suppressed = Self::suppresses_script_body_err_exit(command, &result);
                 if !suppressed {
                     self.run_err_trap(&mut stdout, &mut stderr).await;
                 }
             }
 
-            // errexit (set -e): stop on non-zero exit for top-level simple commands.
-            // List commands handle errexit internally (with && / || chain awareness).
-            // Negated pipelines (! cmd) explicitly handle the exit code.
-            // Only compound commands whose own execution context ignores -e
-            // may suppress a propagated AND-OR failure here; simple function
-            // calls and subshell compounds must still make the parent exit.
+            // errexit (set -e): stop on non-zero exit unless the callee marks
+            // the status as suppressed (for example, a short-circuited AND-OR
+            // list) or the command is an explicitly negated pipeline.
+            // Lists are NOT suppressed here so set -e fires for failing lists.
             if self.is_errexit_enabled() && exit_code != 0 {
-                let suppressed = Self::suppresses_script_body_err_exit(command, &result);
+                let suppressed = matches!(command, Command::Pipeline(p) if p.negated)
+                    || result.errexit_suppressed;
                 if !suppressed {
                     break;
                 }
@@ -2743,8 +2745,16 @@ impl Interpreter {
                 let emit_before = self.output_emit_count;
                 let result = self.execute_command_sequence(&for_cmd.body).await?;
                 self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                let should_errexit = self.is_errexit_enabled()
+                    && result.exit_code != 0
+                    && result.control_flow == ControlFlow::None
+                    && !result.errexit_suppressed;
                 match acc.accumulate(result) {
-                    state::LoopAction::None => {}
+                    state::LoopAction::None => {
+                        if should_errexit {
+                            return Ok(acc.finish());
+                        }
+                    }
                     state::LoopAction::Break => break,
                     state::LoopAction::Continue => continue,
                     state::LoopAction::Exit(r) => return Ok(r),
@@ -2972,8 +2982,16 @@ impl Interpreter {
                 let emit_before = self.output_emit_count;
                 let result = self.execute_command_sequence(&arith_for.body).await?;
                 self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                let should_errexit = self.is_errexit_enabled()
+                    && result.exit_code != 0
+                    && result.control_flow == ControlFlow::None
+                    && !result.errexit_suppressed;
                 match acc.accumulate(result) {
-                    state::LoopAction::None | state::LoopAction::Continue => {}
+                    state::LoopAction::None | state::LoopAction::Continue => {
+                        if should_errexit {
+                            return Ok(acc.finish());
+                        }
+                    }
                     state::LoopAction::Break => break,
                     state::LoopAction::Exit(r) => return Ok(r),
                 }
@@ -3536,8 +3554,16 @@ impl Interpreter {
                 let emit_before = self.output_emit_count;
                 let result = self.execute_command_sequence(body).await?;
                 self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
+                let should_errexit = self.is_errexit_enabled()
+                    && result.exit_code != 0
+                    && result.control_flow == ControlFlow::None
+                    && !result.errexit_suppressed;
                 match acc.accumulate(result) {
-                    state::LoopAction::None => {}
+                    state::LoopAction::None => {
+                        if should_errexit {
+                            return Ok(acc.finish());
+                        }
+                    }
                     state::LoopAction::Break => break,
                     state::LoopAction::Continue => continue,
                     state::LoopAction::Exit(r) => return Ok(r),
@@ -4501,8 +4527,14 @@ impl Interpreter {
                 continue;
             }
 
-            // Check if next operator (if any) is && or ||
+            // Check if this command is followed by another && / || operator.
+            // POSIX `errexit` suppression applies to non-final commands in an
+            // AND-OR list; the final executed command can still abort on failure.
             let current_is_conditional = matches!(op, ListOperator::And | ListOperator::Or);
+            let next_is_conditional = matches!(
+                list.rest.get(i + 1).map(|(op, _)| op),
+                Some(ListOperator::And | ListOperator::Or)
+            );
 
             // Determine if THIS command should be backgrounded.
             // A command is backgrounded when the NEXT separator is Background

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2279,11 +2279,11 @@ impl Interpreter {
                 }
             }
 
-            // Run ERR trap on non-zero exit unless suppressed by AND-OR list, negated pipeline, or compound context
+            // Run ERR trap on non-zero exit (unless in conditional chain).
+            // Lists are suppressed here because execute_list already fired
+            // the ERR trap for the failing subcommand; firing again would
+            // double-invoke the trap (e.g. `set -e; trap 'f' ERR; false`).
             if exit_code != 0 {
-                // Lists are suppressed here because execute_list already fired
-                // the ERR trap for the failing subcommand; firing again would
-                // double-invoke the trap.
                 let suppressed = Self::suppresses_script_body_err_exit(command, &result);
                 if !suppressed {
                     self.run_err_trap(&mut stdout, &mut stderr).await;

--- a/crates/bashkit/tests/integration/set_e_and_or_tests.rs
+++ b/crates/bashkit/tests/integration/set_e_and_or_tests.rs
@@ -287,3 +287,146 @@ echo "SHOULD NOT APPEAR"
         result.stderr
     );
 }
+
+/// set -e: final failure in an AND list should abort following commands.
+#[tokio::test]
+async fn set_e_final_and_failure_exits_in_function() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+f() {
+    true && false
+    echo "SHOULD NOT APPEAR"
+}
+f
+echo "AFTER"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
+    assert!(!result.stdout.contains("AFTER"));
+}
+
+/// set -e: top-level final AND-list failure should abort following commands.
+#[tokio::test]
+async fn set_e_final_and_failure_exits_top_level() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+true && false
+echo "SHOULD NOT APPEAR"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
+}
+
+/// set -e: plain failure in for body should stop before later iterations.
+#[tokio::test]
+async fn set_e_plain_failure_stops_for_loop_immediately() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+for x in a b; do
+    echo "$x"
+    false
+done
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.stdout.trim(), "a");
+}
+
+/// set -e: plain failure in C-style for body should stop before step/next iteration.
+#[tokio::test]
+async fn set_e_plain_failure_stops_arithmetic_for_loop_immediately() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+for ((i=0; i<2; i++)); do
+    echo "$i"
+    false
+done
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.stdout.trim(), "0");
+}
+
+/// set -e: plain failure in while body should stop before later iterations.
+#[tokio::test]
+async fn set_e_plain_failure_stops_while_loop_immediately() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+i=0
+while [[ $i -lt 2 ]]; do
+    echo "$i"
+    ((i++)) || true
+    false
+done
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.stdout.trim(), "0");
+}
+
+/// set -e: plain failure in until body should stop before later iterations.
+#[tokio::test]
+async fn set_e_plain_failure_stops_until_loop_immediately() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+i=0
+until [[ $i -ge 2 ]]; do
+    echo "$i"
+    ((i++)) || true
+    false
+done
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.stdout.trim(), "0");
+}
+
+/// set -e: final failure in an OR list should abort following commands.
+#[tokio::test]
+async fn set_e_final_or_failure_exits_top_level() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+false || false
+echo "SHOULD NOT APPEAR"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
+}


### PR DESCRIPTION
### Motivation
- A previous change over-broadened `set -e` suppression and removed loop-body checks, causing loops and enclosing sequences to continue after failures that should abort.
- Restore POSIX/bash semantics: final failures in AND/OR lists and plain failures in loop bodies must trigger `errexit` unless explicitly suppressed.

### Description
- Reinstate top-level `errexit` handling so only callee-marked suppression or negated pipelines bypass aborting execution in `execute_script_body`.
- Stop loop execution immediately when a loop body returns an unsuppressed non-zero status by checking `result.exit_code`, `result.control_flow`, and `result.errexit_suppressed` before continuing iterations in `for`, arithmetic `for`, `while`, and `until` handlers in `interpreter/mod.rs`.
- Narrow AND/OR-list suppression to non-final/short-circuited elements by tracking `exit_code_from_conditional_context` and using the next-operator to decide suppression in `execute_list`.
- Add regression tests covering final AND/OR failures and immediate loop-abort behavior in `crates/bashkit/tests/integration/set_e_and_or_tests.rs`.

### Testing
- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test -p bashkit --test integration set_e_and_or_tests -- --nocapture` and all integration cases in that suite passed. 
- Ran `cargo test -p bashkit --lib` and the full library test suite passed (no failures). 
- Ran `cargo clippy -p bashkit --lib --tests -- -D warnings` and lints passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae6614832b9093a9d4eccba68e)