### PR TITLE
feat(site): span runtime surface across full hero width

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -77,43 +77,6 @@ import {
             </div>
           </article>
         </div>
-
-        <div class="atlas-hero-runtime">
-          <div class="atlas-stats">
-            {
-              heroStats.map((stat) => (
-                <a
-                  href={stat.href}
-                  class="atlas-stat atlas-stat--link"
-                  target={stat.external ? "_blank" : undefined}
-                  rel={stat.external ? "noopener noreferrer" : undefined}
-                >
-                  <span class="atlas-stat__label">{stat.label}</span>
-                  <strong>{stat.value}</strong>
-                </a>
-              ))
-            }
-          </div>
-
-          <article class="atlas-panel atlas-builtins-panel">
-            <div class="atlas-builtins-panel__copy">
-              <span class="atlas-eyebrow">Runtime surface</span>
-              <h3>Browse the builtins that make the sandbox usable.</h3>
-              <p>
-                Text processing, files, archives, network, Python, TypeScript,
-                and shell control all live in-process.
-              </p>
-            </div>
-            <div class="atlas-chip-list">
-              {
-                builtinPreview.map((name) => (
-                  <span class="atlas-chip">{name}</span>
-                ))
-              }
-            </div>
-            <a href="/builtins" class="atlas-inline-link">See all {builtinCount} builtins</a>
-          </article>
-        </div>
       </div>
 
       <aside class="atlas-panel atlas-signal-panel" aria-label="Runtime example">
@@ -141,6 +104,43 @@ import {
           }
         </div>
       </aside>
+
+      <div class="atlas-hero-runtime">
+        <div class="atlas-stats">
+          {
+            heroStats.map((stat) => (
+              <a
+                href={stat.href}
+                class="atlas-stat atlas-stat--link"
+                target={stat.external ? "_blank" : undefined}
+                rel={stat.external ? "noopener noreferrer" : undefined}
+              >
+                <span class="atlas-stat__label">{stat.label}</span>
+                <strong>{stat.value}</strong>
+              </a>
+            ))
+          }
+        </div>
+
+        <article class="atlas-panel atlas-builtins-panel">
+          <div class="atlas-builtins-panel__copy">
+            <span class="atlas-eyebrow">Runtime surface</span>
+            <h3>Browse the builtins that make the sandbox usable.</h3>
+            <p>
+              Text processing, files, archives, network, Python, TypeScript,
+              and shell control all live in-process.
+            </p>
+          </div>
+          <div class="atlas-chip-list">
+            {
+              builtinPreview.map((name) => (
+                <span class="atlas-chip">{name}</span>
+              ))
+            }
+          </div>
+          <a href="/builtins" class="atlas-inline-link">See all {builtinCount} builtins</a>
+        </article>
+      </div>
     </div>
   </section>
 
@@ -533,10 +533,10 @@ import {
     text-align: right;
   }
   .atlas-hero-runtime {
+    grid-column: 1 / -1;
     display: grid;
-    grid-template-columns: minmax(0, 0.8fr) minmax(0, 2fr);
+    grid-template-columns: minmax(220px, 17rem) minmax(0, 1fr);
     gap: 1rem;
-    margin-top: 0.4rem;
     align-items: stretch;
   }
   .atlas-stats {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -78,40 +78,42 @@ import {
           </article>
         </div>
 
-        <div class="atlas-stats">
-          {
-            heroStats.map((stat) => (
-              <a
-                href={stat.href}
-                class="atlas-stat atlas-stat--link"
-                target={stat.external ? "_blank" : undefined}
-                rel={stat.external ? "noopener noreferrer" : undefined}
-              >
-                <span class="atlas-stat__label">{stat.label}</span>
-                <strong>{stat.value}</strong>
-              </a>
-            ))
-          }
-        </div>
-
-        <article class="atlas-panel atlas-builtins-panel">
-          <div class="atlas-builtins-panel__copy">
-            <span class="atlas-eyebrow">Runtime surface</span>
-            <h3>Browse the builtins that make the sandbox usable.</h3>
-            <p>
-              Text processing, files, archives, network, Python, TypeScript,
-              and shell control all live in-process.
-            </p>
-          </div>
-          <div class="atlas-chip-list">
+        <div class="atlas-hero-runtime">
+          <div class="atlas-stats">
             {
-              builtinPreview.map((name) => (
-                <span class="atlas-chip">{name}</span>
+              heroStats.map((stat) => (
+                <a
+                  href={stat.href}
+                  class="atlas-stat atlas-stat--link"
+                  target={stat.external ? "_blank" : undefined}
+                  rel={stat.external ? "noopener noreferrer" : undefined}
+                >
+                  <span class="atlas-stat__label">{stat.label}</span>
+                  <strong>{stat.value}</strong>
+                </a>
               ))
             }
           </div>
-          <a href="/builtins" class="atlas-inline-link">See all {builtinCount} builtins</a>
-        </article>
+
+          <article class="atlas-panel atlas-builtins-panel">
+            <div class="atlas-builtins-panel__copy">
+              <span class="atlas-eyebrow">Runtime surface</span>
+              <h3>Browse the builtins that make the sandbox usable.</h3>
+              <p>
+                Text processing, files, archives, network, Python, TypeScript,
+                and shell control all live in-process.
+              </p>
+            </div>
+            <div class="atlas-chip-list">
+              {
+                builtinPreview.map((name) => (
+                  <span class="atlas-chip">{name}</span>
+                ))
+              }
+            </div>
+            <a href="/builtins" class="atlas-inline-link">See all {builtinCount} builtins</a>
+          </article>
+        </div>
       </div>
 
       <aside class="atlas-panel atlas-signal-panel" aria-label="Runtime example">
@@ -530,11 +532,18 @@ import {
     font-size: 0.82rem;
     text-align: right;
   }
-  .atlas-stats {
+  .atlas-hero-runtime {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 2fr);
     gap: 1rem;
     margin-top: 0.4rem;
+    align-items: stretch;
+  }
+  .atlas-stats {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-auto-rows: 1fr;
+    gap: 1rem;
   }
   .atlas-stat,
   .atlas-panel {
@@ -870,6 +879,7 @@ import {
       max-width: 18ch;
     }
     .atlas-hero-guide { grid-template-columns: 1fr; }
+    .atlas-hero-runtime { grid-template-columns: 1fr; }
     .atlas-stats { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .atlas-lang-row { grid-template-columns: 1fr; }
   }


### PR DESCRIPTION
## What

Restructures the hero's bottom block so the stat cards and the **Runtime surface** panel form a full-width row, removing the empty space that appeared beside the signal aside.

- Lifts the stats + Runtime surface block out of the left copy column into a full-width hero grid row (`grid-column: 1 / -1`).
- The three stat cards (Built-in commands / Threats mitigated / Haiku eval) stack vertically in a narrow `17rem` left column.
- The Runtime surface builtins panel fills the entire rest of the row, out to the right edge.

## Why

The hero is a two-column grid; the left copy column ran taller than the right signal aside, leaving a blank area at the bottom-right. Spanning the runtime block full-width fills that space and balances the section.

## How

- Moved the `atlas-hero-runtime` block in `site/src/pages/index.astro` from inside `.atlas-hero__copy` to a direct child of `.atlas-hero__grid`, spanning both columns.
- Stats stack with `grid-template-columns: 1fr` + `grid-auto-rows: 1fr` (equal heights, stretch to fill).
- Collapses to the stacked mobile layout at ≤980px (stats go 3-across, panel below).

## Verification

- `pnpm run build` passes including all postbuild verifiers (doc routes, sitemap, robots, link headers, agent skills).
- Reviewed on the Cloudflare branch preview.

---
_Generated by [Claude Code](https://claude.ai/code/session_016Cf5sPxAUASdikqHK8nSL5)_