### PR TITLE
fix(pi): isolate bashkit state per agent start

### DIFF
--- a/examples/bashkit-pi/README.md
+++ b/examples/bashkit-pi/README.md
@@ -56,11 +56,11 @@ pi (LLM agent)
   └── edit tool  ──→ Bash.readFile() + writeFile()  ──→ bashkit VFS (direct)
 ```
 
-Single `Bash` instance shared across all tools. read/write/edit use direct VFS APIs (no shell quoting). bash tool uses `executeSync()`. Both share the same VFS — files created by any tool are visible to all others.
+One `Bash` instance is active per Pi agent session and shared across all tools in that session. read/write/edit use direct VFS APIs (no shell quoting). bash tool uses `executeSync()`. Both share the same per-session VFS — files created by any tool are visible to all others in the same agent session.
 
 ## How It Works
 
-1. Extension creates a single `Bash` instance on load
-2. All four tools (bash, read, write, edit) operate on the same virtual filesystem
-3. Files created by `write` are visible to `bash`, `read`, `edit` — and vice versa
-4. Shell state (variables, cwd, functions) persists across `bash` calls
+1. Extension creates a fresh `Bash` instance for each `before_agent_start` event
+2. All four tools (bash, read, write, edit) operate on that session's virtual filesystem
+3. Files created by `write` are visible to `bash`, `read`, `edit` — and vice versa inside the same session
+4. Shell state (variables, cwd, functions) persists across `bash` calls in the same session, then resets for the next session

--- a/examples/bashkit-pi/bashkit-extension.ts
+++ b/examples/bashkit-pi/bashkit-extension.ts
@@ -4,6 +4,7 @@
  * Uses @everruns/bashkit Node.js bindings (NAPI-RS) — no subprocess, no Python.
  * All operations run against bashkit's in-memory virtual filesystem.
  * State (variables, files, cwd) persists across tool calls within a session.
+ * Each Pi agent start gets a fresh Bash instance; never share VFS across sessions.
  *
  * read/write/edit use direct VFS APIs (readFile, writeFile, mkdir, exists).
  * bash tool uses executeSync for shell commands.
@@ -27,8 +28,23 @@ const __dirname_ext =
 const require_ext = createRequire(resolve(__dirname_ext, "node_modules") + "/");
 const { Bash, BashTool } = require_ext("@everruns/bashkit");
 
-// Single bashkit instance — state persists across all tool calls
-const bash = new Bash({ username: "user", hostname: "pi-sandbox", maxCommands: 1_000_000 });
+const BASH_OPTIONS = {
+	username: "user",
+	hostname: "pi-sandbox",
+	maxCommands: 1_000_000,
+};
+
+function createBash() {
+	return new Bash(BASH_OPTIONS);
+}
+
+// Session boundary: Bash owns VFS, cwd, variables, and functions. Reset it on each
+// agent start so reused Pi processes cannot leak state across tenants/sessions.
+let sessionBash = createBash();
+
+function currentBash() {
+	return sessionBash;
+}
 
 // BashTool for generic system prompt and tool metadata
 const bashTool = new BashTool({ username: "user", hostname: "pi-sandbox" });
@@ -40,7 +56,10 @@ function resolvePath(userPath: string): string {
 }
 
 // Ensure parent directory exists for a file path
-function ensureParentDir(filePath: string): void {
+function ensureParentDir(
+	filePath: string,
+	bash: InstanceType<typeof Bash>,
+): void {
 	const dir = filePath.replace(/\/[^/]*$/, "");
 	if (dir && dir !== filePath && !bash.exists(dir)) {
 		bash.mkdir(dir, true);
@@ -65,6 +84,7 @@ function buildSystemPrompt(): string {
 export default function (pi: any) {
 	// Inject bashkit context into the LLM system prompt
 	pi.on("before_agent_start", async (event: any) => {
+		sessionBash = createBash();
 		return {
 			systemPrompt: event.systemPrompt + "\n\n" + buildSystemPrompt(),
 		};
@@ -93,6 +113,7 @@ export default function (pi: any) {
 			_toolCallId: string,
 			params: { command: string; timeout?: number },
 		) {
+			const bash = currentBash();
 			// Convert caller-supplied seconds to milliseconds for AbortSignal.
 			// If no timeout is given, execute unbounded (subject to Bash instance limits).
 			const signal =
@@ -140,6 +161,7 @@ export default function (pi: any) {
 			_toolCallId: string,
 			params: { path: string; offset?: number; limit?: number },
 		) {
+			const bash = currentBash();
 			const absPath = resolvePath(params.path);
 			const content = bash.readFile(absPath);
 			let lines = content.split("\n");
@@ -154,7 +176,7 @@ export default function (pi: any) {
 			if (params.limit) lines = lines.slice(0, params.limit);
 
 			const numbered = lines
-				.map((line, i) => `${offset + i + 1}\t${line}`)
+				.map((line: string, i: number) => `${offset + i + 1}\t${line}`)
 				.join("\n");
 
 			return {
@@ -185,8 +207,9 @@ export default function (pi: any) {
 			_toolCallId: string,
 			params: { path: string; content: string },
 		) {
+			const bash = currentBash();
 			const absPath = resolvePath(params.path);
-			ensureParentDir(absPath);
+			ensureParentDir(absPath, bash);
 			bash.writeFile(absPath, params.content);
 			return {
 				content: [
@@ -223,6 +246,7 @@ export default function (pi: any) {
 			_toolCallId: string,
 			params: { path: string; oldText: string; newText: string },
 		) {
+			const bash = currentBash();
 			const absPath = resolvePath(params.path);
 			const content = bash.readFile(absPath);
 


### PR DESCRIPTION
### Motivation

- The Pi extension created a module-global `Bash` instance that persisted VFS and shell state across multiple agent starts, allowing cross-session state leakage and poisoning.

### Description

- Replace the module-global `Bash` with a per-session factory: add `BASH_OPTIONS`, `createBash()`, `sessionBash`, and `currentBash()` to manage the active instance.
- Reset the session boundary on agent startup by creating a fresh `Bash` in the `before_agent_start` handler so each agent start gets an isolated VFS and shell state.
- Route the `bash`, `read`, `write`, and `edit` tool implementations to call `currentBash()` at execution time so tools share state only within the same agent session.
- Adjust `ensureParentDir` to accept the `bash` instance and update uses accordingly.
- Update `examples/bashkit-pi/README.md` to document that state is per-session and resets on the next `before_agent_start`.

### Testing

- Ran `git diff --check` to validate diffs (no whitespace errors).
- Ran `tsc` checks for the example which surfaced a note about missing committed Node type definitions (documented warning); TypeScript compilation with adjusted flags completed.
- Performed a smoke test with a local `@everruns/bashkit` stub and a small Node harness which simulated two `before_agent_start` events; the harness asserted same-session sharing and cross-session isolation and printed `{"isolated":true,"constructorCalls":3}`, confirming the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dbbf1c832ba1d6227e205df428)