### PR TITLE
fix(strings): preserve double-dash delimiter

### DIFF
--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -55,7 +55,9 @@ fn parse_strings_args(
         } else if p.flag("-a") {
             // Default behavior, ignore
         } else if let Some(arg) = p.current() {
-            if let Some(rest) = arg.strip_prefix('-')
+            if arg == "--" {
+                p.advance();
+            } else if let Some(rest) = arg.strip_prefix('-')
                 && !rest.is_empty()
                 && rest.chars().all(|c| c.is_ascii_digit())
             {
@@ -309,6 +311,14 @@ mod tests {
         let result = run_strings_with_fs(&["-data.bin"], &[("/-data.bin", data)]).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "dash-file\n");
+    }
+
+    #[tokio::test]
+    async fn test_strings_double_dash_delimits_options() {
+        let data = b"after-delimiter\0";
+        let result = run_strings_with_fs(&["--", "/test.bin"], &[("/test.bin", data)]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "after-delimiter\n");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -37,9 +37,18 @@ fn parse_strings_args(
     };
     let mut files = Vec::new();
     let mut p = super::arg_parser::ArgParser::new(args);
+    // After a `--` delimiter every remaining argument is a filename, even if it
+    // looks like an option (e.g. `strings -- -8` treats `-8` as a file).
+    let mut no_more_options = false;
 
     while !p.is_done() {
-        if let Some(val) = p.flag_value("-n", "strings")? {
+        if no_more_options {
+            if let Some(file) = p.positional() {
+                files.push(file.to_string());
+            } else {
+                p.advance();
+            }
+        } else if let Some(val) = p.flag_value("-n", "strings")? {
             opts.min_length = val
                 .parse()
                 .map_err(|_| format!("strings: invalid minimum string length: '{}'", val))?;
@@ -56,6 +65,7 @@ fn parse_strings_args(
             // Default behavior, ignore
         } else if let Some(arg) = p.current() {
             if arg == "--" {
+                no_more_options = true;
                 p.advance();
             } else if let Some(rest) = arg.strip_prefix('-')
                 && !rest.is_empty()
@@ -319,6 +329,16 @@ mod tests {
         let result = run_strings_with_fs(&["--", "/test.bin"], &[("/test.bin", data)]).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "after-delimiter\n");
+    }
+
+    #[tokio::test]
+    async fn test_strings_double_dash_treats_option_like_arg_as_file() {
+        // After `--`, an option-looking name like `-8` is a filename, not the
+        // `-NUM` minimum-length shorthand.
+        let data = b"numeric-name\0";
+        let result = run_strings_with_fs(&["--", "-8"], &[("/-8", data)]).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "numeric-name\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Fix a regression where `strings` parsed `--` as a positional filename so files following the conventional `--` option delimiter were not processed.

### Description
- In `crates/bashkit/src/builtins/strings.rs` treat `--` as an option delimiter by adding `if arg == "--" { p.advance(); }` before the `-NUM` shorthand branch so `-NUM` parsing and dash-prefixed filenames (e.g. `-data.bin`) keep their intended behavior.
- Add a regression unit test `test_strings_double_dash_delimits_options` that asserts `strings -- /test.bin` reads the file after the delimiter while retaining `test_strings_dash_prefixed_filename` coverage.

### Testing
- Ran `cargo test -p bashkit builtins::strings::tests -- --nocapture` and all `strings` builtin tests passed (16 passed, 0 failed).
- Ran `cargo fmt --check`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b64f34d68832ba8de4319dd6cfc35)