### PR TITLE
test(redirects): verify combined file redirection

### DIFF
--- a/crates/bashkit/tests/spec_cases/bash/pipes-redirects.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/pipes-redirects.test.sh
@@ -165,12 +165,13 @@ sleep: invalid time interval 'abc'
 ### end
 
 ### redirect_both_to_file_content
-# Redirect both stdout and stderr to file with &>
-echo hello; sleep abc
-echo ---
+# Redirect both stdout and stderr to file with &> and verify file content
+{ echo hello; sleep abc; } &>/tmp/both_content.txt
+cat /tmp/both_content.txt
+### bash_diff: bashkit sleep error lacks --help hint from coreutils
 ### expect
 hello
----
+sleep: invalid time interval 'abc'
 ### end
 
 ### redirect_both_devnull


### PR DESCRIPTION
### Motivation
- Fix a malformed spec case that claimed to validate `&>` combined stdout/stderr file redirection but did not actually perform any redirection or verify redirected file contents.

### Description
- Update `crates/bashkit/tests/spec_cases/bash/pipes-redirects.test.sh` `redirect_both_to_file_content` case to run `{ echo hello; sleep abc; } &>/tmp/both_content.txt` and `cat /tmp/both_content.txt` so both stdout and stderr are written to and read from the file.
- Update the test `### expect` to require the `hello` line and the `sleep: invalid time interval 'abc'` diagnostic, and mark the case with the existing `### bash_diff: bashkit sleep error lacks --help hint from coreutils` note.

### Testing
- Ran `git diff --check` with no issues.
- Ran `cargo test -p bashkit --test integration bash_spec_tests -- --nocapture` and confirmed the spec suite passed (integration spec runner: Total: 2052 | Passed: 2027 | Failed: 0 | Skipped: 25 and `test spec_tests::bash_spec_tests ... ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae5e48832b9112a4283f992067)