### PR TITLE
fix(awk): reject oversized single output writes

### DIFF
--- a/crates/bashkit/src/builtins/awk/interpreter.rs
+++ b/crates/bashkit/src/builtins/awk/interpreter.rs
@@ -1000,7 +1000,7 @@ impl AwkInterpreter {
     }
 
     fn has_output_capacity(&self, len: usize) -> bool {
-        self.total_output_bytes <= MAX_AWK_OUTPUT_BYTES.saturating_sub(len)
+        len <= MAX_AWK_OUTPUT_BYTES.saturating_sub(self.total_output_bytes)
     }
 
     fn output_target_count(&self) -> usize {

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -2,10 +2,12 @@
 
 use super::parser::AwkParser;
 use super::{Awk, csv_split_fields};
+#[rustfmt::skip]
 use crate::builtins::limits::{
     AWK_MAX_GETLINE_CACHE_BYTES as MAX_GETLINE_CACHE_BYTES,
     AWK_MAX_GETLINE_CACHED_FILES as MAX_GETLINE_CACHED_FILES,
-    AWK_MAX_GETLINE_FILE_BYTES as MAX_GETLINE_FILE_BYTES, AWK_MAX_OUTPUT_BYTES as MAX_OUTPUT_BYTES,
+    AWK_MAX_GETLINE_FILE_BYTES as MAX_GETLINE_FILE_BYTES,
+    AWK_MAX_OUTPUT_BYTES as MAX_OUTPUT_BYTES,
     AWK_MAX_OUTPUT_TARGETS as MAX_OUTPUT_TARGETS,
 };
 use crate::builtins::{Builtin, Context};
@@ -950,8 +952,12 @@ async fn test_awk_output_limit_exceeded() {
 #[tokio::test]
 async fn test_awk_single_write_over_limit_rejected() {
     // One oversized record must be rejected before buffering stdout.
-    let input = "x".repeat(MAX_OUTPUT_BYTES);
-    let result = run_awk(&["{ print }"], Some(&input)).await.unwrap();
+    // Use MAX_OUTPUT_BYTES + 1 with printf (no ORS) so the write is
+    // unambiguously over the cap regardless of newline/ORS behavior.
+    let input = "x".repeat(MAX_OUTPUT_BYTES + 1);
+    let result = run_awk(&[r#"{ printf "%s", $0 }"#], Some(&input))
+        .await
+        .unwrap();
     assert_eq!(result.exit_code, 2);
     assert!(
         result.stderr.contains("output limit exceeded"),

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -5,7 +5,7 @@ use super::{Awk, csv_split_fields};
 use crate::builtins::limits::{
     AWK_MAX_GETLINE_CACHE_BYTES as MAX_GETLINE_CACHE_BYTES,
     AWK_MAX_GETLINE_CACHED_FILES as MAX_GETLINE_CACHED_FILES,
-    AWK_MAX_GETLINE_FILE_BYTES as MAX_GETLINE_FILE_BYTES,
+    AWK_MAX_GETLINE_FILE_BYTES as MAX_GETLINE_FILE_BYTES, AWK_MAX_OUTPUT_BYTES as MAX_OUTPUT_BYTES,
     AWK_MAX_OUTPUT_TARGETS as MAX_OUTPUT_TARGETS,
 };
 use crate::builtins::{Builtin, Context};
@@ -945,6 +945,20 @@ async fn test_awk_output_limit_exceeded() {
         "stdout should be bounded: {} bytes",
         result.stdout.len()
     );
+}
+
+#[tokio::test]
+async fn test_awk_single_write_over_limit_rejected() {
+    // One oversized record must be rejected before buffering stdout.
+    let input = "x".repeat(MAX_OUTPUT_BYTES);
+    let result = run_awk(&["{ print }"], Some(&input)).await.unwrap();
+    assert_eq!(result.exit_code, 2);
+    assert!(
+        result.stderr.contains("output limit exceeded"),
+        "stderr should mention output limit: {}",
+        result.stderr
+    );
+    assert_eq!(result.stdout.len(), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Motivation
- Prevent a bypass where a single AWK write larger than `AWK_MAX_OUTPUT_BYTES` could be accepted due to an incorrect `saturating_sub` comparison and thus exceed the intended 10MB per-invocation cap.

### Description
- Fix `has_output_capacity` in `crates/bashkit/src/builtins/awk/interpreter.rs` to `len <= MAX_AWK_OUTPUT_BYTES.saturating_sub(self.total_output_bytes)` so the incoming write length is correctly compared against remaining capacity.
- Add a regression test `test_awk_single_write_over_limit_rejected` in `crates/bashkit/src/builtins/awk/tests.rs` which asserts an oversized single record is rejected with exit code `2`, emits the output-limit diagnostic, and leaves stdout empty.
- Adjust imports in the test file to reference `AWK_MAX_OUTPUT_BYTES` as `MAX_OUTPUT_BYTES` for the new test.

### Testing
- Ran `cargo test -p bashkit builtins::awk::tests::test_awk_single_write_over_limit_rejected --lib --no-default-features` and it passed.
- Ran existing AWK tests covering output limits (`test_awk_output_limit_exceeded`, `test_awk_file_redirect_output_limit`, `test_awk_file_redirect_target_limit`) and they passed.
- Ran `cargo clippy -p bashkit --lib --no-default-features -- -D warnings` and `cargo fmt --check`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288fb62fc8832b8dfd2025c00b077a)