### PR TITLE
fix(parser): escape ANSI-C NUL sentinel collisions

### DIFF
--- a/crates/bashkit/src/parser/lexer.rs
+++ b/crates/bashkit/src/parser/lexer.rs
@@ -1297,10 +1297,10 @@ impl<'a> Lexer<'a> {
         out
     }
 
-    /// Append a literal segment while protecting `$` from parse_word expansion.
+    /// Append a literal segment while protecting sentinel-sensitive bytes from parse_word expansion.
     fn push_literal_with_escaped_dollar(dst: &mut String, segment: &str) {
         for ch in segment.chars() {
-            if ch == '$' {
+            if matches!(ch, '\x00' | '$') {
                 dst.push('\x00');
             }
             dst.push(ch);

--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -4013,6 +4013,37 @@ mod tests {
     }
 
     #[test]
+    fn test_ansi_c_quoted_nul_before_dollar_stays_literal() {
+        for input in [
+            "echo $'\\0$(printf pwned)'",
+            "echo $'\\x00$(printf pwned)'",
+            "echo $'\\u0000${SECRET}'",
+            "echo $'\\U00000000${SECRET}'",
+        ] {
+            let parser = Parser::new(input);
+            let script = parser.parse().unwrap();
+            if let Command::Simple(cmd) = &script.commands[0] {
+                assert_eq!(cmd.args.len(), 1);
+                let arg = &cmd.args[0];
+                assert!(arg.quoted, "ANSI-C quoted argument must be quoted: {input}");
+                assert!(
+                    arg.parts
+                        .iter()
+                        .all(|part| matches!(part, WordPart::Literal(_))),
+                    "ANSI-C quoted NUL must not expose expansions for {input}: {:?}",
+                    arg.parts
+                );
+                assert!(
+                    arg.to_string().starts_with('\0'),
+                    "decoded ANSI-C NUL should remain literal for {input}"
+                );
+            } else {
+                panic!("expected simple command");
+            }
+        }
+    }
+
+    #[test]
     fn test_single_quoted_segment_concatenation_stays_literal() {
         let parser = Parser::new("echo foo'$(id)'");
         let script = parser.parse().unwrap();


### PR DESCRIPTION
Closes #2041

ANSI-C escape sequences that produce NUL bytes (`$'\0'`) collide with the internal NUL sentinel used to track quote boundaries. Escape the sentinel so NUL bytes in ANSI-C strings are handled correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sDGUd934hxPk7Ttc2WqMx)_