### PR TITLE
fix(interpreter): shadow arrays for bare local declarations

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6768,16 +6768,17 @@ impl Interpreter {
                     }
                 } else if !is_internal_variable(arg) {
                     if flags.assoc {
-                        self.remember_local_assoc_array_binding(arg);
+                        self.shadow_local_array_bindings(arg, false, true);
                         if self.insert_assoc_array_checked(arg.to_string(), HashMap::new()) {
                             self.insert_local_checked(arg.to_string(), String::new());
                         }
                     } else if flags.array {
-                        self.remember_local_array_binding(arg);
+                        self.shadow_local_array_bindings(arg, true, false);
                         if self.insert_array_checked(arg.to_string(), HashMap::new()) {
                             self.insert_local_checked(arg.to_string(), String::new());
                         }
                     } else {
+                        self.shadow_local_array_bindings(arg, false, false);
                         self.insert_local_checked(arg.to_string(), String::new());
                     }
                     if flags.integer {

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3808,6 +3808,53 @@ f
         assert_eq!(counts, vec![0, 0]);
     }
 
+    /// TM-INF-023: bare local declarations must shadow stale global array bindings.
+    #[tokio::test]
+    async fn tm_inf_023_bare_local_declarations_shadow_global_arrays() {
+        let mut bash = Bash::builder()
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+scalar_shadow=(GLOBAL_INDEXED)
+declare -A indexed_shadow=([k]=GLOBAL_ASSOC)
+assoc_shadow=(GLOBAL_INDEXED)
+f() {
+    local scalar_shadow
+    local -a indexed_shadow
+    local -A assoc_shadow
+    printf "scalar_star=<%s>\n" "${scalar_shadow[*]}"
+    printf "scalar_zero=<%s>\n" "${scalar_shadow[0]}"
+    printf "indexed_star=<%s>\n" "${indexed_shadow[*]}"
+    printf "indexed_key=<%s>\n" "${indexed_shadow[k]}"
+    printf "assoc_star=<%s>\n" "${assoc_shadow[*]}"
+    printf "assoc_zero=<%s>\n" "${assoc_shadow[0]}"
+}
+f
+printf "after_scalar=<%s>\n" "${scalar_shadow[*]}"
+printf "after_indexed=<%s>\n" "${indexed_shadow[*]}"
+printf "after_assoc=<%s>\n" "${assoc_shadow[*]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "scalar_star=<>",
+                "scalar_zero=<>",
+                "indexed_star=<>",
+                "indexed_key=<>",
+                "assoc_star=<>",
+                "assoc_zero=<>",
+                "after_scalar=<GLOBAL_INDEXED>",
+                "after_indexed=<GLOBAL_ASSOC>",
+                "after_assoc=<GLOBAL_INDEXED>",
+            ]
+        );
+    }
+
     /// TM-INF-023: local compound arrays must not leak after a function returns.
     #[tokio::test]
     async fn tm_inf_023_function_local_arrays_do_not_leak() {


### PR DESCRIPTION
### Motivation
- A recent change stopped removing conflicting global array bindings for no-assignment `local` declarations, allowing global indexed/associative arrays to remain visible inside functions and breaking lexical scoping and memory-accounting invariants. 

### Description
- Restore shadowing by calling `shadow_local_array_bindings` for the no-assignment `local` path so `local name`, `local -a name`, and `local -A name` snapshot and remove conflicting global array bindings during the current call frame (`crates/bashkit/src/interpreter/mod.rs`).
- Keep using the checked helpers `insert_array_checked` / `insert_assoc_array_checked` and `insert_local_checked` so array-entry budget and variable limits remain enforced.
- Add an integration regression test `tm_inf_023_bare_local_declarations_shadow_global_arrays` to verify scalar, indexed, and associative bare `local` declarations hide stale globals (`crates/bashkit/tests/integration/threat_model_tests.rs`).

### Testing
- Ran `cargo test -p bashkit --test integration tm_inf_023_bare_local_declarations_shadow_global_arrays` which passed. 
- Ran `cargo test -p bashkit --test integration tm_inf_023_function_local_arrays_do_not_leak` and `cargo test -p bashkit --test integration tm_dos_060_local_compound_array_respects_budget` which both passed. 
- Ran `cargo fmt --check` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288cae6de0832b96c76734ecd4167c)