### PR TITLE
fix(bench): isolate I/O benchmark file writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tabled",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/bashkit-bench/Cargo.toml
+++ b/crates/bashkit-bench/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 clap.workspace = true
 anyhow.workspace = true
+tempfile.workspace = true
 
 # Terminal output
 colored = "3"

--- a/crates/bashkit-bench/src/cases.rs
+++ b/crates/bashkit-bench/src/cases.rs
@@ -1027,9 +1027,9 @@ fn io_cases() -> Vec<BenchCase> {
             Category::Io,
             "Write to file and read back",
             r#"
-echo "hello world" > /tmp/bench_test.txt
-cat /tmp/bench_test.txt
-rm /tmp/bench_test.txt
+echo "hello world" > bench_test.txt
+cat bench_test.txt
+rm bench_test.txt
 "#,
         )
         .with_expected("hello world\n"),
@@ -1038,11 +1038,11 @@ rm /tmp/bench_test.txt
             Category::Io,
             "Append to file",
             r#"
-echo "line1" > /tmp/bench_append.txt
-echo "line2" >> /tmp/bench_append.txt
-echo "line3" >> /tmp/bench_append.txt
-cat /tmp/bench_append.txt
-rm /tmp/bench_append.txt
+echo "line1" > bench_append.txt
+echo "line2" >> bench_append.txt
+echo "line3" >> bench_append.txt
+cat bench_append.txt
+rm bench_append.txt
 "#,
         )
         .with_expected("line1\nline2\nline3\n"),
@@ -1106,4 +1106,20 @@ EOF
         )
         .with_expected("10\n"),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::all_cases;
+
+    #[test]
+    fn benchmark_cases_do_not_use_predictable_shared_tmp_files() {
+        for case in all_cases() {
+            assert!(
+                !case.script.contains("/tmp/bench_"),
+                "{} uses a predictable shared /tmp benchmark path",
+                case.name
+            );
+        }
+    }
 }

--- a/crates/bashkit-bench/src/runners.rs
+++ b/crates/bashkit-bench/src/runners.rs
@@ -325,9 +325,16 @@ impl JustBashInprocRunner {
 
 /// Run a command as a subprocess (one process per invocation)
 async fn run_subprocess(cmd: &str, args: &[&str], script: &str) -> Result<(String, String, i32)> {
-    let child = Command::new(cmd)
+    let workdir = tempfile::Builder::new()
+        .prefix("bashkit-bench-")
+        .tempdir()
+        .context("create isolated benchmark subprocess directory")?;
+    let program = subprocess_program(cmd)?;
+
+    let child = Command::new(&program)
         .args(args)
         .arg(script)
+        .current_dir(workdir.path())
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -340,6 +347,17 @@ async fn run_subprocess(cmd: &str, args: &[&str], script: &str) -> Result<(Strin
     let exit_code = output.status.code().unwrap_or(-1);
 
     Ok((stdout, stderr, exit_code))
+}
+
+fn subprocess_program(cmd: &str) -> Result<PathBuf> {
+    let path = Path::new(cmd);
+    if path.is_relative() && (cmd.contains('/') || cmd.contains('\\')) {
+        Ok(std::env::current_dir()
+            .context("resolve current directory for benchmark subprocess")?
+            .join(path))
+    } else {
+        Ok(path.to_path_buf())
+    }
 }
 
 /// A persistent child process that communicates via JSON lines over stdin/stdout.
@@ -445,4 +463,42 @@ fn workspace_root() -> PathBuf {
 
 fn scripts_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_subprocess, subprocess_program};
+    use std::path::PathBuf;
+
+    #[test]
+    fn subprocess_program_resolves_relative_paths_before_cwd_isolation() {
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            subprocess_program("./just-bash").unwrap(),
+            cwd.join("./just-bash")
+        );
+        assert_eq!(subprocess_program("bash").unwrap(), PathBuf::from("bash"));
+    }
+
+    #[tokio::test]
+    async fn subprocess_runs_relative_io_in_isolated_temp_directory() {
+        let filename = format!("bashkit-bench-isolation-test-{}.txt", std::process::id());
+        let repo_victim = std::env::current_dir().unwrap().join(&filename);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&repo_victim)
+            .unwrap();
+        std::fs::write(&repo_victim, "keep me").unwrap();
+
+        let script = format!("printf changed > {filename}; cat {filename}");
+        let (stdout, stderr, exit_code) =
+            run_subprocess("/bin/sh", &["-c"], &script).await.unwrap();
+
+        assert_eq!(stdout, "changed");
+        assert_eq!(stderr, "");
+        assert_eq!(exit_code, 0);
+        assert_eq!(std::fs::read_to_string(&repo_victim).unwrap(), "keep me");
+        std::fs::remove_file(repo_victim).unwrap();
+    }
 }


### PR DESCRIPTION
### Motivation
- The I/O benchmark cases used predictable global paths under `/tmp` which allowed subprocess runners (including native `bash` and `just-bash` with `--allow-write`) to clobber or remove host files.
- The change prevents unintentional/moderate-risk file overwrite and symlink-clobber primitives during developer benchmark runs.

### Description
- Replace fixed `/tmp/bench_*` paths in the I/O cases with relative filenames (e.g. `bench_test.txt`, `bench_append.txt`) in `crates/bashkit-bench/src/cases.rs` so benchmarks operate on their working directory.
- Run subprocess-based runners from a per-invocation temporary working directory using `tempfile::Builder().tempdir()` and `Command::current_dir(...)` in `crates/bashkit-bench/src/runners.rs` to isolate relative I/O from the caller/repo.
- Add `fn subprocess_program(cmd: &str) -> Result<PathBuf>` to preserve resolution for relative executables (e.g. `./just-bash`) before switching `current_dir`.
- Add regression tests: one test asserts no benchmark script contains predictable `/tmp/bench_` paths, and tests that `run_subprocess` executes in an isolated tempdir without clobbering repo files, both in `crates/bashkit-bench/src/{cases.rs,runners.rs}`.
- Add `tempfile` to `crates/bashkit-bench/Cargo.toml` and updated `Cargo.lock` to include the new dependency.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo test -p bashkit-bench` and all bench-crate tests passed (5 tests, 0 failures).
- Executed a smoke run with `cargo run -p bashkit-bench -- --iterations 1 --warmup 0 --filter io_redirect_write --runners bashkit,bash` which completed and produced matching outputs for the runners.
- Ran `git diff --check` to validate no whitespace/merge issues and there were no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251aded50832bb1a80679a2d9e7fc)