### PR TITLE
test(specs): back limitations.md stance rows with evidence tests

### DIFF
--- a/crates/bashkit/tests/integration/limitations_doc_tests.rs
+++ b/crates/bashkit/tests/integration/limitations_doc_tests.rs
@@ -73,7 +73,7 @@ fn limitation_evidence_tests_exist() {
         let cited = evidence.trim_matches('`');
         if cited.starts_with("l_") {
             assert!(
-                evidence_src.contains(&format!("async fn {cited}(")),
+                evidence_src.contains(&format!("fn {cited}(")),
                 "{id}: evidence test `{cited}` not found in limitations_evidence_tests.rs"
             );
         }

--- a/crates/bashkit/tests/integration/limitations_doc_tests.rs
+++ b/crates/bashkit/tests/integration/limitations_doc_tests.rs
@@ -58,6 +58,29 @@ fn limitations_doc_format() {
 }
 
 #[test]
+fn limitation_evidence_tests_exist() {
+    // Evidence cells citing an `l_*` test must resolve to a test function
+    // in limitations_evidence_tests.rs, so lifting a limitation can't leave
+    // the doc citing a deleted test (or vice versa).
+    let doc = limitations_doc();
+    let evidence_src = {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/integration/limitations_evidence_tests.rs");
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    };
+
+    for (id, evidence) in id_rows(&doc) {
+        let cited = evidence.trim_matches('`');
+        if cited.starts_with("l_") {
+            assert!(
+                evidence_src.contains(&format!("async fn {cited}(")),
+                "{id}: evidence test `{cited}` not found in limitations_evidence_tests.rs"
+            );
+        }
+    }
+}
+
+#[test]
 fn limitation_ids_referenced_from_code_exist_in_doc() {
     // Code comments may cite L-* IDs (e.g. path.rs cites L-FS-001). Every
     // citation must resolve to a row, so lifting a limitation can't leave

--- a/crates/bashkit/tests/integration/limitations_evidence_tests.rs
+++ b/crates/bashkit/tests/integration/limitations_evidence_tests.rs
@@ -30,7 +30,12 @@ async fn l_proc_003_no_process_spawning() {
     let mut bash = Bash::new();
     // `sh -c 'echo hi'` style host escape: /bin/sh is not a spawnable path.
     let result = bash.exec("/bin/sh -c 'echo escaped'").await.unwrap();
-    assert_ne!(result.exit_code, 0);
+    assert_eq!(result.exit_code, 127);
+    assert!(
+        result.stderr.contains("No such file or directory"),
+        "stderr: {}",
+        result.stderr
+    );
     assert!(!result.stdout.contains("escaped"));
 
     let result = bash.exec("definitely-not-a-command").await.unwrap();
@@ -74,8 +79,9 @@ async fn l_net_002_default_deny_no_resolution() {
     let result = bash.exec("curl -s https://example.com").await.unwrap();
     assert_ne!(result.exit_code, 0);
     assert!(
-        !result.stderr.is_empty(),
-        "denied request must explain itself"
+        result.stderr.contains("network access not configured"),
+        "must fail with the default-deny diagnostic, got: {}",
+        result.stderr
     );
 }
 

--- a/crates/bashkit/tests/integration/limitations_evidence_tests.rs
+++ b/crates/bashkit/tests/integration/limitations_evidence_tests.rs
@@ -1,0 +1,122 @@
+//! Evidence tests for `specs/limitations.md`.
+//!
+//! Each test demonstrates one intentional limitation (L-* row) so the
+//! negative spec stays executable: if a limitation is ever lifted, the
+//! matching test starts failing and the row must be removed in the same
+//! change. Test names are cited in the doc's Evidence column;
+//! `limitations_doc_tests` checks the citations resolve.
+
+use bashkit::Bash;
+
+/// L-PROC-002: no job control — `jobs`/`fg`/`bg` are not commands.
+#[tokio::test]
+async fn l_proc_002_no_job_control() {
+    let mut bash = Bash::new();
+    for cmd in ["jobs", "fg", "bg"] {
+        let result = bash.exec(cmd).await.unwrap();
+        assert_eq!(result.exit_code, 127, "{cmd} must be unknown");
+        assert!(
+            result.stderr.contains("command not found"),
+            "{cmd}: {}",
+            result.stderr
+        );
+    }
+}
+
+/// L-PROC-003: no process spawning — names outside the builtin registry,
+/// functions, and aliases never reach a host exec; they fail as unknown.
+#[tokio::test]
+async fn l_proc_003_no_process_spawning() {
+    let mut bash = Bash::new();
+    // `sh -c 'echo hi'` style host escape: /bin/sh is not a spawnable path.
+    let result = bash.exec("/bin/sh -c 'echo escaped'").await.unwrap();
+    assert_ne!(result.exit_code, 0);
+    assert!(!result.stdout.contains("escaped"));
+
+    let result = bash.exec("definitely-not-a-command").await.unwrap();
+    assert_eq!(result.exit_code, 127);
+    assert!(result.stderr.contains("command not found"));
+}
+
+/// L-FS-002: no permission enforcement — mode 000 files remain readable
+/// and writable in the single-tenant VFS.
+#[tokio::test]
+async fn l_fs_002_no_permission_enforcement() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("echo secret > /f && chmod 000 /f && cat /f")
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
+    assert_eq!(result.stdout, "secret\n");
+}
+
+/// L-NET-001: no raw sockets — bash's `/dev/tcp/HOST/PORT` pseudo-device
+/// does not exist; redirecting to it fails instead of opening a socket.
+#[tokio::test]
+async fn l_net_001_no_raw_sockets() {
+    let mut bash = Bash::new();
+    let result = bash.exec("echo x > /dev/tcp/example.com/80").await.unwrap();
+    assert_ne!(result.exit_code, 0);
+    assert!(
+        result.stderr.contains("/dev/tcp"),
+        "stderr: {}",
+        result.stderr
+    );
+}
+
+/// L-NET-002: default-deny networking — with no allowlist configured,
+/// curl cannot reach any host (and nothing is ever DNS-resolved).
+#[cfg(feature = "http_client")]
+#[tokio::test]
+async fn l_net_002_default_deny_no_resolution() {
+    let mut bash = Bash::new();
+    let result = bash.exec("curl -s https://example.com").await.unwrap();
+    assert_ne!(result.exit_code, 0);
+    assert!(
+        !result.stderr.is_empty(),
+        "denied request must explain itself"
+    );
+}
+
+/// L-SIG-001: INT/TERM trap handlers are stored but never delivered in
+/// virtual mode; EXIT traps do fire.
+#[tokio::test]
+async fn l_sig_001_signal_traps_not_delivered() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(r#"trap 'echo TRAPPED' INT; kill -INT $$; echo after"#)
+        .await
+        .unwrap();
+    assert!(
+        !result.stdout.contains("TRAPPED"),
+        "INT trap must not fire: {}",
+        result.stdout
+    );
+    assert!(result.stdout.contains("after"));
+
+    let result = bash
+        .exec(r#"trap 'echo EXITED' EXIT; echo body"#)
+        .await
+        .unwrap();
+    assert!(
+        result.stdout.contains("EXITED"),
+        "EXIT trap must fire: {}",
+        result.stdout
+    );
+}
+
+/// L-GREP-001: `--color`/`--line-buffered` accepted as no-ops — output is
+/// byte-identical to plain grep.
+#[tokio::test]
+async fn l_grep_001_noop_flags() {
+    let mut bash = Bash::new();
+    let plain = bash.exec("printf 'a\\nb\\n' | grep a").await.unwrap();
+    let colored = bash
+        .exec("printf 'a\\nb\\n' | grep --color=always --line-buffered a")
+        .await
+        .unwrap();
+    assert_eq!(plain.exit_code, 0);
+    assert_eq!(colored.exit_code, 0);
+    assert_eq!(plain.stdout, colored.stdout);
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -61,6 +61,7 @@ pub mod issue_873_test;
 pub mod issue_875_test;
 pub mod jq_fuzz_scaffold_tests;
 pub mod limitations_doc_tests;
+pub mod limitations_evidence_tests;
 pub mod live_mount_tests;
 pub mod mkfifo_tests;
 pub mod nested_subscript_tests;

--- a/specs/limitations.md
+++ b/specs/limitations.md
@@ -20,7 +20,9 @@ Intentional-limitation IDs (`L-<AREA>-<NNN>`) are stable: code comments
 and docs reference them (like TM-* threat IDs). Never renumber; mark
 lifted limitations as removed in the PR that lifts them.
 `limitations_doc_format` in `crates/bashkit/tests/integration/` lints the
-table format and ID uniqueness.
+table format and ID uniqueness; evidence cells naming `l_*` tests must
+resolve to functions in `limitations_evidence_tests.rs` (also linted).
+`stance` marks rows that are positions rather than testable behaviors.
 
 ## Intentional Limitations
 
@@ -31,13 +33,13 @@ execution model. Evidence is a threat-model ID, a test, or `stance`
 | ID | Limitation | Why | Evidence |
 |----|------------|-----|----------|
 | L-PROC-001 | `exec` does not replace the process; `exec cmd` runs cmd then stops execution (fd redirects work) | True process replace would break sandbox containment | TM-ESC-005 |
-| L-PROC-002 | No job control (`bg`, `fg`, `jobs`) | Requires process state; interactive-only feature | stance |
-| L-PROC-003 | No process spawning; external commands run as builtins | Core sandbox model: no fork/exec escape surface | stance |
+| L-PROC-002 | No job control (`bg`, `fg`, `jobs`) | Requires process state; interactive-only feature | `l_proc_002_no_job_control` |
+| L-PROC-003 | No process spawning; external commands run as builtins | Core sandbox model: no fork/exec escape surface | `l_proc_003_no_process_spawning` |
 | L-FS-001 | Symlinks stored but never followed in path resolution (`ln -s` works, `read_link()` returns targets, traversal blocked) | Prevents symlink loops and link-based sandbox escapes | TM-DOS-011 |
-| L-FS-002 | No file permission enforcement in the VFS | Single-tenant virtual FS; permissions would be theater | stance |
-| L-NET-001 | No raw network sockets; HTTP only via `curl`/`wget`/`http` builtins | Allowlist-mediated egress is the only network surface | stance |
-| L-NET-002 | No DNS resolution; hosts must appear in the allowlist | Resolution would bypass allowlist intent | stance |
-| L-SIG-001 | `trap` stores INT/TERM handlers but no signal delivery in virtual mode (EXIT, ERR fire) | No host signals exist inside the sandbox | stance |
+| L-FS-002 | No file permission enforcement in the VFS | Single-tenant virtual FS; permissions would be theater | `l_fs_002_no_permission_enforcement` |
+| L-NET-001 | No raw network sockets; HTTP only via `curl`/`wget`/`http` builtins | Allowlist-mediated egress is the only network surface | `l_net_001_no_raw_sockets` |
+| L-NET-002 | No DNS resolution; hosts must appear in the allowlist | Resolution would bypass allowlist intent | `l_net_002_default_deny_no_resolution` |
+| L-SIG-001 | `trap` stores INT/TERM handlers but no signal delivery in virtual mode (EXIT, ERR fire) | No host signals exist inside the sandbox | `l_sig_001_signal_traps_not_delivered` |
 
 ### Design Rationale
 
@@ -99,7 +101,7 @@ pass in CI); only divergences and boundaries are recorded here.
 |----|------|------------|----------|
 | L-AWK-001 | awk | Some complex regex patterns unsupported (engine shared with sed/grep, size-limited) | stance |
 | L-JQ-001 | jq | Alternative `//`: jaq errors on `.foo` applied to null instead of returning null (upstream jaq divergence) | 1 skipped spec test |
-| L-GREP-001 | grep | `--color`/`--colour`, `--line-buffered` accepted as no-ops | stance |
+| L-GREP-001 | grep | `--color`/`--colour`, `--line-buffered` accepted as no-ops | `l_grep_001_noop_flags` |
 | L-CURL-001 | curl | Spec-test coverage for methods/headers/payloads/auth/redirects not ported (needs `http_client` + allowlist in harness); behavior covered by integration tests | stance |
 
 Safety boundaries (enforced, not bugs): printf width/precision caps,


### PR DESCRIPTION
## What

Backs the `stance` rows in `specs/limitations.md` with executable evidence — completing the negative-spec design from #2038/#2039. 7 of 9 rows now cite a test in the new `limitations_evidence_tests.rs`:

| Row | Evidence test |
|---|---|
| L-PROC-002 no job control | `jobs`/`fg`/`bg` → exit 127 |
| L-PROC-003 no process spawning | `/bin/sh -c` escape attempt + unknown command → 127 |
| L-FS-002 no permission enforcement | `chmod 000` file remains readable |
| L-NET-001 no raw sockets | `/dev/tcp/HOST/PORT` redirect fails |
| L-NET-002 default-deny networking | unconfigured `curl` denied (feature-gated) |
| L-SIG-001 traps stored, not delivered | `kill -INT $$` doesn't fire trap; EXIT trap does |
| L-GREP-001 no-op flags | `--color`/`--line-buffered` output byte-identical |

If a limitation is ever lifted, its test fails and forces the row update in the same change. The doc lint gains a third check: evidence cells citing `l_*` names must resolve to actual test functions (and the doc explains the remaining `stance` marker is for positions, not testable behaviors — only L-AWK-001 and L-CURL-001 keep it).

## Why

A negative spec that nothing executes drifts silently — same failure mode as the builtin list (#2038) and the threat ledger (#2039), closed the same way: cite a checkable artifact, lint the citation.

## Found along the way

Probing behaviors before writing tests surfaced a real bash divergence: input redirect from a missing file (`cat < /missing`) aborts the whole `exec()` with `Err` instead of bash's stderr + `$?=1` + continue. Filed as #2050 rather than bundled here (interpreter redirect semantics, own blast radius).

## Tests

`cargo test --test integration --features http_client limitations` — 10 passed (3 lint + 7 evidence); clippy clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1RX6JMsEpWNaXDXTMstMF)_