### PR TITLE
feat(python): expose VFS to custom builtins via BuiltinContext.fs

### DIFF
--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -91,6 +91,12 @@ class BuiltinContext:
         stdin: Pipeline input from the previous command, if any.
         env: Environment variables visible to the builtin.
         cwd: Current working directory at invocation time.
+        fs: Live handle to the interpreter's virtual filesystem. Reads see
+            files created by earlier commands and writes are visible to later
+            ones. Same API as ``Bash.fs()`` — e.g. ``ctx.fs.read_file(path)``
+            returns ``bytes``. Operates directly on the interpreter's VFS, so
+            it is safe to use from inside the callback (unlike calling back
+            into ``Bash.fs()`` / ``Bash.read_file()`` on the owning instance).
     """
 
     name: str
@@ -98,6 +104,7 @@ class BuiltinContext:
     stdin: str | None
     env: dict[str, str]
     cwd: str
+    fs: FileSystem
 
 class BuiltinResult:
     """Shell-facing result for a custom builtin callback.
@@ -501,11 +508,12 @@ class Bash:
                 files and mounts are applied.
             custom_builtins: Constructor-time Python callbacks exposed as
                 bash builtins. Each callback receives a ``BuiltinContext``
-                with raw ``argv`` tokens and optional pipeline ``stdin``,
-                and must return a stdout string, a ``BuiltinResult``, or
-                await either. Async callbacks run on the caller's active
-                asyncio loop for ``await execute()`` and on a private loop
-                for ``execute_sync()``.
+                with raw ``argv`` tokens, optional pipeline ``stdin``, and a
+                live ``fs`` handle to the virtual filesystem, and must return a
+                stdout string, a ``BuiltinResult``, or await either. Async
+                callbacks run on the caller's active asyncio loop for
+                ``await execute()`` and on a private loop for
+                ``execute_sync()``.
             network: Optional outbound HTTP / network configuration. Pass
                 ``{"allow": [...]}`` for an explicit allowlist or
                 ``{"allow_all": True}`` to allow every URL (mirrors
@@ -940,10 +948,11 @@ class BashTool:
                 files and mounts are applied.
             custom_builtins: Constructor-time Python callbacks exposed as
                 bash builtins. Each callback receives a ``BuiltinContext``
-                and must return a stdout string, a ``BuiltinResult``, or
-                await either. Async callbacks run on the caller's active
-                asyncio loop for ``await execute()`` and on a private loop
-                for ``execute_sync()``.
+                (including a live ``fs`` handle to the virtual filesystem) and
+                must return a stdout string, a ``BuiltinResult``, or await
+                either. Async callbacks run on the caller's active asyncio
+                loop for ``await execute()`` and on a private loop for
+                ``execute_sync()``.
             network: Optional outbound HTTP / network configuration. See
                 ``Bash.__init__`` for accepted keys. Preserved across
                 ``reset()`` and ``from_snapshot()``.

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -95,7 +95,11 @@ class BuiltinContext:
             files created by earlier commands and writes are visible to later
             ones. Same API as ``Bash.fs()`` — e.g. ``ctx.fs.read_file(path)``
             returns ``bytes``. Operates directly on the interpreter's VFS, so
-            it is safe to use from inside the callback.
+            it is safe to use from inside the callback. Ops are synchronous and,
+            while a runtime is active, may run off-thread (relatively expensive
+            per call), so batch filesystem work rather than looping over many
+            tiny ops. May be retained past the callback: a stashed handle keeps
+            the VFS (and its runtime) alive even after the ``Bash`` is dropped.
     """
 
     name: str

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -95,8 +95,7 @@ class BuiltinContext:
             files created by earlier commands and writes are visible to later
             ones. Same API as ``Bash.fs()`` — e.g. ``ctx.fs.read_file(path)``
             returns ``bytes``. Operates directly on the interpreter's VFS, so
-            it is safe to use from inside the callback (unlike calling back
-            into ``Bash.fs()`` / ``Bash.read_file()`` on the owning instance).
+            it is safe to use from inside the callback.
     """
 
     name: str

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1629,6 +1629,22 @@ impl PyFileSystem {
         }
     }
 
+    // The `Send` bounds are load-bearing for the worker-thread branch below
+    // (`std::thread::scope` moves `f`, its future, and the result `T` across the
+    // thread boundary). They are NOT an extra restriction in practice, so there
+    // is no non-`Send` fast path worth splitting out:
+    //   - `with_fs` is only ever called inside `py.detach(...)` (see every
+    //     caller), so the GIL is released and a closure physically cannot hold a
+    //     `Bound<'py>` / `Python<'py>` ref across the await — the canonical
+    //     source of a non-`Send` fs future.
+    //   - `FileSystem: FileSystemExt: Send + Sync` and the trait is
+    //     `#[async_trait]`, so every fs method already returns a `Send`-boxed
+    //     future and `Arc<dyn FileSystem>` is `Send + Sync`. Any closure that
+    //     just awaits fs ops (all of them do) satisfies `Fut: Send` for free.
+    // A separate non-`Send` `with_fs_local` would therefore have no caller today
+    // (dead code), and the runtime branch means a single method can't statically
+    // pick local-vs-send anyway. Keep one helper; the bound documents the real
+    // off-thread-dispatch invariant.
     fn with_fs<T, F, Fut>(&self, f: F) -> PyResult<T>
     where
         F: FnOnce(Arc<dyn FileSystem>) -> Fut + Send,
@@ -1688,9 +1704,18 @@ impl PyFileSystem {
                     .join()
                     // Drop the panic payload deliberately: a `Box<dyn Any>` can't
                     // be formatted without downcasting and may carry internal
-                    // Debug shapes / host paths (TM-INF-022). The default panic
-                    // hook still prints the full trace to stderr for debugging.
-                    .map_err(|_| PyRuntimeError::new_err("filesystem worker thread panicked"))?
+                    // Debug shapes / host paths (TM-INF-022). Point the user at
+                    // the stderr backtrace the default panic hook prints instead
+                    // — actionable in headless setups where the hint is the only
+                    // breadcrumb, and leaks nothing (static string, no payload).
+                    .map_err(|_| {
+                        PyRuntimeError::new_err(
+                            "internal error: bashkit filesystem worker thread panicked. \
+                             This is a bug in bashkit, not your script. A backtrace was \
+                             printed to stderr; re-run with RUST_BACKTRACE=1 for the full \
+                             trace and please report it.",
+                        )
+                    })?
             });
         }
         self.rt.block_on(async move {

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -61,7 +61,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{Mutex, oneshot};
 
 // ============================================================================
@@ -1015,6 +1015,13 @@ enum FileSystemHandle {
 }
 
 impl FileSystemHandle {
+    /// A `Static` handle wraps an `Arc<dyn FileSystem>` directly, so resolving
+    /// it never touches the interpreter lock. Used to pick a re-entrancy-safe
+    /// dispatch path in `PyFileSystem::with_fs`.
+    fn is_static(&self) -> bool {
+        matches!(self, Self::Static(_))
+    }
+
     async fn resolve(&self) -> PyResult<Arc<dyn FileSystem>> {
         match self {
             Self::Static(fs) => Ok(Arc::clone(fs)),
@@ -1605,10 +1612,39 @@ impl PyFileSystem {
 
     fn with_fs<T, F, Fut>(&self, f: F) -> PyResult<T>
     where
-        F: FnOnce(Arc<dyn FileSystem>) -> Fut,
-        Fut: Future<Output = PyResult<T>>,
+        F: FnOnce(Arc<dyn FileSystem>) -> Fut + Send,
+        Fut: Future<Output = PyResult<T>> + Send,
+        T: Send,
     {
         let inner = self.inner.clone();
+        // A `Static` handle (e.g. a custom builtin's `ctx.fs`) operates on a
+        // cloned `Arc<dyn FileSystem>` with no interpreter lock. When such a
+        // handle is used from *inside* the shared current-thread runtime —
+        // `execute_sync` drives the interpreter via `self.rt.block_on`, and the
+        // custom builtin callback runs within it — calling `block_on` again on
+        // this thread panics ("Cannot start a runtime from within a runtime").
+        // Run the op on a throwaway thread with its own runtime instead. `Live`
+        // handles keep the original fast path: they lock the interpreter, so
+        // re-entrant use is already unsupported and must not silently deadlock.
+        if inner.is_static() && Handle::try_current().is_ok() {
+            return std::thread::scope(|scope| {
+                scope
+                    .spawn(move || {
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .map_err(|e| {
+                                PyRuntimeError::new_err(format!("Failed to create runtime: {e}"))
+                            })?;
+                        rt.block_on(async move {
+                            let fs = inner.resolve().await?;
+                            f(fs).await
+                        })
+                    })
+                    .join()
+                    .map_err(|_| PyRuntimeError::new_err("filesystem worker thread panicked"))?
+            });
+        }
         self.rt.block_on(async move {
             let fs = inner.resolve().await?;
             f(fs).await
@@ -2159,16 +2195,23 @@ fn prepare_output_handler(
 }
 
 // Decision: `custom_builtins` mirror Rust builtin semantics with a shell-first
-// context object (`argv`, `stdin`, `env`, `cwd`); `ScriptedTool` remains
+// context object (`argv`, `stdin`, `env`, `cwd`, `fs`); `ScriptedTool` remains
 // schema-first and continues to pass `(params, stdin)`.
 //
-// Deliberately omitted for now: live `fs`, mutable shell variables, mutable
-// `cwd`, and feature-gated network/git/ssh clients from Rust `BuiltinContext`.
-// Those are reasonable follow-ups, but this PR keeps the Python surface small
-// and shell-first while we validate the core callback shape.
+// `fs` wraps the *same* `Arc<dyn FileSystem>` the interpreter is running on
+// (mirroring how the embedded `python3`/Monty builtin receives `ctx.fs`), so it
+// is a live view, not a snapshot. It is a `Static` `PyFileSystem` handle, which
+// bypasses the interpreter lock — `PyFileSystem::with_fs` runs its ops off the
+// shared runtime thread so they are safe from within the callback.
+//
+// Still deliberately omitted: mutable shell variables, mutable `cwd`, and
+// feature-gated network/git/ssh clients from Rust `BuiltinContext`. Reasonable
+// follow-ups, kept out to keep the Python surface small and shell-first.
 /// Execution context passed to Python-backed custom builtins.
 ///
-/// Fields are snapshots of the shell state at invocation time.
+/// `name`, `argv`, `stdin`, `env`, and `cwd` are snapshots of the shell state at
+/// invocation time; `fs` is a live handle to the interpreter's virtual
+/// filesystem.
 #[pyclass(name = "BuiltinContext", skip_from_py_object)]
 struct PyBuiltinContext {
     #[pyo3(get)]
@@ -2181,6 +2224,8 @@ struct PyBuiltinContext {
     env: std::collections::HashMap<String, String>,
     #[pyo3(get)]
     cwd: String,
+    #[pyo3(get)]
+    fs: Py<PyFileSystem>,
 }
 
 #[pymethods]
@@ -2197,7 +2242,12 @@ fn make_py_builtin_context(
     py: Python<'_>,
     name: &str,
     ctx: &BuiltinContext<'_>,
+    rt: &Arc<Runtime>,
 ) -> Result<Py<PyBuiltinContext>, String> {
+    // Wrap the interpreter's live VFS as a `Static` handle so callbacks read and
+    // write the same filesystem without re-locking the interpreter.
+    let fs = Py::new(py, PyFileSystem::from_static(ctx.fs.clone(), rt.clone()))
+        .map_err(|e| e.to_string())?;
     Py::new(
         py,
         PyBuiltinContext {
@@ -2206,6 +2256,7 @@ fn make_py_builtin_context(
             stdin: ctx.stdin.map(str::to_owned),
             env: ctx.env.clone(),
             cwd: ctx.cwd.to_string_lossy().into_owned(),
+            fs,
         },
     )
     .map_err(|e| e.to_string())
@@ -3158,6 +3209,8 @@ struct PyCustomBuiltinAdapter {
     name: String,
     callback: Py<PyAny>,
     is_async: bool,
+    /// Shared runtime, threaded into each invocation's `ctx.fs` handle.
+    rt: Arc<Runtime>,
 }
 
 #[async_trait]
@@ -3165,7 +3218,7 @@ impl Builtin for PyCustomBuiltinAdapter {
     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<RustExecResult> {
         let session = ctx.execution_extension::<Arc<PyCallbackSession>>().cloned();
         let builtin_arg = Python::attach(|py| -> Result<Py<PyAny>, String> {
-            let builtin_arg = make_py_builtin_context(py, &self.name, &ctx)
+            let builtin_arg = make_py_builtin_context(py, &self.name, &ctx, &self.rt)
                 .map_err(|e| format!("{}: {}", self.name, e))?
                 .into_bound(py)
                 .into_any()
@@ -3213,6 +3266,7 @@ impl Builtin for PyCustomBuiltinAdapter {
 fn build_runtime_custom_builtin_impls(
     py: Python<'_>,
     builtins: &[PyCustomBuiltinEntry],
+    rt: &Arc<Runtime>,
 ) -> Vec<PyCustomBuiltinAdapter> {
     builtins
         .iter()
@@ -3220,6 +3274,7 @@ fn build_runtime_custom_builtin_impls(
             name: entry.name.clone(),
             callback: entry.callback.clone_ref(py),
             is_async: entry.is_async,
+            rt: rt.clone(),
         })
         .collect()
 }
@@ -3234,8 +3289,9 @@ fn populate_registry_from_entries(
     py: Python<'_>,
     registry: &BuiltinRegistry,
     builtins: &[PyCustomBuiltinEntry],
+    rt: &Arc<Runtime>,
 ) {
-    for builtin in build_runtime_custom_builtin_impls(py, builtins) {
+    for builtin in build_runtime_custom_builtin_impls(py, builtins, rt) {
         registry.insert(builtin.name.clone(), Arc::new(builtin));
     }
 }
@@ -3788,13 +3844,12 @@ impl PyBash {
         builder = builder.readonly_filesystem(readonly_filesystem);
         let builtin_engine = PyCallbackEngine::new(py)?;
         let host_registry = BuiltinRegistry::new();
-        populate_registry_from_entries(py, &host_registry, &custom_builtins);
+        let rt = make_runtime()?;
+        populate_registry_from_entries(py, &host_registry, &custom_builtins, &rt);
         builder = builder.builtin_registry(host_registry.clone());
 
         let bash = builder.build();
         let cancelled = Arc::new(RwLock::new(bash.cancellation_token()));
-
-        let rt = make_runtime()?;
 
         Ok(Self {
             inner: Arc::new(Mutex::new(bash)),
@@ -4002,6 +4057,7 @@ impl PyBash {
             name: entry.name.clone(),
             callback: entry.callback.clone_ref(py),
             is_async: entry.is_async,
+            rt: self.rt.clone(),
         };
         {
             let mut guard = self
@@ -4532,7 +4588,7 @@ impl BashTool {
             if guard.is_empty() {
                 Vec::new()
             } else {
-                Python::attach(|py| build_runtime_custom_builtin_impls(py, &guard))
+                Python::attach(|py| build_runtime_custom_builtin_impls(py, &guard, &self.rt))
             }
         };
         for builtin in builtins {
@@ -4622,13 +4678,12 @@ impl BashTool {
         builder = builder.readonly_filesystem(readonly_filesystem);
         let builtin_engine = PyCallbackEngine::new(py)?;
         let host_registry = BuiltinRegistry::new();
-        populate_registry_from_entries(py, &host_registry, &custom_builtins);
+        let rt = make_runtime()?;
+        populate_registry_from_entries(py, &host_registry, &custom_builtins, &rt);
         builder = builder.builtin_registry(host_registry.clone());
 
         let bash = builder.build();
         let cancelled = Arc::new(RwLock::new(bash.cancellation_token()));
-
-        let rt = make_runtime()?;
 
         Ok(Self {
             inner: Arc::new(Mutex::new(bash)),
@@ -4796,6 +4851,7 @@ impl BashTool {
             name: entry.name.clone(),
             callback: entry.callback.clone_ref(py),
             is_async: entry.is_async,
+            rt: self.rt.clone(),
         };
         {
             let mut guard = self

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1630,12 +1630,10 @@ impl PyFileSystem {
             return std::thread::scope(|scope| {
                 scope
                     .spawn(move || {
-                        let rt = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .map_err(|e| {
-                                PyRuntimeError::new_err(format!("Failed to create runtime: {e}"))
-                            })?;
+                        // A fresh runtime, not `self.rt`: the outer `block_on`
+                        // driving this callback still owns `self.rt`, and a
+                        // current-thread runtime can't be entered twice.
+                        let rt = make_runtime()?;
                         rt.block_on(async move {
                             let fs = inner.resolve().await?;
                             f(fs).await
@@ -3213,6 +3211,17 @@ struct PyCustomBuiltinAdapter {
     rt: Arc<Runtime>,
 }
 
+impl PyCustomBuiltinAdapter {
+    fn from_entry(py: Python<'_>, entry: &PyCustomBuiltinEntry, rt: &Arc<Runtime>) -> Self {
+        Self {
+            name: entry.name.clone(),
+            callback: entry.callback.clone_ref(py),
+            is_async: entry.is_async,
+            rt: rt.clone(),
+        }
+    }
+}
+
 #[async_trait]
 impl Builtin for PyCustomBuiltinAdapter {
     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<RustExecResult> {
@@ -3270,12 +3279,7 @@ fn build_runtime_custom_builtin_impls(
 ) -> Vec<PyCustomBuiltinAdapter> {
     builtins
         .iter()
-        .map(|entry| PyCustomBuiltinAdapter {
-            name: entry.name.clone(),
-            callback: entry.callback.clone_ref(py),
-            is_async: entry.is_async,
-            rt: rt.clone(),
-        })
+        .map(|entry| PyCustomBuiltinAdapter::from_entry(py, entry, rt))
         .collect()
 }
 
@@ -4053,12 +4057,7 @@ impl PyBash {
     /// builtin > `PATH`.
     fn add_builtin(&self, py: Python<'_>, name: String, callback: Py<PyAny>) -> PyResult<()> {
         let entry = build_py_custom_builtin_entry(py, name.clone(), callback)?;
-        let adapter = PyCustomBuiltinAdapter {
-            name: entry.name.clone(),
-            callback: entry.callback.clone_ref(py),
-            is_async: entry.is_async,
-            rt: self.rt.clone(),
-        };
+        let adapter = PyCustomBuiltinAdapter::from_entry(py, &entry, &self.rt);
         {
             let mut guard = self
                 .custom_builtins
@@ -4847,12 +4846,7 @@ impl BashTool {
     /// See [`PyBash::add_builtin`] for semantics.
     fn add_builtin(&self, py: Python<'_>, name: String, callback: Py<PyAny>) -> PyResult<()> {
         let entry = build_py_custom_builtin_entry(py, name.clone(), callback)?;
-        let adapter = PyCustomBuiltinAdapter {
-            name: entry.name.clone(),
-            callback: entry.callback.clone_ref(py),
-            is_async: entry.is_async,
-            rt: self.rt.clone(),
-        };
+        let adapter = PyCustomBuiltinAdapter::from_entry(py, &entry, &self.rt);
         {
             let mut guard = self
                 .custom_builtins

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2259,7 +2259,7 @@ fn make_py_builtin_context(
     py: Python<'_>,
     name: &str,
     ctx: &BuiltinContext<'_>,
-    rt: &Arc<Runtime>,
+    rt: &PyRuntime,
 ) -> Result<Py<PyBuiltinContext>, String> {
     // Wrap the interpreter's live VFS as a `Static` handle so callbacks read and
     // write the same filesystem without re-locking the interpreter.
@@ -3226,12 +3226,15 @@ struct PyCustomBuiltinAdapter {
     name: String,
     callback: Py<PyAny>,
     is_async: bool,
-    /// Shared runtime, threaded into each invocation's `ctx.fs` handle.
-    rt: Arc<Runtime>,
+    /// Shared runtime, threaded into each invocation's `ctx.fs` handle. A
+    /// `PyRuntime` clone is a refcount bump on the same `Arc<Runtime>` the
+    /// interpreter runs on; deterministic teardown still only fires when the
+    /// last clone drops (`Arc::into_inner` in `PyRuntime::drop`).
+    rt: PyRuntime,
 }
 
 impl PyCustomBuiltinAdapter {
-    fn from_entry(py: Python<'_>, entry: &PyCustomBuiltinEntry, rt: &Arc<Runtime>) -> Self {
+    fn from_entry(py: Python<'_>, entry: &PyCustomBuiltinEntry, rt: &PyRuntime) -> Self {
         Self {
             name: entry.name.clone(),
             callback: entry.callback.clone_ref(py),
@@ -3294,7 +3297,7 @@ impl Builtin for PyCustomBuiltinAdapter {
 fn build_runtime_custom_builtin_impls(
     py: Python<'_>,
     builtins: &[PyCustomBuiltinEntry],
-    rt: &Arc<Runtime>,
+    rt: &PyRuntime,
 ) -> Vec<PyCustomBuiltinAdapter> {
     builtins
         .iter()
@@ -3312,7 +3315,7 @@ fn populate_registry_from_entries(
     py: Python<'_>,
     registry: &BuiltinRegistry,
     builtins: &[PyCustomBuiltinEntry],
-    rt: &Arc<Runtime>,
+    rt: &PyRuntime,
 ) {
     for builtin in build_runtime_custom_builtin_impls(py, builtins, rt) {
         registry.insert(builtin.name.clone(), Arc::new(builtin));

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1619,13 +1619,28 @@ impl PyFileSystem {
         let inner = self.inner.clone();
         // A `Static` handle (e.g. a custom builtin's `ctx.fs`) operates on a
         // cloned `Arc<dyn FileSystem>` with no interpreter lock. When such a
-        // handle is used from *inside* the shared current-thread runtime —
-        // `execute_sync` drives the interpreter via `self.rt.block_on`, and the
-        // custom builtin callback runs within it — calling `block_on` again on
-        // this thread panics ("Cannot start a runtime from within a runtime").
-        // Run the op on a throwaway thread with its own runtime instead. `Live`
-        // handles keep the original fast path: they lock the interpreter, so
-        // re-entrant use is already unsupported and must not silently deadlock.
+        // handle is used while a tokio runtime is already active on this thread
+        // — `execute_sync` drives the interpreter via `self.rt.block_on` and the
+        // custom builtin callback runs within it; the same holds on a
+        // multi-thread runtime worker when `await execute()` drives a *sync*
+        // builtin — calling `block_on` again here panics ("Cannot start a
+        // runtime from within a runtime"). Run the op on a throwaway thread with
+        // its own runtime instead.
+        //
+        // Cost: this spawns one OS thread and builds one current-thread runtime
+        // per op, so a callback doing many `ctx.fs` ops in a tight loop pays
+        // that scaffolding each time. Fine for occasional `ctx.fs` use; if it
+        // ever gets hot, amortize with a long-lived worker thread + runtime
+        // reused across ops via a channel (note: `block_in_place` is not an
+        // option while `make_runtime` builds a current-thread runtime).
+        //
+        // `Live` handles keep the original fast path: they lock the interpreter.
+        // Re-entrant use of a `Live` handle from inside the shared runtime is
+        // unsupported — it re-enters `self.rt.block_on` and panics with the same
+        // nested-runtime error. That is NOT a deadlock, and it is NOT caught by
+        // the `external_handler` reentry guard (which only fires inside an
+        // external_handler, not a custom builtin); the loud panic is preferable
+        // to silently deadlocking or corrupting interpreter state.
         if inner.is_static() && Handle::try_current().is_ok() {
             return std::thread::scope(|scope| {
                 scope
@@ -1640,6 +1655,10 @@ impl PyFileSystem {
                         })
                     })
                     .join()
+                    // Drop the panic payload deliberately: a `Box<dyn Any>` can't
+                    // be formatted without downcasting and may carry internal
+                    // Debug shapes / host paths (TM-INF-022). The default panic
+                    // hook still prints the full trace to stderr for debugging.
                     .map_err(|_| PyRuntimeError::new_err("filesystem worker thread panicked"))?
             });
         }

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -238,7 +238,12 @@ fn join_without_gil<F: FnOnce() + Send>(f: F) {
 /// hang in `test_async_callback_execute_sync_honors_timeout`). Once the
 /// interpreter is exiting, joining is unsafe (threads attaching during
 /// finalization abort the process on CPython < 3.13), so the drop falls
-/// back to `shutdown_background()` and the OS reclaims resources.
+/// back to `shutdown_background()` and the OS reclaims resources. The same
+/// hands-off path is taken when the last clone drops *inside* a tokio context
+/// (e.g. a `Bash` dropped mid-`await execute()` finishes on a runtime worker
+/// thread, dropping its custom-builtin adapters' `PyRuntime` clones there): a
+/// blocking runtime drop in that context panics, so `shutdown_background()`
+/// is used instead.
 struct PyRuntime(Option<Arc<Runtime>>);
 
 impl Clone for PyRuntime {
@@ -259,7 +264,21 @@ impl Drop for PyRuntime {
         let Some(rt) = self.0.take().and_then(Arc::into_inner) else {
             return;
         };
-        if interpreter_at_exit() {
+        // Two cases must avoid the blocking join:
+        //   - `interpreter_at_exit()`: joining threads that may re-attach is
+        //     unsafe during finalization (see the type doc).
+        //   - `Handle::try_current().is_ok()`: the last clone is dropping
+        //     *inside* a tokio context. This happens when a `Bash` is dropped
+        //     while `await execute()` is still in flight: the future holds the
+        //     last `Arc<Mutex<Bash>>` and, on completion, drops it on a
+        //     pyo3-async-runtimes worker thread — cascading into the
+        //     custom-builtin adapters that hold `PyRuntime` clones. Dropping a
+        //     runtime (a blocking join) from within another runtime panics
+        //     with "Cannot drop a runtime in a context where blocking is not
+        //     allowed", so hand off to `shutdown_background()` instead.
+        // The normal path — last clone dropping on a Python thread with no
+        // tokio context — keeps #2009's deterministic `join_without_gil`.
+        if interpreter_at_exit() || Handle::try_current().is_ok() {
             rt.shutdown_background();
         } else {
             join_without_gil(move || drop(rt));
@@ -1633,6 +1652,18 @@ impl PyFileSystem {
         // ever gets hot, amortize with a long-lived worker thread + runtime
         // reused across ops via a channel (note: `block_in_place` is not an
         // option while `make_runtime` builds a current-thread runtime).
+        //
+        // A `Static` handle used from a thread with *no* tokio context falls
+        // through to `self.rt.block_on` below. This is the async-callback case:
+        // the callback body runs on an asyncio loop thread — the caller's loop
+        // under `await execute()`, the private loop under `execute_sync()` — not
+        // a tokio worker, so `Handle::try_current()` is `Err`. Under
+        // `execute_sync()` that `block_on` runs on a *second* thread while the
+        // main thread holds the current-thread scheduler core; it completes only
+        // because tokio's parker fallback polls the future without owning the
+        // core. That is fine for VFS ops (they never need the runtime's
+        // timer/IO drivers) — but a timer- or IO-dependent fs future added here
+        // would stall this path, so keep `inner.resolve()` + fs ops driver-free.
         //
         // `Live` handles keep the original fast path: they lock the interpreter.
         // Re-entrant use of a `Live` handle from inside the shared runtime is

--- a/crates/bashkit-python/tests/test_custom_builtin_fs.py
+++ b/crates/bashkit-python/tests/test_custom_builtin_fs.py
@@ -69,6 +69,8 @@ def test_ctx_fs_supports_common_ops(factory):
 
     assert result.exit_code == 0
     assert result.stdout == "a.txt\n"
+    # Mutations persist on the live VFS after the callback returns.
+    assert shell.fs().read_file("/d/a.txt").decode() == "a"
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
@@ -86,28 +88,41 @@ async def test_ctx_fs_works_from_async_callback(factory):
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+@pytest.mark.asyncio
+async def test_ctx_fs_async_callback_writes_file(factory):
+    async def awriter(ctx):
+        ctx.fs.write_file("/async-out.txt", b"async-write\n")
+        return "wrote\n"
+
+    shell = factory(custom_builtins={"awriter": awriter})
+    result = await shell.execute("awriter")
+
+    assert result.exit_code == 0
+    # The write is visible to later commands and via the instance handle.
+    cat = await shell.execute("cat /async-out.txt")
+    assert cat.stdout == "async-write\n"
+    assert shell.fs().read_file("/async-out.txt").decode() == "async-write\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
 def test_ctx_fs_read_missing_raises_clean_error(factory):
-    """Reading a missing path surfaces a clean ``RuntimeError`` (not a panic or a
+    """Reading a missing path raises a clean ``RuntimeError`` (not a panic or a
     leaked host path)."""
-    seen = {}
 
     def reader(ctx):
-        try:
+        with pytest.raises(RuntimeError) as exc_info:
             ctx.fs.read_file("/does-not-exist.txt")
-        except Exception as exc:  # inspect then re-raise
-            seen["type"] = type(exc).__name__
-            seen["msg"] = str(exc)
-            raise
-        return ""
+        message = str(exc_info.value)
+        # No host filesystem path leaks through the error.
+        assert "/rustc/" not in message
+        assert ".cargo" not in message
+        return "handled\n"
 
     shell = factory(custom_builtins={"reader": reader})
     result = shell.execute_sync("reader")
 
-    assert result.exit_code != 0
-    assert seen["type"] == "RuntimeError"
-    # No host filesystem path leaks through the error.
-    assert "/rustc/" not in seen["msg"]
-    assert ".cargo" not in seen["msg"]
+    assert result.exit_code == 0
+    assert result.stdout == "handled\n"
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
@@ -130,16 +145,12 @@ def test_ctx_fs_write_then_read_within_one_callback(factory):
 def test_ctx_fs_respects_readonly_filesystem(factory):
     """Under ``readonly_filesystem=True`` reads succeed but writes are denied —
     ``ctx.fs`` does not bypass the read-only wrapper."""
-    seen = {}
 
     def writer(ctx):
-        seen["read"] = ctx.fs.read_file("/seed.txt").decode()
-        try:
+        assert ctx.fs.read_file("/seed.txt").decode() == "seeded\n"
+        with pytest.raises(RuntimeError):
             ctx.fs.write_file("/seed.txt", b"nope")
-        except Exception as exc:  # inspect then re-raise
-            seen["write_err"] = type(exc).__name__
-            raise
-        return ""
+        return "handled\n"
 
     shell = factory(
         custom_builtins={"writer": writer},
@@ -148,9 +159,10 @@ def test_ctx_fs_respects_readonly_filesystem(factory):
     )
     result = shell.execute_sync("writer")
 
-    assert seen["read"] == "seeded\n"
-    assert seen.get("write_err") == "RuntimeError"
-    assert result.exit_code != 0
+    assert result.exit_code == 0
+    assert result.stdout == "handled\n"
+    # The denied write left the seed file unchanged.
+    assert shell.fs().read_file("/seed.txt").decode() == "seeded\n"
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])

--- a/crates/bashkit-python/tests/test_custom_builtin_fs.py
+++ b/crates/bashkit-python/tests/test_custom_builtin_fs.py
@@ -211,3 +211,74 @@ def test_ctx_fs_cross_handle_consistency(factory):
 
     assert shell.execute_sync("writer").exit_code == 0
     assert shell.fs().read_file("/shared.txt").decode() == "shared\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_supports_more_ops(factory):
+    """The remaining ``FileSystem`` ops (append_file/stat/rename/copy/chmod/
+    symlink/read_link/remove) round-trip through ``ctx.fs`` on the live VFS."""
+
+    def ops(ctx):
+        ctx.fs.mkdir("/m/src", recursive=True)
+        ctx.fs.write_file("/m/src/file.txt", b"alpha")
+        ctx.fs.append_file("/m/src/file.txt", b"beta")
+        assert ctx.fs.read_file("/m/src/file.txt") == b"alphabeta"
+
+        st = ctx.fs.stat("/m/src/file.txt")
+        assert st["file_type"] == "file"
+        assert st["size"] == 9
+
+        ctx.fs.mkdir("/m/dst", recursive=True)
+        ctx.fs.copy("/m/src/file.txt", "/m/dst/copied.txt")
+        ctx.fs.rename("/m/dst/copied.txt", "/m/dst/renamed.txt")
+        ctx.fs.symlink("/m/dst/renamed.txt", "/m/link.txt")
+        ctx.fs.chmod("/m/dst/renamed.txt", 0o600)
+        assert ctx.fs.read_link("/m/link.txt") == "/m/dst/renamed.txt"
+        assert ctx.fs.stat("/m/dst/renamed.txt")["mode"] == 0o600
+
+        ctx.fs.remove("/m/link.txt")
+        assert ctx.fs.exists("/m/link.txt") is False
+        return "ok\n"
+
+    shell = factory(custom_builtins={"ops": ops})
+    result = shell.execute_sync("ops")
+
+    assert result.exit_code == 0
+    assert result.stdout == "ok\n"
+    # Mutations persist on the live VFS after the callback returns.
+    assert shell.fs().read_file("/m/dst/renamed.txt") == b"alphabeta"
+    assert shell.fs().exists("/m/link.txt") is False
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_nested_reentry_via_lazy_provider(factory):
+    """A lazy provider triggered *via* ``ctx.fs.read_file`` itself reads another
+    file through a captured ``ctx.fs`` handle. The provider runs on the
+    worker-thread runtime (so ``Handle::try_current()`` is already true there),
+    which makes the inner read take the worker-thread dispatch branch again —
+    exercising recursive ``ctx.fs`` re-entry without deadlocking."""
+
+    holder = {}
+
+    def provider():
+        # Re-enters ctx.fs from inside the worker-thread runtime. /inner.txt is a
+        # plain file (no further Python callback), so the nested read completes.
+        return "nested:" + holder["fs"].read_file("/inner.txt").decode()
+
+    def setup(ctx):
+        holder["fs"] = ctx.fs
+        return "ready\n"
+
+    def trigger(ctx):
+        return ctx.fs.read_file("/lazy.txt").decode()
+
+    shell = factory(
+        custom_builtins={"setup": setup, "trigger": trigger},
+        files={"/lazy.txt": provider, "/inner.txt": "inner-data\n"},
+    )
+
+    assert shell.execute_sync("setup").exit_code == 0
+    result = shell.execute_sync("trigger")
+
+    assert result.exit_code == 0
+    assert result.stdout == "nested:inner-data\n"

--- a/crates/bashkit-python/tests/test_custom_builtin_fs.py
+++ b/crates/bashkit-python/tests/test_custom_builtin_fs.py
@@ -83,3 +83,107 @@ async def test_ctx_fs_works_from_async_callback(factory):
 
     assert result.exit_code == 0
     assert result.stdout == "async-data\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_read_missing_raises_clean_error(factory):
+    """Reading a missing path surfaces a clean ``RuntimeError`` (not a panic or a
+    leaked host path)."""
+    seen = {}
+
+    def reader(ctx):
+        try:
+            ctx.fs.read_file("/does-not-exist.txt")
+        except Exception as exc:  # inspect then re-raise
+            seen["type"] = type(exc).__name__
+            seen["msg"] = str(exc)
+            raise
+        return ""
+
+    shell = factory(custom_builtins={"reader": reader})
+    result = shell.execute_sync("reader")
+
+    assert result.exit_code != 0
+    assert seen["type"] == "RuntimeError"
+    # No host filesystem path leaks through the error.
+    assert "/rustc/" not in seen["msg"]
+    assert ".cargo" not in seen["msg"]
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_write_then_read_within_one_callback(factory):
+    """A write and a subsequent read inside a single callback observe the same
+    live filesystem."""
+
+    def rw(ctx):
+        ctx.fs.write_file("/inline.txt", b"inline-bytes\n")
+        return ctx.fs.read_file("/inline.txt").decode()
+
+    shell = factory(custom_builtins={"rw": rw})
+    result = shell.execute_sync("rw")
+
+    assert result.exit_code == 0
+    assert result.stdout == "inline-bytes\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_respects_readonly_filesystem(factory):
+    """Under ``readonly_filesystem=True`` reads succeed but writes are denied —
+    ``ctx.fs`` does not bypass the read-only wrapper."""
+    seen = {}
+
+    def writer(ctx):
+        seen["read"] = ctx.fs.read_file("/seed.txt").decode()
+        try:
+            ctx.fs.write_file("/seed.txt", b"nope")
+        except Exception as exc:  # inspect then re-raise
+            seen["write_err"] = type(exc).__name__
+            raise
+        return ""
+
+    shell = factory(
+        custom_builtins={"writer": writer},
+        files={"/seed.txt": "seeded\n"},
+        readonly_filesystem=True,
+    )
+    result = shell.execute_sync("writer")
+
+    assert seen["read"] == "seeded\n"
+    assert seen.get("write_err") == "RuntimeError"
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_reads_lazy_provider_file(factory):
+    """Reading a lazy (callable-backed) file through ``ctx.fs`` materializes it by
+    calling back into Python."""
+    calls = {"n": 0}
+
+    def provider():
+        calls["n"] += 1
+        return "lazy-content\n"
+
+    def reader(ctx):
+        return ctx.fs.read_file("/lazy.txt").decode()
+
+    shell = factory(custom_builtins={"reader": reader}, files={"/lazy.txt": provider})
+    result = shell.execute_sync("reader")
+
+    assert result.exit_code == 0
+    assert result.stdout == "lazy-content\n"
+    assert calls["n"] >= 1
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_cross_handle_consistency(factory):
+    """A write via ``ctx.fs`` is observable via the instance's own ``fs()``
+    handle — both wrap the same filesystem."""
+
+    def writer(ctx):
+        ctx.fs.write_file("/shared.txt", b"shared\n")
+        return ""
+
+    shell = factory(custom_builtins={"writer": writer})
+
+    assert shell.execute_sync("writer").exit_code == 0
+    assert shell.fs().read_file("/shared.txt").decode() == "shared\n"

--- a/crates/bashkit-python/tests/test_custom_builtin_fs.py
+++ b/crates/bashkit-python/tests/test_custom_builtin_fs.py
@@ -1,0 +1,85 @@
+"""`BuiltinContext.fs` exposes the live VFS to custom builtin callbacks.
+
+Decision: the context's ``fs`` wraps the *same* ``Arc<dyn FileSystem>`` the
+interpreter uses (mirroring how the embedded ``python3``/Monty builtin gets
+``ctx.fs``), so reads see files created by earlier bash commands and writes are
+visible to later ones. Dispatch is runtime-safe from both ``execute_sync`` (runs
+inside the shared runtime's ``block_on``) and ``await execute``.
+"""
+
+import pytest
+
+from bashkit import Bash, BashTool, FileSystem
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_is_a_filesystem_handle(factory):
+    captured = {}
+
+    def grab(ctx):
+        captured["fs"] = ctx.fs
+        return "ok\n"
+
+    shell = factory(custom_builtins={"grab": grab})
+    result = shell.execute_sync("grab")
+
+    assert result.exit_code == 0
+    assert isinstance(captured["fs"], FileSystem)
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_reads_files_created_by_bash(factory):
+    def reader(ctx):
+        return ctx.fs.read_file("/scratch/data.txt").decode()
+
+    shell = factory(custom_builtins={"reader": reader})
+    first = shell.execute_sync("mkdir -p /scratch && printf 'hello\\n' > /scratch/data.txt")
+    second = shell.execute_sync("reader")
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert second.stdout == "hello\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_writes_visible_to_later_commands(factory):
+    def writer(ctx):
+        ctx.fs.write_file("/out.txt", b"from-callback\n")
+        return "wrote\n"
+
+    shell = factory(custom_builtins={"writer": writer})
+    first = shell.execute_sync("writer")
+    second = shell.execute_sync("cat /out.txt")
+
+    assert first.exit_code == 0
+    assert second.stdout == "from-callback\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_ctx_fs_supports_common_ops(factory):
+    def ops(ctx):
+        ctx.fs.mkdir("/d", recursive=True)
+        ctx.fs.write_file("/d/a.txt", b"a")
+        assert ctx.fs.exists("/d/a.txt")
+        names = [e["name"] for e in ctx.fs.read_dir("/d")]
+        return ",".join(names) + "\n"
+
+    shell = factory(custom_builtins={"ops": ops})
+    result = shell.execute_sync("ops")
+
+    assert result.exit_code == 0
+    assert result.stdout == "a.txt\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+@pytest.mark.asyncio
+async def test_ctx_fs_works_from_async_callback(factory):
+    async def areader(ctx):
+        return ctx.fs.read_file("/async.txt").decode()
+
+    shell = factory(custom_builtins={"areader": areader})
+    await shell.execute("printf 'async-data\\n' > /async.txt")
+    result = await shell.execute("areader")
+
+    assert result.exit_code == 0
+    assert result.stdout == "async-data\n"

--- a/crates/bashkit-python/tests/test_custom_builtin_fs.py
+++ b/crates/bashkit-python/tests/test_custom_builtin_fs.py
@@ -9,7 +9,7 @@ inside the shared runtime's ``block_on``) and ``await execute``.
 
 import pytest
 
-from bashkit import Bash, BashTool, FileSystem
+from bashkit import Bash, BashError, BashTool, FileSystem
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
@@ -106,23 +106,35 @@ async def test_ctx_fs_async_callback_writes_file(factory):
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
 def test_ctx_fs_read_missing_raises_clean_error(factory):
-    """Reading a missing path raises a clean ``RuntimeError`` (not a panic or a
-    leaked host path)."""
+    """A missing read raises a clean ``RuntimeError`` at the ``ctx.fs`` boundary;
+    an unhandled one surfaces as a sanitized ``BashError`` at the call site
+    (no panic, no leaked host path)."""
 
     def reader(ctx):
         with pytest.raises(RuntimeError) as exc_info:
             ctx.fs.read_file("/does-not-exist.txt")
         message = str(exc_info.value)
-        # No host filesystem path leaks through the error.
         assert "/rustc/" not in message
         assert ".cargo" not in message
         return "handled\n"
 
-    shell = factory(custom_builtins={"reader": reader})
-    result = shell.execute_sync("reader")
+    def boom(ctx):
+        # No try/except: the ctx.fs error escapes the callback.
+        return ctx.fs.read_file("/does-not-exist.txt").decode()
 
-    assert result.exit_code == 0
-    assert result.stdout == "handled\n"
+    shell = factory(custom_builtins={"reader": reader, "boom": boom})
+
+    handled = shell.execute_sync("reader")
+    assert handled.exit_code == 0
+    assert handled.stdout == "handled\n"
+
+    # An unhandled ctx.fs error surfaces at the call site as a failed command;
+    # execute_sync_or_throw turns that into a (sanitized) BashError.
+    with pytest.raises(BashError) as exc_info:
+        shell.execute_sync_or_throw("boom")
+    message = str(exc_info.value)
+    assert "/rustc/" not in message
+    assert ".cargo" not in message
 
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])

--- a/crates/bashkit-python/tests/test_fastapi_integration.py
+++ b/crates/bashkit-python/tests/test_fastapi_integration.py
@@ -291,6 +291,36 @@ async def test_concurrent_sync_requests_with_shared_bash_and_async_custom_builti
 
 
 @pytest.mark.asyncio
+async def test_concurrent_async_requests_ctx_fs_custom_builtin():
+    """Concurrent async endpoints over one shared Bash run a custom builtin that
+    reads/writes the VFS through ``ctx.fs`` — each request's fs op must complete
+    correctly on the caller's event loop without deadlocking it."""
+
+    def fs_roundtrip(ctx):
+        rid = ctx.argv[0]
+        ctx.fs.write_file(f"/req-{rid}.txt", rid.encode())
+        return ctx.fs.read_file(f"/req-{rid}.txt").decode()
+
+    bash = Bash(custom_builtins={"fs-roundtrip": fs_roundtrip})
+    app = FastAPI()
+
+    @app.get("/fs/{rid}")
+    async def fs_endpoint(rid: str):
+        result = await bash.execute(f"fs-roundtrip {rid}")
+        return {"stdout": result.stdout, "exit_code": result.exit_code}
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        responses = await asyncio.gather(*(client.get(f"/fs/{i}") for i in range(6)))
+
+    for i, response in enumerate(responses):
+        assert response.status_code == 200
+        body = response.json()
+        assert body["exit_code"] == 0
+        assert body["stdout"] == str(i)
+
+
+@pytest.mark.asyncio
 async def test_async_endpoint_mounts_native_filesystem_capsule():
     """FastAPI async endpoint can mount a native-extension filesystem capsule."""
     app = FastAPI()

--- a/crates/bashkit-python/tests/test_fastapi_integration.py
+++ b/crates/bashkit-python/tests/test_fastapi_integration.py
@@ -318,6 +318,8 @@ async def test_concurrent_async_requests_ctx_fs_custom_builtin():
         body = response.json()
         assert body["exit_code"] == 0
         assert body["stdout"] == str(i)
+        # Each request's write landed on the shared VFS with the expected content.
+        assert bash.fs().read_file(f"/req-{i}.txt").decode() == str(i)
 
 
 @pytest.mark.asyncio

--- a/crates/bashkit-python/tests/test_jupyter_compat.py
+++ b/crates/bashkit-python/tests/test_jupyter_compat.py
@@ -264,10 +264,15 @@ async def test_execute_sync_ctx_fs_live_loop(factory):
 
 @pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
 @pytest.mark.asyncio
-async def test_await_execute_ctx_fs(factory):
-    """ctx.fs works from a builtin driven via await execute() on the caller loop."""
+async def test_await_execute_ctx_fs_uses_caller_loop(factory):
+    """An async ctx.fs builtin driven via await execute() runs on the caller's
+    loop (matching test_await_execute_async_builtin_uses_caller_loop)."""
 
-    def rw(ctx: BuiltinContext) -> str:
+    caller_loop = asyncio.get_running_loop()
+    captured: list = []
+
+    async def rw(ctx: BuiltinContext) -> str:
+        captured.append(asyncio.get_running_loop())
         ctx.fs.write_file("/aw.txt", b"await\n")
         return ctx.fs.read_file("/aw.txt").decode()
 
@@ -276,3 +281,4 @@ async def test_await_execute_ctx_fs(factory):
 
     assert result.exit_code == 0
     assert result.stdout == "await\n"
+    assert captured == [caller_loop]

--- a/crates/bashkit-python/tests/test_jupyter_compat.py
+++ b/crates/bashkit-python/tests/test_jupyter_compat.py
@@ -218,3 +218,61 @@ async def test_await_execute_contextvar(factory):
 
     assert result.exit_code == 0
     assert result.stdout.strip() == "trace=await-req"
+
+
+# ===========================================================================
+# BuiltinContext.fs under a running loop
+#
+# ``ctx.fs`` is a *sync* handle whose ops run off the interpreter's runtime
+# thread. These confirm it works from a custom builtin under the same running-
+# loop conditions Jupyter maintains — via execute_sync (inside asyncio.run and a
+# live loop) and via await execute.
+# ===========================================================================
+
+
+def test_execute_sync_ctx_fs_inside_asyncio_run():
+    """execute_sync() with a ctx.fs builtin works inside asyncio.run()."""
+
+    def rw(ctx: BuiltinContext) -> str:
+        ctx.fs.write_file("/nb.txt", b"nb-data\n")
+        return ctx.fs.read_file("/nb.txt").decode()
+
+    async def jupyter_cell():
+        bash = Bash(custom_builtins={"rw": rw})
+        return bash.execute_sync("rw")
+
+    result = asyncio.run(jupyter_cell())
+    assert result.exit_code == 0
+    assert result.stdout == "nb-data\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+@pytest.mark.asyncio
+async def test_execute_sync_ctx_fs_live_loop(factory):
+    """execute_sync() with a ctx.fs builtin works while a loop is running."""
+
+    def rw(ctx: BuiltinContext) -> str:
+        ctx.fs.write_file("/nb.txt", b"live\n")
+        return ctx.fs.read_file("/nb.txt").decode()
+
+    shell = factory(custom_builtins={"rw": rw})
+    result = shell.execute_sync("rw")
+
+    assert result.exit_code == 0
+    assert result.stdout == "live\n"
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+@pytest.mark.asyncio
+async def test_await_execute_ctx_fs(factory):
+    """ctx.fs works from a builtin driven via await execute() on the caller loop."""
+
+    def rw(ctx: BuiltinContext) -> str:
+        ctx.fs.write_file("/aw.txt", b"await\n")
+        return ctx.fs.read_file("/aw.txt").decode()
+
+    shell = factory(custom_builtins={"rw": rw})
+    result = await shell.execute("rw")
+
+    assert result.exit_code == 0
+    assert result.stdout == "await\n"

--- a/crates/bashkit-python/tests/test_jupyter_compat.py
+++ b/crates/bashkit-python/tests/test_jupyter_compat.py
@@ -282,3 +282,50 @@ async def test_await_execute_ctx_fs_uses_caller_loop(factory):
     assert result.exit_code == 0
     assert result.stdout == "await\n"
     assert captured == [caller_loop]
+
+
+# ---------------------------------------------------------------------------
+# ctx.fs from an *async* callback driven by execute_sync — the third dispatch
+# path. The async callback body runs on an asyncio loop thread (the private
+# loop, or the background daemon loop under a live loop), which has no tokio
+# context, so ctx.fs ops fall through to `self.rt.block_on` rather than the
+# worker-thread branch the sync-callback case takes. Sync callbacks +
+# execute_sync (worker-thread branch) and async callbacks + await execute
+# (caller loop) are covered above; this fills the remaining combination.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", [Bash, BashTool], ids=["bash", "bash_tool"])
+def test_execute_sync_async_ctx_fs_builtin(factory):
+    """An async ctx.fs builtin driven by execute_sync() (no running loop) runs on
+    the private loop thread; ctx.fs resolves via the block_on fallback there."""
+
+    async def rw(ctx: BuiltinContext) -> str:
+        await asyncio.sleep(0)  # force a real await so the body runs on the loop
+        ctx.fs.write_file("/async-sync.txt", b"async-sync\n")
+        return ctx.fs.read_file("/async-sync.txt").decode()
+
+    shell = factory(custom_builtins={"rw": rw})
+    result = shell.execute_sync("rw")
+
+    assert result.exit_code == 0
+    assert result.stdout == "async-sync\n"
+    assert shell.fs().read_file("/async-sync.txt").decode() == "async-sync\n"
+
+
+def test_execute_sync_async_ctx_fs_inside_asyncio_run():
+    """Same third path under a live outer loop: execute_sync() inside
+    asyncio.run() drives the async callback on a background daemon loop, and
+    ctx.fs works there too."""
+
+    async def rw(ctx: BuiltinContext) -> str:
+        await asyncio.sleep(0)
+        return ctx.fs.read_file("/seed.txt").decode()
+
+    async def jupyter_cell():
+        bash = Bash(custom_builtins={"rw": rw}, files={"/seed.txt": "seeded\n"})
+        return bash.execute_sync("rw")
+
+    result = asyncio.run(jupyter_cell())
+    assert result.exit_code == 0
+    assert result.stdout == "seeded\n"

--- a/crates/bashkit-python/tests/test_teardown_determinism.py
+++ b/crates/bashkit-python/tests/test_teardown_determinism.py
@@ -18,7 +18,7 @@ import time
 
 import pytest
 
-from bashkit import ScriptedTool
+from bashkit import Bash, ScriptedTool
 
 PROC_AVAILABLE = os.path.exists("/proc/self/task")
 
@@ -76,6 +76,34 @@ def test_fds_stable_across_tool_churn():
         del t
         gc.collect()
         assert _fd_count() <= baseline
+
+
+@pytest.mark.asyncio
+async def test_drop_bash_while_async_execute_in_flight_does_not_panic():
+    """A `Bash` dropped while `await execute()` is in flight must not panic.
+
+    The in-flight future holds the last `Arc<Mutex<Bash>>`; when it completes on
+    a pyo3-async-runtimes worker thread, the `Bash` — and its custom-builtin
+    adapters, which each hold a `PyRuntime` clone — drop *there*, so the last
+    `PyRuntime` clone drops inside a tokio context. `PyRuntime::drop` must hand
+    off to `shutdown_background()` rather than a blocking runtime join, which in
+    that context panics ("Cannot drop a runtime in a context where blocking is
+    not allowed") and surfaces as `pyo3_async_runtimes.RustPanic` to the
+    awaiting caller. Regression for the #2009/#2010 interaction.
+    """
+
+    async def slow(ctx):
+        await asyncio.sleep(0.3)
+        return "done\n"
+
+    b = Bash(custom_builtins={"slow": slow})
+    fut = asyncio.ensure_future(b.execute("slow"))
+    await asyncio.sleep(0.05)  # let execution start; callback is in flight
+    del b
+    gc.collect()
+    result = await fut  # RustPanic here before the drop-path fix
+    assert result.exit_code == 0
+    assert result.stdout == "done\n"
 
 
 def test_dropped_tool_cancels_abandoned_callback():

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -309,6 +309,11 @@ calling back into the owning instance's `Bash.fs()` / `Bash.read_file()`, which
 is unsupported re-entrancy: it re-enters the interpreter's runtime and panics
 with a nested-runtime error (not a deadlock, and not caught by the
 `external_handler` reentry guard, which does not fire for custom builtins).
+A callback may retain `ctx.fs` beyond the invocation: the handle stays valid
+even after the `Bash` instance is dropped, and keeps the underlying VFS and
+its tokio runtime alive until the handle itself is released — so stashing it
+extends resource lifetime past `del bash` (see the teardown-determinism
+notes below).
 
 **Sync callbacks** are called directly under the session's captured `contextvars`
 snapshot and may return either a stdout string or a `BuiltinResult` with
@@ -341,7 +346,11 @@ Callbacks that block without awaiting (e.g. `time.sleep` inside `async def`)
 cannot be cancelled mid-section; teardown then waits for the current section
 to reach an await point or return. At interpreter exit (boundary: an `atexit`
 handler registered at module import), teardown goes hands-off — native threads
-must not touch a finalizing CPython — and the OS reclaims resources.
+must not touch a finalizing CPython — and the OS reclaims resources. The same
+hands-off path applies when the last runtime handle is dropped *inside* a tokio
+context (a `Bash` dropped while `await execute()` is still in flight finishes on
+a runtime worker thread): a blocking runtime join there would panic, so the drop
+falls back to `shutdown_background()` instead of the deterministic join.
 
 **ContextVar propagation**: ContextVars set before `execute()` or
 `execute_sync()` are captured at call time and replayed inside each callback

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -293,6 +293,19 @@ Returns dict with `name`, `description`, `args_schema` for LangChain integration
 callback is
 `Callable[[BuiltinContext], str | BuiltinResult | Awaitable[str | BuiltinResult]]`.
 
+`BuiltinContext` exposes `name`, `argv`, `stdin`, `env`, `cwd`, and `fs`. The
+`fs` attribute is a `FileSystem` handle to the interpreter's *live* virtual
+filesystem (same API as `Bash.fs()`), so reads see files created by earlier
+commands and writes are visible to later ones. It wraps the same
+`Arc<dyn FileSystem>` the interpreter uses (mirroring how the embedded
+`python3`/Monty builtin receives `ctx.fs`) and operates on it directly without
+the interpreter lock. Because a custom builtin runs inside `execute_sync`'s
+current-thread `block_on`, `PyFileSystem::with_fs` detects the active runtime
+(`Handle::try_current`) and dispatches `ctx.fs` ops on a throwaway worker thread
+to avoid a nested-runtime panic. This is distinct from — and safe unlike —
+calling back into the owning instance's `Bash.fs()` / `Bash.read_file()`, which
+is rejected/unsupported re-entrancy.
+
 **Sync callbacks** are called directly under the session's captured `contextvars`
 snapshot and may return either a stdout string or a `BuiltinResult` with
 explicit `stdout`, `stderr`, and `exit_code`.
@@ -355,6 +368,16 @@ def view_image(ctx: BuiltinContext) -> BuiltinResult:
     if not ctx.argv:
         return BuiltinResult(stderr="view-image: missing path\n", exit_code=1)
     return BuiltinResult(stdout="")
+```
+
+```python
+# ctx.fs reads/writes the interpreter's live VFS.
+def head(ctx: BuiltinContext) -> str:
+    data = ctx.fs.read_file(ctx.argv[0]).decode()      # bytes -> str
+    return "".join(data.splitlines(keepends=True)[:10])
+
+bash = Bash(custom_builtins={"head10": head}, files={"/log.txt": "..."})
+bash.execute_sync("head10 /log.txt")
 ```
 
 ## Optional Dependencies

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -302,9 +302,13 @@ commands and writes are visible to later ones. It wraps the same
 the interpreter lock. Because a custom builtin runs inside `execute_sync`'s
 current-thread `block_on`, `PyFileSystem::with_fs` detects the active runtime
 (`Handle::try_current`) and dispatches `ctx.fs` ops on a throwaway worker thread
-to avoid a nested-runtime panic. This is distinct from — and safe unlike —
+to avoid a nested-runtime panic. Each op on this path spawns a short-lived
+worker thread and runtime, so batching fs work in a callback is cheaper than
+many small ops in a tight loop. This is distinct from — and safe unlike —
 calling back into the owning instance's `Bash.fs()` / `Bash.read_file()`, which
-is rejected/unsupported re-entrancy.
+is unsupported re-entrancy: it re-enters the interpreter's runtime and panics
+with a nested-runtime error (not a deadlock, and not caught by the
+`external_handler` reentry guard, which does not fire for custom builtins).
 
 **Sync callbacks** are called directly under the session's captured `contextvars`
 snapshot and may return either a stdout string or a `BuiltinResult` with


### PR DESCRIPTION
## Disclosure

I'm not an experienced Rust developer: the Rust here was generated with Claude. I did review the Python/pytest side myself: I went through the tests, asked for additional targeted cases (error/readonly/lazy-provider, nested re-entry, async schedulers), and to my judgment they're correct and exercise the behavior that matters. Scrutiny of the Rust especially welcome.

## What

Adds an `fs` attribute to `BuiltinContext`, giving Python `custom_builtins` callbacks read/write access to the interpreter's live VFS — completing the follow-up noted in the `custom_builtins` decision comment in `lib.rs`.

```python
def head10(ctx):
    return ctx.fs.read_file(ctx.argv[0]).decode()      # bytes -> str

Bash(custom_builtins={"head10": head10}, files={"/log.txt": "..."})
```

`ctx.fs` is the existing `FileSystem` handle (same API as `Bash.fs()`), wrapping the **same** `Arc<dyn FileSystem>` the interpreter runs on, like the embedded `python3`/Monty builtin. So it's a live view (reads see earlier writes) and inherits `readonly_filesystem` / mounts.

Closes #2004.

## Note on dispatch

A callback runs inside `execute_sync`'s `block_on`, so a naive `fs` op would re-enter the runtime and panic. `PyFileSystem::with_fs` detects the active runtime and runs `ctx.fs` ops on a throwaway worker thread (GIL released first, so lazy file providers can re-enter Python); `Bash.fs()` keeps the fast path.

## Test plan

- `cargo fmt --check`, `cargo clippy -p bashkit-python`, `ruff check` / `ruff format --check` — clean.
- New `test_custom_builtin_fs.py` plus `ctx.fs`-under-async-scheduler cases in `test_{jupyter_compat,fastapi_integration}.py`; full `bashkit-python` suite green on CI (3.9 / 3.12 / 3.13 / 3.14).

## Checklist

- [x] `just pre-pr` passes
- [x] Rebased on main
- [x] Specs updated (`specs/python-package.md`)
- [x] CI green