### PR TITLE
feat(js): close Python-binding parity gaps (ctx.fs, network, shellState)

### DIFF
--- a/crates/bashkit-js/Cargo.toml
+++ b/crates/bashkit-js/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs", "jq", "interop", "sqlite"] }
+bashkit = { path = "../bashkit", features = ["scripted_tool", "python", "realfs", "jq", "interop", "http_client", "sqlite"] }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -14,6 +14,7 @@ Homepage: [bashkit.sh](https://bashkit.sh)
 - Cancellation support via `cancel()`
 - Sticky cancellation recovery via `clearCancel()`
 - Snapshot and restore support on `Bash`
+- Outbound HTTP (`curl`/`wget`) behind a URL allowlist with transparent credential injection
 - AI framework adapters for OpenAI, Anthropic, Vercel AI SDK, and LangChain
 
 ## Install
@@ -338,6 +339,21 @@ The callback receives a `BuiltinContext`:
 - `stdin: string | null` — piped input, or `null` if no pipe
 - `env: Record<string, string>` — environment variables (only exported names)
 - `cwd: string` — current working directory
+- `fs: FileSystem` — live handle to the instance's virtual filesystem
+
+`ctx.fs` is the same VFS the executing script sees: reads observe earlier
+script writes, and writes are visible to subsequent commands. It inherits
+mounts and read-only configuration.
+
+```typescript
+const bash = new Bash({
+  customBuiltins: {
+    head10: (ctx) =>
+      ctx.fs.readFile(ctx.argv[0]).split("\n").slice(0, 10).join("\n") + "\n",
+  },
+});
+await bash.execute("head10 /var/log/app.log");
+```
 
 Override precedence: shell function > POSIX special builtin > custom builtin
 
@@ -411,6 +427,58 @@ console.log(restoredTool.executeSync("echo $TOOL_STATE").stdout); // ready\n
 restoredTool.restoreSnapshot(toolShellOnly, { hmacKey });
 ```
 
+## Network
+
+Outbound HTTP (`curl` / `wget`) is disabled by default. Enable it with the
+`network` option, which requires either an explicit URL allowlist or
+`allowAll: true`:
+
+```typescript
+const bash = new Bash({
+  network: {
+    allow: ["https://api.example.com/**"],
+    blockPrivateIps: true, // default
+  },
+});
+
+await bash.execute("curl https://api.example.com/users"); // allowed
+await bash.execute("curl https://evil.example.org"); // denied: not in allowlist
+```
+
+### Credential Injection
+
+Attach credentials to matching requests without exposing them to scripts:
+
+```typescript
+const bash = new Bash({
+  network: {
+    allow: ["https://api.example.com/**"],
+    // Direct injection — the script never sees the secret.
+    credentials: [
+      {
+        pattern: "https://api.example.com/**",
+        kind: "bearer",
+        token: process.env.API_TOKEN!,
+      },
+    ],
+    // Placeholder mode — the script sees an opaque `bk_placeholder_...`
+    // value in $MY_TOKEN; it is swapped for the real secret on the wire.
+    credentialPlaceholders: [
+      {
+        env: "MY_TOKEN",
+        pattern: "https://api.example.com/**",
+        kind: "header",
+        name: "X-Api-Key",
+        value: process.env.API_KEY!,
+      },
+    ],
+  },
+});
+```
+
+Credential kinds: `"bearer"` (requires `token`), `"header"` (requires
+`name` + `value`), `"headers"` (requires `headers: Array<{ name, value }>`).
+
 ## Framework Integrations
 
 ### OpenAI
@@ -464,6 +532,7 @@ import {
 - `restoreSnapshot(data, options?)` / `restoreSnapshotKeyed(data, key)`
 - `Bash.fromSnapshot(data, options?)` / `Bash.fromSnapshotKeyed(data, key)`
 - Direct VFS helpers: `readFile`, `writeFile`, `appendFile`, `mkdir`, `remove`, `exists`, `stat`, `readDir`, `ls`, `glob`, `mount`, `unmount`, `fs`
+- `shellState()` — lightweight inspection snapshot (variables, env, cwd, arrays, aliases, traps)
 
 ### BashTool
 
@@ -502,6 +571,7 @@ import {
 - `python?: boolean`
 - `externalFunctions?: string[]`
 - `customBuiltins?: Record<string, (ctx: BuiltinContext) => string | Promise<string>>` — JS callbacks registered as bash builtins (see [Custom Builtins](#custom-builtins))
+- `network?: NetworkOptions` — outbound HTTP configuration (see [Network](#network))
 
 ### BuiltinContext
 
@@ -510,6 +580,7 @@ import {
 - `stdin: string | null` — piped input, `null` if no pipe
 - `env: Record<string, string>` — exported environment variables
 - `cwd: string` — current working directory
+- `fs: FileSystem` — live handle to the instance's virtual filesystem
 
 ### ExecuteOptions
 

--- a/crates/bashkit-js/__test__/custom-builtins.spec.ts
+++ b/crates/bashkit-js/__test__/custom-builtins.spec.ts
@@ -287,7 +287,10 @@ test("executeSync with custom builtin returns error instead of deadlocking", (t)
   const result = bash.executeSync("mybuiltin");
   t.is(result.exitCode, 1);
   t.false(invoked, "JS callback must not run when the loop is blocked");
-  t.regex(result.stderr, /mybuiltin: custom builtins require execute\(\) \(async\)/);
+  t.regex(
+    result.stderr,
+    /mybuiltin: custom builtins require execute\(\) \(async\)/,
+  );
 });
 
 test("executeSync with addBuiltin custom builtin returns error", (t) => {
@@ -316,7 +319,10 @@ test("BashTool executeSync with custom builtin returns error", (t) => {
   const result = tool.executeSync("mybuiltin");
   t.is(result.exitCode, 1);
   t.false(invoked);
-  t.regex(result.stderr, /mybuiltin: custom builtins require execute\(\) \(async\)/);
+  t.regex(
+    result.stderr,
+    /mybuiltin: custom builtins require execute\(\) \(async\)/,
+  );
 });
 
 test("async execute() still works after a guardrail-rejected executeSync", async (t) => {
@@ -331,4 +337,120 @@ test("async execute() still works after a guardrail-rejected executeSync", async
   const result = await bash.execute("mybuiltin");
   t.is(result.exitCode, 0);
   t.is(result.stdout, "via-async\n");
+});
+
+// ----------------------------------------------------------------------------
+// ctx.fs — live VFS access inside custom builtins (parity with Python's
+// BuiltinContext.fs, see PR #2010)
+// ----------------------------------------------------------------------------
+
+test("ctx.fs reads files written by the script", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "read-it": (ctx) => ctx.fs.readFile(ctx.argv[0]!),
+    },
+  });
+  await bash.execute('echo "from bash" > /tmp/in.txt');
+  const result = await bash.execute("read-it /tmp/in.txt");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, "from bash\n");
+});
+
+test("ctx.fs writes are visible to subsequent commands", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "write-it": (ctx) => {
+        ctx.fs.writeFile("/tmp/out.txt", "from builtin\n");
+        return "";
+      },
+    },
+  });
+  const result = await bash.execute("write-it && cat /tmp/out.txt");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, "from builtin\n");
+});
+
+test("ctx.fs writes are visible within the same pipeline read-back", async (t) => {
+  // Live view: a write made by the builtin is observable by a later
+  // ctx.fs read in another builtin invocation of the same execute() call.
+  const bash = new Bash({
+    customBuiltins: {
+      put: (ctx) => {
+        ctx.fs.writeFile("/tmp/live.txt", ctx.argv[0]! + "\n");
+        return "";
+      },
+      get: (ctx) => ctx.fs.readFile("/tmp/live.txt"),
+    },
+  });
+  const result = await bash.execute("put hello42 && get");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, "hello42\n");
+});
+
+test("ctx.fs supports mkdir/readDir/exists/stat", async (t) => {
+  const seen: string[] = [];
+  const bash = new Bash({
+    customBuiltins: {
+      probe: (ctx) => {
+        ctx.fs.mkdir("/tmp/sub/dir", true);
+        ctx.fs.writeFile("/tmp/sub/dir/a.txt", "x");
+        seen.push(
+          `exists=${ctx.fs.exists("/tmp/sub/dir/a.txt")}`,
+          `entries=${ctx.fs
+            .readDir("/tmp/sub/dir")
+            .map((e) => e.name)
+            .join(",")}`,
+          `size=${ctx.fs.stat("/tmp/sub/dir/a.txt").size}`,
+        );
+        return "";
+      },
+    },
+  });
+  const result = await bash.execute("probe");
+  t.is(result.exitCode, 0);
+  t.deepEqual(seen, ["exists=true", "entries=a.txt", "size=1"]);
+});
+
+test("ctx.fs read of a missing file surfaces as exit 1 + stderr", async (t) => {
+  const bash = new Bash({
+    customBuiltins: {
+      "read-missing": (ctx) => ctx.fs.readFile("/tmp/does-not-exist"),
+    },
+  });
+  const result = await bash.execute("read-missing");
+  t.is(result.exitCode, 1);
+  t.regex(result.stderr, /does-not-exist|not found|No such/i);
+});
+
+test("ctx.fs works with addBuiltin registration", async (t) => {
+  const bash = new Bash();
+  bash.addBuiltin("read-it", (ctx) => ctx.fs.readFile("/tmp/added.txt"));
+  await bash.execute('printf "added" > /tmp/added.txt');
+  const result = await bash.execute("read-it");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, "added");
+});
+
+test("ctx.fs works on BashTool builtins", async (t) => {
+  const tool = new BashTool({
+    customBuiltins: {
+      "read-it": (ctx) => ctx.fs.readFile("/tmp/tool.txt"),
+    },
+  });
+  await tool.execute('printf "tool" > /tmp/tool.txt');
+  const result = await tool.execute("read-it");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, "tool");
+});
+
+test("ctx.fs respects files mounted at construction", async (t) => {
+  const bash = new Bash({
+    files: { "/data/config.json": '{"ok":true}' },
+    customBuiltins: {
+      "read-config": (ctx) => ctx.fs.readFile("/data/config.json"),
+    },
+  });
+  const result = await bash.execute("read-config");
+  t.is(result.exitCode, 0);
+  t.is(result.stdout, '{"ok":true}');
 });

--- a/crates/bashkit-js/__test__/network.spec.ts
+++ b/crates/bashkit-js/__test__/network.spec.ts
@@ -1,0 +1,185 @@
+import test from "ava";
+import { Bash, BashTool } from "../wrapper.js";
+
+// ----------------------------------------------------------------------------
+// Network configuration (http_client) — allowlist + credential injection.
+// Mirrors the Python binding's `network=` kwarg. No test performs a real
+// network request: allowlist denial happens before any connection.
+// ----------------------------------------------------------------------------
+
+test("curl without network config reports network not configured", async (t) => {
+  const bash = new Bash();
+  const result = await bash.execute("curl https://example.com");
+  t.not(result.exitCode, 0);
+  t.regex(result.stderr, /network access not configured/);
+});
+
+test("curl to a URL outside the allowlist is denied", async (t) => {
+  const bash = new Bash({
+    network: { allow: ["https://api.example.com/**"] },
+  });
+  const result = await bash.execute("curl https://blocked.example.org/x");
+  t.not(result.exitCode, 0);
+  t.regex(result.stderr, /not in allowlist/);
+});
+
+test("BashTool accepts network config", async (t) => {
+  const tool = new BashTool({
+    network: { allow: ["https://api.example.com/**"] },
+  });
+  const result = await tool.execute("curl https://blocked.example.org/x");
+  t.not(result.exitCode, 0);
+  t.regex(result.stderr, /not in allowlist/);
+});
+
+test("network config survives reset()", async (t) => {
+  const bash = new Bash({
+    network: { allow: ["https://api.example.com/**"] },
+  });
+  bash.reset();
+  const result = await bash.execute("curl https://blocked.example.org/x");
+  t.not(result.exitCode, 0);
+  t.regex(result.stderr, /not in allowlist/);
+});
+
+test("allowAll mode passes allowlist check for any URL", async (t) => {
+  const bash = new Bash({
+    network: { allowAll: true, blockPrivateIps: true },
+  });
+  // The URL passes the allowlist; the failure (if any) is a connection
+  // error, not an allowlist denial.
+  const result = await bash.execute(
+    "curl --max-time 1 https://nonexistent.invalid/x",
+  );
+  t.notRegex(result.stderr, /not in allowlist/);
+  t.notRegex(result.stderr, /network access not configured/);
+});
+
+// ----------------------------------------------------------------------------
+// Credential placeholders — scripts see an opaque placeholder, never the
+// real secret.
+// ----------------------------------------------------------------------------
+
+test("credential placeholder env var is set to an opaque value", async (t) => {
+  const secret = "super-secret-123";
+  const bash = new Bash({
+    network: {
+      allow: ["https://api.example.com/**"],
+      credentialPlaceholders: [
+        {
+          env: "API_TOKEN",
+          pattern: "https://api.example.com/**",
+          kind: "bearer",
+          token: secret,
+        },
+      ],
+    },
+  });
+  const result = await bash.execute('echo "token=$API_TOKEN"');
+  t.is(result.exitCode, 0);
+  t.regex(result.stdout, /token=bk_placeholder_[0-9a-f]+/);
+  t.false(result.stdout.includes(secret));
+});
+
+test("direct credentials never appear in the shell environment", async (t) => {
+  const secret = "direct-secret-456";
+  const bash = new Bash({
+    network: {
+      allow: ["https://api.example.com/**"],
+      credentials: [
+        {
+          pattern: "https://api.example.com/**",
+          kind: "header",
+          name: "X-Api-Key",
+          value: secret,
+        },
+      ],
+    },
+  });
+  const result = await bash.execute("env");
+  t.is(result.exitCode, 0);
+  t.false(result.stdout.includes(secret));
+});
+
+// ----------------------------------------------------------------------------
+// Constructor validation — mirrors the Python binding's rules.
+// ----------------------------------------------------------------------------
+
+test("network without allow or allowAll throws", (t) => {
+  t.throws(() => new Bash({ network: {} }), {
+    message: /must provide 'allow'.*or 'allowAll: true'/,
+  });
+});
+
+test("allow and allowAll are mutually exclusive", (t) => {
+  t.throws(() => new Bash({ network: { allow: ["x"], allowAll: true } }), {
+    message: /mutually exclusive/,
+  });
+});
+
+test("unknown credential kind throws", (t) => {
+  t.throws(
+    () =>
+      new Bash({
+        network: {
+          allow: ["x"],
+          credentials: [{ pattern: "x", kind: "bogus" }],
+        },
+      }),
+    { message: /unknown kind 'bogus'/ },
+  );
+});
+
+test("bearer credential without token throws", (t) => {
+  t.throws(
+    () =>
+      new Bash({
+        network: {
+          allow: ["x"],
+          credentials: [{ pattern: "x", kind: "bearer" }],
+        },
+      }),
+    { message: /kind 'bearer' requires 'token'/ },
+  );
+});
+
+test("header credential without name/value throws", (t) => {
+  t.throws(
+    () =>
+      new Bash({
+        network: {
+          allow: ["x"],
+          credentials: [{ pattern: "x", kind: "header", name: "X-K" }],
+        },
+      }),
+    { message: /kind 'header' requires 'name' and 'value'/ },
+  );
+});
+
+test("headers credential with empty list throws", (t) => {
+  t.throws(
+    () =>
+      new Bash({
+        network: {
+          allow: ["x"],
+          credentials: [{ pattern: "x", kind: "headers", headers: [] }],
+        },
+      }),
+    { message: /must contain at least one entry/ },
+  );
+});
+
+test("placeholder with empty env name throws", (t) => {
+  t.throws(
+    () =>
+      new Bash({
+        network: {
+          allow: ["x"],
+          credentialPlaceholders: [
+            { env: "", pattern: "x", kind: "bearer", token: "t" },
+          ],
+        },
+      }),
+    { message: /'env' must be a non-empty environment variable name/ },
+  );
+});

--- a/crates/bashkit-js/__test__/network.spec.ts
+++ b/crates/bashkit-js/__test__/network.spec.ts
@@ -169,6 +169,25 @@ test("headers credential with empty list throws", (t) => {
   );
 });
 
+test("headers credential with an empty header name throws", (t) => {
+  t.throws(
+    () =>
+      new Bash({
+        network: {
+          allow: ["x"],
+          credentials: [
+            {
+              pattern: "x",
+              kind: "headers",
+              headers: [{ name: "", value: "v" }],
+            },
+          ],
+        },
+      }),
+    { message: /name must be a non-empty header name/ },
+  );
+});
+
 test("placeholder with empty env name throws", (t) => {
   t.throws(
     () =>

--- a/crates/bashkit-js/__test__/shell-state.spec.ts
+++ b/crates/bashkit-js/__test__/shell-state.spec.ts
@@ -1,0 +1,65 @@
+import test from "ava";
+import { Bash, BashTool } from "../wrapper.js";
+
+// ----------------------------------------------------------------------------
+// shellState() — lightweight inspection snapshot (parity with the Python
+// binding's `shell_state()`).
+// ----------------------------------------------------------------------------
+
+test("shellState captures variables, env, and cwd", async (t) => {
+  const bash = new Bash();
+  await bash.execute(
+    ["x=42", "export GREETING=hello", "mkdir -p /work", "cd /work"].join("\n"),
+  );
+  const state = bash.shellState();
+  t.is(state.variables.x, "42");
+  t.is(state.env.GREETING, "hello");
+  t.is(state.cwd, "/work");
+});
+
+test("shellState captures lastExitCode", async (t) => {
+  const bash = new Bash();
+  await bash.execute("false");
+  t.is(bash.shellState().lastExitCode, 1);
+  await bash.execute("true");
+  t.is(bash.shellState().lastExitCode, 0);
+});
+
+test("shellState captures indexed and associative arrays", async (t) => {
+  const bash = new Bash();
+  await bash.execute(
+    ["arr=(a b c)", "arr[10]=sparse", "declare -A map", "map[key]=value"].join(
+      "\n",
+    ),
+  );
+  const state = bash.shellState();
+  t.deepEqual(state.arrays.arr, {
+    "0": "a",
+    "1": "b",
+    "2": "c",
+    "10": "sparse",
+  });
+  t.deepEqual(state.assocArrays.map, { key: "value" });
+});
+
+test("shellState captures aliases and traps", async (t) => {
+  const bash = new Bash();
+  await bash.execute(["alias ll='ls -l'", "trap 'echo bye' EXIT"].join("\n"));
+  const state = bash.shellState();
+  t.is(state.aliases.ll, "ls -l");
+  t.is(state.traps.EXIT, "echo bye");
+});
+
+test("shellState works on BashTool", async (t) => {
+  const tool = new BashTool();
+  await tool.execute("y=7");
+  t.is(tool.shellState().variables.y, "7");
+});
+
+test("shellState reflects state after reset()", async (t) => {
+  const bash = new Bash();
+  await bash.execute("x=1");
+  t.is(bash.shellState().variables.x, "1");
+  bash.reset();
+  t.false("x" in bash.shellState().variables);
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -1159,6 +1159,11 @@ fn credential_from_parts(
                     "network.{label}: kind 'headers' accepts only 'headers'"
                 ));
             }
+            if let Some(idx) = headers.iter().position(|h| h.name.is_empty()) {
+                return invalid(format!(
+                    "network.{label}: headers[{idx}] name must be a non-empty header name"
+                ));
+            }
             Ok(Credential::headers(
                 headers
                     .iter()

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -19,10 +19,11 @@ use bashkit::interop::fs::{
 use bashkit::tool::VERSION;
 use bashkit::{
     Bash as RustBash, BashTool as RustBashTool, Builtin, BuiltinContext, BuiltinRegistry,
-    ExecResult as RustExecResult, ExecutionLimits, ExtFunctionResult, FileSystem as BashFileSystem,
-    FileType, InMemoryFs, Metadata, MontyObject, OutputCallback, PosixFs, PythonExternalFnHandler,
-    PythonLimits, RealFs, RealFsMode, ScriptedTool as RustScriptedTool,
-    SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
+    Credential, ExecResult as RustExecResult, ExecutionLimits, ExtFunctionResult,
+    FileSystem as BashFileSystem, FileType, InMemoryFs, Metadata, MontyObject, NetworkAllowlist,
+    OutputCallback, PosixFs, PythonExternalFnHandler, PythonLimits, RealFs, RealFsMode,
+    ScriptedTool as RustScriptedTool, SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs,
+    ToolDef, ToolRequest, async_trait,
 };
 use napi::bindgen_prelude::External;
 use napi::{Env, JsValue, Unknown, ValueType, sys};
@@ -725,6 +726,55 @@ pub struct ExecResult {
     pub success: bool,
 }
 
+/// Lightweight snapshot of shell state for inspection (prompt rendering,
+/// debugging). Mirrors the Python binding's `ShellState`; omits function
+/// definitions (use `snapshot()` for full state capture/restore).
+#[napi(object)]
+pub struct ShellState {
+    /// Environment variables.
+    pub env: HashMap<String, String>,
+    /// Shell variables (non-exported).
+    pub variables: HashMap<String, String>,
+    /// Indexed arrays: name → { index (as string) → value }. Sparse indices
+    /// are preserved, hence a map rather than a dense JS array.
+    pub arrays: HashMap<String, HashMap<String, String>>,
+    /// Associative arrays: name → { key → value }.
+    pub assoc_arrays: HashMap<String, HashMap<String, String>>,
+    /// Current working directory.
+    pub cwd: String,
+    /// Exit code of the last executed command.
+    pub last_exit_code: i32,
+    /// Shell aliases.
+    pub aliases: HashMap<String, String>,
+    /// Trap handlers keyed by signal/condition name.
+    pub traps: HashMap<String, String>,
+}
+
+fn shell_state_to_js(view: bashkit::ShellStateView) -> ShellState {
+    ShellState {
+        env: view.env,
+        variables: view.variables,
+        arrays: view
+            .arrays
+            .into_iter()
+            .map(|(name, entries)| {
+                (
+                    name,
+                    entries
+                        .into_iter()
+                        .map(|(idx, value)| (idx.to_string(), value))
+                        .collect(),
+                )
+            })
+            .collect(),
+        assoc_arrays: view.assoc_arrays,
+        cwd: view.cwd.to_string_lossy().into_owned(),
+        last_exit_code: view.last_exit_code,
+        aliases: view.aliases,
+        traps: view.traps,
+    }
+}
+
 // The native JS callback arrives as one `[stdout, stderr]` tuple payload even
 // though napi-rs models the args as `(String, String)`. Keep the public TS
 // wrapper responsible for adapting that odd FFI shape into its
@@ -981,6 +1031,230 @@ pub struct MountConfig {
     pub writable: Option<bool>,
 }
 
+/// A single HTTP header (name/value pair) for credential injection.
+#[napi(object)]
+#[derive(Clone)]
+pub struct CredentialHeader {
+    pub name: String,
+    pub value: String,
+}
+
+/// Credential injected into outbound HTTP requests matching `pattern`.
+///
+/// `kind` selects the shape: `"bearer"` (requires `token`), `"header"`
+/// (requires `name` + `value`), or `"headers"` (requires `headers`).
+/// Scripts never see the secret — it is attached on the wire only.
+#[napi(object)]
+#[derive(Clone)]
+pub struct NetworkCredential {
+    /// URL pattern the credential applies to (e.g. `https://api.example.com/**`).
+    pub pattern: String,
+    /// One of `"bearer"`, `"header"`, `"headers"`.
+    pub kind: String,
+    /// Bearer token (for `kind: "bearer"`).
+    pub token: Option<String>,
+    /// Header name (for `kind: "header"`).
+    pub name: Option<String>,
+    /// Header value (for `kind: "header"`).
+    pub value: Option<String>,
+    /// Header list (for `kind: "headers"`).
+    pub headers: Option<Vec<CredentialHeader>>,
+}
+
+/// Placeholder-mode credential injection: `env` is set to an opaque
+/// placeholder value visible to scripts; outbound requests matching
+/// `pattern` have the placeholder replaced with the real credential.
+#[napi(object)]
+#[derive(Clone)]
+pub struct NetworkCredentialPlaceholder {
+    /// Environment variable that receives the placeholder value.
+    pub env: String,
+    /// URL pattern the credential applies to.
+    pub pattern: String,
+    /// One of `"bearer"`, `"header"`, `"headers"`.
+    pub kind: String,
+    /// Bearer token (for `kind: "bearer"`).
+    pub token: Option<String>,
+    /// Header name (for `kind: "header"`).
+    pub name: Option<String>,
+    /// Header value (for `kind: "header"`).
+    pub value: Option<String>,
+    /// Header list (for `kind: "headers"`).
+    pub headers: Option<Vec<CredentialHeader>>,
+}
+
+/// Outbound network configuration (enables `curl`/`wget`).
+///
+/// Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+/// not both. `blockPrivateIps` defaults to `true`.
+#[napi(object)]
+#[derive(Clone)]
+pub struct NetworkOptions {
+    /// URL patterns permitted for outbound requests.
+    pub allow: Option<Vec<String>>,
+    /// Allow all outbound requests (mutually exclusive with `allow`).
+    pub allow_all: Option<bool>,
+    /// Block requests resolving to private/loopback IPs (default: true).
+    pub block_private_ips: Option<bool>,
+    /// Credentials injected transparently into matching requests.
+    pub credentials: Option<Vec<NetworkCredential>>,
+    /// Placeholder-mode credential injection (see type docs).
+    pub credential_placeholders: Option<Vec<NetworkCredentialPlaceholder>>,
+}
+
+/// Build a core [`Credential`] from the kind-discriminated option fields.
+/// Mirrors the Python binding's `parse_credential_spec` validation rules.
+fn credential_from_parts(
+    label: &str,
+    kind: &str,
+    token: Option<&String>,
+    name: Option<&String>,
+    value: Option<&String>,
+    headers: Option<&Vec<CredentialHeader>>,
+) -> napi::Result<Credential> {
+    let invalid = |msg: String| -> napi::Result<Credential> { Err(napi::Error::from_reason(msg)) };
+    match kind {
+        "bearer" => {
+            let Some(token) = token else {
+                return invalid(format!("network.{label}: kind 'bearer' requires 'token'"));
+            };
+            if name.is_some() || value.is_some() || headers.is_some() {
+                return invalid(format!(
+                    "network.{label}: kind 'bearer' accepts only 'token'"
+                ));
+            }
+            Ok(Credential::bearer(token.clone()))
+        }
+        "header" => {
+            let (Some(name), Some(value)) = (name, value) else {
+                return invalid(format!(
+                    "network.{label}: kind 'header' requires 'name' and 'value'"
+                ));
+            };
+            if name.is_empty() {
+                return invalid(format!(
+                    "network.{label}: 'name' must be a non-empty header name"
+                ));
+            }
+            if token.is_some() || headers.is_some() {
+                return invalid(format!(
+                    "network.{label}: kind 'header' accepts only 'name' and 'value'"
+                ));
+            }
+            Ok(Credential::header(name.clone(), value.clone()))
+        }
+        "headers" => {
+            let Some(headers) = headers else {
+                return invalid(format!(
+                    "network.{label}: kind 'headers' requires 'headers'"
+                ));
+            };
+            if headers.is_empty() {
+                return invalid(format!(
+                    "network.{label}: 'headers' must contain at least one entry"
+                ));
+            }
+            if token.is_some() || name.is_some() || value.is_some() {
+                return invalid(format!(
+                    "network.{label}: kind 'headers' accepts only 'headers'"
+                ));
+            }
+            Ok(Credential::headers(
+                headers
+                    .iter()
+                    .map(|h| (h.name.clone(), h.value.clone()))
+                    .collect::<Vec<_>>(),
+            ))
+        }
+        other => invalid(format!(
+            "network.{label}: unknown kind '{other}' (expected 'bearer', 'header', or 'headers')"
+        )),
+    }
+}
+
+/// Validate `NetworkOptions` up front so `build_bash_from_state` (also used
+/// by `reset()`) can apply them infallibly later.
+fn validate_network_options(net: &NetworkOptions) -> napi::Result<()> {
+    let allow_all = net.allow_all.unwrap_or(false);
+    if allow_all && net.allow.is_some() {
+        return Err(napi::Error::from_reason(
+            "network: 'allow' and 'allowAll' are mutually exclusive",
+        ));
+    }
+    if !allow_all && net.allow.is_none() {
+        return Err(napi::Error::from_reason(
+            "network: must provide 'allow' (list of URL patterns) or 'allowAll: true'",
+        ));
+    }
+    for (idx, cred) in net.credentials.iter().flatten().enumerate() {
+        credential_from_parts(
+            &format!("credentials[{idx}]"),
+            &cred.kind,
+            cred.token.as_ref(),
+            cred.name.as_ref(),
+            cred.value.as_ref(),
+            cred.headers.as_ref(),
+        )?;
+    }
+    for (idx, ph) in net.credential_placeholders.iter().flatten().enumerate() {
+        if ph.env.is_empty() {
+            return Err(napi::Error::from_reason(format!(
+                "network.credentialPlaceholders[{idx}]: 'env' must be a non-empty environment variable name"
+            )));
+        }
+        credential_from_parts(
+            &format!("credentialPlaceholders[{idx}]"),
+            &ph.kind,
+            ph.token.as_ref(),
+            ph.name.as_ref(),
+            ph.value.as_ref(),
+            ph.headers.as_ref(),
+        )?;
+    }
+    Ok(())
+}
+
+/// Apply pre-validated network options to the builder. Panics are impossible
+/// for inputs that passed [`validate_network_options`]; on the (unreachable)
+/// invalid path the credential is skipped.
+fn apply_network_options(
+    mut builder: bashkit::BashBuilder,
+    net: &NetworkOptions,
+) -> bashkit::BashBuilder {
+    let allowlist = if net.allow_all.unwrap_or(false) {
+        NetworkAllowlist::allow_all()
+    } else {
+        NetworkAllowlist::new().allow_many(net.allow.iter().flatten().cloned())
+    }
+    .block_private_ips(net.block_private_ips.unwrap_or(true));
+    builder = builder.network(allowlist);
+    for (idx, cred) in net.credentials.iter().flatten().enumerate() {
+        if let Ok(credential) = credential_from_parts(
+            &format!("credentials[{idx}]"),
+            &cred.kind,
+            cred.token.as_ref(),
+            cred.name.as_ref(),
+            cred.value.as_ref(),
+            cred.headers.as_ref(),
+        ) {
+            builder = builder.credential(&cred.pattern, credential);
+        }
+    }
+    for (idx, ph) in net.credential_placeholders.iter().flatten().enumerate() {
+        if let Ok(credential) = credential_from_parts(
+            &format!("credentialPlaceholders[{idx}]"),
+            &ph.kind,
+            ph.token.as_ref(),
+            ph.name.as_ref(),
+            ph.value.as_ref(),
+            ph.headers.as_ref(),
+        ) {
+            builder = builder.credential_placeholder(&ph.env, &ph.pattern, credential);
+        }
+    }
+    builder
+}
+
 /// Options for creating a Bash or BashTool instance.
 #[napi(object)]
 pub struct BashOptions {
@@ -1026,6 +1300,10 @@ pub struct BashOptions {
     /// builtin and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the
     /// runtime gate is satisfied. Defaults to `false`.
     pub sqlite: Option<bool>,
+    /// Outbound network configuration. When set, enables `curl`/`wget`
+    /// restricted to the configured allowlist, with optional transparent
+    /// credential injection. Omitted = network disabled.
+    pub network: Option<NetworkOptions>,
 }
 
 #[napi(object)]
@@ -1058,6 +1336,7 @@ fn default_opts() -> BashOptions {
         python: None,
         external_functions: None,
         sqlite: None,
+        network: None,
     }
 }
 
@@ -1123,6 +1402,8 @@ struct SharedState {
     allowed_mount_paths: Option<Vec<String>>,
     python: bool,
     sqlite: bool,
+    /// Validated network configuration (see [`validate_network_options`]).
+    network: Option<NetworkOptions>,
     external_functions: Vec<String>,
     external_handler: Option<ExternalHandlerArc>,
     /// Host-owned mutable registry of custom builtins. The same handle is
@@ -1345,26 +1626,30 @@ impl Bash {
     /// Register a JS callback as a custom bash builtin.
     ///
     /// The callback receives a JSON-serialized `BuiltinContext`
-    /// (`{name, argv, stdin, env, cwd}`) and returns the stdout to emit —
-    /// either as a string (sync) or a `Promise<string>` (async). Exceptions
-    /// surface as stderr with exit code 1.
+    /// (`{name, argv, stdin, env, cwd}`) plus a native VFS handle, and
+    /// returns the stdout to emit — either as a string (sync) or a
+    /// `Promise<string>` (async). Exceptions surface as stderr with exit
+    /// code 1. The TS wrapper adapts `(json, fsHandle)` into a single
+    /// `BuiltinContext` object with a live `fs` accessor.
     ///
     /// Unlike `customBuiltins` at construction time, this can be called at
     /// any point in the instance's lifetime — the interpreter consults the
     /// shared registry on every dispatch, so subsequent `execute*()` calls
     /// pick up the new builtin without rebuilding the interpreter or
     /// disturbing the VFS.
-    #[napi(ts_args_type = "name: string, callback: (request: string) => Promise<string>")]
+    #[napi(
+        ts_args_type = "name: string, callback: (requestPair: [string, unknown]) => Promise<string>"
+    )]
     pub fn add_builtin(
         &self,
         name: String,
         callback: napi::bindgen_prelude::Function<
-            (String,),
+            (String, External<NativeFileSystemState>),
             napi::bindgen_prelude::Promise<String>,
         >,
     ) -> napi::Result<()> {
         let tsfn: BuiltinTsfn = callback
-            .build_threadsafe_function::<(String,)>()
+            .build_threadsafe_function::<(String, External<NativeFileSystemState>)>()
             .weak::<true>()
             .build()?;
         self.state.host_registry.insert(
@@ -1753,6 +2038,17 @@ impl Bash {
             self.state.clone(),
         )))
     }
+
+    /// Capture a lightweight snapshot of shell state (variables, env, cwd,
+    /// arrays, aliases, traps) for inspection. Function definitions are
+    /// omitted — use `snapshot()` for full state capture/restore.
+    #[napi]
+    pub fn shell_state(&self) -> napi::Result<ShellState> {
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
+            Ok(shell_state_to_js(bash.shell_state_view()))
+        })
+    }
 }
 
 // ============================================================================
@@ -1911,17 +2207,19 @@ impl BashTool {
 
     /// Register a JS callback as a custom bash builtin.
     /// See [`Bash::add_builtin`] for semantics.
-    #[napi(ts_args_type = "name: string, callback: (request: string) => Promise<string>")]
+    #[napi(
+        ts_args_type = "name: string, callback: (requestPair: [string, unknown]) => Promise<string>"
+    )]
     pub fn add_builtin(
         &self,
         name: String,
         callback: napi::bindgen_prelude::Function<
-            (String,),
+            (String, External<NativeFileSystemState>),
             napi::bindgen_prelude::Promise<String>,
         >,
     ) -> napi::Result<()> {
         let tsfn: BuiltinTsfn = callback
-            .build_threadsafe_function::<(String,)>()
+            .build_threadsafe_function::<(String, External<NativeFileSystemState>)>()
             .weak::<true>()
             .build()?;
         self.state.host_registry.insert(
@@ -2349,6 +2647,17 @@ impl BashTool {
             self.state.clone(),
         )))
     }
+
+    /// Capture a lightweight snapshot of shell state (variables, env, cwd,
+    /// arrays, aliases, traps) for inspection. Function definitions are
+    /// omitted — use `snapshot()` for full state capture/restore.
+    #[napi]
+    pub fn shell_state(&self) -> napi::Result<ShellState> {
+        block_on_with(&self.state, |s| async move {
+            let bash = s.inner.lock().await;
+            Ok(shell_state_to_js(bash.shell_state_view()))
+        })
+    }
 }
 
 // ============================================================================
@@ -2381,10 +2690,13 @@ type ToolTsfn = napi::threadsafe_function::ThreadsafeFunction<
 /// the TSFN return is uniformly `Promise<String>` regardless of whether the
 /// user's callback was sync or async. Both branches resolve via the same
 /// `.await` on the returned `Promise<String>` future.
+///
+/// Args: the JSON-serialized context string plus an opaque native handle to
+/// the interpreter's live VFS (wrapped by the TS dispatcher into `ctx.fs`).
 type BuiltinTsfn = napi::threadsafe_function::ThreadsafeFunction<
-    (String,),
+    (String, External<NativeFileSystemState>),
     napi::bindgen_prelude::Promise<String>,
-    (String,),
+    (String, External<NativeFileSystemState>),
     napi::Status,
     false,
     true,
@@ -2393,7 +2705,8 @@ type BuiltinTsfn = napi::threadsafe_function::ThreadsafeFunction<
 /// Adapts a JS callback into a bashkit [`Builtin`].
 ///
 /// The callback receives a JSON string `{"name", "argv", "stdin", "env", "cwd"}`
-/// and resolves with the stdout to emit. Exceptions/rejections surface as
+/// plus a native VFS handle (surfaced to user code as `ctx.fs`), and resolves
+/// with the stdout to emit. Exceptions/rejections surface as
 /// stderr + exit-code-1 (real-shell semantics).
 struct JsCustomBuiltinAdapter {
     name: String,
@@ -2432,9 +2745,14 @@ impl Builtin for JsCustomBuiltinAdapter {
             .await
             .map_err(|e| bashkit::Error::Execution(format!("{}: semaphore: {}", self.name, e)))?;
 
+        // Wrap the interpreter's live VFS as a `Static` handle so the JS
+        // callback reads and writes the same filesystem without re-locking
+        // the interpreter (mirrors the Python binding's `BuiltinContext.fs`).
+        let fs_handle = External::new(NativeFileSystemState::from_static(ctx.fs.clone()));
+
         // Two-step await: first call_async returns the `Promise<String>`
         // handle from JS, then awaiting the Promise resolves to its value.
-        let promise = match self.callback.call_async((request_str,)).await {
+        let promise = match self.callback.call_async((request_str, fs_handle)).await {
             Ok(p) => p,
             Err(e) => return Ok(RustExecResult::err(format!("{}\n", e), 1)),
         };
@@ -2860,6 +3178,12 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
         builder = builder.env("BASHKIT_ALLOW_INPROCESS_SQLITE", "1");
     }
 
+    // Enable outbound network (curl/wget). Options were validated at
+    // construction time, so application here is infallible.
+    if let Some(ref network) = state.network {
+        builder = apply_network_options(builder, network);
+    }
+
     // Attach the host-owned builtin registry. Entries inserted via JS
     // `addBuiltin()` are visible to the running interpreter without rebuilding.
     builder = builder.builtin_registry(state.host_registry.clone());
@@ -2877,6 +3201,10 @@ fn shared_state_from_opts(
     let ext_fns = opts.external_functions.clone().unwrap_or_default();
     let mounts = opts.mounts.clone();
     let allowed_mount_paths = opts.allowed_mount_paths.clone();
+    if let Some(ref network) = opts.network {
+        validate_network_options(network)?;
+    }
+    let network = opts.network.clone();
     // A single registry handle threaded through the tmp + final SharedState
     // *and* the built interpreter — all observe the same underlying storage.
     let host_registry = BuiltinRegistry::new();
@@ -2912,6 +3240,7 @@ fn shared_state_from_opts(
         allowed_mount_paths: allowed_mount_paths.clone(),
         python: py,
         sqlite: sql,
+        network: network.clone(),
         external_functions: ext_fns.clone(),
         external_handler: external_handler.clone(),
         host_registry: host_registry.clone(),
@@ -2960,6 +3289,7 @@ fn shared_state_from_opts(
         allowed_mount_paths,
         python: py,
         sqlite: sql,
+        network,
         external_functions: ext_fns,
         external_handler,
         host_registry,

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -7,6 +7,11 @@ import type {
   ExecResult,
   BashOptions as NativeBashOptions,
   SnapshotOptions as NativeSnapshotOptions,
+  NetworkOptions,
+  NetworkCredential,
+  NetworkCredentialPlaceholder,
+  CredentialHeader,
+  ShellState,
 } from "./index.cjs";
 
 const require = createRequire(import.meta.url);
@@ -89,7 +94,14 @@ const nativeFileSystemCopy: (
   toPath: string,
 ) => void = native.__fileSystemCopy;
 
-export type { ExecResult };
+export type {
+  ExecResult,
+  NetworkOptions,
+  NetworkCredential,
+  NetworkCredentialPlaceholder,
+  CredentialHeader,
+  ShellState,
+};
 
 /**
  * A file value: either a string, a sync function returning a string,
@@ -105,7 +117,9 @@ const MAX_JSON_NESTING_DEPTH = 64;
  * Execution context passed to a custom builtin registered via
  * `customBuiltins` or `addBuiltin`.
  *
- * All fields are snapshots of the shell state at invocation time.
+ * `name`, `argv`, `stdin`, `env`, and `cwd` are snapshots of the shell
+ * state at invocation time; `fs` is a live handle to the interpreter's
+ * virtual filesystem.
  */
 export interface BuiltinContext {
   /** The command name as invoked. */
@@ -118,6 +132,13 @@ export interface BuiltinContext {
   readonly env: Record<string, string>;
   /** Current working directory. */
   readonly cwd: string;
+  /**
+   * Live handle to the interpreter's virtual filesystem — the same VFS the
+   * executing script sees. Reads observe earlier script writes and writes
+   * are visible to subsequent commands. Inherits mounts and read-only
+   * configuration.
+   */
+  readonly fs: FileSystem;
 }
 
 /**
@@ -216,6 +237,27 @@ export interface BashOptions {
    * resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
    */
   sqlite?: boolean;
+  /**
+   * Outbound network configuration. When set, enables `curl`/`wget`
+   * restricted to the configured allowlist, with optional transparent
+   * credential injection. Omitted = network disabled (no `curl`/`wget`).
+   *
+   * Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+   * not both. `blockPrivateIps` defaults to `true`.
+   *
+   * @example
+   * ```typescript
+   * const bash = new Bash({
+   *   network: {
+   *     allow: ["https://api.example.com/**"],
+   *     credentials: [
+   *       { pattern: "https://api.example.com/**", kind: "bearer", token: secret },
+   *     ],
+   *   },
+   * });
+   * ```
+   */
+  network?: NetworkOptions;
   /**
    * Names of external functions callable from embedded Python code.
    *
@@ -468,6 +510,7 @@ function toNativeOptions(
     python: options?.python,
     externalFunctions: options?.externalFunctions,
     sqlite: options?.sqlite,
+    network: options?.network,
   };
 }
 
@@ -635,6 +678,12 @@ export class FileSystem {
 /**
  * Wrap a {@link BuiltinCallback} for the native `addBuiltin` ABI.
  *
+ * The native side passes the JSON-serialized context plus an opaque VFS
+ * handle. Like the output callback, the napi TSFN delivers the
+ * `(String, External)` args as one `[payload, fsHandle]` tuple; this
+ * wrapper adapts that odd FFI shape into a single {@link BuiltinContext}
+ * object with a live `fs` accessor.
+ *
  * The Rust side expects a uniform `Promise<string>` return, so we always
  * route the callback result through `Promise.resolve` — sync `string`
  * returns get wrapped, native `Promise<string>` returns pass through, and
@@ -643,10 +692,15 @@ export class FileSystem {
  */
 function makeBuiltinDispatcher(
   callback: BuiltinCallback,
-): (payload: string) => Promise<string> {
-  return (payload: string) => {
+): (requestPair: [string, unknown]) => Promise<string> {
+  return (requestPair: [string, unknown]) => {
     try {
-      const ctx = JSON.parse(payload) as BuiltinContext;
+      const [payload, fsHandle] = requestPair;
+      const parsed = JSON.parse(payload) as Omit<BuiltinContext, "fs">;
+      const ctx: BuiltinContext = {
+        ...parsed,
+        fs: FileSystem.fromNative(fsHandle),
+      };
       return Promise.resolve(callback(ctx));
     } catch (e) {
       return Promise.reject(e);
@@ -662,7 +716,7 @@ function registerCustomBuiltins(
   native: {
     addBuiltin(
       name: string,
-      dispatch: (payload: string) => Promise<string>,
+      dispatch: (requestPair: [string, unknown]) => Promise<string>,
     ): void;
   },
   builtins: Record<string, BuiltinCallback> | undefined,
@@ -1086,6 +1140,16 @@ export class Bash {
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
   }
+
+  /**
+   * Capture a lightweight snapshot of shell state (variables, env, cwd,
+   * arrays, aliases, traps) for inspection — e.g. prompt rendering or
+   * debugging. Function definitions are omitted; use `snapshot()` for full
+   * state capture/restore.
+   */
+  shellState(): ShellState {
+    return this.native.shellState();
+  }
 }
 
 /**
@@ -1495,6 +1559,16 @@ export class BashTool {
       .split("\n")
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
+  }
+
+  /**
+   * Capture a lightweight snapshot of shell state (variables, env, cwd,
+   * arrays, aliases, traps) for inspection — e.g. prompt rendering or
+   * debugging. Function definitions are omitted; use `snapshot()` for full
+   * state capture/restore.
+   */
+  shellState(): ShellState {
+    return this.native.shellState();
   }
 
   /** Tool name. */

--- a/specs/implementation-status.md
+++ b/specs/implementation-status.md
@@ -500,7 +500,9 @@ NAPI-RS bindings in `crates/bashkit-js/`. TypeScript wrapper in `wrapper.ts`.
 |-------|---------|-------|
 | `Bash` | `executeSync`, `execute`, `cancel`, `reset`, `snapshot`, `restoreSnapshot`, `fromSnapshot` | Core interpreter |
 | `Bash` (VFS) | `readFile`, `writeFile`, `mkdir`, `exists`, `remove` | Direct VFS access via NAPI |
-| `Bash` (helpers) | `ls`, `glob` | Shell-based convenience wrappers |
+| `Bash` (helpers) | `ls`, `glob`, `shellState` | Shell-based convenience wrappers + state inspection |
+| `Bash` (builtins) | `addBuiltin`, `removeBuiltin`, `customBuiltins` option | JS callbacks as builtins; `ctx.fs` exposes the live VFS |
+| `Bash` (network) | `network` option | `http_client` allowlist + credential injection / placeholders (parity with Python `network=`) |
 | `BashTool` | `executeSync`, `execute`, `cancel`, `reset`, `snapshot`, `restoreSnapshot`, `fromSnapshot` | Interpreter + tool metadata |
 | `BashTool` (metadata) | `name`, `shortDescription`, `description`, `help`, `systemPrompt`, `inputSchema`, `outputSchema`, `version` | LLM tool contract |
 | `BashTool` (helpers) | `readFile`, `writeFile`, `exists`, `ls`, `glob` | Shell-based VFS wrappers |


### PR DESCRIPTION
## What

Closes three feature-parity gaps where the JavaScript binding (`@everruns/bashkit`) lagged behind the Python binding (`bashkit`):

1. **`ctx.fs` in custom builtins** — JS custom builtins now receive a live VFS handle, matching the Python binding's `BuiltinContext.fs` (added in #2010). Previously JS callbacks got only a JSON snapshot (`name`, `argv`, `stdin`, `env`, `cwd`) with no filesystem access.
2. **Outbound network (`http_client`)** — adds a `network` option to `Bash`/`BashTool` with a URL allowlist (`allow` / `allowAll` / `blockPrivateIps`) and transparent credential injection (`credentials`, `credentialPlaceholders`), mirroring the Python `network=` kwarg. Enables `curl`/`wget` in the sandbox.
3. **`shellState()`** — lightweight inspection snapshot (variables, env, cwd, arrays, aliases, traps) on both `Bash` and `BashTool`, matching Python's `shell_state()`.

## Why

Recent PRs concentrated on the Python binding (`ctx.fs` via #2010, async-callback hardening). The JS binding fell behind on host-language capabilities. This brings it back to parity on the gaps that affect what JS embedders can do today — most importantly, custom builtins that can read/write the sandbox VFS, and allowlisted outbound HTTP with secret injection that never exposes credentials to scripts.

## How

- **`ctx.fs`**: the Rust adapter wraps the interpreter's live VFS as a `Static` handle (no interpreter re-lock) and passes it through the threadsafe function alongside the JSON context. The TS wrapper adapts the `[json, fsHandle]` tuple into a single `BuiltinContext` with a live `fs: FileSystem` accessor.
- **Network**: `NetworkOptions` is validated at construction (mutually-exclusive `allow`/`allowAll`, credential-kind shape rules — identical to the Python binding) and applied to `BashBuilder` via `network()` / `credential()` / `credential_placeholder()`. Validation is split from application so `reset()` can rebuild infallibly. The `http_client` feature is enabled in `bashkit-js/Cargo.toml`.
- **`shellState()`**: backed by the core `shell_state_view()` (omits function ASTs); sparse array indices are preserved as stringified keys.

## Tests

- **`ctx.fs`** (8 new, `custom-builtins.spec.ts`): read script-written files, writes visible to later commands, live read-back across builtins in one pipeline, `mkdir`/`readDir`/`exists`/`stat`, missing-file → exit 1, `addBuiltin` registration, `BashTool` builtins, construction-time mounted files.
- **Network** (14 new, `network.spec.ts`): allowlist denial, `allowAll`, survives `reset()`, `BashTool`, placeholder env var is opaque + secret never appears, direct credentials never in `env`, and all constructor validation errors.
- **`shellState()`** (6 new, `shell-state.spec.ts`): variables/env/cwd, `lastExitCode`, indexed + associative + sparse arrays, aliases/traps, `BashTool`, post-`reset()`.
- Full suite green: **514 ava tests**, **137 runtime-compat tests** (node), `tsc --noEmit` on both tsconfigs, `cargo fmt --check` + `clippy -D warnings` clean.

Docs updated: `crates/bashkit-js/README.md` (Network section, `ctx.fs`, `shellState`, BashOptions) and `specs/implementation-status.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019PZnGFu3ABZVTTmaGcXp2L)_