### PR TITLE
fix(parser): preserve expanded backslashes in glob dirs

### DIFF
--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -705,6 +705,10 @@ impl Interpreter {
     /// must not remove arbitrary `\X` pairs from expanded data: parameter and
     /// command substitution can produce literal backslashes after parsing, and
     /// turning `.\.` into `..` would change the lookup directory.
+    ///
+    /// The metacharacter set below must stay in sync with the escape set in
+    /// `Interpreter::quote_expansion_for_quoted_glob` (interpreter/mod.rs); if
+    /// one side adds or drops a character, lookups break or escapes leak.
     fn glob_path_unescape(s: &str) -> String {
         let mut result = String::with_capacity(s.len());
         let mut chars = s.chars().peekable();

--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -697,25 +697,30 @@ impl Interpreter {
         }
     }
 
-    /// Strip backslash escapes (`\X` → `X`) from a path string.
+    /// Strip only parser-inserted glob metacharacter escapes from a path string.
     ///
-    /// `escape_glob_metas_in_quoted_ranges` inserts `\` before metacharacters in
-    /// quoted segments to prevent brace-expansion.  Before using a path component
-    /// for filesystem lookup those escapes must be removed, because VFS paths are
-    /// stored without them.  The glob-pattern component (file_name) is left intact
-    /// because `glob_match_impl` and `contains_glob_chars` already understand `\`.
+    /// `quote_expansion_for_quoted_glob` inserts `\` before metacharacters in
+    /// quoted segments to keep them literal while an adjacent unquoted glob suffix
+    /// remains active.  Directory lookup must remove those synthetic escapes, but
+    /// must not remove arbitrary `\X` pairs from expanded data: parameter and
+    /// command substitution can produce literal backslashes after parsing, and
+    /// turning `.\.` into `..` would change the lookup directory.
     fn glob_path_unescape(s: &str) -> String {
         let mut result = String::with_capacity(s.len());
-        let mut escaped = false;
-        for ch in s.chars() {
-            if escaped {
-                result.push(ch);
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else {
-                result.push(ch);
+        let mut chars = s.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '\\'
+                && let Some(&next) = chars.peek()
+                && matches!(
+                    next,
+                    '\\' | '*' | '?' | '[' | ']' | '{' | '}' | '@' | '!' | '+' | '(' | ')' | '|'
+                )
+            {
+                result.push(next);
+                chars.next();
+                continue;
             }
+            result.push(ch);
         }
         result
     }

--- a/crates/bashkit/tests/integration/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/integration/blackbox_security_tests.rs
@@ -1423,9 +1423,10 @@ mod finding_mixed_quoted_word_quote_metadata {
 
     #[tokio::test]
     async fn unquoted_expansion_backslash_dot_in_glob_dir_stays_literal() {
-        // THREAT[TM-INF-022]: glob directory unescape only removes parser-inserted
+        // THREAT[TM-ESC-001]: glob directory unescape only removes parser-inserted
         // metacharacter escapes. Literal backslashes produced by expansion must not
-        // turn `.\.` into `..` and redirect lookup outside the trusted prefix.
+        // turn `.\.` into `..` and redirect lookup outside the trusted prefix
+        // (path traversal).
         let mut bash = tight_bash();
         bash.exec("mkdir -p /tmp/safe /tmp/secret && touch /tmp/secret/flag.txt")
             .await

--- a/crates/bashkit/tests/integration/blackbox_security_tests.rs
+++ b/crates/bashkit/tests/integration/blackbox_security_tests.rs
@@ -1422,6 +1422,27 @@ mod finding_mixed_quoted_word_quote_metadata {
     }
 
     #[tokio::test]
+    async fn unquoted_expansion_backslash_dot_in_glob_dir_stays_literal() {
+        // THREAT[TM-INF-022]: glob directory unescape only removes parser-inserted
+        // metacharacter escapes. Literal backslashes produced by expansion must not
+        // turn `.\.` into `..` and redirect lookup outside the trusted prefix.
+        let mut bash = tight_bash();
+        bash.exec("mkdir -p /tmp/safe /tmp/secret && touch /tmp/secret/flag.txt")
+            .await
+            .unwrap();
+
+        let result = bash
+            .exec(r#"shopt -s nullglob; p='/tmp/safe/.\./secret/*'; for f in $p; do printf '<%s>\n' "$f"; done"#)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.stdout, "",
+            "literal backslash-dot from expansion traversed during glob lookup"
+        );
+    }
+
+    #[tokio::test]
     async fn literal_brace_expression_in_quoted_glob_prefix_stays_literal() {
         // "{a,b}"/*/ is a QuotedGlobWord (unquoted glob suffix `*/`).  The quoted
         // segment `{a,b}` must NOT brace-expand: the pattern should match the literal


### PR DESCRIPTION
### Motivation

- Prevent unconditional removal of `\` from directory components during glob lookup so literal backslashes produced by parameter/command expansion are not treated as parser escapes and used to traverse (`.\.` → `..`).
- Preserve parser-inserted escapes used to keep quoted-glob metacharacters literal while avoiding changing runtime lookup behavior for expanded data.

### Description

- Change `glob_path_unescape` in `crates/bashkit/src/interpreter/glob.rs` to only strip backslashes when they prefix parser-inserted glob metacharacters (e.g. `\*`, `\{`, `\\`, `\[`), and leave other `\X` sequences intact.
- Keep absolute and relative lookup semantics but use the more restrictive unescape so expansion-produced `\` bytes are preserved for VFS lookup.
- Add a regression integration test `unquoted_expansion_backslash_dot_in_glob_dir_stays_literal` in `crates/bashkit/tests/integration/blackbox_security_tests.rs` that verifies an expanded `/tmp/safe/.\./secret/*` pattern does not traverse into `/tmp/secret`.

### Testing

- Ran the single integration test with `cargo test -p bashkit --test integration blackbox_security_tests::finding_mixed_quoted_word_quote_metadata::unquoted_expansion_backslash_dot_in_glob_dir_stays_literal --features http_client,ssh,sqlite`; the first attempt failed during iteration logic, the test was adjusted and re-run and then passed.
- Ran the full affected integration group with `cargo test -p bashkit --test integration blackbox_security_tests::finding_mixed_quoted_word_quote_metadata --features http_client,ssh,sqlite` and all tests passed.
- Ran `cargo fmt --check` and `git diff --check` and both succeeded with no formatting or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3049fe44f4832bb32bc51e3479dda8)