### PR TITLE
fix(interpreter): suppress ERR trap in conditions

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1121,6 +1121,11 @@ pub struct Interpreter {
     /// True while executing a trap handler. Suppresses recursive DEBUG trap
     /// invocation to prevent amplification attacks (TM-DOS-035).
     in_trap: bool,
+    /// Depth of if/while/until condition evaluation.
+    /// Important decision: condition context is tracked as interpreter state so
+    /// nested AND-OR lists can suppress ERR traps without weakening top-level
+    /// final-command errexit behavior.
+    condition_sequence_depth: usize,
     /// Deferred output process substitutions: after a command writes to the
     /// virtual file path, run these commands with the file content as stdin.
     /// Each entry is (virtual_path, commands_to_run).
@@ -1535,6 +1540,7 @@ impl Interpreter {
             cancelled: Arc::new(AtomicBool::new(false)),
             hooks: crate::hooks::Hooks::default(),
             in_trap: false,
+            condition_sequence_depth: 0,
             deferred_proc_subs: Vec::new(),
             proc_sub_paths: HashSet::new(),
             random_state: AtomicU32::new(random_seed),
@@ -1795,6 +1801,7 @@ impl Interpreter {
         // handler is awaited; clear the re-entrancy guard before each exec so
         // one cancelled script cannot suppress traps in the next script.
         self.in_trap = false;
+        self.condition_sequence_depth = 0;
         self.deferred_proc_subs.clear();
         self.clear_pending_fd_redirect_state();
         // Top-level timeouts drop the interpreter future at await points, so
@@ -4482,7 +4489,14 @@ impl Interpreter {
     /// Execute a sequence of commands used as a condition (no errexit checking)
     /// Used for if/while/until conditions where failure is expected
     async fn execute_condition_sequence(&mut self, commands: &[Command]) -> Result<ExecResult> {
-        self.execute_command_sequence_impl(commands, false).await
+        self.condition_sequence_depth += 1;
+        let result = self.execute_command_sequence_impl(commands, false).await;
+        self.condition_sequence_depth -= 1;
+        result
+    }
+
+    fn is_in_condition_sequence(&self) -> bool {
+        self.condition_sequence_depth > 0
     }
 
     /// Execute commands whose stdout is captured by command substitution.
@@ -4710,7 +4724,7 @@ impl Interpreter {
                 .rest
                 .first()
                 .is_some_and(|(op, _)| matches!(op, ListOperator::Semicolon));
-            if exit_code != 0 && first_op_is_semicolon {
+            if exit_code != 0 && first_op_is_semicolon && !self.is_in_condition_sequence() {
                 self.run_err_trap(&mut stdout, &mut stderr).await;
             }
         }
@@ -4798,7 +4812,10 @@ impl Interpreter {
                     }
 
                     // ERR trap follows the same AND-OR suppression as errexit.
-                    if exit_code != 0 && !exit_code_from_conditional_context {
+                    if exit_code != 0
+                        && !exit_code_from_conditional_context
+                        && !self.is_in_condition_sequence()
+                    {
                         self.run_err_trap(&mut stdout, &mut stderr).await;
                     }
                 }
@@ -4808,8 +4825,10 @@ impl Interpreter {
         // Final errexit check for the last command. A non-zero status only
         // remains suppressed when it was carried from a short-circuited or
         // non-final AND-OR list element; a failing final &&/|| command exits.
-        let should_final_errexit_check =
-            self.is_errexit_enabled() && exit_code != 0 && !exit_code_from_conditional_context;
+        let should_final_errexit_check = self.is_errexit_enabled()
+            && exit_code != 0
+            && !exit_code_from_conditional_context
+            && !self.is_in_condition_sequence();
 
         if should_final_errexit_check {
             return Ok(ExecResult {

--- a/crates/bashkit/tests/integration/set_e_and_or_tests.rs
+++ b/crates/bashkit/tests/integration/set_e_and_or_tests.rs
@@ -430,3 +430,45 @@ echo "SHOULD NOT APPEAR"
     assert_eq!(result.exit_code, 1);
     assert!(!result.stdout.contains("SHOULD NOT APPEAR"));
 }
+
+/// ERR trap: final failing AND-OR command in an if condition is suppressed.
+#[tokio::test]
+async fn err_trap_suppressed_for_final_and_failure_in_if_condition() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+trap 'echo ERR_TRAP_FIRED' ERR
+if true && false; then
+    echo "THEN"
+fi
+echo "AFTER"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout.trim(), "AFTER");
+}
+
+/// ERR trap: final failing AND-OR command in a while condition is suppressed.
+#[tokio::test]
+async fn err_trap_suppressed_for_final_and_failure_in_while_condition() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            r#"
+set -e
+trap 'echo ERR_TRAP_FIRED' ERR
+while true && false; do
+    echo "BODY"
+done
+echo "AFTER"
+"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout.trim(), "AFTER");
+}


### PR DESCRIPTION
### Motivation
- Fix a regression where the ERR trap could fire for a final failing `&&`/`||` element when an AND-OR list is evaluated as a condition (e.g. `if true && false`) because `execute_list` lacked caller context. 
- Preserve the intended behavior that top-level final AND-OR failures still trigger `set -e`/ERR semantics while ensuring condition evaluations do not produce ERR-trap side effects.

### Description
- Add a `condition_sequence_depth: usize` field to `Interpreter` and reset it in `reset_transient_state` to track nested `if`/`while`/`until` condition evaluation depth. 
- Increment/decrement the depth in `execute_condition_sequence` and expose `is_in_condition_sequence()` to query the condition context. 
- Guard `run_err_trap` calls and the final AND-OR `errexit` check in `execute_list` so they are skipped while `is_in_condition_sequence()` is true, preserving suppression of ERR traps and side effects when evaluating conditions. 
- Add integration tests `err_trap_suppressed_for_final_and_failure_in_if_condition` and `err_trap_suppressed_for_final_and_failure_in_while_condition` in `crates/bashkit/tests/integration/set_e_and_or_tests.rs` to cover the regression.

### Testing
- Ran `cargo test -p bashkit --test integration err_trap_suppressed_for_final_and_failure_in_if_condition -- --nocapture` which failed on the original HEAD and passed after the change. 
- Ran `cargo test -p bashkit --test integration set_e_and_or_tests -- --nocapture` and the entire integration test slice passed. 
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --test integration -- -D warnings`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b64f31058832bbb4f7c5c5a18a56a)