### PR TITLE
fix(awk): stream redirected output through vfs to enforce quotas

### DIFF
--- a/crates/bashkit/src/builtins/awk/interpreter.rs
+++ b/crates/bashkit/src/builtins/awk/interpreter.rs
@@ -1,6 +1,6 @@
 //! AWK interpreter - executes a parsed `AwkProgram`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -48,17 +48,12 @@ pub(super) struct AwkInterpreter {
     pub(super) functions: HashMap<String, AwkFunctionDef>,
     /// Current function call depth for recursion limiting
     call_depth: usize,
-    /// Buffered file outputs for `>` redirection (path -> content).
-    /// Truncate mode: first write creates entry, subsequent writes append to buffer.
-    /// Flushed to VFS after execution completes.
-    pub(super) file_outputs: HashMap<String, String>,
-    /// Buffered file outputs for `>>` redirection (path -> content).
-    /// Append mode: content is appended to existing file on flush.
-    pub(super) file_appends: HashMap<String, String>,
-    /// Running byte total across stdout, stderr, and buffered file outputs.
-    /// Keep this O(1): recomputing from redirect maps on every write is quadratic
-    /// for attacker-controlled scripts that print tiny records to many paths.
-    total_output_bytes: usize,
+    /// Paths already seen as `>`/`>>` redirect targets in this AWK run.
+    /// First write truncates (for `>`); later writes stream as appends. Also
+    /// serves as the distinct-target set for the output-target DoS guard.
+    pub(super) file_truncates: HashSet<String>,
+    /// Total bytes streamed to real file redirects, excluding discarded devices.
+    redirected_file_output_bytes: usize,
     /// Cached file inputs for `getline var < file` redirection.
     /// Maps normalized resolved path -> (lines, current_position).
     file_inputs: HashMap<String, (Vec<String>, usize)>,
@@ -85,9 +80,8 @@ impl AwkInterpreter {
             input_lines: Vec::new(),
             line_index: 0,
             functions: HashMap::new(),
-            file_outputs: HashMap::new(),
-            file_appends: HashMap::new(),
-            total_output_bytes: 0,
+            file_truncates: HashSet::new(),
+            redirected_file_output_bytes: 0,
             file_inputs: HashMap::new(),
             file_input_bytes: 0,
             call_depth: 0,
@@ -999,20 +993,18 @@ impl AwkInterpreter {
         Ok(result)
     }
 
+    /// Total bytes accounted across all output streams (O(1): stdout/stderr
+    /// lengths plus the running streamed-redirect counter).
+    fn total_output_bytes(&self) -> usize {
+        self.output.len() + self.stderr_output.len() + self.redirected_file_output_bytes
+    }
+
     fn has_output_capacity(&self, len: usize) -> bool {
-        len <= MAX_AWK_OUTPUT_BYTES.saturating_sub(self.total_output_bytes)
+        len <= MAX_AWK_OUTPUT_BYTES.saturating_sub(self.total_output_bytes())
     }
 
-    fn output_target_count(&self) -> usize {
-        self.file_outputs.len() + self.file_appends.len()
-    }
-
-    fn is_new_output_target(&self, path: &str) -> bool {
-        !self.file_outputs.contains_key(path) && !self.file_appends.contains_key(path)
-    }
-
-    /// Write text to stdout buffer or to a file output buffer based on the target.
-    /// Returns `false` if the write would exceed output resource limits.
+    /// Stream text to stdout, stderr, or the VFS-backed redirect target.
+    /// Returns `false` if output limits or VFS validation reject the write.
     fn write_output(&mut self, text: &str, target: &Option<AwkOutputTarget>) -> bool {
         if !self.has_output_capacity(text.len()) {
             self.stderr_output
@@ -1020,32 +1012,92 @@ impl AwkInterpreter {
             return false;
         }
         match target {
-            None => self.output.push_str(text),
+            None => {
+                self.output.push_str(text);
+                true
+            }
             Some(AwkOutputTarget::Truncate(expr)) | Some(AwkOutputTarget::Append(expr)) => {
                 let path = self.eval_expr(expr).as_string();
-                // Intercept /dev/stderr and /dev/stdout — route to streams, not VFS
-                if path == "/dev/stderr" {
+                // Intercept special devices before VFS work so /dev/null never buffers.
+                if path == "/dev/null" {
+                    true
+                } else if path == "/dev/stderr" {
                     self.stderr_output.push_str(text);
+                    true
                 } else if path == "/dev/stdout" {
                     self.output.push_str(text);
+                    true
                 } else {
-                    if self.is_new_output_target(&path)
-                        && self.output_target_count() >= MAX_AWK_OUTPUT_TARGETS
-                    {
-                        self.stderr_output
-                            .push_str("awk: too many output redirection targets\n");
-                        return false;
-                    }
-                    if matches!(target, Some(AwkOutputTarget::Append(_))) {
-                        self.file_appends.entry(path).or_default().push_str(text);
-                    } else {
-                        self.file_outputs.entry(path).or_default().push_str(text);
-                    }
+                    let append = matches!(target, Some(AwkOutputTarget::Append(_)));
+                    self.write_file_output(&path, text, append)
                 }
             }
         }
-        self.total_output_bytes += text.len();
-        true
+    }
+
+    /// Write redirected output immediately through the VFS so sandbox quotas are
+    /// enforced during AWK execution instead of after unbounded buffering.
+    fn write_file_output(&mut self, path: &str, text: &str, append: bool) -> bool {
+        let resolved = if path.starts_with('/') {
+            PathBuf::from(path)
+        } else {
+            self.cwd.join(path)
+        };
+        let key = resolved.to_string_lossy().into_owned();
+        // Bound the number of distinct redirect targets (DoS guard, parity with
+        // the previous buffered implementation). file_truncates doubles as the
+        // distinct-target set, so reject new targets before inserting them.
+        if !self.file_truncates.contains(&key)
+            && self.file_truncates.len() >= MAX_AWK_OUTPUT_TARGETS
+        {
+            self.stderr_output
+                .push_str("awk: too many output redirection targets\n");
+            return false;
+        }
+        let Some(fs) = &self.fs else {
+            self.stderr_output
+                .push_str("awk: no filesystem available\n");
+            return false;
+        };
+        let fs = fs.clone();
+        let bytes = text.as_bytes().to_vec();
+        // First write to a path truncates (for `>`); later writes append. `>>`
+        // always appends. insert() returns false when the path was already seen.
+        let first_write = self.file_truncates.insert(key);
+        let append = append || !first_write;
+
+        let resolved_for_thread = resolved.clone();
+        let result = std::thread::spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async move {
+                    if append {
+                        fs.append_file(&resolved_for_thread, &bytes).await
+                    } else {
+                        fs.write_file(&resolved_for_thread, &bytes).await
+                    }
+                })
+        })
+        .join();
+
+        match result {
+            Ok(Ok(())) => {
+                self.redirected_file_output_bytes += text.len();
+                true
+            }
+            Ok(Err(e)) => {
+                self.stderr_output
+                    .push_str(&format!("awk: cannot write {path}: {e}\n"));
+                false
+            }
+            Err(_) => {
+                self.stderr_output
+                    .push_str(&format!("awk: cannot write {path}: write worker failed\n"));
+                false
+            }
+        }
     }
 
     /// Execute action. Returns flow control signal.

--- a/crates/bashkit/src/builtins/awk/interpreter.rs
+++ b/crates/bashkit/src/builtins/awk/interpreter.rs
@@ -35,6 +35,84 @@ pub(super) enum AwkFlow {
 // - AWK_MAX_GETLINE_CACHED_FILES (distinct files held open by `getline`).
 // - AWK_MAX_GETLINE_FILE_BYTES / AWK_MAX_GETLINE_CACHE_BYTES (retained input bytes).
 
+/// One redirected VFS write, dispatched to the [`VfsWriter`] thread.
+struct WriteJob {
+    path: PathBuf,
+    bytes: Vec<u8>,
+    append: bool,
+    resp: std::sync::mpsc::Sender<crate::error::Result<()>>,
+}
+
+/// A single long-lived OS thread owning one Tokio runtime that serializes
+/// redirected VFS writes.
+///
+/// AWK executes synchronously inside the outer async runtime, so each
+/// redirected write must hop to a thread with its own runtime to call the async
+/// VFS. Spawning a fresh thread + runtime per write would let a tight
+/// `print > file` loop create thousands of threads/runtimes (DoS). Reusing one
+/// writer for the whole run keeps writes incremental (so VFS quotas are still
+/// enforced as they happen) at O(1) threads.
+struct VfsWriter {
+    tx: Option<std::sync::mpsc::Sender<WriteJob>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl VfsWriter {
+    fn new(fs: Arc<dyn FileSystem>) -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<WriteJob>();
+        let handle = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("awk vfs writer runtime");
+            runtime.block_on(async move {
+                while let Ok(job) = rx.recv() {
+                    let res = if job.append {
+                        fs.append_file(&job.path, &job.bytes).await
+                    } else {
+                        fs.write_file(&job.path, &job.bytes).await
+                    };
+                    let _ = job.resp.send(res);
+                }
+            });
+        });
+        Self {
+            tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    /// Perform one write synchronously on the writer thread. Returns the VFS
+    /// result, or `Err(())` if the writer thread is gone.
+    fn write(
+        &self,
+        path: PathBuf,
+        bytes: Vec<u8>,
+        append: bool,
+    ) -> Result<crate::error::Result<()>, ()> {
+        let (resp_tx, resp_rx) = std::sync::mpsc::channel();
+        let job = WriteJob {
+            path,
+            bytes,
+            append,
+            resp: resp_tx,
+        };
+        self.tx.as_ref().ok_or(())?.send(job).map_err(|_| ())?;
+        resp_rx.recv().map_err(|_| ())
+    }
+}
+
+impl Drop for VfsWriter {
+    fn drop(&mut self) {
+        // Drop the sender first so the writer loop's `rx.recv()` returns Err and
+        // the thread exits, then join it to flush any in-flight write cleanly.
+        drop(self.tx.take());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 pub(super) struct AwkInterpreter {
     pub(super) state: AwkState,
     pub(super) output: String,
@@ -54,6 +132,9 @@ pub(super) struct AwkInterpreter {
     pub(super) file_truncates: HashSet<String>,
     /// Total bytes streamed to real file redirects, excluding discarded devices.
     redirected_file_output_bytes: usize,
+    /// Single reusable writer thread for redirected VFS writes (lazily started
+    /// on the first redirect). Joined when the interpreter is dropped.
+    vfs_writer: Option<VfsWriter>,
     /// Cached file inputs for `getline var < file` redirection.
     /// Maps normalized resolved path -> (lines, current_position).
     file_inputs: HashMap<String, (Vec<String>, usize)>,
@@ -82,6 +163,7 @@ impl AwkInterpreter {
             functions: HashMap::new(),
             file_truncates: HashSet::new(),
             redirected_file_output_bytes: 0,
+            vfs_writer: None,
             file_inputs: HashMap::new(),
             file_input_bytes: 0,
             call_depth: 0,
@@ -1054,35 +1136,25 @@ impl AwkInterpreter {
                 .push_str("awk: too many output redirection targets\n");
             return false;
         }
-        let Some(fs) = &self.fs else {
-            self.stderr_output
-                .push_str("awk: no filesystem available\n");
-            return false;
+        let fs = match &self.fs {
+            Some(fs) => fs.clone(),
+            None => {
+                self.stderr_output
+                    .push_str("awk: no filesystem available\n");
+                return false;
+            }
         };
-        let fs = fs.clone();
         let bytes = text.as_bytes().to_vec();
         // First write to a path truncates (for `>`); later writes append. `>>`
         // always appends. insert() returns false when the path was already seen.
         let first_write = self.file_truncates.insert(key);
         let append = append || !first_write;
 
-        let resolved_for_thread = resolved.clone();
-        let result = std::thread::spawn(move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(async move {
-                    if append {
-                        fs.append_file(&resolved_for_thread, &bytes).await
-                    } else {
-                        fs.write_file(&resolved_for_thread, &bytes).await
-                    }
-                })
-        })
-        .join();
-
-        match result {
+        // Start the single reusable writer thread on first use, then dispatch
+        // every redirected write through it (one thread/runtime per AWK run, not
+        // per write).
+        let writer = self.vfs_writer.get_or_insert_with(|| VfsWriter::new(fs));
+        match writer.write(resolved, bytes, append) {
             Ok(Ok(())) => {
                 self.redirected_file_output_bytes += text.len();
                 true
@@ -1092,7 +1164,7 @@ impl AwkInterpreter {
                     .push_str(&format!("awk: cannot write {path}: {e}\n"));
                 false
             }
-            Err(_) => {
+            Err(()) => {
                 self.stderr_output
                     .push_str(&format!("awk: cannot write {path}: write worker failed\n"));
                 false

--- a/crates/bashkit/src/builtins/awk/mod.rs
+++ b/crates/bashkit/src/builtins/awk/mod.rs
@@ -695,26 +695,8 @@ impl Builtin for Awk {
 }
 
 impl Awk {
-    /// Flush buffered file outputs to VFS.
-    async fn flush_file_outputs(interp: &AwkInterpreter, ctx: &Context<'_>) -> Result<()> {
-        // Truncate mode: write entire buffer as file content
-        for (path, content) in &interp.file_outputs {
-            let path = if path.starts_with('/') {
-                std::path::PathBuf::from(path)
-            } else {
-                ctx.cwd.join(path)
-            };
-            ctx.fs.write_file(&path, content.as_bytes()).await?;
-        }
-        // Append mode: append buffer to existing file (or create)
-        for (path, content) in &interp.file_appends {
-            let path = if path.starts_with('/') {
-                std::path::PathBuf::from(path)
-            } else {
-                ctx.cwd.join(path)
-            };
-            ctx.fs.append_file(&path, content.as_bytes()).await?;
-        }
+    /// AWK redirection streams through VFS as output is produced.
+    async fn flush_file_outputs(_interp: &AwkInterpreter, _ctx: &Context<'_>) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -997,7 +997,7 @@ async fn test_awk_file_redirect_output_limit() {
 
 #[tokio::test]
 async fn test_awk_file_redirect_target_limit() {
-    // Many tiny writes to unique paths must be capped without scanning all prior buffers.
+    // Many tiny writes to unique paths must be capped by the distinct-target guard.
     let program = format!(
         r#"BEGIN {{ for(i=0;i<{};i++) print "x" > ("/tmp/out" i) }}"#,
         MAX_OUTPUT_TARGETS + 1
@@ -1011,6 +1011,57 @@ async fn test_awk_file_redirect_target_limit() {
         "stderr should mention target limit: {}",
         result.stderr
     );
+}
+
+#[tokio::test]
+async fn test_awk_file_redirect_streams_vfs_file_size_limit() {
+    // Redirected output must hit VFS quotas while AWK is still executing,
+    // not after collecting an oversized in-memory buffer.
+    use crate::fs::FsLimits;
+
+    let limits = FsLimits {
+        max_file_size: 100,
+        ..FsLimits::unlimited()
+    };
+    let fs = Arc::new(InMemoryFs::with_limits(limits));
+    let result = run_awk_with_custom_fs(
+        &[r#"BEGIN { for(i=0;i<20;i++) print "abcdef" > "/tmp/out" }"#],
+        None,
+        fs.clone(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.exit_code, 2);
+    assert!(
+        result.stderr.contains("cannot write /tmp/out"),
+        "stderr should mention redirected write failure: {}",
+        result.stderr
+    );
+    let content = fs
+        .read_file(std::path::Path::new("/tmp/out"))
+        .await
+        .unwrap();
+    assert!(
+        content.len() <= 100,
+        "VFS file limit should be enforced incrementally: {} bytes",
+        content.len()
+    );
+}
+
+#[tokio::test]
+async fn test_awk_dev_null_redirect_does_not_count_against_output_limit() {
+    // /dev/null is discarded before any AWK-side redirect buffering.
+    let result = run_awk(
+        &[r#"BEGIN { s = sprintf("%1000s", "x"); for(i=0;i<12000;i++) print s > "/dev/null"; print "done" }"#],
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "done\n");
+    assert_eq!(result.stderr, "");
 }
 
 /// Helper: run AWK with a caller-provided VFS.

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -1050,6 +1050,30 @@ async fn test_awk_file_redirect_streams_vfs_file_size_limit() {
 }
 
 #[tokio::test]
+async fn test_awk_many_redirected_writes_reuse_single_writer() {
+    // A tight redirect loop streams every line through the one reusable writer
+    // thread (no thread/runtime per write). Verify the appends all land.
+    let fs = Arc::new(InMemoryFs::new());
+    let result = run_awk_with_custom_fs(
+        &[r#"BEGIN { for (i = 0; i < 500; i++) print i >> "/tmp/log" }"#],
+        None,
+        fs.clone(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    let content = fs
+        .read_file(std::path::Path::new("/tmp/log"))
+        .await
+        .unwrap();
+    let lines = String::from_utf8(content).unwrap();
+    assert_eq!(lines.lines().count(), 500);
+    assert_eq!(lines.lines().next(), Some("0"));
+    assert_eq!(lines.lines().last(), Some("499"));
+}
+
+#[tokio::test]
 async fn test_awk_dev_null_redirect_does_not_count_against_output_limit() {
     // /dev/null is discarded before any AWK-side redirect buffering.
     let result = run_awk(


### PR DESCRIPTION
### Motivation
- AWK file redirection previously buffered all redirected content in-memory (`file_outputs`/`file_appends`) and flushed at the end, allowing untrusted scripts to allocate large attacker-controlled buffers and bypass VFS quotas and `/dev/null` behavior.

### Description
- Stream redirected writes to the VFS as they are produced by implementing `write_file_output` and calling it from `AwkInterpreter::write_output` instead of accumulating `String` buffers. 
- Preserve `>` semantics by tracking truncated targets with `file_truncates: HashSet<String>` while `>>` continues to append. 
- Record streamed bytes in `redirected_file_output_bytes` and include that in `total_output_bytes` so the existing AWK output budget (`AWK_MAX_OUTPUT_BYTES`) still applies. 
- Special-case `/dev/null`, `/dev/stdout`, and `/dev/stderr` so `/dev/null` writes are discarded immediately and `Awk::flush_file_outputs` becomes a no-op; add regression tests under `crates/bashkit/src/builtins/awk/tests.rs` to cover incremental VFS limits and `/dev/null` behavior.

### Testing
- Ran the targeted unit test `cargo test -p bashkit builtins::awk::tests::test_awk_file_redirect_streams_vfs_file_size_limit` which passed. 
- Ran `cargo test -p bashkit builtins::awk::tests::test_awk_dev_null_redirect_does_not_count_against_output_limit` and `cargo test -p bashkit builtins::awk::tests::test_awk_file_redirect_output_limit` which passed. 
- Ran the whole AWK test module `cargo test -p bashkit builtins::awk::tests::` (90 tests) and all tests passed. 
- Ran formatting and lint checks `cargo fmt --check` and `cargo clippy -p bashkit --all-targets -- -D warnings`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2258dba178832bbb352aee5ddca0ed)