### PR TITLE
fix(interpreter): preserve array budget for local shadows

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6568,16 +6568,28 @@ impl Interpreter {
     }
 
     fn shadow_local_array_bindings(&mut self, name: &str, keep_indexed: bool, keep_assoc: bool) {
-        self.remember_local_array_binding(name);
-        self.remember_local_assoc_array_binding(name);
+        // A newly retained snapshot keeps the removed binding's entries charged
+        // (released at frame pop). When no new snapshot is retained — a second
+        // shadow of the same name in the same frame keeps the first snapshot —
+        // the binding being removed is a transient local that is not retained
+        // anywhere, so its entries must be released now to avoid budget drift.
+        let retained_indexed = self.remember_local_array_binding(name);
+        let retained_assoc = self.remember_local_assoc_array_binding(name);
         if !keep_indexed {
-            self.arrays_mut().remove(name);
+            let removed = self.arrays_mut().remove(name).map_or(0, |arr| arr.len());
+            if !retained_indexed {
+                self.memory_budget.record_array_remove(removed);
+            }
         }
         if !keep_assoc {
-            self.assoc_arrays_mut().remove(name);
+            let removed = self
+                .assoc_arrays_mut()
+                .remove(name)
+                .map_or(0, |arr| arr.len());
+            if !retained_assoc {
+                self.memory_budget.record_array_remove(removed);
+            }
         }
-        // Shadowed array bindings stay retained in the call frame, so keep
-        // their entries charged until the frame is popped.
     }
 
     async fn execute_function_call(
@@ -6608,6 +6620,12 @@ impl Interpreter {
             .enumerate()
             .map(|(i, f)| (i, f.name.clone()))
             .collect();
+        // Interpreter-set FUNCNAME entries are metadata and are inserted
+        // uncharged. Remember how many there are so that on return we credit
+        // back only the *user-added* entries (e.g. `FUNCNAME[7]=x`), which were
+        // charged via the normal array-assignment path. Without this, repeated
+        // FUNCNAME mutation would leak array budget across calls (over-count).
+        let funcname_meta_len = funcname_arr.len();
         let prev_funcname = self
             .arrays_mut()
             .insert("FUNCNAME".to_string(), funcname_arr);
@@ -6633,9 +6651,19 @@ impl Interpreter {
         self.bash_source_stack.pop();
         self.update_bash_source();
 
-        // Restore previous FUNCNAME (or set from remaining stack). FUNCNAME is
-        // interpreter metadata, not user allocation, so it is never charged to
-        // the array-entry memory budget.
+        // Restore previous FUNCNAME (or set from remaining stack). Interpreter
+        // metadata entries are never charged, but a script may have added its
+        // own entries to FUNCNAME while inside the function; those were charged,
+        // so credit them back as the array is discarded to avoid budget drift.
+        let funcname_user_entries = self
+            .arrays
+            .get("FUNCNAME")
+            .map_or(0, |a| a.len())
+            .saturating_sub(funcname_meta_len);
+        if funcname_user_entries > 0 {
+            self.memory_budget
+                .record_array_remove(funcname_user_entries);
+        }
         if self.call_stack.is_empty() {
             self.arrays_mut().remove("FUNCNAME");
         } else if let Some(prev) = prev_funcname {
@@ -11397,25 +11425,38 @@ impl Interpreter {
     }
 
     /// Remember the array binding that a local indexed array declaration shadows.
-    fn remember_local_array_binding(&mut self, name: &str) {
+    /// Snapshot the indexed-array binding a local declaration shadows.
+    ///
+    /// Returns `true` only when this call retained a *new* snapshot in the
+    /// frame. A later shadow of the same name within the same frame keeps the
+    /// first snapshot (`or_insert`) and returns `false`, signalling that the
+    /// binding being replaced is a transient local — not retained anywhere —
+    /// so its entries must be released from the array budget.
+    fn remember_local_array_binding(&mut self, name: &str) -> bool {
         let previous = self.arrays.get(name).cloned();
         if let Some(frame) = self.call_stack.last_mut() {
-            frame
-                .local_arrays
-                .entry(name.to_string())
-                .or_insert(previous);
+            if frame.local_arrays.contains_key(name) {
+                return false;
+            }
+            frame.local_arrays.insert(name.to_string(), previous);
+            return true;
         }
+        false
     }
 
-    /// Remember the array binding that a local associative array declaration shadows.
-    fn remember_local_assoc_array_binding(&mut self, name: &str) {
+    /// Snapshot the associative-array binding a local declaration shadows.
+    /// See [`remember_local_array_binding`](Self::remember_local_array_binding)
+    /// for the meaning of the return value.
+    fn remember_local_assoc_array_binding(&mut self, name: &str) -> bool {
         let previous = self.assoc_arrays.get(name).cloned();
         if let Some(frame) = self.call_stack.last_mut() {
-            frame
-                .local_assoc_arrays
-                .entry(name.to_string())
-                .or_insert(previous);
+            if frame.local_assoc_arrays.contains_key(name) {
+                return false;
+            }
+            frame.local_assoc_arrays.insert(name.to_string(), previous);
+            return true;
         }
+        false
     }
 
     fn restore_array_binding(&mut self, name: &str, previous: Option<HashMap<usize, String>>) {

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6570,19 +6570,14 @@ impl Interpreter {
     fn shadow_local_array_bindings(&mut self, name: &str, keep_indexed: bool, keep_assoc: bool) {
         self.remember_local_array_binding(name);
         self.remember_local_assoc_array_binding(name);
-        let mut removed_entries = 0;
         if !keep_indexed {
-            removed_entries += self.arrays_mut().remove(name).map_or(0, |arr| arr.len());
+            self.arrays_mut().remove(name);
         }
         if !keep_assoc {
-            removed_entries += self
-                .assoc_arrays_mut()
-                .remove(name)
-                .map_or(0, |arr| arr.len());
+            self.assoc_arrays_mut().remove(name);
         }
-        if removed_entries > 0 {
-            self.memory_budget.record_array_remove(removed_entries);
-        }
+        // Shadowed array bindings stay retained in the call frame, so keep
+        // their entries charged until the frame is popped.
     }
 
     async fn execute_function_call(
@@ -6638,23 +6633,14 @@ impl Interpreter {
         self.bash_source_stack.pop();
         self.update_bash_source();
 
-        // Restore previous FUNCNAME (or set from remaining stack)
-        let old_funcname_entries = self.arrays.get("FUNCNAME").map_or(0, |arr| arr.len());
-        let new_funcname_entries = if self.call_stack.is_empty() {
+        // Restore previous FUNCNAME (or set from remaining stack). FUNCNAME is
+        // interpreter metadata, not user allocation, so it is never charged to
+        // the array-entry memory budget.
+        if self.call_stack.is_empty() {
             self.arrays_mut().remove("FUNCNAME");
-            0
         } else if let Some(prev) = prev_funcname {
-            let len = prev.len();
             self.arrays_mut().insert("FUNCNAME".to_string(), prev);
-            len
-        } else {
-            old_funcname_entries
-        };
-        self.memory_budget.array_entries = self
-            .memory_budget
-            .array_entries
-            .saturating_sub(old_funcname_entries)
-            + new_funcname_entries;
+        }
 
         let mut result = result?;
 
@@ -6710,7 +6696,7 @@ impl Interpreter {
                     // Handle compound array assignment: local arr=(1 2 3) or local -a/-A arr=(...)
                     let is_compound = value.starts_with('(') && value.ends_with(')');
                     if is_compound {
-                        self.shadow_local_array_bindings(var_name, !flags.assoc, flags.assoc);
+                        self.shadow_local_array_bindings(var_name, false, false);
                         let inner = &value[1..value.len() - 1];
                         let inserted = if flags.assoc {
                             self.remember_local_assoc_array_binding(var_name);
@@ -6776,12 +6762,12 @@ impl Interpreter {
                     }
                 } else if !is_internal_variable(arg) {
                     if flags.assoc {
-                        self.shadow_local_array_bindings(arg, false, true);
+                        self.shadow_local_array_bindings(arg, false, false);
                         if self.insert_assoc_array_checked(arg.to_string(), HashMap::new()) {
                             self.insert_local_checked(arg.to_string(), String::new());
                         }
                     } else if flags.array {
-                        self.shadow_local_array_bindings(arg, true, false);
+                        self.shadow_local_array_bindings(arg, false, false);
                         if self.insert_array_checked(arg.to_string(), HashMap::new()) {
                             self.insert_local_checked(arg.to_string(), String::new());
                         }
@@ -11434,12 +11420,9 @@ impl Interpreter {
 
     fn restore_array_binding(&mut self, name: &str, previous: Option<HashMap<usize, String>>) {
         let old_entries = self.arrays.get(name).map_or(0, |a| a.len());
-        let new_entries = previous.as_ref().map_or(0, |a| a.len());
-        self.memory_budget.array_entries = self
-            .memory_budget
-            .array_entries
-            .saturating_sub(old_entries)
-            .saturating_add(new_entries);
+        // Saved bindings remain budgeted while shadowed; popping only releases
+        // entries allocated by the local binding currently active in arrays.
+        self.memory_budget.record_array_remove(old_entries);
         if let Some(arr) = previous {
             self.arrays_mut().insert(name.to_string(), arr);
         } else {
@@ -11453,12 +11436,9 @@ impl Interpreter {
         previous: Option<HashMap<String, String>>,
     ) {
         let old_entries = self.assoc_arrays.get(name).map_or(0, |a| a.len());
-        let new_entries = previous.as_ref().map_or(0, |a| a.len());
-        self.memory_budget.array_entries = self
-            .memory_budget
-            .array_entries
-            .saturating_sub(old_entries)
-            .saturating_add(new_entries);
+        // Saved bindings remain budgeted while shadowed; popping only releases
+        // entries allocated by the local binding currently active in assoc_arrays.
+        self.memory_budget.record_array_remove(old_entries);
         if let Some(arr) = previous {
             self.assoc_arrays_mut().insert(name.to_string(), arr);
         } else {

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3855,6 +3855,87 @@ printf "after_assoc=<%s>\n" "${assoc_shadow[*]}"
         );
     }
 
+    /// TM-DOS-060: FUNCNAME bookkeeping must not undercount array budget.
+    #[tokio::test]
+    async fn tm_dos_060_funcname_restore_preserves_array_budget() {
+        let mem = MemoryLimits::new().max_array_entries(3);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+arr[0]=a
+arr[1]=b
+arr[2]=c
+f() { :; }
+f
+extra[0]=x
+printf "%s %s\n" "${#arr[@]}" "${#extra[@]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "3 0");
+    }
+
+    /// TM-DOS-060: saved local array shadows must stay charged to array budget.
+    #[tokio::test]
+    async fn tm_dos_060_local_array_shadow_preserves_array_budget() {
+        let mem = MemoryLimits::new().max_array_entries(3);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+arr=(a b c)
+f() {
+    local arr=(x)
+    printf "inside=%s\n" "${#arr[@]}"
+}
+f
+printf "outside=%s:%s\n" "${#arr[@]}" "${arr[*]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            result.stdout.lines().collect::<Vec<_>>(),
+            vec!["inside=0", "outside=3:a b c"]
+        );
+    }
+
+    /// TM-DOS-060: saved local associative-array shadows must stay charged.
+    #[tokio::test]
+    async fn tm_dos_060_local_assoc_array_shadow_preserves_array_budget() {
+        let mem = MemoryLimits::new().max_array_entries(3);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        let script = r#"
+declare -A map
+map[a]=1
+map[b]=2
+map[c]=3
+f() {
+    local -A map=([x]=9)
+    printf "inside=%s\n" "${#map[@]}"
+}
+f
+printf "outside=%s:%s\n" "${#map[@]}" "${map[a]}${map[b]}${map[c]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            result.stdout.lines().collect::<Vec<_>>(),
+            vec!["inside=0", "outside=3:123"]
+        );
+    }
+
     /// TM-INF-023: local compound arrays must not leak after a function returns.
     #[tokio::test]
     async fn tm_inf_023_function_local_arrays_do_not_leak() {

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -3936,6 +3936,67 @@ printf "outside=%s:%s\n" "${#map[@]}" "${map[a]}${map[b]}${map[c]}"
         );
     }
 
+    /// TM-DOS-060: re-shadowing the same local array in one frame must release
+    /// the replaced transient binding's budget (only the first snapshot is kept,
+    /// so later removals must not leave phantom entries charged).
+    #[tokio::test]
+    async fn tm_dos_060_repeated_local_array_shadow_does_not_drift_budget() {
+        let mem = MemoryLimits::new().max_array_entries(3);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // The first `local arr=(a b c)` fills the budget. The second
+        // `local arr=(x)` replaces it; its three entries must be released so the
+        // single-element reassignment fits. Without releasing them the budget
+        // drifts upward and the second assignment is wrongly rejected.
+        let script = r#"
+f() {
+    local arr=(a b c)
+    printf "first=%s\n" "${#arr[@]}"
+    local arr=(x)
+    printf "second=%s\n" "${#arr[@]}"
+}
+f
+printf "after=%s\n" "${#arr[@]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(
+            result.stdout.lines().collect::<Vec<_>>(),
+            vec!["first=3", "second=1", "after=0"]
+        );
+    }
+
+    /// TM-DOS-060: user mutation of FUNCNAME inside a function must not leak
+    /// array budget after the function returns (interpreter metadata stays
+    /// uncharged, but user-added entries are credited back on discard).
+    #[tokio::test]
+    async fn tm_dos_060_funcname_user_mutation_does_not_leak_budget() {
+        let mem = MemoryLimits::new().max_array_entries(5);
+        let mut bash = Bash::builder()
+            .memory_limits(mem)
+            .session_limits(SessionLimits::unlimited())
+            .build();
+
+        // Each call adds a user entry to FUNCNAME, which is discarded on return.
+        // If the charge leaked, the later 5-element array would not fully fit.
+        let script = r#"
+f() { FUNCNAME[7]=injected; }
+f
+f
+f
+arr=(a b c d e)
+printf "n=%s\n" "${#arr[@]}"
+"#;
+        let result = bash.exec(script).await.unwrap();
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "n=5");
+    }
+
     /// TM-INF-023: local compound arrays must not leak after a function returns.
     #[tokio::test]
     async fn tm_inf_023_function_local_arrays_do_not_leak() {


### PR DESCRIPTION
### Motivation
- Recent local-array scoping changes introduced two memory-accounting regressions that let user scripts undercount `MemoryLimits::max_array_entries` via saved local-array snapshots and `FUNCNAME` bookkeeping. 

### Description
- Keep shadowed array bindings retained in call frames charged to the array-entry budget by removing budget decrements from the shadow path and retaining saved clones in frames (`crates/bashkit/src/interpreter/mod.rs`).
- Stop adjusting user `memory_budget.array_entries` when restoring interpreter-owned `FUNCNAME` metadata so function entry/return cannot undercount user arrays.
- On frame pop, release only the entries allocated by the active local binding using `memory_budget.record_array_remove(...)` when restoring array/assoc bindings so saved snapshots remain budgeted until popped.
- Make `local`/`declare` paths shadow before inserting replacements (indexed and associative arrays) so compound `local arr=(...)` is scoped without creating out-of-budget retained snapshots, and add integration regression tests exercising these cases (`crates/bashkit/tests/integration/threat_model_tests.rs`).

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran the targeted integration suite with `cargo test -p bashkit --test integration tm_dos_060 -- --nocapture` and observed the added tests pass (final run: all tests in the target set passed).
- Ran `cargo clippy -p bashkit --all-targets -- -D warnings` which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288fa4a5e0832b829c6041843c3c4f)