### PR TITLE
fix(parser): keep literal case patterns unexpanded

### DIFF
--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -1239,14 +1239,21 @@ impl<'a> Parser<'a> {
                     | Some(tokens::Token::QuotedWord(_))
                     | Some(tokens::Token::QuotedGlobWord(_))
             ) {
-                let w = match &self.current_token {
+                let pattern = match &self.current_token {
+                    Some(tokens::Token::LiteralWord(w)) => Word {
+                        // LiteralWord already decoded lexer-only sentinels and must not
+                        // be reparsed; otherwise escaped dollars can become expansions.
+                        parts: vec![WordPart::Literal(w.clone())],
+                        quoted: true,
+                        has_unquoted_glob: false,
+                        part_quoted: Vec::new(),
+                    },
                     Some(tokens::Token::Word(w))
-                    | Some(tokens::Token::LiteralWord(w))
                     | Some(tokens::Token::QuotedWord(w))
-                    | Some(tokens::Token::QuotedGlobWord(w)) => w.clone(),
+                    | Some(tokens::Token::QuotedGlobWord(w)) => self.parse_word(w.clone()),
                     _ => unreachable!(),
                 };
-                patterns.push(self.parse_word(w));
+                patterns.push(pattern);
                 self.advance();
 
                 // Check for | between patterns
@@ -4078,6 +4085,28 @@ mod tests {
         } else {
             panic!("expected simple command");
         }
+    }
+
+    #[test]
+    fn test_case_literal_pattern_escaped_dollar_continuation_stays_literal() {
+        let parser =
+            Parser::new(r#"case "xy" in 'x'"\$(echo y)") echo MATCH ;; *) echo NOMATCH ;; esac"#);
+        let script = parser.parse().unwrap();
+
+        let case = match &script.commands[0] {
+            Command::Compound(CompoundCommand::Case(case), _) => case,
+            other => panic!("expected case command, got: {other:?}"),
+        };
+        let pattern = &case.cases[0].patterns[0];
+        assert_eq!(pattern.to_string(), r#"x$(echo y)"#);
+        assert!(
+            pattern
+                .parts
+                .iter()
+                .all(|part| matches!(part, WordPart::Literal(_))),
+            "escaped dollar in literal case pattern must not parse as expansion: {:?}",
+            pattern.parts
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- A previous change decoded the lexer NUL sentinel for escaped `$` into a bare `$` in `LiteralWord`, which exposed a parser bug where `case` patterns that started as literal tokens were being reparsed by `parse_word()` and could accidentally produce expansions (e.g. `'x'"\$(echo y)"`).
- Preserve the literalness of `LiteralWord` case patterns so escaped dollars and other literal content cannot be reinterpreted as expansions during case parsing.

### Description
- Change `parse_case()` to treat `Token::LiteralWord` specially by constructing a `Word` with a single `WordPart::Literal` and `quoted = true` instead of reparsing the token with `parse_word()`.
- Keep the existing behavior for `Word`, `QuotedWord` and `QuotedGlobWord` by calling `parse_word()` for those variants; add a short code comment documenting the reasoning.
- Add a regression unit test `test_case_literal_pattern_escaped_dollar_continuation_stays_literal` that asserts the pattern produced from `'x'"\$(echo y)"` remains `x$(echo y)` and contains only literal parts.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran the existing lexer unit `parser::lexer::tests::test_single_quoted_word_continuation_decodes_escaped_dollar` which passed.
- Ran the new parser unit `parser::tests::test_case_literal_pattern_escaped_dollar_continuation_stays_literal` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b64f2669c832bbc8da28e5328a6b4)