### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,47 +2,37 @@
 
 ## [Unreleased]
 
-### Added
+## [0.11.0] - 2026-06-16
+
+### Highlights
 
 - **`cwd` and `env` construction options for the Node and Python bindings** —
-  callers can set the starting working directory and initial environment at
-  `Bash` construction time instead of paying for a leading `cd`/`export` prelude
+  callers can now set the starting working directory and initial environment
+  directly at `Bash` construction time, instead of paying for a leading
+  `cd`/`export` prelude on every run
   ([#2072](https://github.com/everruns/bashkit/pull/2072)).
-- **Generated builtin inventory** (`specs/status/builtins.json`) plus a
-  `limitations.md` negative spec and a `builtins-drift` workflow that fails on
-  divergence between the registry and the committed inventory
-  ([#2038](https://github.com/everruns/bashkit/pull/2038)).
 
-### Fixed
+### What's Changed
 
-- **Security advisories** — patched the bundled esbuild and PyO3 advisories
-  ([#2069](https://github.com/everruns/bashkit/pull/2069)).
-- **Resource caps** — bounded the JS async execute queue with pre-queue input
-  validation, capped Python external-function handlers to the remaining
-  `max_duration` budget, added IFS word-split field and byte caps to the
-  interpreter, and capped awk multi-subscript arrays
-  ([#2055](https://github.com/everruns/bashkit/pull/2055)).
-- **Parser** — context-aware escaping in quoted glob word ranges, quote-metadata
-  preservation for mixed quoted/unquoted words, and ANSI-C NUL sentinel
-  collision escaping ([#2053](https://github.com/everruns/bashkit/pull/2053)).
-- **Builtins** — `rg` positive globs/type includes no longer unhide hidden
-  directories, `paste` handles a trailing `-d` flag
-  ([#2057](https://github.com/everruns/bashkit/pull/2057)), `compgen` lists
-  builtins from the live registry instead of a hardcoded copy
-  ([#2040](https://github.com/everruns/bashkit/pull/2040)), recursive delete
-  preserves child whiteouts ([#2056](https://github.com/everruns/bashkit/pull/2056)),
-  and a missing input-redirect file is now non-fatal.
+* feat(site): span runtime surface across full hero width ([#2079](https://github.com/everruns/bashkit/pull/2079)) by @chaliy
+* Add GitHub sponsor username ([#2078](https://github.com/everruns/bashkit/pull/2078)) by @chaliy
+* chore: pre-release maintenance — deps update, vet refresh, threat-model & changelog sync ([#2077](https://github.com/everruns/bashkit/pull/2077)) by @chaliy
+* feat(site): simplify hero runtime snippet card ([#2075](https://github.com/everruns/bashkit/pull/2075)) by @chaliy
+* chore: set package author metadata across PyPI, npm, and crates.io ([#2073](https://github.com/everruns/bashkit/pull/2073)) by @chaliy
+* feat(bindings): expose cwd and env options to Node and Python ([#2072](https://github.com/everruns/bashkit/pull/2072)) by @chaliy
+* chore(deps): bump zeroize to 1.9.0 and napi to 3.9.2 ([#2071](https://github.com/everruns/bashkit/pull/2071)) by @chaliy
+* chore(ci): bump github-actions group (setup-uv, codecov, taiki-e) ([#2070](https://github.com/everruns/bashkit/pull/2070)) by @chaliy
+* fix(deps): patch esbuild and PyO3 security advisories ([#2069](https://github.com/everruns/bashkit/pull/2069)) by @chaliy
+* fix(paste): handle trailing -d flag ([#2057](https://github.com/everruns/bashkit/pull/2057)) by @chaliy
+* fix(fs): preserve recursive delete child whiteouts ([#2056](https://github.com/everruns/bashkit/pull/2056)) by @chaliy
+* fix(awk): cap multi-subscript arrays ([#2055](https://github.com/everruns/bashkit/pull/2055)) by @chaliy
+* fix(parser): escape ANSI-C NUL sentinel collisions ([#2053](https://github.com/everruns/bashkit/pull/2053)) by @chaliy
+* test(specs): back limitations.md stance rows with evidence tests ([#2051](https://github.com/everruns/bashkit/pull/2051)) by @chaliy
+* fix(compgen): list builtins from the live registry, not hardcoded copies ([#2040](https://github.com/everruns/bashkit/pull/2040)) by @chaliy
+* chore(specs): threat-model ledger — backfill 12 code-cited IDs, add drift lint, compress 21 KB ([#2039](https://github.com/everruns/bashkit/pull/2039)) by @chaliy
+* feat: generated builtin inventory, limitations negative spec, spec/agent-config compression ([#2038](https://github.com/everruns/bashkit/pull/2038)) by @chaliy
 
-### Changed
-
-- **Dependencies** — bumped `zeroize` to 1.9.0 and `napi` to 3.9.2
-  ([#2071](https://github.com/everruns/bashkit/pull/2071)); bumped the
-  github-actions group (setup-uv, codecov, taiki-e)
-  ([#2070](https://github.com/everruns/bashkit/pull/2070)).
-- **Specs** — threat-model ledger backfilled with 12 code-cited IDs plus a drift
-  lint ([#2039](https://github.com/everruns/bashkit/pull/2039)); `limitations.md`
-  stance rows are now backed by evidence tests
-  ([#2051](https://github.com/everruns/bashkit/pull/2051)).
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.10.0...v0.11.0
 
 ## [0.10.0] - 2026-06-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,7 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.10.0", features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.11.0", features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",


### PR DESCRIPTION
## Release v0.11.0

Minor release — adds new user-facing binding surface on top of a broad fix/hardening cycle since v0.10.0.

### Highlight

- **`cwd` and `env` construction options for the Node and Python bindings** — callers can now set the starting working directory and initial environment directly at `Bash` construction time, instead of paying for a leading `cd`/`export` prelude on every run ([#2072](https://github.com/everruns/bashkit/pull/2072)).

### Version bump

| Manifest | 0.10.0 → 0.11.0 |
|---|---|
| `Cargo.toml` (workspace) | ✅ |
| `crates/bashkit-cli/Cargo.toml` (path-dep pin) | ✅ |
| `crates/bashkit-js/package.json` | ✅ |
| `Cargo.lock` (7 workspace crates) | ✅ |

### Publish-readiness report

- `cargo fmt --check` — ✅ clean.
- `cargo publish --dry-run -p bashkit` — ✅ packages successfully after the CI `monty`/`python` strip (replicated locally; matches `publish.yml`).
- `cargo publish --dry-run -p bashkit-cli` — resolves against published `bashkit` on crates.io; CI publishes `bashkit` first and waits for the index (standard ordering), so it cannot be validated standalone before the core crate is live.
- Version sync — all manifests read `0.11.0`, greater than latest published `0.10.0` on every registry.

### What's Changed

See [CHANGELOG.md](https://github.com/everruns/bashkit/blob/claude/amazing-hypatia-3wx06s/CHANGELOG.md) for the full list (17 PRs).

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.10.0...v0.11.0

On merge, `release.yml` will tag `v0.11.0`, create the GitHub Release, and dispatch the crates.io / PyPI / npm / Homebrew publish workflows.

---
_Generated by [Claude Code](https://claude.ai/code/session_016KufmYgNYcPpM5mcHQkpNj)_