### PR TITLE
fix(ci): suppress phantom failure for coreutils-args-drift on push events

### DIFF
--- a/.github/workflows/coreutils-args-drift.yml
+++ b/.github/workflows/coreutils-args-drift.yml
@@ -18,6 +18,8 @@ name: Coreutils Args Drift
 # permission, and it only commits generated files after tests pass.
 
 on:
+  push:
+    branches: [main]  # guard: accept push events so GitHub doesn't record a phantom failure; all jobs skip on push
   schedule:
     # Weekly Mondays 05:00 UTC. uutils flag changes are rare; weekly is plenty.
     - cron: '0 5 * * 1'
@@ -33,6 +35,7 @@ env:
 jobs:
   regenerate:
     name: Regenerate uutils argument surfaces
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## What

Add `push: branches: [main]` trigger to `coreutils-args-drift.yml` with a job-level `if` guard that skips all jobs on push events.

## Why

GitHub creates failed check-run records (0 jobs, `conclusion: failure`) for schedule-only workflows every time a commit is pushed to main, even though the workflow has no push trigger. This causes persistent red marks in the workflow history that make it look like CI is broken when it is not.

The fix accepts the push event (so GitHub registers a proper check run) but immediately skips all jobs via `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'`. The run will show as neutral/skipped instead of failed.

## How

- Added `push: branches: [main]` to `on:` — one line comment explains why
- Added `if: ...` condition to `regenerate` job; `open-pr` depends on `regenerate` outputs so it automatically skips too

## Tests

Workflow-file-only change. `just pre-pr` passes (fmt, clippy, all 3125 unit tests, cargo vet).

---
_Generated by [Claude Code](https://claude.ai/code/session_011JVbekcFu2CE2f5mkn1RCq)_