### PR TITLE
fix(history): bound persistent command history

### DIFF
--- a/crates/bashkit/src/builtins/environ.rs
+++ b/crates/bashkit/src/builtins/environ.rs
@@ -304,7 +304,9 @@ impl Builtin for History {
                 .collect::<Vec<_>>();
             entries.reverse();
             for (idx, entry) in entries {
-                append_history_line(&mut output, limits.max_history_output_bytes, idx, entry);
+                if !append_history_line(&mut output, limits.max_history_output_bytes, idx, entry) {
+                    break;
+                }
             }
         } else {
             for (idx, entry) in history
@@ -312,7 +314,9 @@ impl Builtin for History {
                 .enumerate()
                 .filter(|(_, entry)| matches_entry(entry))
             {
-                append_history_line(&mut output, limits.max_history_output_bytes, idx, entry);
+                if !append_history_line(&mut output, limits.max_history_output_bytes, idx, entry) {
+                    break;
+                }
             }
         }
 
@@ -320,22 +324,24 @@ impl Builtin for History {
     }
 }
 
+/// Append one formatted history line. Returns `false` when the line does not
+/// fit within `max_bytes`, signalling the caller to stop so the emitted output
+/// is always a prefix of the full listing (never skipping an earlier entry to
+/// fit a later, shorter one).
 fn append_history_line(
     output: &mut String,
     max_bytes: usize,
     idx: usize,
     entry: &crate::interpreter::HistoryEntry,
-) {
-    if output.len() >= max_bytes {
-        return;
-    }
-
+) -> bool {
     use std::fmt::Write;
     let mut line = String::new();
     let _ = writeln!(line, "  {}  {}", idx + 1, entry.command);
-    if output.len().saturating_add(line.len()) <= max_bytes {
-        output.push_str(&line);
+    if output.len().saturating_add(line.len()) > max_bytes {
+        return false;
     }
+    output.push_str(&line);
+    true
 }
 
 #[cfg(test)]

--- a/crates/bashkit/src/builtins/environ.rs
+++ b/crates/bashkit/src/builtins/environ.rs
@@ -267,52 +267,74 @@ impl Builtin for History {
         }
 
         let history = shell.history_entries();
+        let limits = shell.limits();
         let now = chrono::Utc::now().timestamp();
-
-        // Apply filters
-        let filtered: Vec<(usize, &crate::interpreter::HistoryEntry)> = history
-            .iter()
-            .enumerate()
-            .filter(|(_, entry)| {
-                if let Some(ref pat) = grep_pattern
-                    && !entry.command.contains(pat.as_str())
-                {
-                    return false;
-                }
-                if let Some(ref cwd) = cwd_filter
-                    && !entry.cwd.starts_with(cwd.as_str())
-                {
-                    return false;
-                }
-                if failed_only && entry.exit_code == 0 {
-                    return false;
-                }
-                if let Some(secs) = since_secs
-                    && now - entry.timestamp > secs
-                {
-                    return false;
-                }
-                true
-            })
-            .collect();
-
-        // Apply count limit (last N entries)
-        let entries: &[(usize, &crate::interpreter::HistoryEntry)] = if let Some(n) = count {
-            let start = filtered.len().saturating_sub(n);
-            &filtered[start..]
-        } else {
-            &filtered
+        let matches_entry = |entry: &crate::interpreter::HistoryEntry| {
+            if let Some(ref pat) = grep_pattern
+                && !entry.command.contains(pat.as_str())
+            {
+                return false;
+            }
+            if let Some(ref cwd) = cwd_filter
+                && !entry.cwd.starts_with(cwd.as_str())
+            {
+                return false;
+            }
+            if failed_only && entry.exit_code == 0 {
+                return false;
+            }
+            if let Some(secs) = since_secs
+                && now - entry.timestamp > secs
+            {
+                return false;
+            }
+            true
         };
 
-        // Format output: bash-style numbered listing
+        // THREAT[TM-DOS-094]: Do not allocate a filtered copy of all history.
+        // History is already session-capped; output is capped independently.
         let mut output = String::new();
-        for (idx, entry) in entries {
-            use std::fmt::Write;
-            // 1-indexed like bash
-            let _ = writeln!(output, "  {}  {}", idx + 1, entry.command);
+        if let Some(n) = count {
+            let mut entries = history
+                .iter()
+                .enumerate()
+                .rev()
+                .filter(|(_, entry)| matches_entry(entry))
+                .take(n)
+                .collect::<Vec<_>>();
+            entries.reverse();
+            for (idx, entry) in entries {
+                append_history_line(&mut output, limits.max_history_output_bytes, idx, entry);
+            }
+        } else {
+            for (idx, entry) in history
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| matches_entry(entry))
+            {
+                append_history_line(&mut output, limits.max_history_output_bytes, idx, entry);
+            }
         }
 
         Ok(ExecResult::ok(output))
+    }
+}
+
+fn append_history_line(
+    output: &mut String,
+    max_bytes: usize,
+    idx: usize,
+    entry: &crate::interpreter::HistoryEntry,
+) {
+    if output.len() >= max_bytes {
+        return;
+    }
+
+    use std::fmt::Write;
+    let mut line = String::new();
+    let _ = writeln!(line, "  {}  {}", idx + 1, entry.command);
+    if output.len().saturating_add(line.len()) <= max_bytes {
+        output.push_str(&line);
     }
 }
 

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -71,6 +71,25 @@ pub struct HistoryEntry {
     pub duration_ms: u64,
 }
 
+impl HistoryEntry {
+    fn retained_bytes(&self) -> usize {
+        self.command.len().saturating_add(self.cwd.len())
+    }
+}
+
+fn format_history_entries(entries: &[HistoryEntry]) -> String {
+    let mut content = String::new();
+    for entry in entries {
+        use std::fmt::Write;
+        let _ = writeln!(
+            content,
+            "{}|{}|{}|{}|{}",
+            entry.timestamp, entry.exit_code, entry.duration_ms, entry.cwd, entry.command
+        );
+    }
+    content
+}
+
 /// Runtime command surface for an interpreter instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum ShellProfile {
@@ -289,6 +308,8 @@ pub(crate) struct ShellRef<'a> {
     call_stack: &'a [CallFrame],
     /// Command history (read-only, accessed via `history_entries`).
     pub(crate) history: &'a [HistoryEntry],
+    /// Execution limits used by read-only builtins to avoid unbounded formatting.
+    limits: &'a ExecutionLimits,
     /// Shared job table (read-only, accessed via `jobs`).
     pub(crate) jobs: &'a SharedJobTable,
     /// Typed per-execution extensions for the current `exec*()` call.
@@ -296,6 +317,11 @@ pub(crate) struct ShellRef<'a> {
 }
 
 impl ShellRef<'_> {
+    /// Get execution limits visible to read-only builtins.
+    pub(crate) fn limits(&self) -> &ExecutionLimits {
+        self.limits
+    }
+
     /// Check if a name is a registered builtin command.
     pub(crate) fn has_builtin(&self, name: &str) -> bool {
         self.builtins.contains_key(name)
@@ -1030,6 +1056,12 @@ pub struct Interpreter {
     expanding_aliases: HashSet<String>,
     /// Command history entries for the current session.
     history: Vec<HistoryEntry>,
+    /// Retained command/cwd bytes for bounded history accounting.
+    history_bytes: usize,
+    /// Number of retained entries already flushed to the VFS history file.
+    history_saved_entries: usize,
+    /// Whether the VFS history file needs compaction after trimming or clearing.
+    history_needs_rewrite: bool,
     /// Optional VFS path for persisting history between sessions.
     history_file: Option<PathBuf>,
     /// Whether history has been loaded from VFS (to avoid re-loading on each exec).
@@ -1464,6 +1496,9 @@ impl Interpreter {
             aliases: Arc::new(HashMap::new()),
             expanding_aliases: HashSet::new(),
             history: Vec::new(),
+            history_bytes: 0,
+            history_saved_entries: 0,
+            history_needs_rewrite: false,
             history_file: None,
             history_loaded: false,
             subst_generation: 0,
@@ -1813,13 +1848,49 @@ impl Interpreter {
         exit_code: i32,
         duration_ms: u64,
     ) {
-        self.history.push(HistoryEntry {
+        self.push_history_entry(HistoryEntry {
             command,
             timestamp,
             cwd,
             exit_code,
             duration_ms,
         });
+    }
+
+    fn push_history_entry(&mut self, entry: HistoryEntry) {
+        // THREAT[TM-DOS-094]: Long-lived Bash instances retain history across
+        // exec() calls. Enforce entry/byte caps before persistence or listing.
+        if self.limits.max_history_entries == 0 || self.limits.max_history_bytes == 0 {
+            return;
+        }
+
+        let entry_bytes = entry.retained_bytes();
+        if entry_bytes > self.limits.max_history_bytes {
+            return;
+        }
+
+        self.history_bytes = self.history_bytes.saturating_add(entry_bytes);
+        self.history.push(entry);
+        if self.trim_history_to_limits() {
+            self.history_needs_rewrite = true;
+        }
+    }
+
+    fn trim_history_to_limits(&mut self) -> bool {
+        let mut trimmed = false;
+        while self.history.len() > self.limits.max_history_entries
+            || self.history_bytes > self.limits.max_history_bytes
+        {
+            if self.history.is_empty() {
+                self.history_bytes = 0;
+                break;
+            }
+            let removed = self.history.remove(0);
+            self.history_bytes = self.history_bytes.saturating_sub(removed.retained_bytes());
+            self.history_saved_entries = self.history_saved_entries.saturating_sub(1);
+            trimmed = true;
+        }
+        trimmed
     }
 
     /// Set the VFS path for persisting history.
@@ -1833,10 +1904,12 @@ impl Interpreter {
         &self.history
     }
 
-    /// Clear all history entries.
-    #[allow(dead_code)]
+    /// Clear all history entries and reset persistence accounting.
     pub fn clear_history(&mut self) {
         self.history.clear();
+        self.history_bytes = 0;
+        self.history_saved_entries = 0;
+        self.history_needs_rewrite = true;
     }
 
     /// Load history from the VFS history file (if configured). No-op after first call.
@@ -1864,37 +1937,45 @@ impl Interpreter {
                     parts[2].parse::<u64>(),
                 )
             {
-                self.history.push(HistoryEntry {
+                let before = self.history.len();
+                self.push_history_entry(HistoryEntry {
                     timestamp: ts,
                     exit_code: ec,
                     duration_ms: dur,
                     cwd: parts[3].to_string(),
                     command: parts[4].to_string(),
                 });
+                if self.history.len() == before {
+                    self.history_needs_rewrite = true;
+                }
             }
         }
+        self.history_saved_entries = self.history.len();
     }
 
     /// Save history to the VFS history file (if configured).
-    pub async fn save_history(&self) {
+    pub async fn save_history(&mut self) {
         let path = match &self.history_file {
             Some(p) => p.clone(),
             None => return,
         };
-        let mut content = String::new();
-        for entry in &self.history {
-            use std::fmt::Write;
-            let _ = writeln!(
-                content,
-                "{}|{}|{}|{}|{}",
-                entry.timestamp, entry.exit_code, entry.duration_ms, entry.cwd, entry.command
-            );
-        }
-        // Ensure parent directory exists
         if let Some(parent) = path.parent() {
             let _ = self.fs.mkdir(parent, true).await;
         }
-        let _ = self.fs.write_file(&path, content.as_bytes()).await;
+
+        if self.history_needs_rewrite || self.history_saved_entries > self.history.len() {
+            let content = format_history_entries(&self.history);
+            let _ = self.fs.write_file(&path, content.as_bytes()).await;
+            self.history_saved_entries = self.history.len();
+            self.history_needs_rewrite = false;
+            return;
+        }
+
+        if self.history_saved_entries < self.history.len() {
+            let content = format_history_entries(&self.history[self.history_saved_entries..]);
+            let _ = self.fs.append_file(&path, content.as_bytes()).await;
+            self.history_saved_entries = self.history.len();
+        }
     }
 
     /// Capture the current shell state (variables, env, cwd, options).
@@ -5549,6 +5630,7 @@ impl Interpreter {
                     namerefs: Arc::make_mut(&mut self.namerefs),
                     call_stack: &self.call_stack,
                     history: &self.history,
+                    limits: &self.limits,
                     jobs: &self.jobs,
                     execution_extensions,
                 };
@@ -5600,6 +5682,7 @@ impl Interpreter {
                 namerefs: Arc::make_mut(&mut self.namerefs),
                 call_stack: &self.call_stack,
                 history: &self.history,
+                limits: &self.limits,
                 jobs: &self.jobs,
                 execution_extensions,
             };
@@ -7954,7 +8037,7 @@ impl Interpreter {
                     }
                 }
                 builtins::BuiltinSideEffect::ClearHistory => {
-                    self.history.clear();
+                    self.clear_history();
                     // Persist immediately so `history -c` is a same-exec sanitization boundary.
                     self.save_history().await;
                 }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1877,20 +1877,34 @@ impl Interpreter {
     }
 
     fn trim_history_to_limits(&mut self) -> bool {
-        let mut trimmed = false;
-        while self.history.len() > self.limits.max_history_entries
-            || self.history_bytes > self.limits.max_history_bytes
+        // Evict oldest-first. Compute how many leading entries to drop for both
+        // the entry-count and byte budgets, then remove them in a single
+        // `drain` instead of repeated `remove(0)` calls (each of which shifts
+        // the whole vector), so trimming a batch is O(n) rather than O(n*k).
+        let len = self.history.len();
+        let mut drop_count = len.saturating_sub(self.limits.max_history_entries);
+        let mut freed_bytes: usize = self.history[..drop_count]
+            .iter()
+            .map(|e| e.retained_bytes())
+            .sum();
+        while drop_count < len
+            && self.history_bytes.saturating_sub(freed_bytes) > self.limits.max_history_bytes
         {
-            if self.history.is_empty() {
-                self.history_bytes = 0;
-                break;
-            }
-            let removed = self.history.remove(0);
-            self.history_bytes = self.history_bytes.saturating_sub(removed.retained_bytes());
-            self.history_saved_entries = self.history_saved_entries.saturating_sub(1);
-            trimmed = true;
+            freed_bytes = freed_bytes.saturating_add(self.history[drop_count].retained_bytes());
+            drop_count += 1;
         }
-        trimmed
+
+        if drop_count == 0 {
+            return false;
+        }
+
+        self.history.drain(..drop_count);
+        self.history_bytes = self.history_bytes.saturating_sub(freed_bytes);
+        self.history_saved_entries = self.history_saved_entries.saturating_sub(drop_count);
+        if self.history.is_empty() {
+            self.history_bytes = 0;
+        }
+        true
     }
 
     /// Set the VFS path for persisting history.
@@ -1965,16 +1979,27 @@ impl Interpreter {
 
         if self.history_needs_rewrite || self.history_saved_entries > self.history.len() {
             let content = format_history_entries(&self.history);
-            let _ = self.fs.write_file(&path, content.as_bytes()).await;
-            self.history_saved_entries = self.history.len();
-            self.history_needs_rewrite = false;
+            // Only advance persistence accounting when the write succeeds. On a
+            // transient FS error keep `history_needs_rewrite` set so the next
+            // save retries a full rewrite instead of silently dropping deltas.
+            if self.fs.write_file(&path, content.as_bytes()).await.is_ok() {
+                self.history_saved_entries = self.history.len();
+                self.history_needs_rewrite = false;
+            } else {
+                self.history_needs_rewrite = true;
+            }
             return;
         }
 
         if self.history_saved_entries < self.history.len() {
             let content = format_history_entries(&self.history[self.history_saved_entries..]);
-            let _ = self.fs.append_file(&path, content.as_bytes()).await;
-            self.history_saved_entries = self.history.len();
+            if self.fs.append_file(&path, content.as_bytes()).await.is_ok() {
+                self.history_saved_entries = self.history.len();
+            } else {
+                // Append failed: force a full rewrite next time so the missed
+                // delta is not lost.
+                self.history_needs_rewrite = true;
+            }
         }
     }
 

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -105,6 +105,19 @@ pub struct ExecutionLimits {
     /// Default: 1024
     pub max_file_descriptors: usize,
 
+    /// Maximum command history entries retained per Bash instance.
+    /// Default: 1,000
+    pub max_history_entries: usize,
+
+    /// Maximum retained command history bytes per Bash instance.
+    /// Counts command and cwd strings, including loaded persisted history.
+    /// Default: 1MB (1,048,576 bytes)
+    pub max_history_bytes: usize,
+
+    /// Maximum bytes formatted by the `history` builtin in one call.
+    /// Default: 1MB (1,048,576 bytes)
+    pub max_history_output_bytes: usize,
+
     /// Whether to capture the final environment state in ExecResult.
     /// Default: false (opt-in to avoid cloning cost when not needed)
     pub capture_final_env: bool,
@@ -127,6 +140,9 @@ impl Default for ExecutionLimits {
             max_subst_depth: 32,
             max_subshell_depth: 32,
             max_file_descriptors: 1024,
+            max_history_entries: 1_000,
+            max_history_bytes: 1_048_576,        // 1MB
+            max_history_output_bytes: 1_048_576, // 1MB
             capture_final_env: false,
         }
     }
@@ -154,6 +170,7 @@ impl ExecutionLimits {
             timeout: Duration::from_secs(u64::MAX / 2), // effectively no timeout
             max_stdout_bytes: 10_485_760,               // 10 MB
             max_stderr_bytes: 10_485_760,               // 10 MB
+            max_history_output_bytes: 10_485_760,       // 10 MB
             ..Self::default()
         }
     }
@@ -252,6 +269,27 @@ impl ExecutionLimits {
     /// A value of 0 is a valid strict limit that prevents custom descriptors.
     pub fn max_file_descriptors(mut self, count: usize) -> Self {
         self.max_file_descriptors = count;
+        self
+    }
+
+    /// Set maximum retained history entries.
+    /// Passing 0 disables history retention.
+    pub fn max_history_entries(mut self, count: usize) -> Self {
+        self.max_history_entries = count;
+        self
+    }
+
+    /// Set maximum retained history bytes.
+    /// Passing 0 disables history retention.
+    pub fn max_history_bytes(mut self, bytes: usize) -> Self {
+        self.max_history_bytes = bytes;
+        self
+    }
+
+    /// Set maximum `history` builtin output bytes.
+    /// Passing 0 makes `history` output empty.
+    pub fn max_history_output_bytes(mut self, bytes: usize) -> Self {
+        self.max_history_output_bytes = bytes;
         self
     }
 
@@ -899,6 +937,9 @@ mod tests {
         assert_eq!(limits.max_stderr_bytes, 1_048_576);
         assert_eq!(limits.max_subst_depth, 32);
         assert_eq!(limits.max_subshell_depth, 32);
+        assert_eq!(limits.max_history_entries, 1_000);
+        assert_eq!(limits.max_history_bytes, 1_048_576);
+        assert_eq!(limits.max_history_output_bytes, 1_048_576);
         assert!(!limits.capture_final_env);
     }
 

--- a/crates/bashkit/tests/integration/history_tests.rs
+++ b/crates/bashkit/tests/integration/history_tests.rs
@@ -359,3 +359,27 @@ async fn history_output_is_capped_without_count() {
         result.stdout
     );
 }
+
+#[tokio::test]
+async fn history_output_is_a_prefix_when_capped() {
+    // With a tight output cap, once a line does not fit, iteration stops — so
+    // the output is a prefix of the full listing and never skips an earlier
+    // (longer) entry to fit a later (shorter) one.
+    let limits = bashkit::ExecutionLimits::new().max_history_output_bytes(40);
+    let mut bash = Bash::builder().limits(limits).build();
+    bash.exec("echo first-entry-is-deliberately-long-aaaaaaaa")
+        .await
+        .unwrap();
+    bash.exec("echo b").await.unwrap();
+
+    let result = bash.exec("history").await.unwrap();
+    // The oldest entry's line exceeds the cap, so iteration stops there. Under
+    // the old behavior the short "echo b" line would have been appended after
+    // skipping the long one; with prefix semantics it must be absent.
+    assert!(
+        !result.stdout.contains("echo b"),
+        "later short entry must not appear once an earlier entry is skipped: {:?}",
+        result.stdout
+    );
+    assert!(result.stdout.len() <= 40);
+}

--- a/crates/bashkit/tests/integration/history_tests.rs
+++ b/crates/bashkit/tests/integration/history_tests.rs
@@ -248,3 +248,114 @@ async fn history_does_not_record_blank_lines() {
     let lines: Vec<&str> = result.stdout.lines().collect();
     assert_eq!(lines.len(), 1, "should only have one entry: {:?}", lines);
 }
+
+#[tokio::test]
+async fn history_caps_entries_by_execution_limits() {
+    let limits = bashkit::ExecutionLimits::new().max_history_entries(2);
+    let mut bash = Bash::builder().limits(limits).build();
+    bash.exec("echo a").await.unwrap();
+    bash.exec("echo b").await.unwrap();
+    bash.exec("echo c").await.unwrap();
+
+    let result = bash.exec("history").await.unwrap();
+    assert!(
+        !result.stdout.contains("echo a"),
+        "oldest entry should be evicted: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("echo b"),
+        "second entry should remain: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("echo c"),
+        "newest entry should remain: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn history_caps_retained_bytes() {
+    let limits = bashkit::ExecutionLimits::new().max_history_bytes(22);
+    let mut bash = Bash::builder().limits(limits).build();
+    bash.exec("echo aaaa").await.unwrap();
+    bash.exec("echo bbbb").await.unwrap();
+    bash.exec("echo cccc").await.unwrap();
+
+    let result = bash.exec("history").await.unwrap();
+    assert!(
+        !result.stdout.contains("echo aaaa"),
+        "oldest bytes should be evicted: {}",
+        result.stdout
+    );
+    assert!(
+        !result.stdout.contains("echo bbbb"),
+        "middle bytes should be evicted: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("echo cccc"),
+        "newest fitting entry should remain: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn history_load_caps_persisted_entries() {
+    use std::sync::Arc;
+
+    let fs = Arc::new(bashkit::InMemoryFs::new());
+    let history_content = concat!(
+        "1700000000|0|10|/home/user|echo one\n",
+        "1700000001|0|10|/home/user|echo two\n",
+        "1700000002|0|10|/home/user|echo three\n",
+    );
+    fs.mkdir(std::path::Path::new("/home/user"), true)
+        .await
+        .unwrap();
+    fs.write_file(
+        std::path::Path::new("/home/user/.bash_history"),
+        history_content.as_bytes(),
+    )
+    .await
+    .unwrap();
+
+    let limits = bashkit::ExecutionLimits::new().max_history_entries(2);
+    let mut bash = Bash::builder()
+        .fs(fs)
+        .limits(limits)
+        .history_file("/home/user/.bash_history")
+        .build();
+    let result = bash.exec("history").await.unwrap();
+    assert!(
+        !result.stdout.contains("echo one"),
+        "loaded history should be capped: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("echo two"),
+        "second persisted entry should remain: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("echo three"),
+        "newest persisted entry should remain: {}",
+        result.stdout
+    );
+}
+
+#[tokio::test]
+async fn history_output_is_capped_without_count() {
+    let limits = bashkit::ExecutionLimits::new().max_history_output_bytes(20);
+    let mut bash = Bash::builder().limits(limits).build();
+    bash.exec("echo alpha").await.unwrap();
+    bash.exec("echo beta").await.unwrap();
+
+    let result = bash.exec("history").await.unwrap();
+    assert!(
+        result.stdout.len() <= 20,
+        "history output should be capped: {}",
+        result.stdout
+    );
+}

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -261,7 +261,6 @@ max_function_depth: 100,      // Runtime recursion (TM-DOS-020, TM-DOS-021)
 max_ast_depth: 100,           // Parser recursion (TM-DOS-022)
 // TM-DOS-021: Child parsers in command/process substitution inherit remaining
 // depth budget and fuel from parent parser (parser/mod.rs lines 1553, 1670)
-<<<<<<< HEAD
 // TM-DOS-026: Arithmetic evaluator tracks recursion depth, capped at 50
 // (interpreter/mod.rs MAX_ARITHMETIC_DEPTH)
 // TM-DOS-026: Arithmetic evaluator tracks recursion depth, capped at 50.
@@ -1401,6 +1400,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-DOS-091 | SQLite `.dump` cumulative output bypass | `.dump` built the full schema+rows string before checking `max_output_bytes`; an attacker controlling many tables/rows could cause memory to grow far beyond the configured output cap | `bounded_append()` helper enforces the cap after each schema line and each INSERT row; `dispatch()` receives the *remaining* budget (`max_output_bytes - stdout.len()`) from `run_statements` — **FIXED** via #1869 |
 | TM-DOS-092 | Subshell snapshot amplification | Deeply nested `( ... )` keeps CoW state snapshots and call-stack clones alive | `max_subshell_depth` counter (default 32) bounds live explicit subshell snapshots | **MITIGATED** |
 | TM-DOS-093 | jq unbounded generator OOM/hang | `jq -n 'repeat(1)'` / `range(0;1e18)` — the jaq result loop appended every value to an in-memory string with no byte/value/deadline cap; jaq's iterator is synchronous so the async execution timeout cannot preempt it. jq is a core builtin (no opt-in gate) | Cap accumulated output at the caller's `max_stdout_bytes` and poll `ExecutionDeadline::is_expired()` every 4096 values, aborting with a clean error (`builtins/jq/mod.rs`) — **FIXED** |
+| TM-DOS-094 | Persistent command history memory DoS | Long-lived Bash instances can retain, serialize, and list unbounded command history across many `exec()` calls | `ExecutionLimits` caps history entries, retained history bytes, and history output bytes; persisted saves append deltas unless compaction is required — **FIXED** |
 
 ### Accepted (Low Priority)
 
@@ -1434,6 +1434,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Execution timeout (30s) | TM-DOS-023 | `limits.rs` | Yes |
 | Builtin output pre-allocation caps | TM-DOS-058, TM-DOS-090 | `limits.rs`, `builtins/shuf.rs` | Yes |
 | Persistent custom fd cap | TM-DOS-063 | `limits.rs`, `interpreter/mod.rs` | Yes |
+| Command history caps | TM-DOS-094 | `limits.rs`, `interpreter/mod.rs`, `builtins/environ.rs` | Yes |
 | Virtual filesystem | TM-ESC-001, TM-ESC-003 | `fs/memory.rs` | Yes |
 | Filesystem limits | TM-DOS-005 to TM-DOS-010, TM-DOS-014 | `fs/limits.rs` | Yes |
 | Path depth limit (100) | TM-DOS-012 | `fs/limits.rs` | Yes |
@@ -1532,6 +1533,9 @@ ExecutionLimits::new()
     .max_input_bytes(10_000_000)       // TM-DOS-001 (10MB)
     .max_ast_depth(100)                // TM-DOS-022 (also inherited by child parsers: TM-DOS-021)
     .max_parser_operations(100_000)    // TM-DOS-024 (also inherited by child parsers: TM-DOS-021)
+    .max_history_entries(1_000)        // TM-DOS-094
+    .max_history_bytes(1_048_576)      // TM-DOS-094
+    .max_history_output_bytes(1_048_576) // TM-DOS-094
 // Note: MAX_ARITHMETIC_DEPTH (50) is a compile-time constant in interpreter (TM-DOS-026)
 // Note: MAX_AWK_PARSER_DEPTH (100) is a compile-time constant in builtins/awk.rs (TM-DOS-027)
 // Note: MAX_JQ_JSON_DEPTH (100) is a compile-time constant in builtins/jq/ (TM-DOS-027)


### PR DESCRIPTION
### Motivation
- The persistent history feature recorded and serialized every executed command without any caps, allowing a long-lived Bash instance to be driven into memory/CPU exhaustion when fed many or large scripts.
- Saving the entire history after every exec and building full filtered vectors in the `history` builtin amplified the problem by repeatedly allocating large `String`/`Vec` buffers.

### Description
- Add three new execution-limit knobs: `max_history_entries`, `max_history_bytes`, and `max_history_output_bytes` in `ExecutionLimits` and builder accessors to tune or disable history retention. (see `crates/bashkit/src/limits.rs`).
- Enforce bounded in-memory history: track retained bytes, reject oversized single entries, trim oldest entries to respect both entry-count and byte budgets, and maintain `history_bytes` accounting (changes in `crates/bashkit/src/interpreter/mod.rs`).
- Make VFS persistence incremental: track how many entries were flushed, append only new entries, and rewrite the full history file only when trimming/clearing forces compaction (changes to `save_history`/`load_history` and helper `format_history_entries`).
- Make `history` builtin streaming/capped: avoid allocating a full filtered `Vec`, produce lines incrementally and stop when `max_history_output_bytes` is reached, and add `append_history_line` helper (changes in `crates/bashkit/src/builtins/environ.rs`).
- Add `HistoryEntry::retained_bytes()` and tests covering entry-count caps, retained-byte caps, persisted-load capping, and output capping (new/updated tests in `crates/bashkit/tests/integration/history_tests.rs`) and update threat model to document the mitigation (`specs/threat-model.md`).

### Testing
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --all-targets -- -D warnings`, both succeeded.
- Ran the history integration test suite with `cargo test -p bashkit --test integration history_tests -- --nocapture`, all tests passed (20 passed, 0 failed).
- Ran unit tests for the history builtin and limits with `cargo test -p bashkit --lib history -- --nocapture` and `cargo test -p bashkit --lib test_default_limits -- --nocapture`, and all targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ae2368832bb4820c9386be7d5d)