### PR TITLE
[superseded by #2032] fix(git): validate pathspecs to prevent repository escape

### DIFF
--- a/crates/bashkit/src/builtins/git/client.rs
+++ b/crates/bashkit/src/builtins/git/client.rs
@@ -11,7 +11,7 @@
 //! Future phases may integrate more deeply with gitoxide for full compatibility.
 
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use crate::error::{Error, Result};
@@ -1075,6 +1075,45 @@ impl GitClient {
         Ok(())
     }
 
+    /// Validate a user pathspec before joining with `repo_path`.
+    ///
+    /// Git inspection commands must never let absolute paths or `..` escape the
+    /// repository root. The VFS normalizes traversal when reading, so reject it
+    /// before constructing any candidate path.
+    fn validate_repo_pathspec(pathspec: &str) -> Result<PathBuf> {
+        let path = Path::new(pathspec);
+        let mut clean = PathBuf::new();
+
+        for component in path.components() {
+            match component {
+                Component::Normal(part) => clean.push(part),
+                Component::CurDir => {}
+                Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                    return Err(Error::Internal(format!(
+                        "fatal: pathspec '{}' is outside repository",
+                        pathspec
+                    )));
+                }
+            }
+        }
+
+        if clean.as_os_str().is_empty() {
+            if pathspec == "." {
+                return Ok(PathBuf::from("."));
+            }
+            return Err(Error::Internal(
+                "fatal: empty pathspec is outside repository".to_string(),
+            ));
+        }
+
+        Ok(clean)
+    }
+
+    fn tracked_file_matches_pathspec(file: &str, pathspec: &Path) -> bool {
+        let file_path = Path::new(file);
+        file_path == pathspec || file_path.starts_with(pathspec)
+    }
+
     /// Create a new branch.
     pub async fn branch_create(
         &self,
@@ -1312,7 +1351,8 @@ impl GitClient {
                     rev
                 )));
             }
-            let file_path = repo_path.join(path);
+            let safe_path = Self::validate_repo_pathspec(path)?;
+            let file_path = repo_path.join(&safe_path);
             if fs.exists(&file_path).await? {
                 let content = fs.read_file(&file_path).await?;
                 // Sanitize file content from VFS (TM-GIT-015)
@@ -1442,7 +1482,8 @@ impl GitClient {
                     let head_content = fs.read_file(&git_dir.join("HEAD")).await?;
                     let head = String::from_utf8_lossy(&head_content);
                     if let Some(branch) = head.trim().strip_prefix("ref: refs/heads/") {
-                        let ref_path = git_dir.join(format!("refs/heads/{}", branch));
+                        Self::validate_ref_name(branch)?;
+                        let ref_path = git_dir.join("refs/heads").join(branch);
                         if fs.exists(&ref_path).await? {
                             let hash = fs.read_file(&ref_path).await?;
                             // Sanitize hash read from ref file (TM-GIT-015)
@@ -1461,7 +1502,13 @@ impl GitClient {
                 }
                 arg => {
                     // Try to resolve as a branch ref
-                    let ref_path = git_dir.join(format!("refs/heads/{}", arg));
+                    Self::validate_ref_name(arg).map_err(|_| {
+                        Error::Internal(format!(
+                            "fatal: ambiguous argument '{}': unknown revision",
+                            arg
+                        ))
+                    })?;
+                    let ref_path = git_dir.join("refs/heads").join(arg);
                     if fs.exists(&ref_path).await? {
                         let hash = fs.read_file(&ref_path).await?;
                         // Sanitize hash read from ref file (TM-GIT-015)
@@ -1596,11 +1643,24 @@ impl GitClient {
             )));
         }
 
-        // Get files to search
+        // Search only tracked paths inside the repository. Explicit pathspecs
+        // filter tracked files; they are never read directly from the VFS.
+        let tracked_files = self.ls_files(fs, repo_path).await?;
         let files = if paths.is_empty() {
-            self.ls_files(fs, repo_path).await?
+            tracked_files
         } else {
-            paths.iter().map(|p| p.to_string()).collect()
+            let pathspecs = paths
+                .iter()
+                .map(|path| Self::validate_repo_pathspec(path))
+                .collect::<Result<Vec<_>>>()?;
+            tracked_files
+                .into_iter()
+                .filter(|file| {
+                    pathspecs
+                        .iter()
+                        .any(|pathspec| Self::tracked_file_matches_pathspec(file, pathspec))
+                })
+                .collect()
         };
 
         let mut output = String::new();
@@ -1638,7 +1698,8 @@ impl GitClient {
             let head_content = fs.read_file(&git_dir.join("HEAD")).await?;
             let head = String::from_utf8_lossy(&head_content);
             if let Some(branch) = head.trim().strip_prefix("ref: refs/heads/") {
-                let ref_path = git_dir.join(format!("refs/heads/{}", branch));
+                Self::validate_ref_name(branch)?;
+                let ref_path = git_dir.join("refs/heads").join(branch);
                 if fs.exists(&ref_path).await? {
                     let hash = fs.read_file(&ref_path).await?;
                     return Ok(String::from_utf8_lossy(&hash).trim().to_string());
@@ -1647,14 +1708,21 @@ impl GitClient {
             return Ok(head.trim().to_string());
         }
 
-        // Try as branch name
-        let ref_path = git_dir.join(format!("refs/heads/{}", refspec));
-        if fs.exists(&ref_path).await? {
-            let hash = fs.read_file(&ref_path).await?;
-            return Ok(String::from_utf8_lossy(&hash).trim().to_string());
+        // Try as branch name. Invalid ref names cannot be resolved via the VFS.
+        if Self::validate_ref_name(refspec).is_ok() {
+            let ref_path = git_dir.join("refs/heads").join(refspec);
+            if fs.exists(&ref_path).await? {
+                let hash = fs.read_file(&ref_path).await?;
+                return Ok(String::from_utf8_lossy(&hash).trim().to_string());
+            }
+        } else if !refspec.chars().all(|ch| ch.is_ascii_hexdigit()) {
+            return Err(Error::Internal(format!(
+                "fatal: ambiguous argument '{}': unknown revision",
+                refspec
+            )));
         }
 
-        // Assume it's a commit hash
+        // Assume hex-looking input is a commit hash or prefix.
         Ok(refspec.to_string())
     }
 }

--- a/crates/bashkit/tests/integration/git_inspection_tests.rs
+++ b/crates/bashkit/tests/integration/git_inspection_tests.rs
@@ -87,6 +87,40 @@ mod show {
         let result = bash.exec("cd /repo && git show").await.unwrap();
         assert_ne!(result.exit_code, 0);
     }
+
+    #[tokio::test]
+    async fn show_file_rejects_absolute_path_outside_repo() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        bash.exec(r#"echo "outside secret" > /secret.txt"#)
+            .await
+            .unwrap();
+
+        let result = bash
+            .exec("cd /repo && git show HEAD:/secret.txt")
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(!result.stdout.contains("outside secret"));
+    }
+
+    #[tokio::test]
+    async fn show_file_rejects_parent_traversal_outside_repo() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        bash.exec(r#"echo "outside secret" > /secret.txt"#)
+            .await
+            .unwrap();
+
+        let result = bash
+            .exec("cd /repo && git show HEAD:../secret.txt")
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(!result.stdout.contains("outside secret"));
+    }
 }
 
 mod ls_files {
@@ -202,6 +236,29 @@ mod rev_parse {
         assert_ne!(result.exit_code, 0);
         assert!(result.stderr.contains("not a git repository"));
     }
+
+    #[tokio::test]
+    async fn branch_ref_rejects_parent_traversal_outside_refs() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        bash.exec(
+            r#"
+cd /repo
+mkdir -p .git/refs
+printf 'outside-secret' > .git/refs/secret
+"#,
+        )
+        .await
+        .unwrap();
+
+        let result = bash
+            .exec("cd /repo && git rev-parse ../secret")
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(!result.stdout.contains("outside-secret"));
+    }
 }
 
 mod restore {
@@ -260,6 +317,29 @@ mod merge_base {
         let result = bash.exec("cd /repo && git merge-base HEAD").await.unwrap();
         assert_ne!(result.exit_code, 0);
     }
+
+    #[tokio::test]
+    async fn merge_base_rejects_parent_traversal_ref() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        bash.exec(
+            r#"
+cd /repo
+mkdir -p .git/refs
+printf 'outside-secret' > .git/refs/secret
+"#,
+        )
+        .await
+        .unwrap();
+
+        let result = bash
+            .exec("cd /repo && git merge-base HEAD ../secret")
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(!result.stdout.contains("outside-secret"));
+    }
 }
 
 mod grep {
@@ -303,5 +383,39 @@ mod grep {
         setup_repo(&mut bash).await;
         let result = bash.exec("cd /repo && git grep").await.unwrap();
         assert_ne!(result.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn grep_rejects_absolute_path_outside_repo() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        bash.exec(r#"echo "outside secret" > /secret.txt"#)
+            .await
+            .unwrap();
+
+        let result = bash
+            .exec("cd /repo && git grep secret /secret.txt")
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(!result.stdout.contains("outside secret"));
+    }
+
+    #[tokio::test]
+    async fn grep_rejects_parent_traversal_outside_repo() {
+        let mut bash = create_git_bash();
+        setup_repo(&mut bash).await;
+        bash.exec(r#"echo "outside secret" > /secret.txt"#)
+            .await
+            .unwrap();
+
+        let result = bash
+            .exec("cd /repo && git grep secret ../secret.txt")
+            .await
+            .unwrap();
+
+        assert_ne!(result.exit_code, 0);
+        assert!(!result.stdout.contains("outside secret"));
     }
 }


### PR DESCRIPTION
### Motivation
- Patch repository-boundary leakage in virtual git inspection commands that allowed absolute paths or `..` to be resolved outside the repo and read from the VFS. 
- Ensure `git show`, `git grep`, `git rev-parse`, and `git merge-base` respect repository containment and do not disclose files mounted elsewhere in the VFS.
- Add regression coverage to prevent future regressions.

### Description
- Add `validate_repo_pathspec` to reject absolute paths, `..`, root/prefix components, and empty pathspecs before composing `repo_path` joins. (`crates/bashkit/src/builtins/git/client.rs`)
- Use validated pathspecs in `git show HEAD:<path>` to ensure only repo-contained files are read. (`show`)
- Restrict `git grep` so explicit pathspecs are validated and applied as filters against the tracked file list rather than being read directly from the VFS. (`grep`)
- Validate ref names via existing `validate_ref_name` before constructing `.git/refs/heads/<name>` paths, and tighten `rev-parse`/`resolve_ref`/`merge-base` logic to refuse traversal-like ref names while still accepting hex-looking commit hashes. (`rev-parse`, `resolve_ref`, `merge-base`)
- Add helper `tracked_file_matches_pathspec` and update tests by adding regression cases covering absolute and parent-traversal attempts for `show`, `grep`, `rev-parse`, and `merge-base`. (`crates/bashkit/tests/integration/git_inspection_tests.rs`)

### Testing
- Ran `cargo fmt --check` and formatting checks passed. 
- Ran integration tests for git: `cargo test -p bashkit --features git --test integration git_inspection_tests -- --nocapture` and all tests (including new regression tests) passed. 
- Ran linting with `cargo clippy -p bashkit --features git --test integration -- -D warnings` and the check completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251b0de70832bad7278b6f6713ae7)