### PR TITLE
fix(interpreter): preserve mixed word IFS boundaries

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -9210,7 +9210,8 @@ impl Interpreter {
             let has_mixed_part_quotes =
                 word.part_quoted.iter().any(|q| *q) && word.part_quoted.iter().any(|q| !*q);
             if has_mixed_part_quotes {
-                let mut fields = vec![String::new()];
+                let mut segments = Vec::new();
+                let mut sentinel_haystack = self.variables.get("IFS").cloned().unwrap_or_default();
                 for (idx, part) in word.parts.iter().enumerate() {
                     let part_is_quoted = word.part_quoted.get(idx).copied().unwrap_or(word.quoted);
                     let part_has_expansion = matches!(
@@ -9236,24 +9237,58 @@ impl Interpreter {
                     };
 
                     if part_has_expansion && !part_is_quoted {
-                        let split = self.ifs_split(&value)?;
-                        if let Some((first, rest)) = split.split_first() {
-                            if let Some(current) = fields.last_mut() {
-                                current.push_str(first);
-                            }
-                            for field in rest {
-                                fields.push(field.clone());
-                            }
+                        sentinel_haystack.push_str(&value);
+                        segments.push((value, false, false));
+                    } else {
+                        let value =
+                            if part_is_quoted && part_has_expansion && word.has_unquoted_glob {
+                                Self::quote_expansion_for_quoted_glob(&value)
+                            } else {
+                                value
+                            };
+                        let preserves_empty_field = part_is_quoted && value.is_empty();
+                        sentinel_haystack.push_str(&value);
+                        segments.push((value, true, preserves_empty_field));
+                    }
+                }
+
+                // Pick a sentinel char absent from the data so empty quoted
+                // fields survive splitting and can be stripped afterward. If no
+                // candidate is free (astronomically unlikely), skip the sentinel
+                // rather than fall back to NUL, which is a valid data byte.
+                let empty_field_sentinel = segments
+                    .iter()
+                    .any(|(_, _, preserves_empty_field)| *preserves_empty_field)
+                    .then(|| {
+                        OPERAND_QUOTE_MARK_CANDIDATES
+                            .iter()
+                            .copied()
+                            .find(|candidate| !sentinel_haystack.contains(*candidate))
+                    })
+                    .flatten();
+
+                let mut expanded_for_split = String::new();
+                for (value, is_protected, preserves_empty_field) in segments {
+                    if is_protected {
+                        // Field splitting scans the whole expanded word. Mark literal and
+                        // quoted segments as protected so unquoted expansion delimiters can
+                        // still create boundaries between adjacent protected segments.
+                        expanded_for_split.push(QUOTED_SEGMENT_START);
+                        if preserves_empty_field
+                            && let Some(empty_field_sentinel) = empty_field_sentinel
+                        {
+                            expanded_for_split.push(empty_field_sentinel);
                         }
-                    } else if let Some(current) = fields.last_mut() {
-                        // Quoted expansion results must not undergo brace/glob expansion
-                        // when an unquoted glob is elsewhere in the word. Escape special
-                        // chars so that expand_braces/expand_glob_item treat them as literals.
-                        if part_is_quoted && part_has_expansion && word.has_unquoted_glob {
-                            current.push_str(&Self::quote_expansion_for_quoted_glob(&value));
-                        } else {
-                            current.push_str(&value);
-                        }
+                        expanded_for_split.push_str(&value);
+                        expanded_for_split.push(QUOTED_SEGMENT_END);
+                    } else {
+                        expanded_for_split.push_str(&value);
+                    }
+                }
+                let mut fields = self.ifs_split(&expanded_for_split)?;
+                if let Some(empty_field_sentinel) = empty_field_sentinel {
+                    for field in &mut fields {
+                        field.retain(|ch| ch != empty_field_sentinel);
                     }
                 }
                 return Ok(fields);
@@ -15158,6 +15193,19 @@ cat /tmp/test_fd_exec_public.txt"#,
         assert_eq!(result.exit_code, 0);
         let lines: Vec<&str> = result.stdout.lines().collect();
         assert_eq!(lines, vec!["count:2", "arg1:x ya", "arg2:b"]);
+    }
+
+    // Regression: unquoted IFS delimiters in a mixed word separate adjacent
+    // literal/quoted segments even when the expansion contributes no field text.
+    #[tokio::test]
+    async fn test_mixed_quote_unquoted_ifs_boundary_before_quoted_suffix() {
+        let result = run_script(
+            r#"a=" "; b="q"; set -- p$a"$b"; echo "count:$#"; echo "arg1:$1"; echo "arg2:$2""#,
+        )
+        .await;
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<&str> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["count:2", "arg1:p", "arg2:q"]);
     }
 
     /// Issue #1184: input process substitution temp files must be cleaned up


### PR DESCRIPTION
### Motivation
- Mixed quoted/unquoted words lost IFS boundary information when each unquoted expansion part was split independently, producing incorrect argument boundaries (e.g. `p$a"$b"` collapsed to `pq`).
- Preserve POSIX IFS splitting semantics across words with interleaved quoted and unquoted segments while keeping quoted segments literal.

### Description
- Defer splitting for mixed words: assemble the whole mixed-word expansion into a single string with protected quoted segments and then call `ifs_split` on the assembled result in `expand_word_to_fields`.
- Preserve empty quoted segments by injecting a temporary sentinel chosen from `OPERAND_QUOTE_MARK_CANDIDATES` and removing it after splitting to avoid dropping delimiter-only fields.
- Add regression test `test_mixed_quote_unquoted_ifs_boundary_before_quoted_suffix` that exercises `p$a"$b"` semantics.
- All changes are localized to `crates/bashkit/src/interpreter/mod.rs`.

### Testing
- Ran the targeted unit test `cargo test -p bashkit test_mixed_quote_unquoted_ifs_boundary_before_quoted_suffix --lib`; it failed on the old code and passed after the fix.
- Ran `cargo test -p bashkit mixed_quote --lib` and all mixed-quote-related tests passed.
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --lib -- -D warnings`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b64f36344832ba342a33001a6ae62)