### PR TITLE
fix(vfs): use CSPRNG for random devices

### DIFF
--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -463,18 +463,14 @@ impl InMemoryFs {
     /// THREAT[TM-DOS-003]: Generate bounded random bytes for /dev/urandom.
     /// Returns exactly 8192 bytes to prevent unbounded reads while
     /// supporting common patterns like `od -N8 -tx1 /dev/urandom`.
-    fn generate_random_bytes() -> Vec<u8> {
-        use std::collections::hash_map::RandomState;
-        use std::hash::{BuildHasher, Hasher};
-
+    fn generate_random_bytes() -> Result<Vec<u8>> {
         const SIZE: usize = 8192;
-        let mut buf = Vec::with_capacity(SIZE);
-        while buf.len() < SIZE {
-            let h = RandomState::new().build_hasher().finish();
-            buf.extend_from_slice(&h.to_ne_bytes());
-        }
-        buf.truncate(SIZE);
-        buf
+        let mut buf = vec![0; SIZE];
+        // Important decision: use the OS CSPRNG backing getrandom, not
+        // non-CSPRNG hasher seeds, because scripts commonly use these paths
+        // for tokens, salts, nonces, and keys.
+        getrandom::fill(&mut buf).map_err(|_| IoError::other("random device unavailable"))?;
+        Ok(buf)
     }
 
     /// Compute current usage statistics.
@@ -1010,7 +1006,7 @@ impl FileSystem for InMemoryFs {
 
         // /dev/urandom and /dev/random: return bounded random bytes
         if path == Path::new("/dev/urandom") || path == Path::new("/dev/random") {
-            return Ok(Self::generate_random_bytes());
+            return Self::generate_random_bytes();
         }
 
         // First try with a read lock for the common (non-lazy) case
@@ -2278,6 +2274,23 @@ mod tests {
         let fs = InMemoryFs::new();
         let content = fs.read_file(Path::new("/dev/urandom")).await.unwrap();
         assert_eq!(content.len(), 8192);
+    }
+
+    #[test]
+    fn test_random_device_source_uses_csprng() {
+        let source = include_str!("memory.rs");
+        let production_source = source
+            .split("fn test_random_device_source_uses_csprng")
+            .next()
+            .unwrap();
+        assert!(
+            production_source.contains("getrandom::fill"),
+            "/dev/random devices must use the OS CSPRNG"
+        );
+        assert!(
+            !production_source.contains("std::collections::hash_map::RandomState"),
+            "/dev/random devices must not use HashMap hasher seeds as randomness"
+        );
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/fs/memory.rs
+++ b/crates/bashkit/src/fs/memory.rs
@@ -460,7 +460,7 @@ impl InMemoryFs {
         }
     }
 
-    /// THREAT[TM-DOS-003]: Generate bounded random bytes for /dev/urandom.
+    /// THREAT[TM-DOS-003]: Generate bounded random bytes for `/dev/urandom` and `/dev/random`.
     /// Returns exactly 8192 bytes to prevent unbounded reads while
     /// supporting common patterns like `od -N8 -tx1 /dev/urandom`.
     fn generate_random_bytes() -> Result<Vec<u8>> {
@@ -2279,16 +2279,22 @@ mod tests {
     #[test]
     fn test_random_device_source_uses_csprng() {
         let source = include_str!("memory.rs");
-        let production_source = source
-            .split("fn test_random_device_source_uses_csprng")
-            .next()
-            .unwrap();
+        // Extract just the generate_random_bytes function body so the check
+        // is not brittle against imports, variable names, or other uses of
+        // RandomState elsewhere in the file.
+        let fn_body = source
+            .split("fn generate_random_bytes")
+            .nth(1)
+            .expect("generate_random_bytes must exist in memory.rs");
+        // Take up to the next top-level `fn ` at the same indentation level
+        // (four spaces + "fn "), which terminates the function block.
+        let fn_body = fn_body.split("\n    fn ").next().unwrap_or(fn_body);
         assert!(
-            production_source.contains("getrandom::fill"),
-            "/dev/random devices must use the OS CSPRNG"
+            fn_body.contains("getrandom") && fn_body.contains("fill"),
+            "/dev/random devices must use the OS CSPRNG (getrandom::fill or use getrandom::fill)"
         );
         assert!(
-            !production_source.contains("std::collections::hash_map::RandomState"),
+            !fn_body.contains("RandomState"),
             "/dev/random devices must not use HashMap hasher seeds as randomness"
         );
     }


### PR DESCRIPTION
### Motivation

- The VFS exposed `/dev/urandom` and `/dev/random` but generated bytes via `std::collections::hash_map::RandomState`, which is not a CSPRNG and can mislead scripts to use weak randomness for secrets. 
- Replace the weak generator with the OS-backed CSPRNG so sandboxed scripts receive security-grade randomness while keeping bounded reads to mitigate DoS.

### Description

- Replace `generate_random_bytes()` implementation to allocate an 8192-byte buffer and fill it with `getrandom::fill`, preserving the 8KB bounded-read behavior. 
- Change `generate_random_bytes()` signature to return `Result<Vec<u8>>` and map `getrandom` failures to a safe `IoError::other("random device unavailable")`. 
- Adjust the `/dev/urandom` and `/dev/random` read path to propagate the `Result` returned by the generator. 
- Add a regression unit test `test_random_device_source_uses_csprng` that asserts the production source contains `getrandom::fill` and does not contain `std::collections::hash_map::RandomState` to prevent accidental reintroduction of the weak generator.

### Testing

- Ran formatting checks with `cargo fmt --check`, which succeeded. 
- Ran targeted unit tests with `cargo test -p bashkit` for `test_random_device_source_uses_csprng`, `test_dev_urandom_returns_bytes`, `test_dev_random_returns_bytes`, and `test_dev_urandom_returns_different_data`, and all passed. 
- Ran lints with `cargo clippy -p bashkit --all-targets -- -D warnings`, which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251adfaa0832baec6ab60a9a949e7)