### PR TITLE
fix(python): scope env to exported vars only, drop shell-local variable merge

### DIFF
--- a/crates/bashkit/tests/integration/python_security_tests.rs
+++ b/crates/bashkit/tests/integration/python_security_tests.rs
@@ -612,14 +612,8 @@ mod whitebox_env_security {
             .exec("INTERNAL_VAR=secret\npython3 -c \"import os\nprint(os.getenv('INTERNAL_VAR', 'none'))\"")
             .await
             .unwrap();
-        // Unexported vars should not be visible to Python
-        // (bash semantics: only exported vars are in env)
-        // Note: bashkit merges variables, so this tests that behavior
-        if r.exit_code == 0 {
-            // If visible, verify it's the expected value (no corruption)
-            let out = r.stdout.trim();
-            assert!(out == "none" || out == "secret");
-        }
+        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.stdout.trim(), "none");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/python/env_leak.test.sh
+++ b/crates/bashkit/tests/spec_cases/python/env_leak.test.sh
@@ -9,12 +9,20 @@ python3 -c "import os; print(os.getenv('_READONLY_x', 'none'))"
 none
 ### end
 
-### user_variable_still_visible
-# Regular user variables should still be accessible from Python
-MY_VAR=hello
+### exported_variable_visible
+# Exported variables are visible in Python via os.environ
+export MY_VAR=hello
 python3 -c "import os; print(os.getenv('MY_VAR', 'missing'))"
 ### expect
 hello
+### end
+
+### unexported_variable_not_visible
+# Non-exported shell variables are NOT visible in Python (matches bash semantics)
+UNEXPORTED_VAR=secret
+python3 -c "import os; print(os.getenv('UNEXPORTED_VAR', 'none'))"
+### expect
+none
 ### end
 
 ### shopt_not_visible


### PR DESCRIPTION
Superseded by #2058 — implementation change and test updates combined into one PR covering both issues #2043 and #2044.