### PR TITLE
[superseded by #2031] fix(expand): cap output bytes and reject oversized tab stops

### DIFF
--- a/crates/bashkit/src/builtins/expand.rs
+++ b/crates/bashkit/src/builtins/expand.rs
@@ -2,6 +2,9 @@
 
 use async_trait::async_trait;
 
+use super::limits::{
+    EXPAND_MAX_OUTPUT_BYTES as MAX_OUTPUT_BYTES, EXPAND_MAX_TAB_STOP as MAX_TAB_STOP,
+};
 use super::{Builtin, BuiltinHelper, Context, read_text_file, resolve_path};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
@@ -38,10 +41,16 @@ impl Builtin for Expand {
                     if i >= ctx.args.len() {
                         return Ok(Self::err("option requires an argument -- 't'", 1));
                     }
-                    tab_stops = parse_tab_stops(&ctx.args[i]);
+                    tab_stops = match parse_tab_stops(&ctx.args[i]) {
+                        Ok(stops) => stops,
+                        Err(e) => return Ok(Self::err(e, 1)),
+                    };
                 }
                 s if s.starts_with("-t") && s.len() > 2 => {
-                    tab_stops = parse_tab_stops(&s[2..]);
+                    tab_stops = match parse_tab_stops(&s[2..]) {
+                        Ok(stops) => stops,
+                        Err(e) => return Ok(Self::err(e, 1)),
+                    };
                 }
                 _ => files.push(&ctx.args[i]),
             }
@@ -71,9 +80,13 @@ impl Builtin for Expand {
                 if ch == '\t' {
                     let next_stop = next_tab_stop(col, &tab_stops);
                     let spaces = next_stop - col;
-                    for _ in 0..spaces {
-                        output.push(' ');
+                    if output.len().saturating_add(spaces) > MAX_OUTPUT_BYTES {
+                        return Ok(Self::err(
+                            format!("output exceeds byte limit ({MAX_OUTPUT_BYTES})"),
+                            1,
+                        ));
                     }
+                    output.extend(std::iter::repeat_n(' ', spaces));
                     col = next_stop;
                 } else {
                     output.push(ch);
@@ -126,10 +139,15 @@ impl Builtin for Unexpand {
                     if i >= ctx.args.len() {
                         return Ok(Self::err("option requires an argument -- 't'", 1));
                     }
-                    let parsed_tab_stops = parse_tab_stops(&ctx.args[i]);
-                    if parsed_tab_stops.is_empty() {
-                        return Ok(Self::err(format!("invalid tab size: '{}'", ctx.args[i]), 1));
-                    }
+                    let parsed_tab_stops = match parse_tab_stops(&ctx.args[i]) {
+                        Ok(stops) => stops,
+                        Err(_) => {
+                            return Ok(Self::err(
+                                format!("invalid tab size: '{}'", ctx.args[i]),
+                                1,
+                            ));
+                        }
+                    };
                     tab_stops = parsed_tab_stops;
                     all = true; // -t implies -a
                 }
@@ -227,13 +245,22 @@ impl Builtin for Unexpand {
     }
 }
 
-fn parse_tab_stops(s: &str) -> Vec<usize> {
-    s.split(',')
-        .filter_map(|p| p.trim().parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .collect()
+fn parse_tab_stops(s: &str) -> std::result::Result<Vec<usize>, String> {
+    let mut stops = Vec::new();
+    for part in s.split(',') {
+        let trimmed = part.trim();
+        let Ok(stop) = trimmed.parse::<usize>() else {
+            return Err(format!("invalid tab size: '{s}'"));
+        };
+        if stop == 0 || stop > MAX_TAB_STOP {
+            return Err(format!("invalid tab size: '{s}'"));
+        }
+        stops.push(stop);
+    }
+    if stops.is_empty() {
+        return Err(format!("invalid tab size: '{s}'"));
+    }
+    Ok(stops)
 }
 
 fn next_tab_stop(col: usize, tab_stops: &[usize]) -> usize {
@@ -320,6 +347,24 @@ mod tests {
         let result = run_expand(&["-t", "4"], Some("\thello")).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "    hello");
+    }
+
+    #[tokio::test]
+    async fn test_expand_rejects_oversized_tab_stop() {
+        let result = run_expand(&["-t", "1000000000"], Some("\thello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.stderr, "expand: invalid tab size: '1000000000'\n");
+    }
+
+    #[tokio::test]
+    async fn test_expand_rejects_output_amplification_over_cap() {
+        let input = "\t".repeat((MAX_OUTPUT_BYTES / MAX_TAB_STOP) + 1);
+        let result = run_expand(&["-t", &MAX_TAB_STOP.to_string()], Some(&input)).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(
+            result.stderr,
+            format!("expand: output exceeds byte limit ({MAX_OUTPUT_BYTES})\n")
+        );
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/limits.rs
+++ b/crates/bashkit/src/builtins/limits.rs
@@ -33,6 +33,11 @@ pub(crate) const CURL_MAX_REDIRECTS: u32 = 10;
 /// dirs/pushd/popd: max entries on the directory stack.
 pub(crate) const DIRSTACK_MAX_SIZE: usize = 4096;
 
+/// expand/unexpand: max accepted tab stop width.
+pub(crate) const EXPAND_MAX_TAB_STOP: usize = 10_000;
+/// expand: max output bytes per invocation before interpreter-level truncation.
+pub(crate) const EXPAND_MAX_OUTPUT_BYTES: usize = 1_048_576;
+
 /// mktemp: max name-collision retries before giving up.
 pub(crate) const MKTEMP_MAX_ATTEMPTS: usize = 64;
 


### PR DESCRIPTION
### Motivation
- Prevent a resource-exhaustion DoS where `expand -t N` accepted arbitrarily large `N` and a single `\t` could be expanded into enormous in-memory output.

### Description
- Add per-builtin caps in `crates/bashkit/src/builtins/limits.rs`: `EXPAND_MAX_TAB_STOP` and `EXPAND_MAX_OUTPUT_BYTES`.
- Validate tab-stop arguments by changing `parse_tab_stops` to return `Result<Vec<usize>, String>` and reject `0` or values `> MAX_TAB_STOP`.
- Use validated tab stops in both `expand` and `unexpand`; make `expand` check `output.len()` before appending spaces and return an error when the `EXPAND_MAX_OUTPUT_BYTES` cap would be exceeded, and use `output.extend(std::iter::repeat_n(...))` for efficient appends.
- Add regression tests in `crates/bashkit/src/builtins/expand.rs` that assert rejection of oversized tab stops and rejection when input would amplify output beyond the configured cap.

### Testing
- Ran `cargo fmt --check` (passed).
- Ran targeted tests with `cargo test -p bashkit builtins::expand::tests --lib` and the new/affected expand tests passed (all tests in that suite succeeded).
- Ran `cargo clippy -p bashkit --lib -- -D warnings` (passed).
- Unit test run in the repository showed the new tests passing alongside existing expand/unexpand tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2251ad9320832b9ab8455ad6c4c57e)