### PR TITLE
fix(compgen): list builtins from the live registry, not hardcoded copies

### DIFF
--- a/crates/bashkit-cli/src/interactive.rs
+++ b/crates/bashkit-cli/src/interactive.rs
@@ -27,21 +27,6 @@ const RC_FILE: &str = "/home/user/.bashkitrc";
 const SOURCE_RC_ENV: &str = "BASHKIT_SOURCE_RC";
 const MAX_HISTORY: usize = 1000;
 
-// Same list as compgen.rs — keep in sync.
-const BUILTIN_COMMANDS: &[&str] = &[
-    "alias", "assert", "awk", "base64", "basename", "bc", "break", "cat", "cd", "chmod", "chown",
-    "clear", "column", "comm", "compgen", "continue", "cp", "curl", "cut", "date", "declare", "df",
-    "diff", "dirname", "dirs", "dotenv", "du", "echo", "env", "envsubst", "eval", "exit", "expand",
-    "export", "expr", "false", "fc", "find", "fold", "grep", "gunzip", "gzip", "head", "help",
-    "hexdump", "history", "hostname", "iconv", "id", "jq", "json", "join", "kill", "ln", "local",
-    "log", "ls", "mkdir", "mktemp", "mv", "nl", "od", "paste", "popd", "printenv", "printf",
-    "pushd", "pwd", "read", "readlink", "readonly", "realpath", "retry", "return", "rev", "rg",
-    "rm", "rmdir", "sed", "semver", "seq", "set", "shift", "shopt", "sleep", "sort", "source",
-    "split", "stat", "strings", "tac", "tail", "tar", "tee", "test", "timeout", "touch", "tr",
-    "tree", "true", "type", "uname", "unexpand", "uniq", "unset", "wait", "watch", "wc", "wget",
-    "whoami", "xargs", "xxd", "yes",
-];
-
 // --- Incomplete input detection ---
 
 fn is_incomplete_input(err_msg: &str) -> bool {
@@ -159,6 +144,10 @@ fn expand_ps1(ps1: &str, state: &bashkit::ShellStateView) -> String {
 struct BashkitHelper {
     fs: Arc<dyn bashkit::FileSystem>,
     state_fn: Box<dyn Fn() -> bashkit::ShellStateView + Send + Sync>,
+    /// Registered builtin names, snapshotted at startup from
+    /// `Bash::builtin_names()` — same live-registry source as `compgen -b`,
+    /// never a hardcoded list (the old one drifted to 109 of 156 names).
+    builtin_names: Vec<String>,
 }
 
 impl BashkitHelper {
@@ -274,9 +263,9 @@ impl Completer for BashkitHelper {
 
         if is_command_position {
             // Complete builtins
-            for &cmd in BUILTIN_COMMANDS {
+            for cmd in &self.builtin_names {
                 if cmd.starts_with(partial) {
-                    candidates.push(cmd.to_string());
+                    candidates.push(cmd.clone());
                 }
             }
             // Complete functions and aliases
@@ -475,6 +464,7 @@ pub async fn run(mut bash: bashkit::Bash, exit_state: Arc<ExitState>) -> Result<
     let helper = BashkitHelper {
         fs,
         state_fn: Box::new(move || state_for_helper.lock().unwrap().clone()),
+        builtin_names: bash.builtin_names(),
     };
 
     let mut editor = Editor::with_config(config)?;
@@ -902,6 +892,7 @@ mod tests {
         BashkitHelper {
             fs: Arc::clone(&fs),
             state_fn: Box::new(move || state.clone()),
+            builtin_names: bash.builtin_names(),
         }
     }
 

--- a/crates/bashkit/src/builtins/compgen.rs
+++ b/crates/bashkit/src/builtins/compgen.rs
@@ -9,6 +9,7 @@
 //!   compgen -d                                # directories
 //!   compgen -v                                # variables
 //!   compgen -b                                # builtins
+//!   compgen -a                                # aliases
 //!   compgen -c                                # commands (builtins, functions, aliases, PATH)
 //!   compgen -A function                       # by action type
 

--- a/crates/bashkit/src/builtins/compgen.rs
+++ b/crates/bashkit/src/builtins/compgen.rs
@@ -8,7 +8,8 @@
 //!   compgen -f                                # filenames
 //!   compgen -d                                # directories
 //!   compgen -v                                # variables
-//!   compgen -c                                # commands (builtins)
+//!   compgen -b                                # builtins
+//!   compgen -c                                # commands (builtins, functions, aliases, PATH)
 //!   compgen -A function                       # by action type
 
 use async_trait::async_trait;
@@ -20,21 +21,6 @@ use crate::interpreter::ExecResult;
 /// compgen builtin - bash completion generator.
 pub struct Compgen;
 
-/// Hardcoded list of known builtin command names.
-const BUILTIN_COMMANDS: &[&str] = &[
-    "alias", "assert", "awk", "base64", "basename", "bc", "break", "cat", "cd", "chmod", "chown",
-    "clear", "column", "comm", "compgen", "continue", "cp", "curl", "cut", "date", "declare", "df",
-    "diff", "dirname", "dirs", "dotenv", "du", "echo", "env", "envsubst", "eval", "exit", "expand",
-    "export", "expr", "false", "find", "fold", "grep", "gunzip", "gzip", "head", "hexdump",
-    "history", "hostname", "iconv", "id", "json", "join", "kill", "ln", "local", "log", "ls",
-    "mkdir", "mktemp", "mv", "nl", "od", "paste", "popd", "printenv", "printf", "pushd", "pwd",
-    "read", "readlink", "readonly", "realpath", "retry", "return", "rev", "rm", "rmdir", "sed",
-    "semver", "seq", "set", "shift", "shopt", "shuf", "sleep", "sort", "source", "split", "stat",
-    "strings", "tac", "tail", "tar", "tee", "test", "timeout", "touch", "tr", "tree", "truncate",
-    "true", "uname", "unexpand", "uniq", "unset", "wait", "watch", "wc", "wget", "whoami", "xargs",
-    "xxd", "yes",
-];
-
 #[async_trait]
 impl Builtin for Compgen {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -42,6 +28,9 @@ impl Builtin for Compgen {
         let mut gen_files = false;
         let mut gen_dirs = false;
         let mut gen_commands = false;
+        let mut gen_builtins = false;
+        let mut gen_functions = false;
+        let mut gen_aliases = false;
         let mut gen_variables = false;
         let mut actions: Vec<String> = Vec::new();
         let mut prefix: Option<String> = None;
@@ -62,6 +51,8 @@ impl Builtin for Compgen {
                 "-f" => gen_files = true,
                 "-d" => gen_dirs = true,
                 "-c" => gen_commands = true,
+                "-b" => gen_builtins = true,
+                "-a" => gen_aliases = true,
                 "-v" => gen_variables = true,
                 "-A" => {
                     i += 1;
@@ -101,11 +92,11 @@ impl Builtin for Compgen {
             match action.as_str() {
                 "file" => gen_files = true,
                 "directory" => gen_dirs = true,
-                "command" | "builtin" => gen_commands = true,
+                "command" => gen_commands = true,
+                "builtin" => gen_builtins = true,
                 "variable" => gen_variables = true,
-                "function" | "alias" => {
-                    // No functions/aliases in virtual env, produce empty
-                }
+                "function" => gen_functions = true,
+                "alias" => gen_aliases = true,
                 _ => {
                     return Ok(ExecResult::err(
                         format!("compgen: unknown action '{action}'\n"),
@@ -145,32 +136,45 @@ impl Builtin for Compgen {
             }
         }
 
-        // -c: commands (builtins + functions + aliases + PATH executables)
-        if gen_commands {
-            // Builtins
-            for &cmd in BUILTIN_COMMANDS {
-                if cmd.starts_with(pfx) {
-                    completions.push(cmd.to_string());
+        // -b / -A builtin (and -c): names from the live registry — the same
+        // source as `Bash::builtin_names()` — never a hardcoded list, which
+        // drifted (109 names vs 156 registered) before this was wired up.
+        // `ctx.shell` is None only for custom/external builtin contexts,
+        // which have no interpreter introspection by design.
+        if (gen_builtins || gen_commands)
+            && let Some(ref shell) = ctx.shell
+        {
+            for name in shell.builtin_names() {
+                if name.starts_with(pfx) {
+                    completions.push(name);
                 }
             }
-            #[cfg(feature = "jq")]
-            if "jq".starts_with(pfx) {
-                completions.push("jq".to_string());
-            }
+        }
 
-            // Functions from shell context
-            if let Some(ref shell) = ctx.shell {
-                for name in shell.functions.keys() {
-                    if name.starts_with(pfx) {
-                        completions.push(name.clone());
-                    }
-                }
-                for name in shell.aliases.keys() {
-                    if name.starts_with(pfx) {
-                        completions.push(name.clone());
-                    }
+        // -A function (and -c): defined shell functions
+        if (gen_functions || gen_commands)
+            && let Some(ref shell) = ctx.shell
+        {
+            for name in shell.functions.keys() {
+                if name.starts_with(pfx) {
+                    completions.push(name.clone());
                 }
             }
+        }
+
+        // -a / -A alias (and -c): defined aliases
+        if (gen_aliases || gen_commands)
+            && let Some(ref shell) = ctx.shell
+        {
+            for name in shell.aliases.keys() {
+                if name.starts_with(pfx) {
+                    completions.push(name.clone());
+                }
+            }
+        }
+
+        // -c: PATH executables on top of builtins/functions/aliases
+        if gen_commands {
             // PATH executables from VFS
             let path_var = ctx
                 .variables
@@ -210,11 +214,14 @@ impl Builtin for Compgen {
             && !gen_files
             && !gen_dirs
             && !gen_commands
+            && !gen_builtins
+            && !gen_functions
+            && !gen_aliases
             && !gen_variables
             && actions.is_empty()
         {
             return Ok(ExecResult::err(
-                "compgen: usage: compgen [-W wordlist] [-f] [-d] [-c] [-v] [-A action] [word]\n"
+                "compgen: usage: compgen [-W wordlist] [-f] [-d] [-c] [-b] [-a] [-v] [-A action] [word]\n"
                     .to_string(),
                 1,
             ));
@@ -300,17 +307,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commands() {
-        let r = run(&["-c", "--", "ec"], None, None).await;
-        assert_eq!(r.exit_code, 0);
-        assert!(r.stdout.contains("echo\n"));
-    }
-
-    #[tokio::test]
-    async fn test_jq_completion_matches_enabled_feature() {
-        let r = run(&["-c", "--", "jq"], None, None).await;
-        assert_eq!(r.exit_code == 0, cfg!(feature = "jq"));
-        assert_eq!(r.stdout.contains("jq\n"), cfg!(feature = "jq"));
+    async fn test_commands_without_shell_context_yields_no_builtins() {
+        // Builtin names come from the live registry via `ctx.shell`; custom/
+        // external builtin contexts (shell: None) have no introspection.
+        // Registry-backed behavior is covered by tests/integration/compgen_tests.rs.
+        let r = run(&["-b", "--", "ec"], None, None).await;
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stdout.is_empty());
     }
 
     #[tokio::test]
@@ -372,9 +375,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_action_flag() {
+        // Parses and runs; name generation needs shell context (None here),
+        // so no matches. Registry-backed -A coverage lives in
+        // tests/integration/compgen_tests.rs.
         let r = run(&["-A", "command", "--", "ec"], None, None).await;
-        assert_eq!(r.exit_code, 0);
-        assert!(r.stdout.contains("echo\n"));
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stdout.is_empty());
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -302,6 +302,10 @@ pub(crate) struct ShellRef<'a> {
     pub(crate) namerefs: &'a mut HashMap<String, String>,
     /// Registered builtin commands (read-only, accessed via `has_builtin`).
     pub(crate) builtins: &'a HashMap<String, Arc<dyn Builtin>>,
+    /// Host-owned builtin registry, when configured (read-only). Needed so
+    /// introspection builtins (`compgen -b`) list host-registered commands
+    /// alongside baked-in ones, matching `Bash::builtin_names()`.
+    pub(crate) host_builtins: Option<&'a crate::builtins::BuiltinRegistry>,
     /// Defined shell functions (read-only, accessed via `has_function`).
     pub(crate) functions: &'a HashMap<String, FunctionDef>,
     /// Call stack frames (read-only, accessed via `call_stack_depth`/`call_stack_frame_name`).
@@ -316,6 +320,20 @@ pub(crate) struct ShellRef<'a> {
     pub(crate) execution_extensions: Arc<builtins::ExecutionExtensions>,
 }
 
+/// Sorted, deduped union of baked-in/custom builtins and the host registry.
+fn merged_builtin_names(
+    builtins: &HashMap<String, Arc<dyn Builtin>>,
+    host_builtins: Option<&crate::builtins::BuiltinRegistry>,
+) -> Vec<String> {
+    let mut names: Vec<String> = builtins.keys().cloned().collect();
+    if let Some(reg) = host_builtins {
+        names.extend(reg.names());
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
 impl ShellRef<'_> {
     /// Get execution limits visible to read-only builtins.
     pub(crate) fn limits(&self) -> &ExecutionLimits {
@@ -325,6 +343,12 @@ impl ShellRef<'_> {
     /// Check if a name is a registered builtin command.
     pub(crate) fn has_builtin(&self, name: &str) -> bool {
         self.builtins.contains_key(name)
+    }
+
+    /// Sorted names of all registered builtins (baked-in + custom + host
+    /// registry) — same contract as [`crate::Bash::builtin_names`].
+    pub(crate) fn builtin_names(&self) -> Vec<String> {
+        merged_builtin_names(self.builtins, self.host_builtins)
     }
 
     /// Check if a name is a defined shell function.
@@ -5648,6 +5672,7 @@ impl Interpreter {
                 let execution_extensions = self.current_execution_extensions();
                 let shell_ref = ShellRef {
                     builtins: &self.builtins,
+                    host_builtins: self.host_builtins.as_ref(),
                     functions: &self.functions,
                     aliases: Arc::make_mut(&mut self.aliases),
                     traps: Arc::make_mut(&mut self.traps),
@@ -5700,6 +5725,7 @@ impl Interpreter {
             let execution_extensions = self.current_execution_extensions();
             let shell_ref = ShellRef {
                 builtins: &self.builtins,
+                host_builtins: self.host_builtins.as_ref(),
                 functions: &self.functions,
                 aliases: Arc::make_mut(&mut self.aliases),
                 traps: Arc::make_mut(&mut self.traps),
@@ -5879,13 +5905,7 @@ impl Interpreter {
     /// Sorted names of all registered builtins (baked-in + custom + host
     /// registry). See [`crate::Bash::builtin_names`].
     pub(crate) fn builtin_names(&self) -> Vec<String> {
-        let mut names: Vec<String> = self.builtins.keys().cloned().collect();
-        if let Some(reg) = &self.host_builtins {
-            names.extend(reg.names());
-        }
-        names.sort();
-        names.dedup();
-        names
+        merged_builtin_names(&self.builtins, self.host_builtins.as_ref())
     }
 
     // THREAT[TM-DOS-089]: Box the final dispatch split so function lookup,

--- a/crates/bashkit/tests/integration/compgen_tests.rs
+++ b/crates/bashkit/tests/integration/compgen_tests.rs
@@ -1,0 +1,106 @@
+//! Behavioral tests for `compgen` builtin/function/alias listing.
+//!
+//! `compgen -b` must reflect the live builtin registry — the same source
+//! `Bash::builtin_names()` reads — not a hardcoded list that drifts as
+//! builtins are added (it sat at 109 names while the registry had 156).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use bashkit::{Bash, Builtin, BuiltinContext, BuiltinRegistry, ExecResult, async_trait};
+
+struct NoopBuiltin;
+
+#[async_trait]
+impl Builtin for NoopBuiltin {
+    async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        Ok(ExecResult::ok(String::new()))
+    }
+}
+
+fn stdout_set(result: &ExecResult) -> HashSet<String> {
+    result
+        .stdout
+        .lines()
+        .map(|l| l.to_string())
+        .collect::<HashSet<_>>()
+}
+
+#[tokio::test]
+async fn compgen_b_matches_builtin_names() {
+    let mut bash = Bash::new();
+    let names: HashSet<String> = bash.builtin_names().into_iter().collect();
+
+    let result = bash.exec("compgen -b").await.unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    let listed = stdout_set(&result);
+
+    assert_eq!(
+        listed, names,
+        "compgen -b must list exactly the registered builtins"
+    );
+}
+
+#[tokio::test]
+async fn compgen_b_includes_host_registered_builtin() {
+    let registry = BuiltinRegistry::new();
+    registry.insert("my-host-cmd", Arc::new(NoopBuiltin));
+    let mut bash = Bash::builder().builtin_registry(registry).build();
+
+    let result = bash.exec("compgen -b my-host").await.unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "my-host-cmd\n");
+
+    // And builtin_names() agrees.
+    assert!(bash.builtin_names().iter().any(|n| n == "my-host-cmd"));
+}
+
+#[tokio::test]
+async fn compgen_action_builtin_lists_builtins_only() {
+    let mut bash = Bash::new();
+    // `awk` is a bashkit builtin; with -A builtin it must appear even though
+    // it's not a builtin in real bash.
+    let result = bash.exec("compgen -A builtin awk").await.unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "awk\n");
+
+    // -A builtin must NOT include functions.
+    let result = bash
+        .exec("myfn() { :; }; compgen -A builtin myfn")
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(result.stdout, "");
+}
+
+#[tokio::test]
+async fn compgen_action_function_lists_functions() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("greet() { echo hi; }; other() { :; }; compgen -A function gre")
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "greet\n");
+}
+
+#[tokio::test]
+async fn compgen_action_alias_lists_aliases() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("alias ll='ls -l'; alias gg='git'; compgen -A alias l")
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "ll\n");
+}
+
+#[tokio::test]
+async fn compgen_c_includes_registry_builtins_and_functions() {
+    let mut bash = Bash::new();
+    let result = bash.exec("ech_fn() { :; }; compgen -c ech").await.unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    let listed = stdout_set(&result);
+    assert!(listed.contains("echo"), "got: {listed:?}");
+    assert!(listed.contains("ech_fn"), "got: {listed:?}");
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -29,6 +29,7 @@ pub mod builtin_registry_tests;
 pub mod byte_range_panic_tests;
 pub mod cancellation_tests;
 pub mod cmdsub_quote_test;
+pub mod compgen_tests;
 pub mod coproc_tests;
 pub mod coreutils_differential_tests;
 pub mod credential_injection_tests;

--- a/specs/interactive-shell.md
+++ b/specs/interactive-shell.md
@@ -55,7 +55,7 @@ PS2 defaults to `> ` for continuation lines. Both can be set via
 Completes based on context:
 
 - **Command position** (start of line, after `;`/`|`/`&&`/`||`):
-  builtins (100+), aliases
+  builtins (live registry via `Bash::builtin_names()`), aliases
 - **Argument position**: VFS paths (files and directories)
 - **`$` prefix**: environment and shell variables
 - Directories show trailing `/`


### PR DESCRIPTION
## What

`compgen` listed builtins from a hardcoded 109-name array while the live registry has 156 — and `bashkit-cli`'s REPL tab completion kept a *second* hardcoded copy with a "keep in sync" comment. Both now read the registry, the same source as `Bash::builtin_names()` and the generated `specs/status/builtins.json`.

- `ShellRef` gains read access to the host builtin registry (plus a `builtin_names()` helper shared with `Interpreter`), so host-registered builtins complete too.
- New bash-parity flags: `compgen -b` (builtins) and `-a` (aliases).
- `-A builtin` now lists builtins only — it previously aliased the full `-c` command set.
- `-A function` / `-A alias` actually emit functions and aliases; they previously returned empty under a stale "no functions/aliases in virtual env" comment, even though the `-c` path right below read both from shell state.
- CLI tab completion snapshots `builtin_names()` at REPL startup instead of the drifted list.

## Why

This was the last hardcoded builtin inventory in the tree (flagged while building the generated-inventory work in #2038). An agent asking `compgen -b` got an answer missing 47 commands, including every feature-gated builtin and rg/type/which/yaml/csv.

## Tests

Failing-tests-first: `tests/integration/compgen_tests.rs` —
- `compgen -b` output **set-equal** to `Bash::builtin_names()` (the drift-killer invariant)
- host-registered builtin appears in `-b`
- `-A builtin` excludes functions; `-A function` / `-A alias` list correctly
- `-c` includes registry builtins + functions

Stale unit tests asserting the hardcoded list (with `shell: None`) updated to document the design: no shell context → no introspection. Full validation: clippy (CI features) clean, workspace slice + integration (1001 passed), bashkit-cli 80/80, spec tests green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1RX6JMsEpWNaXDXTMstMF)_