### PR TITLE
fix(js): prevent ScriptedTool.executeSync deadlock on registered-tool invocation

### DIFF
--- a/crates/bashkit-js/__test__/integration.spec.ts
+++ b/crates/bashkit-js/__test__/integration.spec.ts
@@ -537,6 +537,37 @@ test("integration: async ScriptedTool concurrent execution", async (t) => {
   t.is(second.stdout.trim(), "second:two");
 });
 
+test("integration: ScriptedTool executeSync returns error instead of deadlocking", (t) => {
+  let invoked = false;
+  const tool = new ScriptedTool({ name: "sync_guard" });
+  tool.addTool("ping", "Ping callback", () => {
+    invoked = true;
+    return "pong\n";
+  });
+
+  const result = tool.executeSync("ping");
+  t.is(result.exitCode, 1);
+  t.false(invoked, "JS callback must not run when the event loop is blocked");
+  t.regex(
+    result.stderr,
+    /ping: registered tools require execute\(\) \(async\)/,
+  );
+});
+
+test("integration: ScriptedTool executeSyncOrThrow throws instead of deadlocking", (t) => {
+  let invoked = false;
+  const tool = new ScriptedTool({ name: "sync_throw_guard" });
+  tool.addTool("ping", "Ping callback", () => {
+    invoked = true;
+    return "pong\n";
+  });
+
+  t.throws(() => tool.executeSyncOrThrow("ping"), {
+    instanceOf: BashError,
+  });
+  t.false(invoked);
+});
+
 // ============================================================================
 // ExecResult contract
 // ============================================================================

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -2670,7 +2670,7 @@ impl ScriptedTool {
             let callback = move |args: &ToolArgs| -> Result<String, String> {
                 if in_sync_execute_depth.load(Ordering::SeqCst) > 0 {
                     return Err(format!(
-                        "{}: {}",
+                        "{}: {}\n",
                         tool_name, SYNC_SCRIPTED_TOOL_DEADLOCK_ERROR
                     ));
                 }
@@ -2698,8 +2698,8 @@ impl ScriptedTool {
                             // Sanitize JS callback errors here — don't let exception
                             // details (paths, connection strings, stack traces) leak
                             // into script stderr. Only the generic form passes through.
-                            .map_err(|_| format!("{}: callback failed", tool_name_clone)),
-                        Err(_) => Err(format!("{}: semaphore error", tool_name_clone)),
+                            .map_err(|_| format!("{}: callback failed\n", tool_name_clone)),
+                        Err(_) => Err(format!("{}: semaphore error\n", tool_name_clone)),
                     };
                     let _ = tx.send(result);
                 });

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -76,6 +76,11 @@ const ON_OUTPUT_REENTRY_ERROR: &str = "onOutput cannot re-enter the same Bash in
 // so the user sees a real error and can migrate to async execute().
 const SYNC_BUILTIN_DEADLOCK_ERROR: &str = "custom builtins require execute() (async). executeSync() would deadlock because the JS event loop is blocked while the synchronous call is in flight";
 
+// Decision: ScriptedTool tool callbacks also dispatch through Node's event
+// loop. Reject registered-tool execution from executeSync before queueing the
+// callback so untrusted scripts cannot hang the process indefinitely.
+const SYNC_SCRIPTED_TOOL_DEADLOCK_ERROR: &str = "registered tools require execute() (async). executeSync() would deadlock because the JS event loop is blocked while the synchronous call is in flight";
+
 struct OnOutputReentryScope {
     depth: Arc<AtomicUsize>,
 }
@@ -2451,6 +2456,10 @@ struct JsToolEntry {
     /// Wrapped in Arc so we can share references with Rust ScriptedTool callbacks
     /// (ThreadsafeFunction doesn't implement Clone).
     callback: Arc<ToolTsfn>,
+    /// Shared depth counter incremented by ScriptedTool.executeSync. Non-zero
+    /// means the Node event loop is blocked by native sync execution, so the
+    /// TSFN callback would never run.
+    in_sync_execute_depth: Arc<AtomicUsize>,
 }
 
 /// Compose JS callbacks as bash builtins for multi-tool orchestration.
@@ -2466,6 +2475,7 @@ pub struct ScriptedTool {
     rt: Mutex<tokio::runtime::Runtime>,
     max_commands: Option<u32>,
     max_loop_iterations: Option<u32>,
+    in_sync_execute_depth: Arc<AtomicUsize>,
 }
 
 #[napi]
@@ -2485,6 +2495,7 @@ impl ScriptedTool {
             rt: Mutex::new(rt),
             max_commands: options.max_commands,
             max_loop_iterations: options.max_loop_iterations,
+            in_sync_execute_depth: Arc::new(AtomicUsize::new(0)),
         })
     }
 
@@ -2518,6 +2529,7 @@ impl ScriptedTool {
             description,
             schema: schema_val,
             callback: Arc::new(tsfn),
+            in_sync_execute_depth: self.in_sync_execute_depth.clone(),
         });
         Ok(())
     }
@@ -2531,6 +2543,7 @@ impl ScriptedTool {
     /// Execute a bash script synchronously.
     #[napi]
     pub fn execute_sync(&self, commands: String) -> napi::Result<ExecResult> {
+        let _sync_scope = SyncExecuteScope::enter(self.in_sync_execute_depth.clone());
         let tool = self.build_rust_tool();
         let rt_guard = self.rt.blocking_lock();
         let resp = rt_guard.block_on(async move {
@@ -2641,6 +2654,10 @@ impl ScriptedTool {
     fn build_rust_tool(&self) -> RustScriptedTool {
         let mut builder = RustScriptedTool::builder(&self.name);
 
+        // sanitize_errors(false): JS callback errors are already sanitized inside
+        // the closure below; this setting lets the trusted deadlock message pass through.
+        builder = builder.sanitize_errors(false);
+
         if let Some(ref desc) = self.short_desc {
             builder = builder.short_description(desc);
         }
@@ -2648,8 +2665,16 @@ impl ScriptedTool {
         for entry in &self.tools {
             let tsfn = entry.callback.clone();
             let tool_name = entry.name.clone();
+            let in_sync_execute_depth = entry.in_sync_execute_depth.clone();
 
             let callback = move |args: &ToolArgs| -> Result<String, String> {
+                if in_sync_execute_depth.load(Ordering::SeqCst) > 0 {
+                    return Err(format!(
+                        "{}: {}",
+                        tool_name, SYNC_SCRIPTED_TOOL_DEADLOCK_ERROR
+                    ));
+                }
+
                 // Serialize params + stdin as JSON for the JS callback
                 let request = serde_json::json!({
                     "params": args.params,
@@ -2670,8 +2695,11 @@ impl ScriptedTool {
                         Ok(_permit) => tsfn_clone
                             .call_async((request_str,))
                             .await
-                            .map_err(|e| format!("{}: {}", tool_name_clone, e)),
-                        Err(e) => Err(format!("{}: semaphore error: {}", tool_name_clone, e)),
+                            // Sanitize JS callback errors here — don't let exception
+                            // details (paths, connection strings, stack traces) leak
+                            // into script stderr. Only the generic form passes through.
+                            .map_err(|_| format!("{}: callback failed", tool_name_clone)),
+                        Err(_) => Err(format!("{}: semaphore error", tool_name_clone)),
                     };
                     let _ = tx.send(result);
                 });

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -1636,10 +1636,10 @@ export class ScriptedTool {
    * Execute a bash script synchronously.
    *
    * Note: ScriptedTool callbacks run asynchronously via Node's event loop.
-   * This method will deadlock if any registered tool callback is invoked.
-   * Use `execute()` (async) instead for scripts that call registered tools.
-   * Only use this for scripts that don't invoke any registered tools
-   * (e.g., pure bash without tool calls).
+   * If a registered tool is invoked, this method returns a non-zero result
+   * instead of queueing a callback that would deadlock. Use `execute()`
+   * (async) for scripts that call registered tools. Only use this for scripts
+   * that don't invoke any registered tools (e.g., pure bash).
    */
   executeSync(commands: string): ExecResult {
     return this.native.executeSync(commands);
@@ -1658,7 +1658,8 @@ export class ScriptedTool {
   /**
    * Execute synchronously. Throws `BashError` on non-zero exit.
    *
-   * Same caveats as `executeSync()` — use `executeOrThrow()` instead.
+   * Same caveats as `executeSync()` — throws when a registered tool would
+   * require the blocked Node event loop. Use `executeOrThrow()` instead.
    */
   executeSyncOrThrow(commands: string): ExecResult {
     const result = this.native.executeSync(commands);


### PR DESCRIPTION
## Summary

- Track `executeSync` call depth via `AtomicUsize` shared across all registered tool entries
- Check depth at callback entry point: if the JS event loop is blocked, return a clear error immediately instead of queuing a TSFN call that would never resolve
- Sanitize JS callback errors inside the closure so `sanitize_errors(false)` only exposes the trusted deadlock message, not arbitrary JS exception details
- Add integration tests verifying `executeSync` returns exit 1 with the deadlock message and `executeSyncOrThrow` throws `BashError`
- Update `wrapper.ts` JSDoc to document the non-deadlock behavior

## Test plan

- [ ] `integration: ScriptedTool executeSync returns error instead of deadlocking` passes
- [ ] `integration: ScriptedTool executeSyncOrThrow throws instead of deadlocking` passes
- [ ] Existing `async ScriptedTool` tests continue to pass
- [ ] `cargo clippy` and `cargo fmt` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJCd66SbLcxjwzLovzJ2s)_