### PR TITLE
fix(ci): pin release action SHAs and scope permissions to job level

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,18 +6,17 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  actions: write
-
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     # Only run if manually triggered OR commit message starts with "chore(release): prepare v"
     if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release): prepare v') }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -101,7 +100,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
Fixes #1855

Pin mutable action tags to commit SHAs to prevent supply-chain attacks if an
action tag is retargeted. Move workflow-level permissions to job scope as an
additional hardening measure.

- `actions/checkout@v6` → pinned to `df4cb1c` (SHA)
- `softprops/action-gh-release@v3` → pinned to `b430933` (SHA)
- Move `contents: write` + `actions: write` from workflow level to `release` job level