### PR TITLE
fix(jq): bind setpath arguments before recursion

### DIFF
--- a/crates/bashkit/src/builtins/jq/compat.rs
+++ b/crates/bashkit/src/builtins/jq/compat.rs
@@ -44,13 +44,16 @@ pub(super) const ARGS_VAR_NAME: &str = "$ARGS";
 /// top-down). The trailing `;` after every def is required.
 pub(super) const JQ_COMPAT_DEFS: &str = r#"
 def setpath(p; v):
-  if (p | length) == 0 then v
-  else p[0] as $k |
-    (if . == null then
-      if ($k | type) == "number" then [] else {} end
-    else . end) |
-    .[$k] |= setpath(p[1:]; v)
-  end;
+  p as $p | v as $v |
+  def _bashkit_setpath($path; $value):
+    if ($path | length) == 0 then $value
+    else $path[0] as $k |
+      (if . == null then
+        if ($k | type) == "number" then [] else {} end
+      else . end) |
+      .[$k] |= _bashkit_setpath($path[1:]; $value)
+    end;
+  _bashkit_setpath($p; $v);
 def leaf_paths: paths(scalars);
 def match(re; flags):
   matches(re; flags)[] |

--- a/crates/bashkit/src/builtins/jq/tests.rs
+++ b/crates/bashkit/src/builtins/jq/tests.rs
@@ -800,6 +800,28 @@ async fn regex_invalid_pattern_yields_short_error() {
 }
 
 #[tokio::test]
+async fn setpath_binds_dynamic_path_to_original_input() {
+    let result = run_jq(r#"setpath(.path; 1)"#, r#"{"path":["a"]}"#)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.trim(),
+        "{\n  \"path\": [\n    \"a\"\n  ],\n  \"a\": 1\n}"
+    );
+}
+
+#[tokio::test]
+async fn setpath_binds_dynamic_value_to_original_input() {
+    let result = run_jq(r#"setpath(["a"]; .path[0])"#, r#"{"path":["expected"]}"#)
+        .await
+        .unwrap();
+    assert_eq!(
+        result.trim(),
+        "{\n  \"path\": [\n    \"expected\"\n  ],\n  \"a\": \"expected\"\n}"
+    );
+}
+
+#[tokio::test]
 async fn regex_invalid_flag_yields_short_error() {
     let result = run_jq_result(r#"match("x"; "z")"#, r#""x""#).await.unwrap();
     assert_ne!(result.exit_code, 0);


### PR DESCRIPTION
### Motivation
- The compatibility `setpath(p; v)` implementation re-evaluated `p` and `v` at each recursion step, causing dynamic path/value expressions to be evaluated against the nested child `.` instead of the original input.

### Description
- Bind `p` and `v` once before recursion by adding `p as $p | v as $v` and delegating recursion to an inner helper `_bashkit_setpath($path; $value)` in `crates/bashkit/src/builtins/jq/compat.rs`.
- Use the helper to perform the same update logic but with `$path`/`$value` bound, restoring jq-compatible semantics for dynamic filters.
- Add two regression tests in `crates/bashkit/src/builtins/jq/tests.rs`: `setpath_binds_dynamic_path_to_original_input` and `setpath_binds_dynamic_value_to_original_input` to validate dynamic `p` and `v` use-cases.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran `cargo test -p bashkit --features jq builtins::jq::tests::setpath_binds_dynamic -- --nocapture` which passed and validated the two new tests.
- Ran `cargo test -p bashkit --features jq builtins::jq::tests:: -- --nocapture` which passed the full jq builtin test set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dc2fc8832ba95228136f467433)