### PR TITLE
chore: pre-release maintenance — deps update, vet refresh, threat-model & changelog sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`cwd` and `env` construction options for the Node and Python bindings** —
+  callers can set the starting working directory and initial environment at
+  `Bash` construction time instead of paying for a leading `cd`/`export` prelude
+  ([#2072](https://github.com/everruns/bashkit/pull/2072)).
+- **Generated builtin inventory** (`specs/status/builtins.json`) plus a
+  `limitations.md` negative spec and a `builtins-drift` workflow that fails on
+  divergence between the registry and the committed inventory
+  ([#2038](https://github.com/everruns/bashkit/pull/2038)).
+
+### Fixed
+
+- **Security advisories** — patched the bundled esbuild and PyO3 advisories
+  ([#2069](https://github.com/everruns/bashkit/pull/2069)).
+- **Resource caps** — bounded the JS async execute queue with pre-queue input
+  validation, capped Python external-function handlers to the remaining
+  `max_duration` budget, added IFS word-split field and byte caps to the
+  interpreter, and capped awk multi-subscript arrays
+  ([#2055](https://github.com/everruns/bashkit/pull/2055)).
+- **Parser** — context-aware escaping in quoted glob word ranges, quote-metadata
+  preservation for mixed quoted/unquoted words, and ANSI-C NUL sentinel
+  collision escaping ([#2053](https://github.com/everruns/bashkit/pull/2053)).
+- **Builtins** — `rg` positive globs/type includes no longer unhide hidden
+  directories, `paste` handles a trailing `-d` flag
+  ([#2057](https://github.com/everruns/bashkit/pull/2057)), `compgen` lists
+  builtins from the live registry instead of a hardcoded copy
+  ([#2040](https://github.com/everruns/bashkit/pull/2040)), recursive delete
+  preserves child whiteouts ([#2056](https://github.com/everruns/bashkit/pull/2056)),
+  and a missing input-redirect file is now non-fatal.
+
+### Changed
+
+- **Dependencies** — bumped `zeroize` to 1.9.0 and `napi` to 3.9.2
+  ([#2071](https://github.com/everruns/bashkit/pull/2071)); bumped the
+  github-actions group (setup-uv, codecov, taiki-e)
+  ([#2070](https://github.com/everruns/bashkit/pull/2070)).
+- **Specs** — threat-model ledger backfilled with 12 code-cited IDs plus a drift
+  lint ([#2039](https://github.com/everruns/bashkit/pull/2039)); `limitations.md`
+  stance rows are now backed by evidence tests
+  ([#2051](https://github.com/everruns/bashkit/pull/2051)).
+
 ## [0.10.0] - 2026-06-11
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "antithesis_sdk"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
 dependencies = [
  "libc",
  "libloading 0.8.9",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -871,7 +871,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1471,7 +1471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2481,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2689,9 +2689,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -4339,7 +4339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4396,7 +4396,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4829,9 +4829,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -5103,7 +5103,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5767,9 +5767,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -5785,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5798,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5808,9 +5808,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5818,9 +5818,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5831,9 +5831,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -5887,9 +5887,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5926,7 +5926,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -671,6 +671,68 @@ let bash = Bash::builder()
 // Commits use virtual identity, never host ~/.gitconfig
 ```
 
+### SSH Security (TM-SSH-*)
+
+The `ssh`/`scp`/`sftp` builtins (opt-in `ssh` feature) connect to remote hosts
+through a sandboxed client. Connections are default-deny: callers must allowlist
+each host via `SshConfig::allow(...)`, and credentials come only from the VFS —
+never the host `~/.ssh/`.
+
+| Threat | Attack Example | Mitigation | Status |
+|--------|---------------|------------|--------|
+| Unauthorized host access (TM-SSH-001) | Connect to arbitrary hosts | Host allowlist (default-deny) | MITIGATED |
+| Credential leakage (TM-SSH-002) | Read host `~/.ssh/` keys | Keys from VFS only | MITIGATED |
+| Session exhaustion (TM-SSH-003) | Open many concurrent sessions | Max concurrent sessions limit | MITIGATED |
+| OOM via large response (TM-SSH-004) | Server sends huge output | Streaming size limit | MITIGATED |
+| Connection hang (TM-SSH-005) | Server never responds | Configurable timeout | MITIGATED |
+| MITM via unverified host key (TM-SSH-006) | Attacker intercepts connection | Strict host key checking (default: on) | MITIGATED |
+| Non-standard port access (TM-SSH-007) | Connect to services on unexpected ports | Port allowlist | MITIGATED |
+| Remote command injection (TM-SSH-008) | Inject via remote path in SCP | Shell-escape remote paths | MITIGATED |
+
+### TypeScript / ZapCode Security (TM-TS-*)
+
+The `typescript` feature embeds the ZapCode runtime. Scripts run under
+wall-clock, memory, allocation, and stack-depth limits, and all filesystem
+access is bridged through Bashkit's VFS — never the host filesystem.
+
+| Threat | Attack Example | Mitigation | Status |
+|--------|---------------|------------|--------|
+| Infinite loop (TM-TS-001) | `while (true) {}` | ZapCode time limit (default 30s) | MITIGATED |
+| Memory exhaustion (TM-TS-002) | Large allocation | `max_memory` (64MB) + `max_allocations` (1M) | MITIGATED |
+| Stack overflow (TM-TS-003) | Deep recursion | `max_stack_depth` (512) | MITIGATED |
+| Allocation bomb (TM-TS-004) | Many small objects | `max_allocations` (1M) | MITIGATED |
+| Real filesystem read (TM-TS-005) | Read host files via VFS | VFS bridge reads only Bashkit VFS | MITIGATED |
+| VFS write escape (TM-TS-006) | Write to host | VFS bridge writes only Bashkit VFS | MITIGATED |
+| Path traversal (TM-TS-007) | `../../etc/passwd` | Paths resolved within sandbox | MITIGATED |
+| Host `/tmp` escape (TM-TS-011) | Operations escape to host | All operations through Bashkit VFS | MITIGATED |
+| Limit bypass (TM-TS-018) | Evade Bashkit caps via TS | Command budget still enforced | MITIGATED |
+
+Full per-threat coverage (TM-TS-001 … TM-TS-020), including error-isolation and
+exit-code propagation cases, lives in the spec and the `threat_ts_*` tests.
+
+### Request Signing & Snapshot Integrity (TM-CRY-*, TM-SNAP-*)
+
+The `bot-auth` request signer (Ed25519, RFC 9421) and the snapshot
+serialization API both handle key material and integrity tags.
+
+| Threat | Attack Example | Mitigation | Status |
+|--------|---------------|------------|--------|
+| Private key recovery (TM-CRY-001) | Heap/core-dump inspection of the Ed25519 seed | `BotAuthConfig` zeroizes the seed in `Drop`; debug output redacts key material | MITIGATED |
+| Snapshot forgery (TM-SNAP-001) | Forge a valid digest using the public `BKSNAP01` tag | Keyed HMAC API (`to_bytes_keyed`/`from_bytes_keyed`) for tamper-evident snapshots | MITIGATED |
+
+`from_bytes` uses `SHA-256(BKSNAP01 || payload)` (the tag is a public constant,
+so it detects accidental corruption, not forgery); `from_bytes_keyed` uses
+`HMAC-SHA256(secret_key, payload)` with a caller-provided key for authenticity.
+
+### RealFs Mount Security (TM-FS-*)
+
+The `realfs` feature can mount real host directories into the VFS. Mounts are
+read-only by default and gated by an allowlist.
+
+| Threat | Attack Example | Mitigation | Status |
+|--------|---------------|------------|--------|
+| Permissive RealFs mount (TM-FS-013) | `mount_real_readonly_at("/", …)` exposes the whole host | Allowlist-first: broad roots (`/`, `/etc`, `/root`, `/home`, …) and any path component matching `.ssh`, `.aws`, `.kube`, `.docker`, `.gnupg`, `.gcloud` are refused unless explicitly allowlisted | MITIGATED |
+
 ### Unicode Security (TM-UNI-*)
 
 Unicode input from untrusted scripts creates attack surface across the parser, builtins,
@@ -789,8 +851,13 @@ All threats use stable IDs in the format `TM-<CATEGORY>-<NUMBER>`:
 | TM-INT | Internal Error Handling |
 | TM-LOG | Logging Security |
 | TM-GIT | Git Security |
+| TM-SSH | SSH Security |
 | TM-PY | Python/Monty Security |
 | TM-SQL | SQLite Security |
+| TM-TS | TypeScript/ZapCode Security |
+| TM-CRY | Cryptography / Request Signing |
+| TM-SNAP | Snapshot Integrity |
+| TM-FS | RealFs Mount Security |
 | TM-UNI | Unicode Security |
 
 Full threat analysis: [`specs/threat-model.md`][spec]

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -189,11 +189,18 @@ improvements. The requirement is that they are **tracked**, not silently skipped
 
 ### Deferred items
 
-None currently open.
+Standing transitive limitation:
 
-Previously tracked items have been resolved: #880 (ArgParser migration),
-#881 (errexit propagation helper), and #1634 (RustCrypto 0.10/0.11 split —
-the `md-5`/`sha1`/`sha2` stack is now unified on the 0.11 line).
+- **RustCrypto 0.10/0.11 split** (was tracked as #1634, now closed). Our
+  directly-declared hashes (`md-5`/`sha1`/`sha2`) are on the 0.11 line, but the
+  dependency tree still pulls in the 0.10 line transitively — `aes-gcm 0.10.3`
+  (and its `digest 0.10` / `sha2 0.10` / `aead 0.5` / `cipher 0.4` chain) via
+  `turso_core`, plus the `russh` / `argon2` crypto stack. Resolution remains
+  blocked on those upstreams releasing on the 0.11 line; no in-tree action
+  available.
+
+Previously tracked items resolved: #880 (ArgParser migration), #881 (errexit
+propagation helper).
 
 ## Automation
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -187,14 +187,13 @@ multi-file refactors, cross-cutting changes), the pass must:
 Deferred items are **not** failures — they are expected for large-scope
 improvements. The requirement is that they are **tracked**, not silently skipped.
 
-### Deferred from 2026-05-17 run
+### Deferred items
 
-| Issue | Section | Description |
-|-------|---------|-------------|
-| #1634 | Dependencies | RustCrypto stack split between 0.10 and 0.11 lines, blocked on `turso_core` / `aes-gcm` upstreams |
+None currently open.
 
-Previously tracked items (#880 ArgParser migration, #881 errexit
-propagation helper) have been resolved.
+Previously tracked items have been resolved: #880 (ArgParser migration),
+#881 (errexit propagation helper), and #1634 (RustCrypto 0.10/0.11 split —
+the `md-5`/`sha1`/`sha2` stack is now unified on the 0.11 line).
 
 ## Automation
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -100,7 +100,7 @@ version = "3.0.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.antithesis_sdk]]
-version = "0.2.8"
+version = "0.2.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.anyhow]]
@@ -244,7 +244,7 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.cc]]
-version = "1.2.63"
+version = "1.2.64"
 criteria = "safe-to-deploy"
 
 [[exemptions.cfg-if]]
@@ -952,7 +952,7 @@ version = "0.1.34"
 criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
-version = "0.3.100"
+version = "0.3.102"
 criteria = "safe-to-deploy"
 
 [[exemptions.keccak]]
@@ -1044,7 +1044,7 @@ version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.memchr]]
-version = "2.8.1"
+version = "2.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.memoffset]]
@@ -1780,7 +1780,7 @@ version = "0.4.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.smallvec]]
-version = "1.15.1"
+version = "1.15.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.socket2]]
@@ -2092,7 +2092,7 @@ version = "0.11.1+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasip2]]
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasip3]]
@@ -2100,23 +2100,23 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
-version = "0.2.123"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-futures]]
-version = "0.4.73"
+version = "0.4.75"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro]]
-version = "0.2.123"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.123"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
-version = "0.2.123"
+version = "0.2.125"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasm-encoder]]
@@ -2136,7 +2136,7 @@ version = "0.244.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.web-sys]]
-version = "0.3.100"
+version = "0.3.102"
 criteria = "safe-to-deploy"
 
 [[exemptions.webpki-root-certs]]


### PR DESCRIPTION
## What

Pre-release maintenance pass per `specs/maintenance.md`.

- **deps**: `cargo update` — 12 transitive patch bumps (memchr, smallvec, cc, js-sys, web-sys, the wasm-bindgen stack, wasip2, antithesis_sdk); cargo-vet exemptions regenerated to match the new lock. Direct deps were already at latest; `cargo audit`/`deny`/`vet` all clean.
- **docs (threat-model)**: the public guide (`crates/bashkit/docs/threat-model.md`) was missing five user-facing security categories present in the spec. Added a section + reference-table row for each:
  - **TM-SSH** — SSH client (host allowlist, VFS-only keys, host-key checking, …)
  - **TM-TS** — TypeScript/ZapCode (time/memory/alloc/stack limits, VFS-only FS)
  - **TM-CRY** — Ed25519 request signing (seed zeroized on drop)
  - **TM-SNAP** — snapshot integrity (keyed-HMAC API)
  - **TM-FS** — RealFs mount allowlist
- **changelog/specs**: populated the empty `CHANGELOG.md` `[Unreleased]` section with the ~20 commits since v0.10.0; updated `specs/maintenance.md` deferred-items section. The RustCrypto note (was #1634, now closed) is described accurately: our direct hashes (`md-5`/`sha1`/`sha2`) are on the 0.11 line, but the 0.10 line persists transitively via `turso_core`/`aes-gcm` and the `russh`/`argon2` stack — upstream-blocked, no in-tree action.

## Why

The maintenance checklist requires deps current and clean, the public threat model in sync with the spec, and the changelog reflecting all changes since the last release.

## How / Verification

No code changed — docs, dependency lockfile, and vet exemptions only.

- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo doc -D warnings` — clean
- `cargo audit` (0 vulns), `cargo deny check licenses sources`, `cargo vet --locked` — pass
- Tests against the updated lock: main slice (4739), doc tests (137), proptest_security (18), failpoints (14), realfs (36), ssh-builtin (24), bash-comparison differential vs real bash 5.2.21 — all green
- All 14 examples run; builtin-inventory regen shows no drift
- CI / nightly / fuzz green on `main`