### PR TITLE
chore(ci): bump github-actions group (setup-uv, codecov, taiki-e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           command: check licenses sources
 
       - name: Install cargo-vet
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
         with:
           tool: cargo-vet
 
@@ -99,7 +99,7 @@ jobs:
       - name: Install uutils coreutils multicall for differential tests
         id: install_uutils
         continue-on-error: true
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
         with:
           tool: coreutils
       - name: Verify uutils on PATH

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
         with:
           tool: cargo-llvm-cov
 
@@ -91,7 +91,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Generate Python-driven Rust coverage
         run: |
@@ -132,7 +132,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
         with:
           tool: cargo-llvm-cov
 
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/cobertura.xml,coverage/python-rust-coverage.json,coverage/node-rust-coverage.json

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -212,7 +212,7 @@ jobs:
           echo "---"
           echo "Total files: $(ls -1 dist/ | wc -l)"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - run: uvx twine check dist/*
 
   # Smoke-test wheels on each OS, including the new cp314 artifacts
@@ -282,7 +282,7 @@ jobs:
       - name: List dist files
         run: ls -lhR dist/
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always dist/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Ruff check
         run: uvx ruff check crates/bashkit-python
@@ -111,7 +111,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0


### PR DESCRIPTION
Corrected subset of the Dependabot group bump in #2067. That PR's grouped update collapsed two semantically-named action refs into generic release SHAs, which broke CI. This PR keeps the safe updates and drops the two regressions.

## What

**Applied (safe):**
- `astral-sh/setup-uv` v7 → v8.2.0
- `codecov/codecov-action` v6 (`e79a696` → `fb8b358`)
- `taiki-e/install-action` v2 (`4bc351f` → `7a79fe8`) for the generic `with: tool:` installs (cargo-vet, coreutils, cargo-llvm-cov)

**Dropped from #2067 (break CI):**
- `dtolnay/rust-toolchain` `@nightly` (`5b84223` → `e081816`) — broke **Build wheel (Pyodide/Emscripten)**: `wasm32-unknown-emscripten` std was no longer installed for the pinned nightly (`error[E0463]: can't find crate for std`).
- `taiki-e/install-action` `@cargo-tarpaulin` tag (`3d6bdc4` → `7a79fe8`) — the tool-specific tag was collapsed into a generic release SHA, so the step no longer installed tarpaulin. **Generate Rust Coverage** failed with `error: no such command: tarpaulin`.

## Why

#2067's CI was red on those two jobs (plus the `Python Check` aggregator). PR #2069, which had no action bumps, passed all of them — confirming both failures were introduced by the grouped bump, not pre-existing. (#2067 also hit a transient rustup cache flake on `Build wheel`, unrelated to the bumps.)

## Verification

YAML validated for all touched workflows. Behavior is validated by CI itself running green on this PR.

Supersedes #2067.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyvhVVRep8MD3yECMaAuUB)_