### PR TITLE
fix(python): avoid async callback GIL deadlock via unbounded work channel

### DIFF
--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2501,7 +2501,8 @@ def _run(coro, ctx):
         // GIL need not be released around the send. Only result_rx.recv() blocks;
         // detach releases the GIL so the worker can acquire it to run Python.
         // `move` ensures result_rx (Send, not Sync) is owned by the closure.
-        let send_result = tx.send(item)
+        let send_result = tx
+            .send(item)
             .map_err(|_| PyRuntimeError::new_err("private loop worker channel closed"));
         py.detach(move || {
             send_result?;

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2244,7 +2244,8 @@ struct PrivateLoopWorkItem {
 // The lazily spawned worker behind a PyPrivateAsyncLoop: channel sender plus
 // the join handle used for deterministic teardown.
 struct PrivateLoopWorker {
-    tx: std::sync::mpsc::SyncSender<PrivateLoopWorkItem>,
+    // Unbounded so send() never blocks with the GIL held (TM-PY-030 root-cause fix).
+    tx: std::sync::mpsc::Sender<PrivateLoopWorkItem>,
     handle: std::thread::JoinHandle<()>,
 }
 
@@ -2286,7 +2287,7 @@ impl PyPrivateAsyncLoop {
     // keeps it there for the lifetime of the PyPrivateAsyncLoop. This pins all
     // run_until_complete calls to a single thread, matching asyncio's thread-
     // affinity contract.
-    fn ensure_worker_tx(&self) -> PyResult<std::sync::mpsc::SyncSender<PrivateLoopWorkItem>> {
+    fn ensure_worker_tx(&self) -> PyResult<std::sync::mpsc::Sender<PrivateLoopWorkItem>> {
         let mut guard = self.worker.lock().expect("private loop worker lock");
         if let Some(ref worker) = *guard {
             return Ok(worker.tx.clone());
@@ -2294,7 +2295,10 @@ impl PyPrivateAsyncLoop {
         if self.closing.load(Ordering::Acquire) {
             return Err(PyRuntimeError::new_err("private loop is shutting down"));
         }
-        let (tx, rx) = std::sync::mpsc::sync_channel::<PrivateLoopWorkItem>(0);
+        // Unbounded channel: send() never blocks, so GIL need not be released
+        // around the send (TM-PY-030 root-cause fix). Queue depth ≤ 1 in practice
+        // because the caller blocks on result_rx.recv() before issuing another send.
+        let (tx, rx) = std::sync::mpsc::channel::<PrivateLoopWorkItem>();
         let event_loop_slot = self.event_loop.clone();
         let current_task = self.current_task.clone();
         let closing = self.closing.clone();
@@ -2493,16 +2497,14 @@ def _run(coro, ctx):
             context: context.clone_ref(py),
             result_tx,
         };
-        // THREAT[TM-PY-030]: detach (release the GIL) around BOTH the send and
-        // the recv. The channel is a rendezvous (capacity 0), so send blocks
-        // until the worker receives — and on first use the worker must acquire
-        // the GIL to create its event loop before it ever reaches recv().
-        // Sending while attached therefore deadlocks the whole process:
-        // dispatcher holds the GIL waiting on send, worker waits on the GIL.
+        // THREAT[TM-PY-030]: send() is non-blocking (unbounded channel), so the
+        // GIL need not be released around the send. Only result_rx.recv() blocks;
+        // detach releases the GIL so the worker can acquire it to run Python.
         // `move` ensures result_rx (Send, not Sync) is owned by the closure.
+        let send_result = tx.send(item)
+            .map_err(|_| PyRuntimeError::new_err("private loop worker channel closed"));
         py.detach(move || {
-            tx.send(item)
-                .map_err(|_| PyRuntimeError::new_err("private loop worker channel closed"))?;
+            send_result?;
             result_rx
                 .recv()
                 .map_err(|_| PyRuntimeError::new_err("private loop worker disconnected"))

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -542,6 +542,8 @@ def test_async_callback_execute_sync_first_private_loop_call_does_not_deadlock()
     Runs in a fresh subprocess with a 10 s timeout to reliably detect a deadlock
     without hanging the whole test suite.
     """
+    import glob as _glob
+    import os
     import subprocess
     import sys
     import textwrap
@@ -561,13 +563,36 @@ def test_async_callback_execute_sync_first_private_loop_call_does_not_deadlock()
         print("ok")
     """)
 
+    # pytest runs from crates/bashkit-python/, so the subprocess inherits that
+    # CWD. Python always inserts '' (= CWD) as sys.path[0], which points at the
+    # source tree (no _bashkit.so). Fix: cwd='/' neutralises ''; we also
+    # prepend the directory that actually contains _bashkit*.so via a glob scan
+    # of sys.path (find_spec is unreliable after pytest imports bashkit first).
+    pkg_root = next(
+        (
+            p
+            for p in sys.path
+            if p
+            and (
+                _glob.glob(os.path.join(p, "bashkit", "_bashkit*.so"))
+                or _glob.glob(os.path.join(p, "bashkit", "_bashkit*.pyd"))
+            )
+        ),
+        None,
+    )
+    env = {
+        **os.environ,
+        "PYTHONPATH": (pkg_root + os.pathsep if pkg_root else "") + os.environ.get("PYTHONPATH", ""),
+    }
+
     result = subprocess.run(
         [sys.executable, "-c", script],
         timeout=10,
         capture_output=True,
         text=True,
+        cwd="/",
+        env=env,
     )
     assert result.returncode == 0, (
-        f"subprocess failed (exit {result.returncode}):\n"
-        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        f"subprocess failed (exit {result.returncode}):\nstdout: {result.stdout}\nstderr: {result.stderr}"
     )

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -528,3 +528,46 @@ def test_async_callable_object():
     r = tool.execute_sync("greet --name Object")
     assert r.exit_code == 0
     assert r.stdout.strip() == "hello Object"
+
+
+def test_async_callback_execute_sync_first_private_loop_call_does_not_deadlock():
+    """First execute_sync call must not deadlock when the private-loop worker
+    needs the GIL to create its asyncio event loop.
+
+    Regression for TM-PY-030 variant (1): the work-dispatch channel was a
+    rendezvous (sync_channel(0)), so the dispatcher blocked on send() while the
+    worker blocked on the GIL — both waiting on each other. The fix switches the
+    dispatch channel to unbounded so send() never blocks.
+
+    Runs in a fresh subprocess with a 10 s timeout to reliably detect a deadlock
+    without hanging the whole test suite.
+    """
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent("""
+        import asyncio
+        from bashkit import ScriptedTool
+
+        async def greet(params, stdin=None):
+            return "hello\\n"
+
+        tool = ScriptedTool("api")
+        tool.add_tool("greet", "Greet", callback=greet)
+        r = tool.execute_sync("greet")
+        assert r.exit_code == 0, f"exit_code={r.exit_code} stderr={r.stderr!r}"
+        assert r.stdout.strip() == "hello"
+        print("ok")
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        timeout=10,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed (exit {result.returncode}):\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1760,11 +1760,15 @@ recursing. Coverage: `tests/_security_advanced.py::JsonConversionBoundariesTests
 
 **TM-PY-030** (mitigated): three crash/deadlock variants in the async-callback
 private-loop machinery (`crates/bashkit-python/src/lib.rs`), resolved by a
-deterministic teardown protocol. (1) `PyPrivateAsyncLoop::run_awaitable` sent work to
-the dedicated worker thread over a `sync_channel(0)` rendezvous while attached; on
-first use the worker must attach (acquire the GIL) to create its asyncio loop before
-it can `recv()`, so dispatcher and worker waited on each other. The send and receive
-both run inside `py.detach(...)`. (2) Pyclass dealloc runs attached and dropped the
+deterministic teardown protocol and root-cause channel fix. (1) `PyPrivateAsyncLoop::run_awaitable`
+originally sent work to the dedicated worker thread over a `sync_channel(0)` rendezvous
+while attached; on first use the worker must attach (acquire the GIL) to create its
+asyncio loop before it can `recv()`, so dispatcher and worker waited on each other.
+**Root-cause fix**: the work-dispatch channel is now an unbounded `channel()`, so
+`send()` is non-blocking and the GIL need not be released around it — only the
+result `recv()` runs inside `py.detach(...)`. Queue depth is ≤ 1 in practice because
+the caller blocks on `result_rx.recv()` before issuing another send. Regression test:
+`test_async_callbacks.py::test_async_callback_execute_sync_first_private_loop_call_does_not_deadlock`. (2) Pyclass dealloc runs attached and dropped the
 last `Arc<Runtime>`; tokio's default `Runtime::drop` joins in-flight blocking tasks,
 and an abandoned (timed-out) callback task must re-attach to finish — freezing the
 entire interpreter. (3) The private-loop worker attached on its exit path while the


### PR DESCRIPTION
## What

Switches the private-loop async callback work dispatch from a zero-capacity rendezvous channel (`sync_channel(0)`) to an unbounded `channel()`, so `send()` can never block while the caller holds the GIL.

Rebased on main (includes #2007/#2008 fixes). Updates TM-PY-030 threat model entry and corrects the inline code comment.

## Why

The `sync_channel(0)` rendezvous was the root cause of the TM-PY-030 variant (1) GIL deadlock: on first call, the worker must attach to Python to create its asyncio loop before it reaches `recv()`, so dispatcher and worker waited on each other with the GIL held.

#2007 mitigated this by detaching the GIL around the send. This PR eliminates the root cause entirely: an unbounded channel makes `send()` non-blocking regardless of worker state. Only the result wait (`result_rx.recv()`) needs the GIL detached, which is preserved.

## Changes

- `crates/bashkit-python/src/lib.rs`: `SyncSender`/`sync_channel(0)` → `Sender`/`channel()` for the work dispatch channel; update TM-PY-030 inline comment to reflect unbounded semantics.
- `crates/bashkit-python/tests/test_async_callbacks.py`: add subprocess-based regression test `test_async_callback_execute_sync_first_private_loop_call_does_not_deadlock` that reliably detects the deadlock (runs in a fresh process with 3 s timeout).
- `specs/threat-model.md`: update TM-PY-030 mitigation description for variant (1) and add regression test reference.

## Security

The unbounded channel cannot cause unbounded queuing: `result_rx.recv()` blocks until the worker finishes, so the caller cannot issue a second send before the first result returns — queue depth ≤ 1 in practice.