### PR TITLE
fix(find): enforce 1 MiB output cap for -printf and default output

### DIFF
--- a/crates/bashkit/src/builtins/limits.rs
+++ b/crates/bashkit/src/builtins/limits.rs
@@ -42,6 +42,9 @@ pub(crate) const CURL_MAX_REQUEST_BODY_BYTES: usize = 10_000_000;
 /// dirs/pushd/popd: max entries on the directory stack.
 pub(crate) const DIRSTACK_MAX_SIZE: usize = 4096;
 
+/// find: total stdout cap for default and `-printf` output.
+pub(crate) const FIND_MAX_OUTPUT_BYTES: usize = 1_048_576;
+
 /// mktemp: max name-collision retries before giving up.
 pub(crate) const MKTEMP_MAX_ATTEMPTS: usize = 64;
 

--- a/crates/bashkit/src/builtins/ls/find.rs
+++ b/crates/bashkit/src/builtins/ls/find.rs
@@ -271,7 +271,12 @@ async fn collect_find_plan_data(
             had_error = true;
             continue;
         }
-        if let Err(e) = find_recursive(ctx, &path, path_str, &temp_opts, 0, &mut output).await {
+        // Exec planning collects the full match set; an output cap would
+        // silently drop entries and run `-exec` on a partial list, so this
+        // pass is uncapped.
+        if let Err(e) =
+            find_recursive(ctx, &path, path_str, &temp_opts, 0, &mut output, usize::MAX).await
+        {
             errors.push_str(&format!("find: '{}': {}\n", path_str, e));
             had_error = true;
         }
@@ -373,12 +378,24 @@ impl Builtin for Find {
                 continue;
             }
 
-            if let Err(e) = find_recursive(&ctx, &path, path_str, &opts, 0, &mut output).await {
-                // Output-cap errors are reported as "find: <message>" (no path
+            if let Err(e) = find_recursive(
+                &ctx,
+                &path,
+                path_str,
+                &opts,
+                0,
+                &mut output,
+                FIND_MAX_OUTPUT_BYTES,
+            )
+            .await
+            {
+                // The output-cap error is reported as "find: <message>" (no path
                 // context) to avoid a double prefix. All other errors include
                 // the search path for context.
-                let msg = match e {
-                    crate::error::Error::Execution(ref s) => format!("find: {}\n", s),
+                let msg = match &e {
+                    crate::error::Error::Execution(s) if s == OUTPUT_CAP_MSG => {
+                        format!("find: {s}\n")
+                    }
                     _ => format!("find: '{}': {}\n", path_str, e),
                 };
                 errors.push_str(&msg);
@@ -437,6 +454,7 @@ fn find_recursive<'a>(
     opts: &'a FindOptions,
     current_depth: usize,
     output: &'a mut String,
+    output_cap: usize,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
     Box::pin(async move {
         // Check if this entry matches
@@ -490,12 +508,12 @@ fn find_recursive<'a>(
         // Output if matches (or if no filters, show everything)
         if type_matches && name_matches && path_matches && above_min_depth {
             if let Some(ref fmt) = opts.printf_format {
-                find_printf_format(fmt, display_path, &metadata, output)?;
+                find_printf_format(fmt, display_path, &metadata, output, output_cap)?;
             } else {
                 // Append path and terminator atomically: both must fit or neither is
                 // written, so callers never see a partial final line.
                 let terminator = if opts.print0 { "\0" } else { "\n" };
-                push_find_line(output, display_path, terminator)?;
+                push_find_line(output, display_path, terminator, output_cap)?;
             }
         }
 
@@ -527,6 +545,7 @@ fn find_recursive<'a>(
                     opts,
                     current_depth + 1,
                     output,
+                    output_cap,
                 )
                 .await?;
             }
@@ -536,37 +555,37 @@ fn find_recursive<'a>(
     })
 }
 
-/// Append `value` to `output`, returning an error if the total would exceed
-/// `FIND_MAX_OUTPUT_BYTES`. Used by `-printf` format expansion.
-fn push_find_output(output: &mut String, value: &str) -> crate::error::Result<()> {
-    if output.len() + value.len() > FIND_MAX_OUTPUT_BYTES {
-        return Err(crate::error::Error::Execution(
-            "output size limit exceeded".to_string(),
-        ));
+const OUTPUT_CAP_MSG: &str = "output size limit exceeded";
+
+/// Append `value` to `output`, returning an error if the total would exceed `cap`.
+fn push_find_output(output: &mut String, value: &str, cap: usize) -> crate::error::Result<()> {
+    if output.len() + value.len() > cap {
+        return Err(crate::error::Error::Execution(OUTPUT_CAP_MSG.to_string()));
     }
     output.push_str(value);
     Ok(())
 }
 
-/// Append a single char to `output`, respecting `FIND_MAX_OUTPUT_BYTES`.
-fn push_find_char(output: &mut String, value: char) -> crate::error::Result<()> {
-    if output.len() + value.len_utf8() > FIND_MAX_OUTPUT_BYTES {
-        return Err(crate::error::Error::Execution(
-            "output size limit exceeded".to_string(),
-        ));
+/// Append a single char to `output`, returning an error if the total would exceed `cap`.
+fn push_find_char(output: &mut String, value: char, cap: usize) -> crate::error::Result<()> {
+    if output.len() + value.len_utf8() > cap {
+        return Err(crate::error::Error::Execution(OUTPUT_CAP_MSG.to_string()));
     }
     output.push(value);
     Ok(())
 }
 
-/// Atomically append `path` + `terminator` to `output`.
+/// Atomically append `path` + `terminator` to `output`, respecting `cap`.
 /// Both are written together or neither is, so callers never see a partial line.
-fn push_find_line(output: &mut String, path: &str, terminator: &str) -> crate::error::Result<()> {
+fn push_find_line(
+    output: &mut String,
+    path: &str,
+    terminator: &str,
+    cap: usize,
+) -> crate::error::Result<()> {
     let needed = path.len() + terminator.len();
-    if output.len() + needed > FIND_MAX_OUTPUT_BYTES {
-        return Err(crate::error::Error::Execution(
-            "output size limit exceeded".to_string(),
-        ));
+    if output.len() + needed > cap {
+        return Err(crate::error::Error::Execution(OUTPUT_CAP_MSG.to_string()));
     }
     output.push_str(path);
     output.push_str(terminator);
@@ -579,37 +598,40 @@ fn find_printf_format(
     display_path: &str,
     metadata: &crate::fs::Metadata,
     output: &mut String,
+    cap: usize,
 ) -> crate::error::Result<()> {
     let mut chars = fmt.chars().peekable();
     while let Some(ch) = chars.next() {
         match ch {
             '\\' => match chars.next() {
-                Some('n') => push_find_char(output, '\n')?,
-                Some('t') => push_find_char(output, '\t')?,
-                Some('0') => push_find_char(output, '\0')?,
-                Some('\\') => push_find_char(output, '\\')?,
+                Some('n') => push_find_char(output, '\n', cap)?,
+                Some('t') => push_find_char(output, '\t', cap)?,
+                Some('0') => push_find_char(output, '\0', cap)?,
+                Some('\\') => push_find_char(output, '\\', cap)?,
                 Some(c) => {
-                    push_find_char(output, '\\')?;
-                    push_find_char(output, c)?;
+                    push_find_char(output, '\\', cap)?;
+                    push_find_char(output, c, cap)?;
                 }
                 None => {}
             },
             '%' => match chars.next() {
-                None => push_find_char(output, '%')?,
+                None => push_find_char(output, '%', cap)?,
                 Some('f') => {
                     let name = std::path::Path::new(display_path)
                         .file_name()
                         .map(|s| s.to_string_lossy().to_string())
                         .unwrap_or_else(|| display_path.to_string());
-                    push_find_output(output, &name)?;
+                    push_find_output(output, &name, cap)?;
                 }
-                Some('p') => push_find_output(output, display_path)?,
+                Some('p') => push_find_output(output, display_path, cap)?,
                 Some('P') => {
                     let rel = display_path.strip_prefix("./").unwrap_or(display_path);
-                    push_find_output(output, rel)?;
+                    push_find_output(output, rel, cap)?;
                 }
-                Some('s') => push_find_output(output, &metadata.size.to_string())?,
-                Some('m') => push_find_output(output, &format!("{:o}", metadata.mode & 0o7777))?,
+                Some('s') => push_find_output(output, &metadata.size.to_string(), cap)?,
+                Some('m') => {
+                    push_find_output(output, &format!("{:o}", metadata.mode & 0o7777), cap)?
+                }
                 Some('M') => {
                     let type_ch = if metadata.file_type.is_dir() {
                         'd'
@@ -618,12 +640,12 @@ fn find_printf_format(
                     } else {
                         '-'
                     };
-                    push_find_char(output, type_ch)?;
+                    push_find_char(output, type_ch, cap)?;
                     for shift in [6u32, 3, 0] {
                         let bits = (metadata.mode >> shift) & 7;
-                        push_find_char(output, if bits & 4 != 0 { 'r' } else { '-' })?;
-                        push_find_char(output, if bits & 2 != 0 { 'w' } else { '-' })?;
-                        push_find_char(output, if bits & 1 != 0 { 'x' } else { '-' })?;
+                        push_find_char(output, if bits & 4 != 0 { 'r' } else { '-' }, cap)?;
+                        push_find_char(output, if bits & 2 != 0 { 'w' } else { '-' }, cap)?;
+                        push_find_char(output, if bits & 1 != 0 { 'x' } else { '-' }, cap)?;
                     }
                 }
                 Some('y') => {
@@ -634,7 +656,7 @@ fn find_printf_format(
                     } else {
                         'f'
                     };
-                    push_find_char(output, ch)?;
+                    push_find_char(output, ch, cap)?;
                 }
                 Some('d') => {
                     let base = display_path.strip_prefix("./").unwrap_or(display_path);
@@ -643,7 +665,7 @@ fn find_printf_format(
                     } else {
                         base.matches('/').count() + 1
                     };
-                    push_find_output(output, &depth.to_string())?;
+                    push_find_output(output, &depth.to_string(), cap)?;
                 }
                 Some('T') => {
                     if chars.peek() == Some(&'@') {
@@ -654,18 +676,18 @@ fn find_printf_format(
                             .ok()
                             .map(|d| d.as_secs())
                             .unwrap_or(0);
-                        push_find_output(output, &secs.to_string())?;
+                        push_find_output(output, &secs.to_string(), cap)?;
                     } else {
-                        push_find_output(output, "%T")?;
+                        push_find_output(output, "%T", cap)?;
                     }
                 }
-                Some('%') => push_find_char(output, '%')?,
+                Some('%') => push_find_char(output, '%', cap)?,
                 Some(c) => {
-                    push_find_char(output, '%')?;
-                    push_find_char(output, c)?;
+                    push_find_char(output, '%', cap)?;
+                    push_find_char(output, c, cap)?;
                 }
             },
-            c => push_find_char(output, c)?,
+            c => push_find_char(output, c, cap)?,
         }
     }
     Ok(())

--- a/crates/bashkit/src/builtins/ls/find.rs
+++ b/crates/bashkit/src/builtins/ls/find.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use std::path::Path;
 
 use super::glob_match;
+use crate::builtins::limits::FIND_MAX_OUTPUT_BYTES;
 use crate::builtins::{Builtin, Context, ExecutionPlan, SubCommand, resolve_path};
 use crate::error::Result;
 use crate::interpreter::{ControlFlow, ExecResult};
@@ -373,7 +374,14 @@ impl Builtin for Find {
             }
 
             if let Err(e) = find_recursive(&ctx, &path, path_str, &opts, 0, &mut output).await {
-                errors.push_str(&format!("find: '{}': {}\n", path_str, e));
+                // Output-cap errors are reported as "find: <message>" (no path
+                // context) to avoid a double prefix. All other errors include
+                // the search path for context.
+                let msg = match e {
+                    crate::error::Error::Execution(ref s) => format!("find: {}\n", s),
+                    _ => format!("find: '{}': {}\n", path_str, e),
+                };
+                errors.push_str(&msg);
                 had_error = true;
             }
         }
@@ -482,10 +490,12 @@ fn find_recursive<'a>(
         // Output if matches (or if no filters, show everything)
         if type_matches && name_matches && path_matches && above_min_depth {
             if let Some(ref fmt) = opts.printf_format {
-                output.push_str(&find_printf_format(fmt, display_path, &metadata));
+                find_printf_format(fmt, display_path, &metadata, output)?;
             } else {
-                output.push_str(display_path);
-                output.push(if opts.print0 { '\0' } else { '\n' });
+                // Append path and terminator atomically: both must fit or neither is
+                // written, so callers never see a partial final line.
+                let terminator = if opts.print0 { "\0" } else { "\n" };
+                push_find_line(output, display_path, terminator)?;
             }
         }
 
@@ -526,111 +536,138 @@ fn find_recursive<'a>(
     })
 }
 
-/// Format a path using find's -printf format string.
-fn find_printf_format(fmt: &str, display_path: &str, metadata: &crate::fs::Metadata) -> String {
-    let mut out = String::new();
-    let chars: Vec<char> = fmt.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        match chars[i] {
-            '\\' => {
-                i += 1;
-                if i < chars.len() {
-                    match chars[i] {
-                        'n' => out.push('\n'),
-                        't' => out.push('\t'),
-                        '0' => out.push('\0'),
-                        '\\' => out.push('\\'),
-                        c => {
-                            out.push('\\');
-                            out.push(c);
-                        }
-                    }
-                }
-            }
-            '%' => {
-                i += 1;
-                if i >= chars.len() {
-                    out.push('%');
-                    continue;
-                }
-                match chars[i] {
-                    'f' => {
-                        let name = std::path::Path::new(display_path)
-                            .file_name()
-                            .map(|s| s.to_string_lossy().to_string())
-                            .unwrap_or_else(|| display_path.to_string());
-                        out.push_str(&name);
-                    }
-                    'p' => out.push_str(display_path),
-                    'P' => {
-                        // In builtin context, display_path is already relative
-                        let rel = display_path.strip_prefix("./").unwrap_or(display_path);
-                        out.push_str(rel);
-                    }
-                    's' => out.push_str(&metadata.size.to_string()),
-                    'm' => out.push_str(&format!("{:o}", metadata.mode & 0o7777)),
-                    'M' => {
-                        let type_ch = if metadata.file_type.is_dir() {
-                            'd'
-                        } else if metadata.file_type.is_symlink() {
-                            'l'
-                        } else {
-                            '-'
-                        };
-                        out.push(type_ch);
-                        for shift in [6, 3, 0] {
-                            let bits = (metadata.mode >> shift) & 7;
-                            out.push(if bits & 4 != 0 { 'r' } else { '-' });
-                            out.push(if bits & 2 != 0 { 'w' } else { '-' });
-                            out.push(if bits & 1 != 0 { 'x' } else { '-' });
-                        }
-                    }
-                    'y' => {
-                        let ch = if metadata.file_type.is_dir() {
-                            'd'
-                        } else if metadata.file_type.is_symlink() {
-                            'l'
-                        } else {
-                            'f'
-                        };
-                        out.push(ch);
-                    }
-                    'd' => {
-                        // Approximate depth from display_path
-                        let base = display_path.strip_prefix("./").unwrap_or(display_path);
-                        let depth = if base == "." || base.is_empty() {
-                            0
-                        } else {
-                            base.matches('/').count() + 1
-                        };
-                        out.push_str(&depth.to_string());
-                    }
-                    'T' => {
-                        i += 1;
-                        if i < chars.len() && chars[i] == '@' {
-                            let secs = metadata
-                                .modified
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .ok()
-                                .map(|d| d.as_secs())
-                                .unwrap_or(0);
-                            out.push_str(&secs.to_string());
-                        } else {
-                            out.push_str("%T");
-                            continue;
-                        }
-                    }
-                    '%' => out.push('%'),
-                    c => {
-                        out.push('%');
-                        out.push(c);
-                    }
-                }
-            }
-            c => out.push(c),
-        }
-        i += 1;
+/// Append `value` to `output`, returning an error if the total would exceed
+/// `FIND_MAX_OUTPUT_BYTES`. Used by `-printf` format expansion.
+fn push_find_output(output: &mut String, value: &str) -> crate::error::Result<()> {
+    if output.len() + value.len() > FIND_MAX_OUTPUT_BYTES {
+        return Err(crate::error::Error::Execution(
+            "output size limit exceeded".to_string(),
+        ));
     }
-    out
+    output.push_str(value);
+    Ok(())
+}
+
+/// Append a single char to `output`, respecting `FIND_MAX_OUTPUT_BYTES`.
+fn push_find_char(output: &mut String, value: char) -> crate::error::Result<()> {
+    if output.len() + value.len_utf8() > FIND_MAX_OUTPUT_BYTES {
+        return Err(crate::error::Error::Execution(
+            "output size limit exceeded".to_string(),
+        ));
+    }
+    output.push(value);
+    Ok(())
+}
+
+/// Atomically append `path` + `terminator` to `output`.
+/// Both are written together or neither is, so callers never see a partial line.
+fn push_find_line(output: &mut String, path: &str, terminator: &str) -> crate::error::Result<()> {
+    let needed = path.len() + terminator.len();
+    if output.len() + needed > FIND_MAX_OUTPUT_BYTES {
+        return Err(crate::error::Error::Execution(
+            "output size limit exceeded".to_string(),
+        ));
+    }
+    output.push_str(path);
+    output.push_str(terminator);
+    Ok(())
+}
+
+/// Format a path using find's -printf format string.
+fn find_printf_format(
+    fmt: &str,
+    display_path: &str,
+    metadata: &crate::fs::Metadata,
+    output: &mut String,
+) -> crate::error::Result<()> {
+    let mut chars = fmt.chars().peekable();
+    loop {
+        let Some(ch) = chars.next() else { break };
+        match ch {
+            '\\' => match chars.next() {
+                Some('n') => push_find_char(output, '\n')?,
+                Some('t') => push_find_char(output, '\t')?,
+                Some('0') => push_find_char(output, '\0')?,
+                Some('\\') => push_find_char(output, '\\')?,
+                Some(c) => {
+                    push_find_char(output, '\\')?;
+                    push_find_char(output, c)?;
+                }
+                None => {}
+            },
+            '%' => match chars.next() {
+                None => push_find_char(output, '%')?,
+                Some('f') => {
+                    let name = std::path::Path::new(display_path)
+                        .file_name()
+                        .map(|s| s.to_string_lossy().to_string())
+                        .unwrap_or_else(|| display_path.to_string());
+                    push_find_output(output, &name)?;
+                }
+                Some('p') => push_find_output(output, display_path)?,
+                Some('P') => {
+                    let rel = display_path.strip_prefix("./").unwrap_or(display_path);
+                    push_find_output(output, rel)?;
+                }
+                Some('s') => push_find_output(output, &metadata.size.to_string())?,
+                Some('m') => push_find_output(output, &format!("{:o}", metadata.mode & 0o7777))?,
+                Some('M') => {
+                    let type_ch = if metadata.file_type.is_dir() {
+                        'd'
+                    } else if metadata.file_type.is_symlink() {
+                        'l'
+                    } else {
+                        '-'
+                    };
+                    push_find_char(output, type_ch)?;
+                    for shift in [6u32, 3, 0] {
+                        let bits = (metadata.mode >> shift) & 7;
+                        push_find_char(output, if bits & 4 != 0 { 'r' } else { '-' })?;
+                        push_find_char(output, if bits & 2 != 0 { 'w' } else { '-' })?;
+                        push_find_char(output, if bits & 1 != 0 { 'x' } else { '-' })?;
+                    }
+                }
+                Some('y') => {
+                    let ch = if metadata.file_type.is_dir() {
+                        'd'
+                    } else if metadata.file_type.is_symlink() {
+                        'l'
+                    } else {
+                        'f'
+                    };
+                    push_find_char(output, ch)?;
+                }
+                Some('d') => {
+                    let base = display_path.strip_prefix("./").unwrap_or(display_path);
+                    let depth = if base == "." || base.is_empty() {
+                        0
+                    } else {
+                        base.matches('/').count() + 1
+                    };
+                    push_find_output(output, &depth.to_string())?;
+                }
+                Some('T') => {
+                    if chars.peek() == Some(&'@') {
+                        chars.next();
+                        let secs = metadata
+                            .modified
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .ok()
+                            .map(|d| d.as_secs())
+                            .unwrap_or(0);
+                        push_find_output(output, &secs.to_string())?;
+                    } else {
+                        push_find_output(output, "%T")?;
+                    }
+                }
+                Some('%') => push_find_char(output, '%')?,
+                Some(c) => {
+                    push_find_char(output, '%')?;
+                    push_find_char(output, c)?;
+                }
+            },
+            c => push_find_char(output, c)?,
+        }
+    }
+    Ok(())
 }

--- a/crates/bashkit/src/builtins/ls/find.rs
+++ b/crates/bashkit/src/builtins/ls/find.rs
@@ -581,8 +581,7 @@ fn find_printf_format(
     output: &mut String,
 ) -> crate::error::Result<()> {
     let mut chars = fmt.chars().peekable();
-    loop {
-        let Some(ch) = chars.next() else { break };
+    while let Some(ch) = chars.next() {
         match ch {
             '\\' => match chars.next() {
                 Some('n') => push_find_char(output, '\n')?,

--- a/crates/bashkit/src/builtins/ls/tests.rs
+++ b/crates/bashkit/src/builtins/ls/tests.rs
@@ -2654,8 +2654,8 @@ async fn test_find_printf_rejects_oversized_single_entry_output() {
         "should fail when printf output exceeds cap"
     );
     assert!(
-        result.stderr.contains("output size limit exceeded") || result.stderr.contains("find:"),
-        "stderr should report the limit: {}",
+        result.stderr.contains("find: output size limit exceeded"),
+        "stderr should report the limit with prefix: {}",
         result.stderr
     );
     assert!(
@@ -2696,8 +2696,8 @@ async fn test_find_printf_rejects_oversized_aggregate_output() {
     let result = Find.execute(ctx).await.unwrap();
     assert_eq!(result.exit_code, 1, "aggregate output should hit cap");
     assert!(
-        result.stderr.contains("output size limit exceeded") || result.stderr.contains("find:"),
-        "stderr should report the limit: {}",
+        result.stderr.contains("find: output size limit exceeded"),
+        "stderr should report the limit with prefix: {}",
         result.stderr
     );
     assert!(

--- a/crates/bashkit/src/builtins/ls/tests.rs
+++ b/crates/bashkit/src/builtins/ls/tests.rs
@@ -4,6 +4,7 @@ use super::find::{Find, build_find_exec_commands, parse_find_args};
 use super::glob_match;
 use super::list::Ls;
 use super::rmdir::Rmdir;
+use crate::builtins::limits::FIND_MAX_OUTPUT_BYTES;
 use crate::builtins::{Builtin, Context, ExecutionPlan};
 
 use std::collections::HashMap;
@@ -2617,4 +2618,91 @@ async fn test_find_plan_exec_with_missing_path_returns_status_plan() {
         }
         _ => panic!("expected BatchWithStatus plan"),
     }
+}
+
+// ==================== find output cap tests ====================
+
+#[tokio::test]
+async fn test_find_printf_rejects_oversized_single_entry_output() {
+    let (fs, mut cwd, mut variables) = create_test_ctx().await;
+    let env = HashMap::new();
+
+    fs.write_file(&cwd.join("a.txt"), b"x").await.unwrap();
+
+    // A -printf format that produces more than FIND_MAX_OUTPUT_BYTES for a single entry.
+    let fmt = "x".repeat(FIND_MAX_OUTPUT_BYTES + 1);
+    let args = vec!["-printf".to_string(), fmt];
+    let ctx = Context {
+        args: &args,
+        env: &env,
+        variables: &mut variables,
+        cwd: &mut cwd,
+        fs: fs.clone(),
+        stdin: None,
+        #[cfg(feature = "http_client")]
+        http_client: None,
+        #[cfg(feature = "git")]
+        git_client: None,
+        #[cfg(feature = "ssh")]
+        ssh_client: None,
+        shell: None,
+    };
+
+    let result = Find.execute(ctx).await.unwrap();
+    assert_eq!(
+        result.exit_code, 1,
+        "should fail when printf output exceeds cap"
+    );
+    assert!(
+        result.stderr.contains("output size limit exceeded") || result.stderr.contains("find:"),
+        "stderr should report the limit: {}",
+        result.stderr
+    );
+    assert!(
+        result.stdout.len() <= FIND_MAX_OUTPUT_BYTES,
+        "stdout must not exceed cap: len={}",
+        result.stdout.len()
+    );
+}
+
+#[tokio::test]
+async fn test_find_printf_rejects_oversized_aggregate_output() {
+    let (fs, mut cwd, mut variables) = create_test_ctx().await;
+    let env = HashMap::new();
+
+    fs.write_file(&cwd.join("a.txt"), b"x").await.unwrap();
+    fs.write_file(&cwd.join("b.txt"), b"x").await.unwrap();
+
+    // Each entry produces just over half the cap; two entries together exceed it.
+    let half = FIND_MAX_OUTPUT_BYTES / 2 + 1;
+    let fmt = "y".repeat(half);
+    let args = vec!["-printf".to_string(), fmt];
+    let ctx = Context {
+        args: &args,
+        env: &env,
+        variables: &mut variables,
+        cwd: &mut cwd,
+        fs: fs.clone(),
+        stdin: None,
+        #[cfg(feature = "http_client")]
+        http_client: None,
+        #[cfg(feature = "git")]
+        git_client: None,
+        #[cfg(feature = "ssh")]
+        ssh_client: None,
+        shell: None,
+    };
+
+    let result = Find.execute(ctx).await.unwrap();
+    assert_eq!(result.exit_code, 1, "aggregate output should hit cap");
+    assert!(
+        result.stderr.contains("output size limit exceeded") || result.stderr.contains("find:"),
+        "stderr should report the limit: {}",
+        result.stderr
+    );
+    assert!(
+        result.stdout.len() <= FIND_MAX_OUTPUT_BYTES,
+        "stdout must not exceed cap: len={}",
+        result.stdout.len()
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #2021. Adds a `FIND_MAX_OUTPUT_BYTES` (1 MiB) cap to `find`'s stdout path to prevent resource-exhaustion DoS via unbounded `-printf` or default output.

- **`push_find_line`**: atomic path+terminator write — checks the cap before committing any bytes so callers never receive a partial final line
- **`push_find_output` / `push_find_char`**: bulk and per-char helpers used by `-printf` expansion; both gate on the running total before each write
- **`find_printf_format`**: rewritten with `chars().peekable()` (no `Vec<char>` heap alloc); now returns `Result<()>` and routes all output through the cap-checked helpers
- **Error formatting**: output-cap errors are reported as `find: <message>` (no redundant path context); other errors keep the `find: '<path>': <msg>` form
- **Tests**: two new unit tests — single-entry overflow and aggregate overflow across multiple matched entries

## Test plan

- [ ] `cargo test -p bashkit --lib -- builtins::ls::tests` — all 75 pass
- [ ] `cargo fmt --check` — clean
- [ ] New tests: `test_find_printf_rejects_oversized_single_entry_output`, `test_find_printf_rejects_oversized_aggregate_output`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqJCd66SbLcxjwzLovzJ2s)_