### PR TITLE
fix(bench): secure parallel benchmark cache

### DIFF
--- a/scripts/bench-parallel.sh
+++ b/scripts/bench-parallel.sh
@@ -7,6 +7,8 @@
 #   ./scripts/bench-parallel.sh --dry    # parse last run without re-running
 set -euo pipefail
 
+# Cache Criterion output in the caller's private cache directory. Avoid shared /tmp
+# paths so local users cannot pre-create symlinks or poison --dry parsing.
 RESULTS_DIR="crates/bashkit/benches/results"
 HOSTNAME=$(hostname 2>/dev/null || echo "unknown")
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -14,24 +16,46 @@ ARCH=$(uname -m)
 CPUS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo "?")
 TIMESTAMP=$(date +%s)
 MONIKER="${HOSTNAME}-${OS}-${ARCH}"
+CACHE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}"
+CACHE_DIR="${CACHE_ROOT}/bashkit"
+OUTPUT_FILE="${CACHE_DIR}/criterion-parallel-output.txt"
+TEMP_OUTPUT=""
+cleanup_temp_output() {
+    if [[ -n "${TEMP_OUTPUT}" && -e "${TEMP_OUTPUT}" ]]; then
+        rm -f "${TEMP_OUTPUT}"
+    fi
+}
+trap cleanup_temp_output EXIT
+
+mkdir -p "$RESULTS_DIR" "$CACHE_DIR"
+if [[ -L "$CACHE_DIR" ]]; then
+    echo "Refusing symlinked cache directory: $CACHE_DIR"
+    exit 1
+fi
+chmod 700 "$CACHE_DIR"
 
 # Run benchmark unless --dry
 if [[ "${1:-}" != "--dry" ]]; then
     echo "Running parallel_execution benchmark..."
-    cargo bench --bench parallel_execution 2>&1 | tee /tmp/criterion-output.txt
+    TEMP_OUTPUT=$(mktemp "${CACHE_DIR}/criterion-parallel-output.XXXXXX")
+    chmod 600 "$TEMP_OUTPUT"
+    cargo bench --bench parallel_execution 2>&1 | tee "$TEMP_OUTPUT"
+    mv -f "$TEMP_OUTPUT" "$OUTPUT_FILE"
+    TEMP_OUTPUT=""
+    chmod 600 "$OUTPUT_FILE"
 else
-    if [[ ! -f /tmp/criterion-output.txt ]]; then
-        echo "No previous output found at /tmp/criterion-output.txt"
+    if [[ ! -f "$OUTPUT_FILE" || -L "$OUTPUT_FILE" ]]; then
+        echo "No previous output found at $OUTPUT_FILE"
         exit 1
     fi
-    echo "Using cached output from /tmp/criterion-output.txt"
+    echo "Using cached output from $OUTPUT_FILE"
 fi
 
 # Extract median time from Criterion output for lines matching a pattern
 # Usage: extract_times <grep_pattern> >> output_file
 extract_times() {
     local pattern="$1"
-    grep -A2 "$pattern" /tmp/criterion-output.txt | \
+    grep -A2 "$pattern" "$OUTPUT_FILE" | \
         awk -v pat="$pattern" '
             $0 ~ pat {name=$1}
             /time:/ {
@@ -92,10 +116,10 @@ cat >> "$MD_PATH" <<EOF
 EOF
 
 # Calculate speedups from the parsed output
-python3 -c "
-import re, sys
+OUTPUT_FILE="$OUTPUT_FILE" python3 -c "
+import os, re, sys
 
-text = open('/tmp/criterion-output.txt').read()
+text = open(os.environ['OUTPUT_FILE']).read()
 
 # Parse all timing results: name -> median_ms
 results = {}

--- a/scripts/tests/test_bench_parallel.py
+++ b/scripts/tests/test_bench_parallel.py
@@ -1,0 +1,93 @@
+import os
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def make_workspace(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "crates/bashkit/benches/results").mkdir(parents=True)
+    script = repo / "scripts/bench-parallel.sh"
+    script.write_text(Path("scripts/bench-parallel.sh").read_text())
+    script.chmod(script.stat().st_mode | stat.S_IXUSR)
+    return repo
+
+
+def make_fake_cargo(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cargo = bin_dir / "cargo"
+    cargo.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            cat <<'EOF'
+            workload_types/light_sequential
+                              time:   [10.000 ms 11.000 ms 12.000 ms]
+            workload_types/light_parallel
+                              time:   [5.000 ms 6.000 ms 7.000 ms]
+            parallel_scaling/medium_seq/10
+                              time:   [20.000 ms 21.000 ms 22.000 ms]
+            parallel_scaling/medium_par/10
+                              time:   [10.000 ms 11.000 ms 12.000 ms]
+            single_parse
+                              time:   [1.000 ms 2.000 ms 3.000 ms]
+            EOF
+            """
+        )
+    )
+    cargo.chmod(cargo.stat().st_mode | stat.S_IXUSR)
+    return bin_dir
+
+
+def run_script(repo: Path, cache: Path, bin_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "XDG_CACHE_HOME": str(cache),
+            "HOME": str(repo / "home"),
+        }
+    )
+    return subprocess.run(
+        [str(repo / "scripts/bench-parallel.sh"), *args],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_bench_parallel_cache_uses_private_cache_not_shared_tmp(tmp_path: Path) -> None:
+    repo = make_workspace(tmp_path)
+    bin_dir = make_fake_cargo(tmp_path)
+    cache = tmp_path / "cache"
+    fixed_tmp = Path("/tmp/criterion-output.txt")
+    if fixed_tmp.exists() or fixed_tmp.is_symlink():
+        fixed_tmp.unlink()
+
+    run_script(repo, cache, bin_dir)
+
+    assert not fixed_tmp.exists()
+    output_file = cache / "bashkit/criterion-parallel-output.txt"
+    assert output_file.is_file()
+    assert not output_file.is_symlink()
+    assert stat.S_IMODE((cache / "bashkit").stat().st_mode) == 0o700
+    assert stat.S_IMODE(output_file.stat().st_mode) == 0o600
+
+
+def test_bench_parallel_dry_reads_private_cache(tmp_path: Path) -> None:
+    repo = make_workspace(tmp_path)
+    bin_dir = make_fake_cargo(tmp_path)
+    cache = tmp_path / "cache"
+
+    run_script(repo, cache, bin_dir)
+    completed = run_script(repo, cache, bin_dir, "--dry")
+
+    assert f"Using cached output from {cache}/bashkit/criterion-parallel-output.txt" in completed.stdout
+    markdown = next((repo / "crates/bashkit/benches/results").glob("criterion-parallel-*.md"))
+    assert "| light | 11.000 ms | 6.000 ms | **1.83x** |" in markdown.read_text()


### PR DESCRIPTION
### Motivation
- Prevent local attackers from pre-creating symlinks or poisoning a predictable `/tmp` file used by the parallel benchmark helper. 
- Keep developer tooling safe while preserving existing `--dry` parsing and result saving behavior.

### Description
- Replace the fixed `/tmp/criterion-output.txt` use with a per-user cache file at `${XDG_CACHE_HOME:-$HOME/.cache}/bashkit/criterion-parallel-output.txt` and centralize the path in `bench-parallel.sh` via `OUTPUT_FILE`.
- Capture live benchmark output to a `mktemp`-created temporary file inside the cache directory, then `mv` it into place and set restrictive permissions with `chmod 600`, and register a `trap` to clean temporary artifacts.
- Create the cache directory with `mkdir -p` and `chmod 700`, and refuse to run if the cache directory is a symlink to avoid symlink-based attacks.
- Update all parsers/grep/python invocation in the script to read from the secure `OUTPUT_FILE` (the grep/awk extractor and the Python speedup parser), and adjust printed messages accordingly.
- Add a pytest integration-style test `scripts/tests/test_bench_parallel.py` that uses a fake `cargo` to validate the script writes to the private cache, does not touch `/tmp/criterion-output.txt`, enforces file permissions, and that `--dry` reads the private cache.

### Testing
- Ran `bash -n scripts/bench-parallel.sh` to verify script syntax, which succeeded.
- Ran `python3 -m pytest scripts/tests/test_bench_parallel.py -q` and the new tests passed (`2 passed`).
- Ran `python3 -m pytest scripts/tests -q` and the full scripts test set passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adce1c832b81f7115deaf3e0c5)