### PR TITLE
fix(base64): preserve binary data

### DIFF
--- a/crates/bashkit/src/builtins/base64.rs
+++ b/crates/bashkit/src/builtins/base64.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use base64::Engine;
 
 use super::arg_parser::ArgParser;
-use super::{Builtin, BuiltinHelper, Context, read_text_file};
+use super::{Builtin, BuiltinHelper, Context};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
@@ -16,6 +16,20 @@ use crate::interpreter::ExecResult;
 ///   -d, --decode    Decode base64 input
 ///   -w COLS         Wrap encoded lines after COLS characters (default: 76, 0 = no wrap)
 pub struct Base64;
+
+fn stdin_to_bytes(input: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(input.len());
+    for ch in input.chars() {
+        let code = ch as u32;
+        if code <= u8::MAX as u32 {
+            bytes.push(code as u8);
+        } else {
+            let mut buf = [0; 4];
+            bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+        }
+    }
+    bytes
+}
 
 impl BuiltinHelper for Base64 {
     const NAME: &'static str = "base64";
@@ -58,38 +72,37 @@ impl Builtin for Base64 {
             }
         }
 
-        // Get input: from file, stdin, or empty
+        // Get input bytes: file reads must be byte-exact; stdin may contain the
+        // interpreter's Latin-1 byte-preserving surrogate string.
         let input = if let Some(ref path) = file {
             if path == "-" {
-                ctx.stdin.unwrap_or("").to_string()
+                stdin_to_bytes(ctx.stdin.unwrap_or(""))
             } else {
                 let resolved = super::resolve_path(ctx.cwd, path);
-                match read_text_file(ctx.fs.as_ref(), &resolved, "base64").await {
-                    Ok(text) => text,
+                match ctx.fs.read_file(&resolved).await {
+                    Ok(bytes) => bytes,
                     Err(_) => {
                         return Ok(Self::err_path(path, "No such file or directory", 1));
                     }
                 }
             }
         } else {
-            ctx.stdin.unwrap_or("").to_string()
+            stdin_to_bytes(ctx.stdin.unwrap_or(""))
         };
 
         if decode {
-            // Decode: strip whitespace, then decode
-            let cleaned: String = input.chars().filter(|c| !c.is_whitespace()).collect();
+            // Decode: strip ASCII whitespace, then decode.
+            let cleaned: Vec<u8> = input
+                .into_iter()
+                .filter(|byte| !byte.is_ascii_whitespace())
+                .collect();
             match base64::engine::general_purpose::STANDARD.decode(&cleaned) {
-                Ok(bytes) => {
-                    // Output raw bytes as string (lossy for non-UTF8)
-                    let output = String::from_utf8_lossy(&bytes).to_string();
-                    Ok(ExecResult::ok(output))
-                }
+                Ok(bytes) => Ok(ExecResult::ok_bytes(bytes)),
                 Err(e) => Ok(Self::err(format!("invalid input: {e}"), 1)),
             }
         } else {
-            // Encode
-            let encoded =
-                base64::engine::general_purpose::STANDARD.encode(input.trim_end_matches('\n'));
+            // Encode exact input bytes, including trailing newlines.
+            let encoded = base64::engine::general_purpose::STANDARD.encode(input);
             let output = if wrap > 0 {
                 // Wrap at specified column width
                 let mut wrapped = String::new();
@@ -112,7 +125,7 @@ impl Builtin for Base64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fs::InMemoryFs;
+    use crate::fs::{FileSystem, InMemoryFs};
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::sync::Arc;
@@ -154,6 +167,38 @@ mod tests {
         assert!(
             !result.stdout.trim().contains('\n'),
             "should not wrap with -w 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_encode_preserves_trailing_newline() {
+        let result = run_base64(&["-w", "0"], Some("hello\n")).await;
+        assert_eq!(result.stdout, "aGVsbG8K\n");
+    }
+
+    #[tokio::test]
+    async fn test_encode_binary_file_preserves_bytes() {
+        let args = vec!["-w".to_string(), "0".to_string(), "/blob".to_string()];
+        let env = HashMap::new();
+        let mut variables = HashMap::new();
+        let mut cwd = PathBuf::from("/");
+        let fs = Arc::new(InMemoryFs::new());
+        fs.write_file(PathBuf::from("/blob").as_path(), &[0xff, b'\n', b'\n'])
+            .await
+            .unwrap();
+        let ctx = Context::new_for_test(&args, &env, &mut variables, &mut cwd, fs, None);
+
+        let result = Base64.execute(ctx).await.expect("base64 execute failed");
+
+        assert_eq!(result.stdout, "/woK\n");
+    }
+
+    #[tokio::test]
+    async fn test_decode_binary_preserves_stdout_bytes() {
+        let result = run_base64(&["-d"], Some("AAH//kIAfw==")).await;
+        assert_eq!(
+            result.stdout_bytes.as_deref(),
+            Some(&[0x00, 0x01, 0xff, 0xfe, b'B', 0x00, 0x7f][..])
         );
     }
 

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -841,6 +841,7 @@ impl<'a> BashkitContext<'a> {
     fn into_exec_result(self) -> ExecResult {
         ExecResult {
             stdout: self.stdout,
+            stdout_bytes: None,
             stderr: self.stderr,
             exit_code: self.exit_code,
             ..Default::default()

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -7583,7 +7583,10 @@ impl Interpreter {
                     if is_dev_null(&path) {
                         match redirect.fd {
                             Some(2) => result.stderr = String::new(),
-                            _ => result.stdout = String::new(),
+                            _ => {
+                                result.stdout = String::new();
+                                result.stdout_bytes = None;
+                            }
                         }
                     } else {
                         if redirect.kind == RedirectKind::Output
@@ -7608,15 +7611,19 @@ impl Interpreter {
                                 result.stderr = String::new();
                             }
                             _ => {
-                                if let Err(e) =
-                                    self.fs.write_file(&path, result.stdout.as_bytes()).await
-                                {
+                                let stdout = result
+                                    .stdout_bytes
+                                    .as_deref()
+                                    .unwrap_or(result.stdout.as_bytes());
+                                if let Err(e) = self.fs.write_file(&path, stdout).await {
                                     result.stdout = String::new();
+                                    result.stdout_bytes = None;
                                     result.stderr = format!("bash: {}: {}\n", target_path, e);
                                     result.exit_code = 1;
                                     return Ok(result);
                                 }
                                 result.stdout = String::new();
+                                result.stdout_bytes = None;
                             }
                         }
                     }
@@ -7627,7 +7634,10 @@ impl Interpreter {
                     if is_dev_null(&path) {
                         match redirect.fd {
                             Some(2) => result.stderr = String::new(),
-                            _ => result.stdout = String::new(),
+                            _ => {
+                                result.stdout = String::new();
+                                result.stdout_bytes = None;
+                            }
                         }
                     } else {
                         match redirect.fd {
@@ -7642,15 +7652,19 @@ impl Interpreter {
                                 result.stderr = String::new();
                             }
                             _ => {
-                                if let Err(e) =
-                                    self.fs.append_file(&path, result.stdout.as_bytes()).await
-                                {
+                                let stdout = result
+                                    .stdout_bytes
+                                    .as_deref()
+                                    .unwrap_or(result.stdout.as_bytes());
+                                if let Err(e) = self.fs.append_file(&path, stdout).await {
                                     result.stdout = String::new();
+                                    result.stdout_bytes = None;
                                     result.stderr = format!("bash: {}: {}\n", target_path, e);
                                     result.exit_code = 1;
                                     return Ok(result);
                                 }
                                 result.stdout = String::new();
+                                result.stdout_bytes = None;
                             }
                         }
                     }
@@ -7660,15 +7674,21 @@ impl Interpreter {
                     let path = self.resolve_path(&target_path);
                     if is_dev_null(&path) {
                         result.stdout = String::new();
+                        result.stdout_bytes = None;
                         result.stderr = String::new();
                     } else {
-                        let combined = format!("{}{}", result.stdout, result.stderr);
-                        if let Err(e) = self.fs.write_file(&path, combined.as_bytes()).await {
+                        let mut combined = result
+                            .stdout_bytes
+                            .clone()
+                            .unwrap_or_else(|| result.stdout.as_bytes().to_vec());
+                        combined.extend_from_slice(result.stderr.as_bytes());
+                        if let Err(e) = self.fs.write_file(&path, &combined).await {
                             result.stderr = format!("bash: {}: {}\n", target_path, e);
                             result.exit_code = 1;
                             return Ok(result);
                         }
                         result.stdout = String::new();
+                        result.stdout_bytes = None;
                         result.stderr = String::new();
                     }
                 }

--- a/crates/bashkit/src/interpreter/state.rs
+++ b/crates/bashkit/src/interpreter/state.rs
@@ -53,6 +53,8 @@ pub enum BuiltinSideEffect {
 pub struct ExecResult {
     /// Standard output
     pub stdout: String,
+    /// Exact stdout bytes when a builtin produces binary data.
+    pub stdout_bytes: Option<Vec<u8>>,
     /// Standard error
     pub stderr: String,
     /// Exit code
@@ -81,6 +83,18 @@ impl ExecResult {
     pub fn ok(stdout: impl Into<String>) -> Self {
         Self {
             stdout: stdout.into(),
+            stderr: String::new(),
+            exit_code: 0,
+            ..Default::default()
+        }
+    }
+
+    /// Create a successful result with exact stdout bytes.
+    pub fn ok_bytes(bytes: Vec<u8>) -> Self {
+        let stdout = bytes.iter().map(|&byte| byte as char).collect();
+        Self {
+            stdout,
+            stdout_bytes: Some(bytes),
             stderr: String::new(),
             exit_code: 0,
             ..Default::default()

--- a/crates/bashkit/tests/integration/base64_binary_tests.rs
+++ b/crates/bashkit/tests/integration/base64_binary_tests.rs
@@ -1,0 +1,41 @@
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use std::path::Path;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn base64_decode_redirection_preserves_binary_bytes() {
+    let fs = Arc::new(InMemoryFs::new());
+    let mut bash = Bash::builder().fs(fs.clone()).build();
+
+    let result = bash
+        .exec("printf 'AAH//kIAfw==' | base64 -d > /decoded.bin")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "");
+    assert_eq!(
+        fs.read_file(Path::new("/decoded.bin")).await.unwrap(),
+        vec![0x00, 0x01, 0xff, 0xfe, b'B', 0x00, 0x7f]
+    );
+}
+
+#[tokio::test]
+async fn base64_roundtrips_binary_file_through_redirection() {
+    let fs = Arc::new(InMemoryFs::new());
+    fs.write_file(Path::new("/input.bin"), &[0xff, b'\n', b'\n'])
+        .await
+        .unwrap();
+    let mut bash = Bash::builder().fs(fs.clone()).build();
+
+    let result = bash
+        .exec("base64 -w 0 /input.bin | base64 -d > /roundtrip.bin")
+        .await
+        .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(
+        fs.read_file(Path::new("/roundtrip.bin")).await.unwrap(),
+        vec![0xff, b'\n', b'\n']
+    );
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -21,6 +21,7 @@ pub mod awk_pattern_tests;
 pub mod awk_printf_expr_test;
 pub mod awk_range_pattern_tests;
 pub mod background_exec_tests;
+pub mod base64_binary_tests;
 pub mod bash_source_tests;
 pub mod blackbox_security_tests;
 pub mod builtin_error_security_tests;


### PR DESCRIPTION
### Motivation
- The `base64` builtin previously converted file/stdin bytes through lossy UTF-8 and trimmed trailing newlines, corrupting arbitrary binary data and preventing exact round-trips.\
- Builtin output/redirect paths need a way to carry exact bytes when a builtin produces binary stdout.\

### Description
- Read file input as raw bytes and convert pipeline `stdin` into a byte vector (`stdin_to_bytes`) so encoding operates on exact bytes (no lossy UTF-8 nor `trim_end_matches('\n')`).\
- Decode into exact bytes and return them via a new `ExecResult::ok_bytes` / `ExecResult::stdout_bytes` field so binary decoded output is preserved.\
- Update interpreter redirection logic to prefer `stdout_bytes` when present for write/append/combined redirects so file writes preserve binary data.\
- Add unit tests for trailing-newline preservation, binary-file encoding, and decode-byte preservation, plus integration tests that exercise decode redirection and a full binary file round-trip.\

### Testing
- Ran `cargo fmt --check` (passed).\
- Ran `cargo test -p bashkit base64` exercising the `base64` unit tests and new integration coverage (9 unit tests + integration tests executed); all relevant tests passed.\
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adf6a8832ba6b196e98132a7de)