### PR TITLE
fix(builtins): reject zero join fields

### DIFF
--- a/crates/bashkit/src/builtins/join.rs
+++ b/crates/bashkit/src/builtins/join.rs
@@ -44,9 +44,15 @@ impl Builtin for Join {
 
         while !p.is_done() {
             if let Some(val) = p.flag_value_opt("-1") {
-                opts.field1 = val.parse().unwrap_or(1);
+                opts.field1 = match parse_field_number("-1", val) {
+                    Ok(field) => field,
+                    Err(message) => return Ok(ExecResult::err(message, 1)),
+                };
             } else if let Some(val) = p.flag_value_opt("-2") {
-                opts.field2 = val.parse().unwrap_or(1);
+                opts.field2 = match parse_field_number("-2", val) {
+                    Ok(field) => field,
+                    Err(message) => return Ok(ExecResult::err(message, 1)),
+                };
             } else if let Some(val) = p.flag_value_opt("-t") {
                 opts.separator = val.chars().next().unwrap_or(' ');
             } else if let Some(val) = p.flag_value_opt("-a") {
@@ -134,6 +140,14 @@ impl Builtin for Join {
 
         Ok(ExecResult::ok(output))
     }
+}
+
+fn parse_field_number(option: &str, value: &str) -> std::result::Result<usize, String> {
+    let field = value.parse().unwrap_or(1);
+    if field == 0 {
+        return Err(format!("join: invalid field number for {}: 0\n", option));
+    }
+    Ok(field)
 }
 
 async fn read_input(
@@ -236,5 +250,29 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         // "b 2" should appear as unpairable from file1
         assert!(result.stdout.contains("b 2"));
+    }
+
+    #[tokio::test]
+    async fn test_join_rejects_zero_file1_field() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        fs.write_file(Path::new("/f1"), b"a 1").await.unwrap();
+        fs.write_file(Path::new("/f2"), b"a x").await.unwrap();
+
+        let result = run_join(&["-1", "0", "/f1", "/f2"], fs).await;
+
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid field number"));
+    }
+
+    #[tokio::test]
+    async fn test_join_rejects_zero_file2_field() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        fs.write_file(Path::new("/f1"), b"a 1").await.unwrap();
+        fs.write_file(Path::new("/f2"), b"a x").await.unwrap();
+
+        let result = run_join(&["-2", "0", "/f1", "/f2"], fs).await;
+
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid field number"));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent unsigned-underflow panics and DoS risk by rejecting zero-valued numeric options that are used as 1-based indices or sizes.
- `split` zero-value cases were inspected and validated to already return errors for `-l 0`, `-b 0`, and `-n 0` before loops run.
- `join` accepted `-1 0`/`-2 0` and later computed `field - 1`, which can underflow and panic in overflow-checking builds.

### Description
- Add `parse_field_number(option, value)` to validate `-1`/`-2` values and return a readable error string for zero fields.
- Wire `parse_field_number` into the `join` argument parsing and convert its `Err` into an `ExecResult::err` so `join -1 0` / `join -2 0` fail cleanly.
- Add two regression tests `test_join_rejects_zero_file1_field` and `test_join_rejects_zero_file2_field` that assert a nonzero exit code and an "invalid field number" message.
- No behavioural change to valid inputs; `split` already enforces nonzero values and was left unchanged.

### Testing
- Ran `cargo fmt --check` and it passed.
- Ran targeted unit tests `cargo test -p bashkit builtins::join::tests --lib` and `cargo test -p bashkit builtins::split::tests::test_split_zero --lib`, and both passed.
- Ran `cargo clippy -p bashkit --lib -- -D warnings` and it passed.
- Ran full crate unit tests `cargo test -p bashkit --lib` (all tests) and they passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225e3c2660832bbd1c2df16f8bd28b)