### PR TITLE
fix(ci): repair drift-workflow YAML and fix GIL deadlocks hanging Coverage

### DIFF
--- a/.github/workflows/coreutils-args-drift.yml
+++ b/.github/workflows/coreutils-args-drift.yml
@@ -18,8 +18,6 @@ name: Coreutils Args Drift
 # permission, and it only commits generated files after tests pass.
 
 on:
-  push:
-    branches: [main]  # guard: accept push events so GitHub doesn't record a phantom failure; all jobs skip on push
   schedule:
     # Weekly Mondays 05:00 UTC. uutils flag changes are rare; weekly is plenty.
     - cron: '0 5 * * 1'
@@ -35,7 +33,6 @@ env:
 jobs:
   regenerate:
     name: Regenerate uutils argument surfaces
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -196,7 +193,10 @@ jobs:
         working-directory: bashkit
         env:
           BASHKIT_RUN_COREUTILS_DIFF: '1'
-        run: cargo test -p bashkit --test integration -- coreutils_differential_tests::
+        # Quoted: a plain scalar ending in `:` is invalid YAML (parsed as a
+        # mapping key) and broke parsing of this entire file, which made
+        # GitHub record a failed zero-job run on every push to main.
+        run: 'cargo test -p bashkit --test integration -- coreutils_differential_tests::'
 
       - name: Capture drift patch
         id: diff

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,7 @@ jobs:
   coverage:
     name: Generate Rust Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -68,6 +69,9 @@ jobs:
   python-coverage:
     name: Generate Python Binding Coverage
     runs-on: ubuntu-latest
+    # Bounded so a hung test fails fast instead of occupying a runner for
+    # GitHub's 6 h default (a GIL deadlock once did exactly that).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -116,6 +120,7 @@ jobs:
   node-coverage:
     name: Generate Node Binding Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -175,6 +180,7 @@ jobs:
     name: Upload Coverage
     needs: [coverage, python-coverage, node-coverage]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       actions: read

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -179,11 +179,45 @@ enum PyFileMount {
 
 const PY_FILE_PROVIDER_TYPE_ERROR_PREFIX: &str = "__bashkit_py_file_provider_type_error__:";
 
-fn make_runtime() -> PyResult<Arc<Runtime>> {
+/// Pyclass-held handle to the shared per-instance tokio runtime.
+///
+/// Decision: dropping the last handle shuts the runtime down with
+/// `shutdown_background()` instead of tokio's default blocking shutdown.
+/// Pyclass dealloc runs while attached to the Python interpreter (GIL
+/// held), and the default `Runtime::drop` joins in-flight blocking tasks.
+/// An abandoned (timed-out) Python callback task must re-attach — acquire
+/// the GIL — to finish, so joining it from dealloc deadlocks the whole
+/// process (seen as a 6 h CI hang in
+/// `test_async_callback_execute_sync_honors_timeout`). Background shutdown
+/// lets such tasks finish on their own once the GIL is released.
+struct PyRuntime(Option<Arc<Runtime>>);
+
+impl Clone for PyRuntime {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl std::ops::Deref for PyRuntime {
+    type Target = Arc<Runtime>;
+    fn deref(&self) -> &Arc<Runtime> {
+        self.0.as_ref().expect("runtime taken only in Drop")
+    }
+}
+
+impl Drop for PyRuntime {
+    fn drop(&mut self) {
+        if let Some(rt) = self.0.take().and_then(Arc::into_inner) {
+            rt.shutdown_background();
+        }
+    }
+}
+
+fn make_runtime() -> PyResult<PyRuntime> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .map(Arc::new)
+        .map(|rt| PyRuntime(Some(Arc::new(rt))))
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to create runtime: {e}")))
 }
 
@@ -1480,18 +1514,18 @@ fn capture_shell_state(
 #[pyclass(name = "FileSystem")]
 struct PyFileSystem {
     inner: FileSystemHandle,
-    rt: Arc<Runtime>,
+    rt: PyRuntime,
 }
 
 impl PyFileSystem {
-    fn from_static(inner: Arc<dyn FileSystem>, rt: Arc<Runtime>) -> Self {
+    fn from_static(inner: Arc<dyn FileSystem>, rt: PyRuntime) -> Self {
         Self {
             inner: FileSystemHandle::Static(inner),
             rt,
         }
     }
 
-    fn from_live(inner: Arc<Mutex<Bash>>, rt: Arc<Runtime>) -> Self {
+    fn from_live(inner: Arc<Mutex<Bash>>, rt: PyRuntime) -> Self {
         Self {
             inner: FileSystemHandle::Live {
                 inner,
@@ -1503,7 +1537,7 @@ impl PyFileSystem {
 
     fn from_live_with_reentry_guard(
         inner: Arc<Mutex<Bash>>,
-        rt: Arc<Runtime>,
+        rt: PyRuntime,
         external_handler_reentry_depth: Arc<AtomicUsize>,
     ) -> Self {
         Self {
@@ -2292,16 +2326,25 @@ def _run(coro, ctx):
         // the worker thread can acquire it to run Python.
         let tx = self.ensure_worker_tx()?;
         let (result_tx, result_rx) = std::sync::mpsc::sync_channel(0);
-        tx.send(PrivateLoopWorkItem {
+        let item = PrivateLoopWorkItem {
             awaitable: awaitable.clone_ref(py),
             context: context.clone_ref(py),
             result_tx,
-        })
-        .map_err(|_| PyRuntimeError::new_err("private loop worker channel closed"))?;
-        // Release the GIL while waiting so the worker thread can acquire it.
+        };
+        // Detach (release the GIL) around BOTH the send and the recv. The
+        // channel is a rendezvous (capacity 0), so send blocks until the
+        // worker receives — and on first use the worker must acquire the GIL
+        // to create its event loop before it ever reaches recv(). Sending
+        // while attached therefore deadlocks the whole process: dispatcher
+        // holds the GIL waiting on send, worker waits on the GIL.
         // `move` ensures result_rx (Send, not Sync) is owned by the closure.
-        py.detach(move || result_rx.recv())
-            .map_err(|_| PyRuntimeError::new_err("private loop worker disconnected"))?
+        py.detach(move || {
+            tx.send(item)
+                .map_err(|_| PyRuntimeError::new_err("private loop worker channel closed"))?;
+            result_rx
+                .recv()
+                .map_err(|_| PyRuntimeError::new_err("private loop worker disconnected"))
+        })?
     }
 }
 
@@ -3298,7 +3341,7 @@ pub struct PyBash {
     inner: Arc<Mutex<Bash>>,
     /// Shared tokio runtime — reused across all sync calls to avoid
     /// per-call OS thread/fd exhaustion (issue #414).
-    rt: Arc<Runtime>,
+    rt: PyRuntime,
     /// Cancellation token. Wrapped in RwLock so reset() can swap it to
     /// the new interpreter's token without requiring &mut self.
     cancelled: Arc<RwLock<Arc<AtomicBool>>>,
@@ -4163,7 +4206,7 @@ pub struct BashTool {
     inner: Arc<Mutex<Bash>>,
     /// Shared tokio runtime — reused across all sync calls to avoid
     /// per-call OS thread/fd exhaustion (issue #414).
-    rt: Arc<Runtime>,
+    rt: PyRuntime,
     /// Cancellation token. Wrapped in RwLock so reset() can swap it to
     /// the new interpreter's token without requiring &mut self.
     cancelled: Arc<RwLock<Arc<AtomicBool>>>,
@@ -4949,7 +4992,7 @@ pub struct ScriptedTool {
     env_vars: Vec<(String, String)>,
     /// Shared tokio runtime — reused across all sync calls to avoid
     /// per-call OS thread/fd exhaustion (issue #414).
-    rt: Arc<Runtime>,
+    rt: PyRuntime,
     callback_engine: Arc<PyCallbackEngine>,
     max_commands: Option<u64>,
     max_loop_iterations: Option<u64>,

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -181,7 +181,7 @@ const PY_FILE_PROVIDER_TYPE_ERROR_PREFIX: &str = "__bashkit_py_file_provider_typ
 
 /// Pyclass-held handle to the shared per-instance tokio runtime.
 ///
-/// Decision: dropping the last handle shuts the runtime down with
+/// THREAT[TM-PY-030]: dropping the last handle shuts the runtime down with
 /// `shutdown_background()` instead of tokio's default blocking shutdown.
 /// Pyclass dealloc runs while attached to the Python interpreter (GIL
 /// held), and the default `Runtime::drop` joins in-flight blocking tasks.
@@ -2331,12 +2331,12 @@ def _run(coro, ctx):
             context: context.clone_ref(py),
             result_tx,
         };
-        // Detach (release the GIL) around BOTH the send and the recv. The
-        // channel is a rendezvous (capacity 0), so send blocks until the
-        // worker receives — and on first use the worker must acquire the GIL
-        // to create its event loop before it ever reaches recv(). Sending
-        // while attached therefore deadlocks the whole process: dispatcher
-        // holds the GIL waiting on send, worker waits on the GIL.
+        // THREAT[TM-PY-030]: detach (release the GIL) around BOTH the send and
+        // the recv. The channel is a rendezvous (capacity 0), so send blocks
+        // until the worker receives — and on first use the worker must acquire
+        // the GIL to create its event loop before it ever reaches recv().
+        // Sending while attached therefore deadlocks the whole process:
+        // dispatcher holds the GIL waiting on send, worker waits on the GIL.
         // `move` ensures result_rx (Send, not Sync) is owned by the closure.
         py.detach(move || {
             tx.send(item)

--- a/crates/bashkit-python/tests/test_async_callbacks.py
+++ b/crates/bashkit-python/tests/test_async_callbacks.py
@@ -65,6 +65,37 @@ def test_async_callback_execute_sync_honors_timeout():
     assert callback_done.wait(timeout=2.0), "slow callback did not finish within 2 s"
 
 
+def test_dealloc_during_inflight_callback_does_not_deadlock():
+    """Dropping the tool while a timed-out callback still runs must not hang.
+
+    Regression for TM-PY-030 (2): pyclass dealloc runs with the GIL held and
+    drops the tool's tokio runtime. The default runtime drop joins in-flight
+    blocking tasks, and the abandoned callback task needs the GIL to finish —
+    deadlocking the whole interpreter. Runtime shutdown must not block.
+    """
+
+    callback_done = threading.Event()
+
+    async def slow(params, stdin=None):
+        await asyncio.sleep(0.25)
+        callback_done.set()
+        return "late\n"
+
+    tool = ScriptedTool("api", timeout_seconds=0.05)
+    tool.add_tool("slow", "Slow", callback=slow)
+
+    r = tool.execute_sync("slow")
+    assert r.exit_code == 1
+
+    # Dealloc the tool (and its runtime) while the abandoned callback is
+    # still sleeping on the private-loop worker thread.
+    del tool
+    gc.collect()
+
+    # The orphaned callback finishes on its own once the GIL is free.
+    assert callback_done.wait(timeout=2.0), "slow callback did not finish within 2 s"
+
+
 def test_async_callback_sync_execute():
     """Async callback works via execute_sync()."""
 

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -1731,6 +1731,7 @@ caller's GIL hold.
 
 | TM-PY-026 | reset() discards security config | `BashTool.reset()` creates new `Bash` with bare builder, dropping all configured limits | `PyBash::reset` and `BashTool::reset` rebuild via `replace_live_bash_with_builder` + `build_live_builder`, which preserves the original limits, env, and registered builtins | **MITIGATED** |
 | TM-PY-027 | Unbounded recursion in JSON conversion | `py_to_json`/`json_to_py` recurse without depth limit on nested dicts/lists | `json_to_py_inner`, `py_to_json_inner`, and the MontyObject converters all carry a `depth` arg; depth > `MAX_NESTING_DEPTH = 64` raises `ValueError("… nesting depth exceeds maximum of 64")` | **MITIGATED** |
+| TM-PY-030 | GIL deadlock via async-callback private loop | Private-loop dispatch blocked on a rendezvous channel while attached (GIL held), and pyclass dealloc joined in-flight blocking tasks that must re-attach to finish — either froze the whole process (observed as a 6 h CI hang) | Dispatch detaches around both the send and the receive; `PyRuntime` drop shuts the tokio runtime down with `shutdown_background()` instead of a blocking join | **MITIGATED** |
 
 **TM-PY-026** (mitigated): `PyBash::reset` and `BashTool::reset` (`crates/bashkit-python/src/lib.rs`)
 rebuild the inner `Bash` via `replace_live_bash_with_builder` + `build_live_builder`, which
@@ -1742,6 +1743,19 @@ re-applies the original limits, env, and registered builtins. Regression tests:
 MontyObject converters in `crates/bashkit-python/src/lib.rs` carry a `depth: usize` argument.
 At `depth > MAX_NESTING_DEPTH = 64`, conversion raises a Python `ValueError` instead of
 recursing. Coverage: `tests/_security_advanced.py::JsonConversionBoundariesTests`.
+
+**TM-PY-030** (mitigated): two deadlock variants in the async-callback private-loop
+machinery (`crates/bashkit-python/src/lib.rs`). (1) `PyPrivateAsyncLoop::run_awaitable`
+sent work to the dedicated worker thread over a `sync_channel(0)` rendezvous while
+attached; on first use the worker must attach (acquire the GIL) to create its asyncio
+loop before it can `recv()`, so dispatcher and worker waited on each other. The send
+and receive now both run inside `py.detach(...)`. (2) Pyclass dealloc runs attached
+and dropped the last `Arc<Runtime>`; tokio's default `Runtime::drop` joins in-flight
+blocking tasks, and an abandoned (timed-out) callback task must re-attach to finish —
+freezing the entire interpreter. The `PyRuntime` handle now shuts the runtime down
+with `shutdown_background()` on last drop. Regression tests:
+`tests/test_async_callbacks.py::test_async_callback_execute_sync_honors_timeout`,
+`…::test_dealloc_during_inflight_callback_does_not_deadlock`.
 
 | TM-PY-029 | Host clock information disclosure | `datetime.date.today()` / `datetime.datetime.now()` expose host system time and timezone | Intentional — required for correct datetime semantics | **ACCEPTED** |
 


### PR DESCRIPTION
## What

Fixes both red workflows on main and removes the misdiagnosed suppression hack:

1. **`coreutils-args-drift.yml` was invalid YAML.** The differential-harness step's `run:` value ends in a bare `::` (`-- coreutils_differential_tests::`); a plain YAML scalar ending in a colon parses as a mapping key, so the whole file failed to parse. GitHub recorded a failed zero-job run (named by file path) on **every push to main** since the file landed. Quoted the scalar and reverted the push-trigger + skip-guard from the previous suppression attempt — valid schedule-only workflows don't create push runs, so it's unnecessary once the file parses.

2. **Two GIL deadlocks froze async-callback `execute_sync` (TM-PY-030).** The Coverage job hung for 6 hours in `test_async_callback_execute_sync_honors_timeout`; reproduced locally and confirmed via gdb backtraces:
   - Private-loop dispatch sent work over a `sync_channel(0)` rendezvous **while attached** (GIL held). On first use, the worker thread must attach to create its asyncio loop before it ever reaches `recv()`, so dispatcher and worker waited on each other. Fix: detach around both the send and the receive.
   - Pyclass dealloc (GIL held) dropped the last `Arc<Runtime>`, whose default `Drop` joins in-flight blocking tasks. An abandoned timed-out callback task needs the GIL to finish, freezing the entire interpreter. Fix: new `PyRuntime` handle shuts the runtime down with `shutdown_background()` on last drop; orphaned tasks finish once the GIL is released.

   This slipped in with #1918 because pushes to main cancel in-progress Coverage/Python runs, so the merged version never completed a binding-test run.

3. **Hardening:** `timeout-minutes` on all four coverage jobs so a future hang fails in minutes instead of GitHub's 6-hour default.

## Tests

- New regression test `test_dealloc_during_inflight_callback_does_not_deadlock` (drops the tool while the abandoned callback is still running).
- `test_async_callback_execute_sync_honors_timeout` hung deterministically before (3/3 repros under `timeout`, gdb stacks match both deadlocks); passes now.
- Full bashkit-python suite: 694 passed, 2 skipped in ~21 s. `just pre-pr` green (fmt, clippy, tests, cargo vet). `ruff check` / `ruff format --check` clean. All workflow YAML validated.

## Specs

- `specs/threat-model.md`: added TM-PY-030 with both variants; mitigation points tagged with `THREAT[TM-PY-030]` comments.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtAsttyBKbB8jQFwzxTw1F)_