### PR TITLE
fix(limits): count exec calls before parsing

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1687,6 +1687,15 @@ impl Interpreter {
         self.session_limits = limits;
     }
 
+    /// Count a host-level Bash::exec invocation before parsing untrusted input.
+    pub(crate) fn begin_exec_invocation(&mut self) -> Result<()> {
+        self.counters.reset_for_execution();
+        self.counters.tick_exec_call();
+        self.counters
+            .check_session_limits(&self.session_limits)
+            .map_err(|e| crate::error::Error::Execution(e.to_string()))
+    }
+
     /// Set per-instance memory limits.
     pub fn set_memory_limits(&mut self, limits: crate::limits::MemoryLimits) {
         self.memory_limits = limits;
@@ -2203,30 +2212,17 @@ impl Interpreter {
 
     /// Execute a script.
     pub async fn execute(&mut self, script: &Script) -> Result<ExecResult> {
-        // Reset per-execution counters so each exec() gets a fresh budget.
-        // Without this, hitting the limit in one exec() permanently poisons the session.
-        self.counters.reset_for_execution();
+        // Note: Bash::exec() resets per-exec counters and counts the session
+        // invocation before parsing, so parse/budget failures also consume the
+        // max_exec_calls budget. Internal callers of Interpreter::execute() do
+        // not represent host-level exec() invocations.
 
-        // Note: per-exec state reset (traps, exit code, options) is done in
-        // Bash::exec() before calling this method, to avoid clearing state
-        // set by internal callers like execute_bash_builtin.
-
-        // THREAT[TM-DOS-059]: Increment session-level exec call counter and
-        // check session limits before starting execution.
-        self.counters.tick_exec_call();
-        let result = match self
-            .counters
-            .check_session_limits(&self.session_limits)
-            .map_err(|e| crate::error::Error::Execution(e.to_string()))
-        {
-            Ok(()) => {
-                let result = self.execute_script_body(script, true, true).await;
-                // Script boundary cleanup: background jobs are scoped to a single exec()
-                // call, so they cannot accumulate across long-lived sessions.
-                let _ = self.jobs.lock().await.wait_all_results().await;
-                result
-            }
-            Err(e) => Err(e),
+        let result = {
+            let result = self.execute_script_body(script, true, true).await;
+            // Script boundary cleanup: background jobs are scoped to a single exec()
+            // call, so they cannot accumulate across long-lived sessions.
+            let _ = self.jobs.lock().await.wait_all_results().await;
+            result
         };
 
         if result.is_err() {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -677,6 +677,10 @@ impl Bash {
         // THREAT[TM-ISO-005/006/007]: Reset transient state between exec() calls
         self.interpreter.reset_transient_state();
 
+        // THREAT[TM-DOS-059]: Count every host exec() call at the boundary so
+        // malformed or parser-expensive scripts cannot bypass session limits.
+        self.interpreter.begin_exec_invocation()?;
+
         // Check raw input size before hooks to avoid allocating/copying oversized
         // untrusted scripts in hook payloads.
         let input_len = script.len();

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3506,6 +3506,29 @@ mod session_limits {
         );
     }
 
+    /// TM-DOS-059: Malformed scripts count toward exec() call limit before parsing.
+    #[tokio::test]
+    async fn tm_dos_059_parse_errors_count_toward_exec_call_limit() {
+        let session = SessionLimits::new()
+            .max_exec_calls(1)
+            .max_total_commands(u64::MAX);
+        let mut bash = Bash::builder().session_limits(session).build();
+
+        let parse_err = bash.exec("if").await;
+        assert!(parse_err.is_err(), "malformed script should fail parsing");
+
+        let limit_err = bash.exec("echo should_fail").await;
+        assert!(
+            limit_err.is_err(),
+            "second exec() should fail because parse errors consume exec budget"
+        );
+        let msg = limit_err.unwrap_err().to_string();
+        assert!(
+            msg.contains("session") && msg.contains("exec"),
+            "error should mention session exec limit: {msg}"
+        );
+    }
+
     /// TM-DOS-059: Session counters persist across exec() calls (not reset).
     #[tokio::test]
     async fn tm_dos_059_counter_persistence() {


### PR DESCRIPTION
### Motivation
- Session `max_exec_calls` was only incremented inside `Interpreter::execute`, after parsing and budget checks, allowing malformed or parser-expensive inputs to bypass the session exec-call budget and enable a DoS vector. 
- The goal is to ensure every host-visible `Bash::exec` invocation consumes session exec budget at the boundary so parse/budget failures cannot be used to circumvent limits.

### Description
- Add `Interpreter::begin_exec_invocation()` to reset per-exec counters, tick the session exec-call counter, and validate session limits via `ExecutionCounters::check_session_limits`.
- Call `self.interpreter.begin_exec_invocation()?` at the start of `Bash::exec_impl` before input validation and parsing so malformed or parser-heavy scripts count toward `max_exec_calls`.
- Remove the previous `tick_exec_call()` semantics from internal `Interpreter::execute` so only host-level `Bash::exec` invocations are counted.
- Add an integration test `tm_dos_059_parse_errors_count_toward_exec_call_limit` proving a parse error consumes an exec invocation and the next valid `exec()` is rejected when `max_exec_calls` is exhausted.

### Testing
- Ran `cargo fmt --check` and it passed. 
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` and it passed with no warnings. 
- Ran targeted tests: `cargo test -p bashkit tm_dos_059_parse_errors_count_toward_exec_call_limit -- --nocapture` and `cargo test -p bashkit session_limits`, and all included tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae35e0832ba52d25b98b0e2d07)