### PR TITLE
fix(readlink): cap symlink canonicalization paths

### DIFF
--- a/crates/bashkit/src/builtins/path.rs
+++ b/crates/bashkit/src/builtins/path.rs
@@ -377,6 +377,13 @@ enum ReadlinkMode {
 
 const READLINK_MAX_SYMLINK_DEPTH: usize = 40;
 
+fn readlink_path_within_limits(path: &Path) -> bool {
+    // THREAT[TM-DOS-013]: Canonicalization may compose symlink targets plus
+    // remaining components repeatedly; keep every intermediate path inside the
+    // VFS path budget before collecting components or normalizing again.
+    crate::fs::FsLimits::default().validate_path(path).is_ok()
+}
+
 async fn canonicalize_readlink_path(
     fs: &dyn crate::fs::FileSystem,
     cwd: &Path,
@@ -414,11 +421,14 @@ async fn follow_readlink_symlinks(
     let mut depth = 0;
 
     loop {
-        if depth > READLINK_MAX_SYMLINK_DEPTH {
+        if depth > READLINK_MAX_SYMLINK_DEPTH || !readlink_path_within_limits(&path) {
             return None;
         }
 
         let normalized = crate::fs::normalize_path(&path);
+        if !readlink_path_within_limits(&normalized) {
+            return None;
+        }
         let components: Vec<_> = normalized.components().collect();
         let mut current = std::path::PathBuf::from("/");
         let mut followed = false;
@@ -434,6 +444,9 @@ async fn follow_readlink_symlinks(
 
             if let Ok(target) = fs.read_link(&current).await {
                 depth += 1;
+                if !readlink_path_within_limits(&target) {
+                    return None;
+                }
                 let link_parent = current.parent().unwrap_or_else(|| Path::new("/"));
                 let mut next = if target.is_absolute() {
                     target
@@ -447,6 +460,9 @@ async fn follow_readlink_symlinks(
                     }
                 }
 
+                if !readlink_path_within_limits(&next) {
+                    return None;
+                }
                 path = crate::fs::normalize_path(&next);
                 followed = true;
                 break;
@@ -738,6 +754,20 @@ mod tests {
         let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
         fs.symlink(Path::new("/b"), Path::new("/a")).await.unwrap();
         fs.symlink(Path::new("/a"), Path::new("/b")).await.unwrap();
+
+        let result = run_readlink_with_fs(&["-m", "/a"], fs).await;
+
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_readlink_canonicalize_rejects_growing_symlink_path() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        let target = format!("/a/{}", "x".repeat(128));
+        fs.symlink(Path::new(&target), Path::new("/a"))
+            .await
+            .unwrap();
 
         let result = run_readlink_with_fs(&["-m", "/a"], fs).await;
 

--- a/crates/bashkit/src/builtins/path.rs
+++ b/crates/bashkit/src/builtins/path.rs
@@ -377,11 +377,17 @@ enum ReadlinkMode {
 
 const READLINK_MAX_SYMLINK_DEPTH: usize = 40;
 
-fn readlink_path_within_limits(path: &Path) -> bool {
+fn readlink_path_within_limits(fs: &dyn crate::fs::FileSystem, path: &Path) -> bool {
     // THREAT[TM-DOS-013]: Canonicalization may compose symlink targets plus
     // remaining components repeatedly; keep every intermediate path inside the
     // VFS path budget before collecting components or normalizing again.
-    crate::fs::FsLimits::default().validate_path(path).is_ok()
+    //
+    // Validate against both the active filesystem's configured limits (which
+    // may be stricter than the default) and the default bounded limits — the
+    // latter still caps unlimited backends (e.g. RealFs reports
+    // `FsLimits::unlimited()`), so the effective bound is the intersection.
+    fs.limits().validate_path(path).is_ok()
+        && crate::fs::FsLimits::default().validate_path(path).is_ok()
 }
 
 async fn canonicalize_readlink_path(
@@ -421,12 +427,12 @@ async fn follow_readlink_symlinks(
     let mut depth = 0;
 
     loop {
-        if depth > READLINK_MAX_SYMLINK_DEPTH || !readlink_path_within_limits(&path) {
+        if depth > READLINK_MAX_SYMLINK_DEPTH || !readlink_path_within_limits(fs, &path) {
             return None;
         }
 
         let normalized = crate::fs::normalize_path(&path);
-        if !readlink_path_within_limits(&normalized) {
+        if !readlink_path_within_limits(fs, &normalized) {
             return None;
         }
         let components: Vec<_> = normalized.components().collect();
@@ -444,7 +450,7 @@ async fn follow_readlink_symlinks(
 
             if let Ok(target) = fs.read_link(&current).await {
                 depth += 1;
-                if !readlink_path_within_limits(&target) {
+                if !readlink_path_within_limits(fs, &target) {
                     return None;
                 }
                 let link_parent = current.parent().unwrap_or_else(|| Path::new("/"));
@@ -460,7 +466,7 @@ async fn follow_readlink_symlinks(
                     }
                 }
 
-                if !readlink_path_within_limits(&next) {
+                if !readlink_path_within_limits(fs, &next) {
                     return None;
                 }
                 path = crate::fs::normalize_path(&next);
@@ -773,6 +779,36 @@ mod tests {
 
         assert_eq!(result.exit_code, 1);
         assert!(result.stdout.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_readlink_respects_stricter_filesystem_path_limit() {
+        // `/a` -> `/bbb...(40)`; canonicalizing `/a/ccc...(15)` composes a
+        // ~57-byte path. That fits under the default 4096 budget but exceeds a
+        // stricter per-filesystem limit, which must be honored.
+        let link_target = format!("/{}", "b".repeat(40));
+        let query = format!("/a/{}", "c".repeat(15));
+
+        // Stricter fs: composed path exceeds max_path_length(50) -> rejected.
+        let strict_fs = Arc::new(InMemoryFs::with_limits(
+            crate::fs::FsLimits::default().max_path_length(50),
+        )) as Arc<dyn FileSystem>;
+        strict_fs
+            .symlink(Path::new(&link_target), Path::new("/a"))
+            .await
+            .unwrap();
+        let strict = run_readlink_with_fs(&["-m", &query], strict_fs).await;
+        assert_eq!(strict.exit_code, 1, "stricter fs limit should reject");
+        assert!(strict.stdout.is_empty());
+
+        // Default fs: same composition is within budget -> resolves.
+        let lax_fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        lax_fs
+            .symlink(Path::new(&link_target), Path::new("/a"))
+            .await
+            .unwrap();
+        let lax = run_readlink_with_fs(&["-m", &query], lax_fs).await;
+        assert_eq!(lax.exit_code, 0, "default budget should resolve");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -502,7 +502,10 @@ impl InMemoryFs {
                     // Lazy files count by their declared metadata size
                     total_bytes += metadata.size;
                 }
-                FsEntry::Symlink { .. } => {}
+                FsEntry::Symlink { metadata, .. } => {
+                    // THREAT[TM-DOS-013]: Symlink target bytes count toward total usage
+                    total_bytes += metadata.size;
+                }
             }
             if Self::entry_counts_toward_file_count(entry) {
                 file_count += 1;
@@ -535,8 +538,11 @@ impl InMemoryFs {
                 FsEntry::File { content, .. } | FsEntry::Fifo { content, .. } => {
                     content.len() as u64
                 }
-                FsEntry::LazyFile { metadata, .. } => metadata.size,
-                FsEntry::Directory { .. } | FsEntry::Symlink { .. } => 0,
+                // THREAT[TM-DOS-013]: Symlink target bytes count toward total usage
+                FsEntry::LazyFile { metadata, .. } | FsEntry::Symlink { metadata, .. } => {
+                    metadata.size
+                }
+                FsEntry::Directory { .. } => 0,
             };
             current_total += entry_size;
             if Self::entry_counts_toward_file_count(entry) {
@@ -1571,20 +1577,17 @@ impl FileSystem for InMemoryFs {
         self.limits
             .validate_path(link)
             .map_err(|e| IoError::other(e.to_string()))?;
+        self.limits
+            .validate_path(target)
+            .map_err(|e| IoError::other(e.to_string()))?;
         let link = Self::normalize_path(link);
+        let target_size = target.as_os_str().as_encoded_bytes().len();
         let mut entries = self.entries.write().unwrap();
 
-        // THREAT[TM-DOS-045]: Symlinks count toward file count - enforce limit
-        let is_new = !entries.contains_key(&link);
-        if is_new {
-            let file_count = entries
-                .values()
-                .filter(|entry| Self::entry_counts_toward_file_count(entry))
-                .count() as u64;
-            self.limits
-                .check_file_count(file_count)
-                .map_err(|e| IoError::other(e.to_string()))?;
-        }
+        // THREAT[TM-DOS-045]: Symlinks count toward file count.
+        // THREAT[TM-DOS-013]: Symlink target bytes count toward filesystem usage.
+        // check_write_limits enforces single-file size, total bytes, and file count.
+        self.check_write_limits(&entries, &link, target_size)?;
 
         entries.insert(
             link,
@@ -1592,7 +1595,7 @@ impl FileSystem for InMemoryFs {
                 target: target.to_path_buf(),
                 metadata: Metadata {
                     file_type: FileType::Symlink,
-                    size: 0,
+                    size: target_size as u64,
                     mode: 0o777,
                     modified: SystemTime::now(),
                     created: SystemTime::now(),
@@ -2636,6 +2639,39 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("too many files") || err.contains("limit"));
+    }
+
+    #[tokio::test]
+    async fn test_symlink_validates_target_path_limits() {
+        let fs = InMemoryFs::new();
+        let long_component = "x".repeat(crate::fs::limits::DEFAULT_MAX_FILENAME_LENGTH + 1);
+        let target = PathBuf::from(format!("/tmp/{long_component}"));
+
+        let result = fs.symlink(&target, Path::new("/tmp/link")).await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("filename too long")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_symlink_target_bytes_count_toward_total_limit() {
+        let limits = FsLimits::new().max_total_bytes(20);
+        let fs = InMemoryFs::with_limits(limits);
+
+        fs.symlink(Path::new("/target-one"), Path::new("/tmp/link1"))
+            .await
+            .unwrap();
+        let result = fs
+            .symlink(Path::new("/target-two"), Path::new("/tmp/link2"))
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("filesystem full"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- `readlink -f/-m/-e` canonicalizer could repeatedly compose attacker-controlled symlink targets with remaining path components and grow intermediate paths synchronously, enabling a bounded but large memory/CPU DoS. 
- `InMemoryFs::symlink` stored targets verbatim and did not account target bytes against VFS usage or validate target path limits, leaving the canonicalizer able to amplify those bytes.

### Description
- Add `readlink_path_within_limits` and guard `follow_readlink_symlinks` so every intermediate path, normalized path, symlink target, and composed `next` path are validated against the VFS path budget before normalization/iteration. 
- Preserve the existing symlink hop cap (`READLINK_MAX_SYMLINK_DEPTH`) while adding the path-size checks to prevent synchronous amplification. 
- Harden `InMemoryFs::symlink` to `validate_path(target)`, charge symlink-target bytes to `check_write_limits`, and store `metadata.size = target_size` so target bytes count toward `max_total_bytes` and related limits. 
- Add regression tests: a `readlink` test that rejects growing self-referential symlink paths and `InMemoryFs` tests that validate symlink target path limits and that symlink target bytes count toward total-byte limits.

### Testing
- Ran `cargo test -p bashkit builtins::path::tests::test_readlink --lib` and the modified `readlink` suite passed. 
- Ran `cargo test -p bashkit fs::memory::tests::test_symlink --lib` and the `InMemoryFs` symlink tests passed. 
- Ran `cargo clippy -p bashkit --lib -- -D warnings` with no warnings. 
- Ran `cargo fmt --check` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288fa4b920832b9bf2b6a7c3849a2c)