### PR TITLE
fix(builtins): bound expand tab expansion

### DIFF
--- a/crates/bashkit/src/builtins/expand.rs
+++ b/crates/bashkit/src/builtins/expand.rs
@@ -2,6 +2,9 @@
 
 use async_trait::async_trait;
 
+use super::limits::{
+    EXPAND_MAX_OUTPUT_BYTES as MAX_OUTPUT_BYTES, EXPAND_MAX_TAB_STOP as MAX_TAB_STOP,
+};
 use super::{Builtin, BuiltinHelper, Context, read_text_file, resolve_path};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
@@ -38,10 +41,16 @@ impl Builtin for Expand {
                     if i >= ctx.args.len() {
                         return Ok(Self::err("option requires an argument -- 't'", 1));
                     }
-                    tab_stops = parse_tab_stops(&ctx.args[i]);
+                    tab_stops = match parse_tab_stops(&ctx.args[i]) {
+                        Ok(stops) => stops,
+                        Err(e) => return Ok(Self::err(e, 1)),
+                    };
                 }
                 s if s.starts_with("-t") && s.len() > 2 => {
-                    tab_stops = parse_tab_stops(&s[2..]);
+                    tab_stops = match parse_tab_stops(&s[2..]) {
+                        Ok(stops) => stops,
+                        Err(e) => return Ok(Self::err(e, 1)),
+                    };
                 }
                 _ => files.push(&ctx.args[i]),
             }
@@ -65,25 +74,45 @@ impl Builtin for Expand {
         };
 
         let mut output = String::new();
-        for line in input.split('\n') {
+        // Use split_terminator to avoid an extra empty segment (and trailing newline) when
+        // input ends with '\n'.
+        for line in input.split_terminator('\n') {
             let mut col = 0;
             for ch in line.chars() {
                 if ch == '\t' {
                     let next_stop = next_tab_stop(col, &tab_stops);
                     let spaces = next_stop - col;
-                    for _ in 0..spaces {
-                        output.push(' ');
+                    if output.len().saturating_add(spaces) > MAX_OUTPUT_BYTES {
+                        return Ok(Self::err(
+                            format!("output exceeds byte limit ({MAX_OUTPUT_BYTES})"),
+                            1,
+                        ));
                     }
+                    output.extend(std::iter::repeat_n(' ', spaces));
                     col = next_stop;
                 } else {
+                    if output.len() >= MAX_OUTPUT_BYTES {
+                        return Ok(Self::err(
+                            format!("output exceeds byte limit ({MAX_OUTPUT_BYTES})"),
+                            1,
+                        ));
+                    }
                     output.push(ch);
                     col += 1;
                 }
             }
+            if output.len() >= MAX_OUTPUT_BYTES {
+                return Ok(Self::err(
+                    format!("output exceeds byte limit ({MAX_OUTPUT_BYTES})"),
+                    1,
+                ));
+            }
             output.push('\n');
         }
 
-        // Remove trailing extra newline from split
+        // Preserve trailing-newline behavior: split_terminator omits the final empty segment
+        // so we only have newlines after actual lines. If the input did NOT end with '\n',
+        // remove the last newline we added.
         if !input.ends_with('\n') && output.ends_with('\n') {
             output.pop();
         }
@@ -126,10 +155,15 @@ impl Builtin for Unexpand {
                     if i >= ctx.args.len() {
                         return Ok(Self::err("option requires an argument -- 't'", 1));
                     }
-                    let parsed_tab_stops = parse_tab_stops(&ctx.args[i]);
-                    if parsed_tab_stops.is_empty() {
-                        return Ok(Self::err(format!("invalid tab size: '{}'", ctx.args[i]), 1));
-                    }
+                    let parsed_tab_stops = match parse_tab_stops(&ctx.args[i]) {
+                        Ok(stops) => stops,
+                        Err(_) => {
+                            return Ok(Self::err(
+                                format!("invalid tab size: '{}'", ctx.args[i]),
+                                1,
+                            ));
+                        }
+                    };
                     tab_stops = parsed_tab_stops;
                     all = true; // -t implies -a
                 }
@@ -227,13 +261,22 @@ impl Builtin for Unexpand {
     }
 }
 
-fn parse_tab_stops(s: &str) -> Vec<usize> {
-    s.split(',')
-        .filter_map(|p| p.trim().parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .collect()
+fn parse_tab_stops(s: &str) -> std::result::Result<Vec<usize>, String> {
+    let mut stops = Vec::new();
+    for part in s.split(',') {
+        let trimmed = part.trim();
+        let Ok(stop) = trimmed.parse::<usize>() else {
+            return Err(format!("invalid tab size: '{s}'"));
+        };
+        if stop == 0 || stop > MAX_TAB_STOP {
+            return Err(format!("invalid tab size: '{s}'"));
+        }
+        stops.push(stop);
+    }
+    if stops.is_empty() {
+        return Err(format!("invalid tab size: '{s}'"));
+    }
+    Ok(stops)
 }
 
 fn next_tab_stop(col: usize, tab_stops: &[usize]) -> usize {
@@ -320,6 +363,31 @@ mod tests {
         let result = run_expand(&["-t", "4"], Some("\thello")).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "    hello");
+    }
+
+    #[tokio::test]
+    async fn test_expand_rejects_oversized_tab_stop() {
+        let result = run_expand(&["-t", "1000000000"], Some("\thello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.stderr, "expand: invalid tab size: '1000000000'\n");
+    }
+
+    #[tokio::test]
+    async fn test_expand_rejects_output_amplification_over_cap() {
+        let input = "\t".repeat((MAX_OUTPUT_BYTES / MAX_TAB_STOP) + 1);
+        let result = run_expand(&["-t", &MAX_TAB_STOP.to_string()], Some(&input)).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(
+            result.stderr,
+            format!("expand: output exceeds byte limit ({MAX_OUTPUT_BYTES})\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unexpand_rejects_oversized_tab_stop() {
+        let result = run_unexpand(&["-t", "1000000000"], Some("        hello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert_eq!(result.stderr, "unexpand: invalid tab size: '1000000000'\n");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/limits.rs
+++ b/crates/bashkit/src/builtins/limits.rs
@@ -39,6 +39,11 @@ pub(crate) const CURL_MAX_REDIRECTS: u32 = 10;
 #[cfg(feature = "http_client")]
 pub(crate) const CURL_MAX_REQUEST_BODY_BYTES: usize = 10_000_000;
 
+/// expand/unexpand: max accepted tab stop width.
+pub(crate) const EXPAND_MAX_TAB_STOP: usize = 10_000;
+/// expand: max output bytes per invocation before interpreter-level truncation.
+pub(crate) const EXPAND_MAX_OUTPUT_BYTES: usize = 1_048_576;
+
 /// dirs/pushd/popd: max entries on the directory stack.
 pub(crate) const DIRSTACK_MAX_SIZE: usize = 4096;
 


### PR DESCRIPTION
Prevent resource-exhaustion DoS where `expand -t N` accepted arbitrarily large `N` or produced unbounded output via tab amplification.

### Changes
- Add `EXPAND_MAX_TAB_STOP` (10,000) and `EXPAND_MAX_OUTPUT_BYTES` (1 MiB) caps in `limits.rs`
- `parse_tab_stops` returns `Result` and rejects `0` or values `> MAX_TAB_STOP`
- Enforce output cap before appending **any** character (not just tab spaces), fixing the gap noted in review
- Use `split_terminator('\n')` to avoid trailing extra newline when input ends with `\n`
- Add regression tests: oversized tab stop rejection (`expand` + `unexpand`), output amplification cap

Replaces #2028 (original branch had orphaned git history).

### Testing
- All 12 expand/unexpand tests pass: `cargo test -p bashkit builtins::expand::tests --lib`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJCd66SbLcxjwzLovzJ2s)_