### PR TITLE
fix(parser): avoid brace range budget overflow

### DIFF
--- a/crates/bashkit/src/parser/budget.rs
+++ b/crates/bashkit/src/parser/budget.rs
@@ -278,8 +278,9 @@ fn estimate_brace_range_size(content: &str) -> Option<u64> {
         } else {
             1
         };
-        let range = (end - start).unsigned_abs();
-        return Some(range / step + 1);
+        let range = ((end as i128) - (start as i128)).unsigned_abs();
+        let count = range / u128::from(step) + 1;
+        return Some(u64::try_from(count).unwrap_or(u64::MAX));
     }
 
     // Try single-char range
@@ -424,6 +425,14 @@ mod tests {
         assert_eq!(estimate_brace_range_size("1..100"), Some(100));
         assert_eq!(estimate_brace_range_size("-5..5"), Some(11));
         assert_eq!(estimate_brace_range_size("1..100..10"), Some(10));
+    }
+
+    #[test]
+    fn estimate_numeric_range_extreme_i64_endpoints() {
+        assert_eq!(
+            estimate_brace_range_size("-9223372036854775808..9223372036854775807"),
+            Some(u64::MAX),
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Static budget validator subtracted `i64` endpoints for numeric brace ranges, which can overflow for extreme valid `i64` inputs and panic at the `Bash::exec` boundary causing a DoS. 

### Description

- Widen endpoint subtraction to `i128` and compute the element count with `u128` division to avoid signed overflow when estimating brace ranges in `crates/bashkit/src/parser/budget.rs`. 
- Saturate extremely large counts by returning `u64::MAX` when the computed count doesn't fit into a `u64`. 
- Add a regression test `estimate_numeric_range_extreme_i64_endpoints` covering the `-9223372036854775808..9223372036854775807` case. 

### Testing

- Ran `cargo test -p bashkit parser::budget` and the whole parser budget test group passed. 
- Ran the targeted test `cargo test -p bashkit parser::budget::tests::estimate_numeric_range_extreme_i64_endpoints` which passed. 
- Ran `cargo clippy -p bashkit --lib -- -D warnings` and `cargo fmt --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae1f38832b95595faafbf61fb4)