### PR TITLE
feat(bindings): expose cwd and env options to Node and Python

### DIFF
--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -89,6 +89,8 @@ import { Bash } from "@everruns/bashkit";
 const bash = new Bash({
   username: "agent",
   hostname: "sandbox",
+  cwd: "/home/agent",
+  env: { PROJECT: "bashkit" },
   maxCommands: 1000,
   maxLoopIterations: 10000,
   maxMemory: 10 * 1024 * 1024,

--- a/crates/bashkit-js/README.md
+++ b/crates/bashkit-js/README.md
@@ -568,6 +568,8 @@ import {
 
 - `username?: string`
 - `hostname?: string`
+- `cwd?: string` — initial working directory (avoids a leading `cd`)
+- `env?: Record<string, string>` — initial environment variables (avoids an `export` prelude)
 - `maxCommands?: number`
 - `maxLoopIterations?: number`
 - `maxMemory?: number`

--- a/crates/bashkit-js/__test__/cwd-env-options.spec.ts
+++ b/crates/bashkit-js/__test__/cwd-env-options.spec.ts
@@ -1,0 +1,40 @@
+import test from "ava";
+import { Bash, BashTool } from "../wrapper.js";
+
+// ----------------------------------------------------------------------------
+// cwd / env constructor options (issue #2068) — set the starting directory and
+// initial environment without a leading `cd`/`export` prelude.
+// ----------------------------------------------------------------------------
+
+test("cwd option sets the starting working directory", async (t) => {
+  const bash = new Bash({ cwd: "/home/user" });
+  const result = await bash.execute("pwd");
+  t.is(result.stdout, "/home/user\n");
+  t.is(bash.shellState().cwd, "/home/user");
+});
+
+test("env option exposes variables without an export prelude", async (t) => {
+  const bash = new Bash({ env: { HOME: "/home/user", LANG: "en_US.UTF-8" } });
+  const result = await bash.execute('echo "$HOME $LANG"');
+  t.is(result.stdout, "/home/user en_US.UTF-8\n");
+  t.is(bash.shellState().env.HOME, "/home/user");
+});
+
+test("cwd and env survive reset()", async (t) => {
+  const bash = new Bash({ cwd: "/home/user", env: { TOKEN: "abc" } });
+  await bash.execute("cd / ; unset TOKEN");
+  bash.reset();
+  const result = await bash.execute('pwd ; echo "$TOKEN"');
+  t.is(result.stdout, "/home/user\nabc\n");
+});
+
+test("cwd and env options work on BashTool", async (t) => {
+  const tool = new BashTool({ cwd: "/srv", env: { APP: "bashkit" } });
+  const result = await tool.execute('pwd ; echo "$APP"');
+  t.is(result.stdout, "/srv\nbashkit\n");
+});
+
+test("env option appears in BashTool help", (t) => {
+  const tool = new BashTool({ env: { API_BASE: "https://example.com" } });
+  t.true(tool.help().includes("API_BASE"));
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -1271,6 +1271,12 @@ fn apply_network_options(
 pub struct BashOptions {
     pub username: Option<String>,
     pub hostname: Option<String>,
+    /// Initial working directory for the shell (mirrors `Bash::builder().cwd()`).
+    /// Avoids a leading `cd "$cwd"` command just to set the starting directory.
+    pub cwd: Option<String>,
+    /// Initial environment variables (mirrors `Bash::builder().env()`).
+    /// Applied before execution so scripts see them without an `export` prelude.
+    pub env: Option<HashMap<String, String>>,
     pub max_commands: Option<u32>,
     pub max_loop_iterations: Option<u32>,
     pub max_total_loop_iterations: Option<u32>,
@@ -1328,6 +1334,8 @@ fn default_opts() -> BashOptions {
     BashOptions {
         username: None,
         hostname: None,
+        cwd: None,
+        env: None,
         max_commands: None,
         max_loop_iterations: None,
         max_total_loop_iterations: None,
@@ -1397,6 +1405,8 @@ struct SharedState {
     async_execute_semaphore: Arc<Semaphore>,
     username: Option<String>,
     hostname: Option<String>,
+    cwd: Option<String>,
+    env: Option<HashMap<String, String>>,
     max_commands: Option<u32>,
     max_loop_iterations: Option<u32>,
     max_total_loop_iterations: Option<u32>,
@@ -2119,6 +2129,14 @@ impl BashTool {
         }
         if let Some(ref hostname) = state.hostname {
             builder = builder.hostname(hostname);
+        }
+        if let Some(ref cwd) = state.cwd {
+            builder = builder.cwd(cwd.as_str());
+        }
+        if let Some(ref env) = state.env {
+            for (k, v) in env {
+                builder = builder.env(k, v);
+            }
         }
 
         builder.limits(build_limits(state)).build()
@@ -3173,6 +3191,14 @@ fn build_bash_from_state(state: &SharedState, files: Option<&HashMap<String, Str
     if let Some(ref h) = state.hostname {
         builder = builder.hostname(h);
     }
+    if let Some(ref cwd) = state.cwd {
+        builder = builder.cwd(cwd.as_str());
+    }
+    if let Some(ref env) = state.env {
+        for (k, v) in env {
+            builder = builder.env(k, v);
+        }
+    }
 
     builder = builder.limits(build_limits(state));
 
@@ -3278,6 +3304,8 @@ fn shared_state_from_opts(
         async_execute_semaphore: Arc::new(Semaphore::new(MAX_PENDING_ASYNC_EXECUTIONS)),
         username: opts.username.clone(),
         hostname: opts.hostname.clone(),
+        cwd: opts.cwd.clone(),
+        env: opts.env.clone(),
         max_commands: opts.max_commands,
         max_loop_iterations: opts.max_loop_iterations,
         max_total_loop_iterations: opts.max_total_loop_iterations,
@@ -3328,6 +3356,8 @@ fn shared_state_from_opts(
         async_execute_semaphore: Arc::new(Semaphore::new(MAX_PENDING_ASYNC_EXECUTIONS)),
         username: opts.username,
         hostname: opts.hostname,
+        cwd: opts.cwd,
+        env: opts.env,
         max_commands: opts.max_commands,
         max_loop_iterations: opts.max_loop_iterations,
         max_total_loop_iterations: opts.max_total_loop_iterations,

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -154,6 +154,30 @@ export type BuiltinCallback = (ctx: BuiltinContext) => string | Promise<string>;
 export interface BashOptions {
   username?: string;
   hostname?: string;
+  /**
+   * Initial working directory for the shell.
+   *
+   * Sets the starting `cwd` directly instead of running a leading
+   * `cd "${cwd}"` command, avoiding the parse/exec overhead.
+   *
+   * @example
+   * ```typescript
+   * const bash = new Bash({ cwd: "/home/user" });
+   * ```
+   */
+  cwd?: string;
+  /**
+   * Initial environment variables, applied before execution.
+   *
+   * Scripts see these immediately without an `export` prelude. Keys are
+   * variable names, values are their string values.
+   *
+   * @example
+   * ```typescript
+   * const bash = new Bash({ env: { HOME: "/home/user", LANG: "en_US.UTF-8" } });
+   * ```
+   */
+  env?: Record<string, string>;
   maxCommands?: number;
   maxLoopIterations?: number;
   maxTotalLoopIterations?: number;
@@ -550,6 +574,8 @@ function toNativeOptions(
   return {
     username: options?.username,
     hostname: options?.hostname,
+    cwd: options?.cwd,
+    env: options?.env,
     maxCommands: options?.maxCommands,
     maxLoopIterations: options?.maxLoopIterations,
     maxTotalLoopIterations: options?.maxTotalLoopIterations,

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -74,6 +74,8 @@ from bashkit import Bash
 bash = Bash(
     username="agent",
     hostname="sandbox",
+    cwd="/home/agent",
+    env={"LANG": "en_US.UTF-8"},
     max_commands=1000,
     max_loop_iterations=10000,
     max_memory=10 * 1024 * 1024,

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -465,6 +465,8 @@ class Bash:
         self,
         username: str | None = None,
         hostname: str | None = None,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
         max_commands: int | None = None,
         max_loop_iterations: int | None = None,
         max_memory: int | None = None,
@@ -485,6 +487,10 @@ class Bash:
         Args:
             username: Custom username (default ``"user"``).
             hostname: Custom hostname (default ``"bashkit"``).
+            cwd: Initial working directory for the shell. Sets the starting
+                directory directly instead of running a leading ``cd``.
+            env: Initial environment variables applied before execution, so
+                scripts see them without an ``export`` prelude.
             max_commands: Limit total commands executed.
             max_loop_iterations: Limit iterations per loop.
             max_memory: Memory limit in bytes for the VFS.
@@ -716,6 +722,8 @@ class Bash:
         data: bytes,
         username: str | None = None,
         hostname: str | None = None,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
         max_commands: int | None = None,
         max_loop_iterations: int | None = None,
         max_memory: int | None = None,
@@ -740,6 +748,8 @@ class Bash:
         key: bytes,
         username: str | None = None,
         hostname: str | None = None,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
         max_commands: int | None = None,
         max_loop_iterations: int | None = None,
         max_memory: int | None = None,
@@ -922,6 +932,8 @@ class BashTool:
         self,
         username: str | None = None,
         hostname: str | None = None,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
         max_commands: int | None = None,
         max_loop_iterations: int | None = None,
         max_memory: int | None = None,
@@ -938,6 +950,10 @@ class BashTool:
         Args:
             username: Custom username (default ``"user"``).
             hostname: Custom hostname (default ``"bashkit"``).
+            cwd: Initial working directory for the shell. Sets the starting
+                directory directly instead of running a leading ``cd``.
+            env: Initial environment variables applied before execution, so
+                scripts see them without an ``export`` prelude.
             max_commands: Limit total commands executed.
             max_loop_iterations: Limit iterations per loop.
             max_memory: Memory limit in bytes for the VFS.
@@ -1188,6 +1204,8 @@ class BashTool:
         data: bytes,
         username: str | None = None,
         hostname: str | None = None,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
         max_commands: int | None = None,
         max_loop_iterations: int | None = None,
         max_memory: int | None = None,
@@ -1208,6 +1226,8 @@ class BashTool:
         key: bytes,
         username: str | None = None,
         hostname: str | None = None,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
         max_commands: int | None = None,
         max_loop_iterations: int | None = None,
         max_memory: int | None = None,

--- a/crates/bashkit-python/examples/bash_basics.py
+++ b/crates/bashkit-python/examples/bash_basics.py
@@ -226,6 +226,13 @@ def demo_config():
     print(f"hostname: {r.stdout.strip()}")
     assert r.stdout.strip() == "sandbox"
 
+    # Starting directory and environment — set directly instead of running a
+    # leading `cd`/`export`.
+    configured = Bash(cwd="/home/agent", env={"PROJECT": "bashkit"})
+    r = configured.execute_sync('echo "$PWD in $PROJECT"')
+    print(f"cwd/env:  {r.stdout.strip()}")
+    assert r.stdout.strip() == "/home/agent in bashkit"
+
     # Resource limits
     limited = Bash(max_loop_iterations=50)
     r = limited.execute_sync("i=0; while true; do i=$((i+1)); done; echo $i")

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -3695,6 +3695,10 @@ pub struct PyBash {
     cancelled: Arc<RwLock<Arc<AtomicBool>>>,
     username: Option<String>,
     hostname: Option<String>,
+    /// Initial working directory for the shell (mirrors `Bash::builder().cwd()`).
+    cwd: Option<String>,
+    /// Initial environment variables (mirrors `Bash::builder().env()`).
+    env: Option<HashMap<String, String>>,
     /// Whether Monty Python execution is enabled (`python`/`python3` builtins).
     python: bool,
     /// Whether the embedded SQLite (`sqlite`/`sqlite3`) builtin is enabled.
@@ -3752,6 +3756,14 @@ impl PyBash {
         if let Some(ref hostname) = self.hostname {
             builder = builder.hostname(hostname);
         }
+        if let Some(ref cwd) = self.cwd {
+            builder = builder.cwd(cwd.as_str());
+        }
+        if let Some(ref env) = self.env {
+            for (k, v) in env {
+                builder = builder.env(k, v);
+            }
+        }
 
         let mut limits = ExecutionLimits::new();
         if let Some(max_commands) = self.max_commands {
@@ -3805,6 +3817,8 @@ impl PyBash {
     #[pyo3(signature = (
         username=None,
         hostname=None,
+        cwd=None,
+        env=None,
         max_commands=None,
         max_loop_iterations=None,
         max_memory=None,
@@ -3825,6 +3839,8 @@ impl PyBash {
         py: Python<'_>,
         username: Option<String>,
         hostname: Option<String>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
         max_memory: Option<u64>,
@@ -3847,6 +3863,14 @@ impl PyBash {
         }
         if let Some(ref h) = hostname {
             builder = builder.hostname(h);
+        }
+        if let Some(ref c) = cwd {
+            builder = builder.cwd(c.as_str());
+        }
+        if let Some(ref env) = env {
+            for (k, v) in env {
+                builder = builder.env(k, v);
+            }
         }
 
         let mut limits = ExecutionLimits::new();
@@ -3942,6 +3966,8 @@ impl PyBash {
             cancelled,
             username,
             hostname,
+            cwd,
+            env,
             python,
             sqlite,
             external_functions: external_functions.unwrap_or_default(),
@@ -4253,6 +4279,8 @@ impl PyBash {
         data,
         username=None,
         hostname=None,
+        cwd=None,
+        env=None,
         max_commands=None,
         max_loop_iterations=None,
         max_memory=None,
@@ -4274,6 +4302,8 @@ impl PyBash {
         data: Vec<u8>,
         username: Option<String>,
         hostname: Option<String>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
         max_memory: Option<u64>,
@@ -4293,6 +4323,8 @@ impl PyBash {
             py,
             username,
             hostname,
+            cwd,
+            env,
             max_commands,
             max_loop_iterations,
             max_memory,
@@ -4319,6 +4351,8 @@ impl PyBash {
         key,
         username=None,
         hostname=None,
+        cwd=None,
+        env=None,
         max_commands=None,
         max_loop_iterations=None,
         max_memory=None,
@@ -4341,6 +4375,8 @@ impl PyBash {
         key: Vec<u8>,
         username: Option<String>,
         hostname: Option<String>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
         max_memory: Option<u64>,
@@ -4360,6 +4396,8 @@ impl PyBash {
             py,
             username,
             hostname,
+            cwd,
+            env,
             max_commands,
             max_loop_iterations,
             max_memory,
@@ -4564,6 +4602,10 @@ pub struct BashTool {
     cancelled: Arc<RwLock<Arc<AtomicBool>>>,
     username: Option<String>,
     hostname: Option<String>,
+    /// Initial working directory for the shell (mirrors `Bash::builder().cwd()`).
+    cwd: Option<String>,
+    /// Initial environment variables (mirrors `Bash::builder().env()`).
+    env: Option<HashMap<String, String>>,
     /// Tracking list for `is_async` flag detection (used by session capture).
     /// Kept in sync with `host_registry` by `add_builtin` / `remove_builtin`.
     /// Wrapped in `Arc<StdMutex<_>>` so post-construction registration works
@@ -4602,6 +4644,14 @@ impl BashTool {
         }
         if let Some(ref hostname) = self.hostname {
             builder = builder.hostname(hostname);
+        }
+        if let Some(ref cwd) = self.cwd {
+            builder = builder.cwd(cwd.as_str());
+        }
+        if let Some(ref env) = self.env {
+            for (k, v) in env {
+                builder = builder.env(k, v);
+            }
         }
 
         let mut limits = ExecutionLimits::new();
@@ -4648,6 +4698,14 @@ impl BashTool {
         if let Some(ref hostname) = self.hostname {
             builder = builder.hostname(hostname);
         }
+        if let Some(ref cwd) = self.cwd {
+            builder = builder.cwd(cwd.as_str());
+        }
+        if let Some(ref env) = self.env {
+            for (k, v) in env {
+                builder = builder.env(k, v);
+            }
+        }
 
         let mut limits = ExecutionLimits::new();
         if let Some(mc) = self.max_commands {
@@ -4687,6 +4745,8 @@ impl BashTool {
     #[pyo3(signature = (
         username=None,
         hostname=None,
+        cwd=None,
+        env=None,
         max_commands=None,
         max_loop_iterations=None,
         max_memory=None,
@@ -4702,6 +4762,8 @@ impl BashTool {
         py: Python<'_>,
         username: Option<String>,
         hostname: Option<String>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
         max_memory: Option<u64>,
@@ -4720,6 +4782,14 @@ impl BashTool {
         }
         if let Some(ref h) = hostname {
             builder = builder.hostname(h);
+        }
+        if let Some(ref c) = cwd {
+            builder = builder.cwd(c.as_str());
+        }
+        if let Some(ref env) = env {
+            for (k, v) in env {
+                builder = builder.env(k, v);
+            }
         }
 
         let mut limits = ExecutionLimits::new();
@@ -4771,6 +4841,8 @@ impl BashTool {
             cancelled,
             username,
             hostname,
+            cwd,
+            env,
             custom_builtins: Arc::new(StdMutex::new(custom_builtins)),
             host_registry,
             builtin_engine,
@@ -5036,6 +5108,8 @@ impl BashTool {
         data,
         username=None,
         hostname=None,
+        cwd=None,
+        env=None,
         max_commands=None,
         max_loop_iterations=None,
         max_memory=None,
@@ -5053,6 +5127,8 @@ impl BashTool {
         data: Vec<u8>,
         username: Option<String>,
         hostname: Option<String>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
         max_memory: Option<u64>,
@@ -5068,6 +5144,8 @@ impl BashTool {
             py,
             username,
             hostname,
+            cwd,
+            env,
             max_commands,
             max_loop_iterations,
             max_memory,
@@ -5090,6 +5168,8 @@ impl BashTool {
         key,
         username=None,
         hostname=None,
+        cwd=None,
+        env=None,
         max_commands=None,
         max_loop_iterations=None,
         max_memory=None,
@@ -5108,6 +5188,8 @@ impl BashTool {
         key: Vec<u8>,
         username: Option<String>,
         hostname: Option<String>,
+        cwd: Option<String>,
+        env: Option<HashMap<String, String>>,
         max_commands: Option<u64>,
         max_loop_iterations: Option<u64>,
         max_memory: Option<u64>,
@@ -5123,6 +5205,8 @@ impl BashTool {
             py,
             username,
             hostname,
+            cwd,
+            env,
             max_commands,
             max_loop_iterations,
             max_memory,

--- a/crates/bashkit-python/tests/_bashkit_categories.py
+++ b/crates/bashkit-python/tests/_bashkit_categories.py
@@ -34,6 +34,41 @@ def test_bash_custom_construction():
     assert bash is not None
 
 
+def test_bash_cwd_option_sets_starting_directory():
+    """cwd kwarg sets the starting directory without a leading `cd` (issue #2068)."""
+    bash = Bash(cwd="/home/user")
+    r = bash.execute_sync("pwd")
+    assert r.stdout.strip() == "/home/user"
+    assert bash.shell_state().cwd == "/home/user"
+
+
+def test_bash_env_option_exposes_variables():
+    """env kwarg exposes variables without an `export` prelude (issue #2068)."""
+    bash = Bash(env={"HOME": "/home/user", "LANG": "en_US.UTF-8"})
+    r = bash.execute_sync('echo "$HOME $LANG"')
+    assert r.stdout.strip() == "/home/user en_US.UTF-8"
+    assert bash.shell_state().env["HOME"] == "/home/user"
+
+
+def test_bash_cwd_and_env_survive_reset():
+    bash = Bash(cwd="/home/user", env={"TOKEN": "abc"})
+    bash.execute_sync("cd / ; unset TOKEN")
+    bash.reset()
+    r = bash.execute_sync('pwd ; echo "$TOKEN"')
+    assert r.stdout == "/home/user\nabc\n"
+
+
+def test_bashtool_cwd_and_env_options():
+    tool = BashTool(cwd="/srv", env={"APP": "bashkit"})
+    r = tool.execute_sync('pwd ; echo "$APP"')
+    assert r.stdout == "/srv\nbashkit\n"
+
+
+def test_bashtool_env_option_appears_in_help():
+    tool = BashTool(env={"API_BASE": "https://example.com"})
+    assert "API_BASE" in tool.help()
+
+
 # -- Bash: Sync execution --------------------------------------------------
 
 

--- a/crates/bashkit-python/tests/test_basic.py
+++ b/crates/bashkit-python/tests/test_basic.py
@@ -16,6 +16,11 @@ _categories = __import__("_bashkit_categories")
 _NAMES = (
     "test_bash_default_construction",
     "test_bash_custom_construction",
+    "test_bash_cwd_option_sets_starting_directory",
+    "test_bash_env_option_exposes_variables",
+    "test_bash_cwd_and_env_survive_reset",
+    "test_bashtool_cwd_and_env_options",
+    "test_bashtool_env_option_appears_in_help",
     "test_bash_echo",
     "test_bash_exit_code",
     "test_bash_stderr",

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -68,6 +68,7 @@ use futures_core::Stream;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
@@ -557,6 +558,8 @@ pub struct BashToolBuilder {
     hostname: Option<String>,
     /// Execution limits
     limits: Option<ExecutionLimits>,
+    /// Initial working directory for the shell
+    cwd: Option<PathBuf>,
     /// Environment variables to set
     env_vars: Vec<(String, String)>,
     /// Custom builtins (name, implementation). Arc enables reuse across create_bash calls.
@@ -593,6 +596,12 @@ impl BashToolBuilder {
     /// Set execution limits
     pub fn limits(mut self, limits: ExecutionLimits) -> Self {
         self.limits = Some(limits);
+        self
+    }
+
+    /// Set the initial working directory for the shell
+    pub fn cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
         self
     }
 
@@ -726,6 +735,7 @@ impl BashToolBuilder {
             username: self.username.clone(),
             hostname: self.hostname.clone(),
             limits: self.limits.clone(),
+            cwd: self.cwd.clone(),
             env_vars: self.env_vars.clone(),
             builtins: self.builtins.clone(),
             builtin_names,
@@ -780,6 +790,7 @@ pub struct BashTool {
     username: Option<String>,
     hostname: Option<String>,
     limits: Option<ExecutionLimits>,
+    cwd: Option<PathBuf>,
     env_vars: Vec<(String, String)>,
     builtins: Vec<(String, Arc<dyn Builtin>)>,
     /// Names of custom builtins (for documentation)
@@ -806,6 +817,9 @@ impl BashTool {
         }
         if let Some(ref limits) = self.limits {
             builder = builder.limits(limits.clone());
+        }
+        if let Some(ref cwd) = self.cwd {
+            builder = builder.cwd(cwd.clone());
         }
         for (key, value) in &self.env_vars {
             builder = builder.env(key, value);
@@ -958,6 +972,7 @@ impl Tool for BashTool {
             username: self.username.clone(),
             hostname: self.hostname.clone(),
             limits: self.limits.clone(),
+            cwd: self.cwd.clone(),
             env_vars: self.env_vars.clone(),
             builtins: self.builtins.clone(),
         }
@@ -970,6 +985,7 @@ impl Tool for BashTool {
             username: self.username.clone(),
             hostname: self.hostname.clone(),
             limits: self.limits.clone(),
+            cwd: self.cwd.clone(),
             env_vars: self.env_vars.clone(),
             builtins: self.builtins.clone(),
         }
@@ -1610,6 +1626,24 @@ mod tests {
         assert_eq!(resp.stdout, "hello\n");
         assert_eq!(resp.exit_code, 0);
         assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn test_bash_tool_builder_cwd() {
+        let tool = BashTool::builder().cwd("/tmp/work").build();
+        assert_eq!(tool.cwd, Some(PathBuf::from("/tmp/work")));
+    }
+
+    #[tokio::test]
+    async fn test_tool_cwd_sets_starting_directory() {
+        let tool = BashTool::builder().cwd("/tmp").build();
+        let req = ToolRequest {
+            commands: "pwd".to_string(),
+            timeout_ms: None,
+        };
+        let resp = tool.execute(req).await;
+        assert_eq!(resp.stdout, "/tmp\n");
+        assert_eq!(resp.exit_code, 0);
     }
 
     #[test]

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -58,7 +58,8 @@ examples: `crates/bashkit-python/examples/`.
 ### BashTool / Bash
 
 `BashTool` wraps the Rust `Bash` interpreter with `Arc<Mutex<>>` for thread
-safety. Constructor kwargs: `username`, `hostname`, `max_commands`,
+safety. Constructor kwargs: `username`, `hostname`, `cwd` (initial working
+directory), `env` (initial environment variables), `max_commands`,
 `max_loop_iterations`, `readonly_filesystem`, `files` (initial files; values
 may be eager strings or lazy sync callables), `network`, `custom_builtins`,
 etc. Methods: `await execute(cmd)` / `execute_sync(cmd)` / `reset()`; direct


### PR DESCRIPTION
## What

Expose the Rust `Bash::builder().cwd()` / `.env()` options in the NAPI-RS (Node/TypeScript) and PyO3 (Python) bindings, so callers can set the starting working directory and initial environment at construction time.

Closes #2068.

## Why

The Rust core already supports `cwd`/`env` on the builder, but the bindings did not surface them. Node/Python users had to run a leading `bash.execute('cd "..."')` or an `export` prelude just to set the starting directory/env — paying parse + exec overhead for something the interpreter can do at construction.

Both options are fully optional (`cwd?`/`env?` in TS, `Option<…>` in Rust, `cwd=None, env=None` in Python); omitting them preserves existing behavior exactly.

## How

- **Node** (`bashkit-js`): added `cwd`/`env` to `BashOptions` (Rust `#[napi]` struct + TS interface + `toNativeOptions` mapping), threaded through `SharedState`, and applied in `build_bash_from_state` — so they take effect on construction **and** survive `reset()` — plus the `BashTool` metadata builder.
- **Python** (`bashkit-python`): added `cwd`/`env` kwargs to the `Bash`/`BashTool` constructors, their `from_snapshot`/`from_snapshot_keyed` static methods, and the live/tool rebuilders; updated the `.pyi` stub.
- **Core** (`bashkit`): added `cwd` to `BashToolBuilder` (it already had `env`) so the `BashTool` tool-call execution path honors the starting directory too.

No new attack surface: `cwd`/`env` were already settable from inside a script via `cd`/`export`; this is a construction-time convenience mirroring the existing `username`/`hostname` options. No new dependencies, no `unsafe`.

## Tests

- **Core**: `BashToolBuilder::cwd` builder test + a `pwd`-through-tool execution test. Full core lib suite green (2675 passed) with `--features http_client,ssh,sqlite`.
- **Python**: 5 new tests in `_bashkit_categories.py` (cwd starting dir, env exposure, persistence across `reset()`, BashTool path, env-in-`help()`); `test_basic.py` 59 passed.
- **Node**: new `__test__/cwd-env-options.spec.ts` (5 tests) covering the same; basic + shell-state specs still green.
- **Smoke**: `examples/bash_basics.py` (runs in CI) extended with a cwd/env demo and executed successfully.
- Workspace `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `ruff check`/`format`, `prettier`, `oxlint` all clean.

## Docs

Updated both binding READMEs, the `.pyi` stub docstrings, inline `#[napi]`/TS doc comments, and `specs/python-package.md`.