### PR TITLE
fix(python): cap external function handlers with remaining max_duration budget

### DIFF
--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -614,11 +614,6 @@ fn python_external_timeout_error() -> ExtFunctionResult {
     ))
 }
 
-fn remaining_python_budget(deadline: Option<Instant>) -> Option<Duration> {
-    let deadline = deadline?;
-    deadline.checked_duration_since(Instant::now())
-}
-
 async fn call_external_with_deadline(
     external_fns: &PythonExternalFns,
     function_name: String,
@@ -626,10 +621,13 @@ async fn call_external_with_deadline(
     kwargs: Vec<(MontyObject, MontyObject)>,
     deadline: Option<Instant>,
 ) -> ExtFunctionResult {
-    let Some(remaining) = remaining_python_budget(deadline) else {
+    let Some(deadline) = deadline else {
+        // Instant::checked_add overflowed (very large max_duration); run uncapped.
+        return (external_fns.handler)(function_name, args, kwargs).await;
+    };
+    let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
         return python_external_timeout_error();
     };
-
     match tokio::time::timeout(
         remaining,
         (external_fns.handler)(function_name, args, kwargs),

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -30,7 +30,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::{Builtin, Context, ExecutionDeadline, resolve_path};
 use crate::error::Result;
@@ -151,6 +151,10 @@ impl PythonLimits {
 ///
 /// Receives `(function_name, positional_args, keyword_args)` directly from monty.
 /// Return `ExtFunctionResult::Return(value)` for success or `ExtFunctionResult::Error(exc)` for failure.
+///
+/// Important security decision: the Python builtin wraps each awaited handler
+/// in the remaining [`PythonLimits::max_duration`] budget. Host handlers are
+/// trusted code, but should still enforce their own I/O and service limits.
 pub type PythonExternalFnHandler = Arc<
     dyn Fn(
             String,
@@ -433,17 +437,9 @@ impl Builtin for Python {
             ));
         }
 
-        // Merge env and variables so exported vars (set via `export`) are visible
-        // to Python's os.getenv(). Variables override env (bash semantics).
-        // THREAT[TM-INF]: Filter internal markers (including SHOPT_*) to prevent
-        // information disclosure via os.environ (issue #999).
-        let mut merged_env = ctx.env.clone();
-        merged_env.extend(
-            ctx.variables
-                .iter()
-                .filter(|(k, _)| !crate::interpreter::is_hidden_variable(k))
-                .map(|(k, v)| (k.clone(), v.clone())),
-        );
+        // THREAT[TM-INF]: Python environment access is intentionally scoped
+        // to exported variables only (`ctx.env`). Shell-local variables in
+        // `ctx.variables` may contain wrapper secrets or internal markers.
 
         // Clamp Monty's wall-clock budget to the caller's remaining execution
         // deadline (like the TypeScript builtin) so a CPU-bound script cannot
@@ -462,7 +458,7 @@ impl Builtin for Python {
             &filename,
             ctx.fs.clone(),
             ctx.cwd,
-            &merged_env,
+            ctx.env,
             &limits,
             self.external_fns.as_ref(),
         )
@@ -505,6 +501,9 @@ async fn run_python(
         .max_recursion_depth(Some(py_limits.max_recursion));
 
     let tracker = LimitedTracker::new(limits);
+    // Important security decision: cap awaited host callbacks with the same wall-clock
+    // budget as Monty so external functions cannot pin execution between VM steps.
+    let python_deadline = Instant::now().checked_add(py_limits.max_duration);
 
     // Run the synchronous start() phase, then extract collected output.
     // PrintWriter::CollectString is not Send, so we scope it to avoid holding across .await.
@@ -533,10 +532,12 @@ async fn run_python(
             }
             RunProgress::FunctionCall(call) => {
                 let result = if let Some(ef) = external_fns {
-                    (ef.handler)(
+                    call_external_with_deadline(
+                        ef,
                         call.function_name.clone(),
                         call.args.clone(),
                         call.kwargs.clone(),
+                        python_deadline,
                     )
                     .await
                 } else {
@@ -606,12 +607,44 @@ async fn run_python(
     }
 }
 
+fn python_external_timeout_error() -> ExtFunctionResult {
+    ExtFunctionResult::Error(MontyException::new(
+        ExcType::RuntimeError,
+        Some("Python external function exceeded max_duration".into()),
+    ))
+}
+
+fn remaining_python_budget(deadline: Option<Instant>) -> Option<Duration> {
+    let deadline = deadline?;
+    deadline.checked_duration_since(Instant::now())
+}
+
+async fn call_external_with_deadline(
+    external_fns: &PythonExternalFns,
+    function_name: String,
+    args: Vec<MontyObject>,
+    kwargs: Vec<(MontyObject, MontyObject)>,
+    deadline: Option<Instant>,
+) -> ExtFunctionResult {
+    let Some(remaining) = remaining_python_budget(deadline) else {
+        return python_external_timeout_error();
+    };
+
+    match tokio::time::timeout(
+        remaining,
+        (external_fns.handler)(function_name, args, kwargs),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => python_external_timeout_error(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // VFS bridging: Monty OsCall → Bashkit FileSystem
 // ---------------------------------------------------------------------------
 
-/// Dispatch a Monty OsCall to the appropriate VFS operation.
-///
 /// Monty's `OsFunctionCall` is a tagged enum carrying typed args. We project it
 /// to the generic `(positional, keyword)` `MontyObject` view via the public
 /// `to_args()` and dispatch on the stable `name()` string (kept byte-identical
@@ -1506,12 +1539,21 @@ mod tests {
         fn_names: &[&str],
         handler: PythonExternalFnHandler,
     ) -> ExecResult {
+        run_with_external_and_limits(code, fn_names, handler, PythonLimits::default()).await
+    }
+
+    async fn run_with_external_and_limits(
+        code: &str,
+        fn_names: &[&str],
+        handler: PythonExternalFnHandler,
+        limits: PythonLimits,
+    ) -> ExecResult {
         let args = vec!["-c".to_string(), code.to_string()];
         let env = opt_in_env();
         let mut variables = HashMap::new();
         let mut cwd = PathBuf::from("/home/user");
         let fs = Arc::new(InMemoryFs::new());
-        let py = Python::with_limits(PythonLimits::default())
+        let py = Python::with_limits(limits)
             .with_external_handler(fn_names.iter().map(|s| s.to_string()).collect(), handler);
         let ctx = Context::new_for_test(&args, &env, &mut variables, &mut cwd, fs, None);
         py.execute(ctx).await.unwrap()
@@ -1525,6 +1567,33 @@ mod tests {
         let r = run_with_external("print(get_answer())", &["get_answer"], handler).await;
         assert_eq!(r.exit_code, 0);
         assert_eq!(r.stdout, "42\n");
+    }
+
+    #[tokio::test]
+    async fn test_external_fn_handler_timeout_uses_python_deadline() {
+        let handler: PythonExternalFnHandler = Arc::new(|_name, _args, _kwargs| {
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                ExtFunctionResult::Return(MontyObject::Int(1))
+            })
+        });
+        let started = Instant::now();
+        let r = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_with_external_and_limits(
+                "print(slow())",
+                &["slow"],
+                handler,
+                PythonLimits::default().max_duration(Duration::from_millis(25)),
+            ),
+        )
+        .await
+        .expect("Python external call should observe max_duration");
+
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stderr.contains("RuntimeError"));
+        assert!(r.stderr.contains("exceeded max_duration"));
+        assert!(started.elapsed() < Duration::from_millis(500));
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/integration/python_security_tests.rs
+++ b/crates/bashkit/tests/integration/python_security_tests.rs
@@ -612,14 +612,8 @@ mod whitebox_env_security {
             .exec("INTERNAL_VAR=secret\npython3 -c \"import os\nprint(os.getenv('INTERNAL_VAR', 'none'))\"")
             .await
             .unwrap();
-        // Unexported vars should not be visible to Python
-        // (bash semantics: only exported vars are in env)
-        // Note: bashkit merges variables, so this tests that behavior
-        if r.exit_code == 0 {
-            // If visible, verify it's the expected value (no corruption)
-            let out = r.stdout.trim();
-            assert!(out == "none" || out == "secret");
-        }
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "none");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/python/env_leak.test.sh
+++ b/crates/bashkit/tests/spec_cases/python/env_leak.test.sh
@@ -9,12 +9,20 @@ python3 -c "import os; print(os.getenv('_READONLY_x', 'none'))"
 none
 ### end
 
-### user_variable_still_visible
-# Regular user variables should still be accessible from Python
-MY_VAR=hello
+### exported_variable_visible
+# Exported variables are visible in Python via os.environ
+export MY_VAR=hello
 python3 -c "import os; print(os.getenv('MY_VAR', 'missing'))"
 ### expect
 hello
+### end
+
+### unexported_variable_not_visible
+# Non-exported shell variables are NOT visible in Python (matches bash semantics)
+UNEXPORTED_VAR=secret
+python3 -c "import os; print(os.getenv('UNEXPORTED_VAR', 'none'))"
+### expect
+none
 ### end
 
 ### shopt_not_visible

--- a/specs/python-builtin.md
+++ b/specs/python-builtin.md
@@ -115,7 +115,8 @@ let bash = Bash::builder()
 - Handler signature: `(function_name: String, positional_args: Vec<MontyObject>, keyword_args: Vec<(MontyObject, MontyObject)>) -> Pin<Box<dyn Future<Output = ExtFunctionResult> + Send>>`.
 - Returns `ExtFunctionResult::Return(MontyObject)` (value to Python) or `ExtFunctionResult::Error(MontyException)` (raises).
 - **Dispatch:** one handler receives all registered names; dispatch on `function_name` inside it.
-- **Trust model:** same as `BashBuilder::builtin()` and `ScriptedTool` callbacks — host registers trusted Rust code, untrusted scripts invoke by name.
+- **Timeouts:** Each awaited handler call is wrapped in the remaining `PythonLimits::max_duration` wall-clock budget for the current Python invocation. If the budget expires while a handler is pending, Bashkit resumes Python with a `RuntimeError` instead of waiting for the handler indefinitely.
+- **Trust model:** same as `BashBuilder::builtin()` and `ScriptedTool` callbacks — host registers trusted Rust code, untrusted scripts invoke by name. Handlers are trusted host code and should still enforce independent limits for outbound I/O, remote services, and other resources they consume.
 - **Unstable re-exports:** `MontyObject`, `ExtFunctionResult`, `MontyException`, `ExcType` re-exported from the `monty` crate (git-pinned, not on crates.io); may break between bashkit releases.
 
 ### Security


### PR DESCRIPTION
Closes #2043, Closes #2044

**Python external function deadline enforcement (issue #2043):** wraps each awaited external function handler call in `tokio::time::timeout` using the remaining `PythonLimits::max_duration` wall-clock budget. Handlers that exceed the remaining budget get a `RuntimeError` instead of blocking indefinitely. `Instant::checked_add` overflow (very large `max_duration`) is treated as no deadline rather than an immediate timeout.

**Python env scope (issue #2044):** removes the `merged_env` block that merged shell-local `ctx.variables` into the Python subprocess environment. Only exported variables (`ctx.env`) are now visible to Python, matching real bash semantics and closing the shell-secret disclosure path (TM-INF). Tightens integration and spec tests to assert unexported variables return `"none"` from `os.getenv()`.