### PR TITLE
fix(awk): cap multi-subscript arrays

### DIFF
--- a/crates/bashkit/src/builtins/awk/parser.rs
+++ b/crates/bashkit/src/builtins/awk/parser.rs
@@ -3,7 +3,10 @@
 use std::collections::HashMap;
 
 use super::{AwkAction, AwkExpr, AwkFunctionDef, AwkOutputTarget, AwkPattern, AwkProgram, AwkRule};
-use crate::builtins::limits::AWK_MAX_PARSER_DEPTH as MAX_AWK_PARSER_DEPTH;
+use crate::builtins::limits::{
+    AWK_MAX_MULTI_SUBSCRIPTS as MAX_AWK_MULTI_SUBSCRIPTS,
+    AWK_MAX_PARSER_DEPTH as MAX_AWK_PARSER_DEPTH,
+};
 use crate::builtins::search_common::build_regex;
 use crate::error::{Error, Result};
 
@@ -1484,8 +1487,15 @@ impl<'a> AwkParser<'a> {
                 self.pos += 1; // consume '['
                 let mut subscripts = vec![self.parse_expression()?];
                 self.skip_whitespace();
-                // Handle multi-subscript: arr[e1, e2, ...] joined by SUBSEP
+                // THREAT[TM-DOS-027]: SUBSEP_CONCAT still evaluates recursively, so cap
+                // attacker-controlled comma lists before folding them into a left-deep AST.
                 while self.pos < self.input.len() && self.current_char().unwrap() == ',' {
+                    if subscripts.len() >= MAX_AWK_MULTI_SUBSCRIPTS {
+                        return Err(Error::Execution(format!(
+                            "awk: too many array subscripts (max {})",
+                            MAX_AWK_MULTI_SUBSCRIPTS
+                        )));
+                    }
                     self.pos += 1; // consume ','
                     self.skip_whitespace();
                     subscripts.push(self.parse_expression()?);

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -594,6 +594,17 @@ async fn test_awk_multi_subscript() {
 }
 
 #[tokio::test]
+async fn test_awk_rejects_too_many_multi_subscripts() {
+    // Regression: unbounded multi-subscript lists built a recursive SUBSEP_CONCAT AST.
+    let subscripts = std::iter::repeat_n("1", 101).collect::<Vec<_>>().join(",");
+    let program = format!("BEGIN {{ a[{subscripts}] = 1 }}");
+
+    let err = run_awk(&[&program], Some("")).await.unwrap_err();
+
+    assert!(err.to_string().contains("too many array subscripts"));
+}
+
+#[tokio::test]
 async fn test_awk_subsep_defined() {
     // Issue #396.3: SUBSEP should be defined as \034
     let result = run_awk(&[r#"BEGIN { print length(SUBSEP) }"#], Some(""))

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -597,7 +597,9 @@ async fn test_awk_multi_subscript() {
 #[tokio::test]
 async fn test_awk_rejects_too_many_multi_subscripts() {
     // Regression: unbounded multi-subscript lists built a recursive SUBSEP_CONCAT AST.
-    let subscripts = std::iter::repeat_n("1", AWK_MAX_MULTI_SUBSCRIPTS + 1).collect::<Vec<_>>().join(",");
+    let subscripts = std::iter::repeat_n("1", AWK_MAX_MULTI_SUBSCRIPTS + 1)
+        .collect::<Vec<_>>()
+        .join(",");
     let program = format!("BEGIN {{ a[{subscripts}] = 1 }}");
 
     let err = run_awk(&[&program], Some("")).await.unwrap_err();

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -7,6 +7,7 @@ use crate::builtins::limits::{
     AWK_MAX_GETLINE_CACHE_BYTES as MAX_GETLINE_CACHE_BYTES,
     AWK_MAX_GETLINE_CACHED_FILES as MAX_GETLINE_CACHED_FILES,
     AWK_MAX_GETLINE_FILE_BYTES as MAX_GETLINE_FILE_BYTES,
+    AWK_MAX_MULTI_SUBSCRIPTS,
     AWK_MAX_OUTPUT_BYTES as MAX_OUTPUT_BYTES,
     AWK_MAX_OUTPUT_TARGETS as MAX_OUTPUT_TARGETS,
 };
@@ -596,7 +597,7 @@ async fn test_awk_multi_subscript() {
 #[tokio::test]
 async fn test_awk_rejects_too_many_multi_subscripts() {
     // Regression: unbounded multi-subscript lists built a recursive SUBSEP_CONCAT AST.
-    let subscripts = std::iter::repeat_n("1", 101).collect::<Vec<_>>().join(",");
+    let subscripts = std::iter::repeat_n("1", AWK_MAX_MULTI_SUBSCRIPTS + 1).collect::<Vec<_>>().join(",");
     let program = format!("BEGIN {{ a[{subscripts}] = 1 }}");
 
     let err = run_awk(&[&program], Some("")).await.unwrap_err();

--- a/crates/bashkit/src/builtins/limits.rs
+++ b/crates/bashkit/src/builtins/limits.rs
@@ -19,6 +19,8 @@ pub(crate) const ARCHIVE_MAX_DECOMPRESSION_RATIO: usize = 100;
 
 /// awk: max parser recursion depth.
 pub(crate) const AWK_MAX_PARSER_DEPTH: usize = 100;
+/// awk: max comma-separated subscripts in one array key.
+pub(crate) const AWK_MAX_MULTI_SUBSCRIPTS: usize = 100;
 /// awk: max user-function call depth at runtime.
 pub(crate) const AWK_MAX_CALL_DEPTH: usize = 64;
 /// awk: total output byte cap per invocation.


### PR DESCRIPTION
Closes #2046

Introduces `AWK_MAX_MULTI_SUBSCRIPTS` (100) and enforces it at **parse time** when collecting comma-separated subscripts in `arr[e1,e2,...]` expressions. The parser rejects any subscript list longer than the cap, preventing pathological left-deep `SUBSEP_CONCAT` AST construction from adversarial scripts. Adds a regression test that verifies rejection when the cap is exceeded (using `AWK_MAX_MULTI_SUBSCRIPTS + 1` so it tracks the constant).