### PR TITLE
fix(read): trim trailing IFS whitespace when assigning final variable

### DIFF
--- a/crates/bashkit/src/builtins/read.rs
+++ b/crates/bashkit/src/builtins/read.rs
@@ -294,11 +294,16 @@ impl Builtin for Read {
                 continue;
             }
             let value = if i == var_names.len() - 1 {
-                // Bash gives the final variable the unsplit remaining input.
-                // Preserve original separators instead of reconstructing from IFS.
+                // Bash gives the final variable the unsplit remaining input,
+                // then strips trailing IFS whitespace. Preserve original
+                // separators without keeping whitespace Bash trims.
                 words
                     .get(i)
-                    .map(|field| line[field.start..].to_string())
+                    .map(|field| {
+                        line[field.start..]
+                            .trim_end_matches(|ch| ifs.contains(ch) && " \t\n".contains(ch))
+                            .to_string()
+                    })
                     .unwrap_or_default()
             } else if i < words.len() {
                 words[i].text.to_string()
@@ -679,6 +684,48 @@ mod tests {
         let vars = extract_vars(&result);
         assert_eq!(vars.get("A").unwrap(), "1");
         assert_eq!(vars.get("B").unwrap(), "2:3");
+    }
+
+    #[tokio::test]
+    async fn read_last_var_trims_trailing_ifs_whitespace() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let mut env = HashMap::new();
+        env.insert("IFS".to_string(), " ".to_string());
+        let args = vec!["A".to_string(), "B".to_string()];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            Some("a   b  c  "),
+        );
+        let result = Read.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let vars = extract_vars(&result);
+        assert_eq!(vars.get("A").unwrap(), "a");
+        assert_eq!(vars.get("B").unwrap(), "b  c");
+    }
+
+    #[tokio::test]
+    async fn read_last_var_trims_only_trailing_ifs_whitespace() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let mut env = HashMap::new();
+        env.insert("IFS".to_string(), ",:".to_string());
+        let args = vec!["A".to_string(), "B".to_string()];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            Some("1,2:3  "),
+        );
+        let result = Read.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let vars = extract_vars(&result);
+        assert_eq!(vars.get("A").unwrap(), "1");
+        assert_eq!(vars.get("B").unwrap(), "2:3  ");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
@@ -149,3 +149,17 @@ IFS=",:"; read -r a b <<< "1,2:3"; echo "$a|$b"
 ### expect
 1|2:3
 ### end
+
+### read_last_var_trims_trailing_ifs_whitespace
+# Last read variable preserves middle separators but strips trailing IFS whitespace
+IFS=" "; read -r a b <<< "a   b  c  "; printf 'a=<%s> b=<%s> len=%d\n' "$a" "$b" "${#b}"
+### expect
+a=<a> b=<b  c> len=4
+### end
+
+### read_last_var_keeps_trailing_non_ifs_whitespace
+# Trailing spaces remain when they are not IFS characters
+IFS=",:"; read -r a b <<< "1,2:3  "; printf 'a=<%s> b=<%s> len=%d\n' "$a" "$b" "${#b}"
+### expect
+a=<1> b=<2:3  > len=5
+### end


### PR DESCRIPTION
### Motivation
- The final `read` variable was assigned from the original input slice (`line[field.start..]`) which preserved trailing IFS whitespace and diverged from Bash semantics.
- The goal is to preserve original middle delimiters while trimming only trailing IFS whitespace so scripts relying on Bash-compatible behavior are not broken.

### Description
- Change final-variable assignment to trim trailing IFS whitespace using `trim_end_matches` while still using the original slice start to preserve internal delimiters in `crates/bashkit/src/builtins/read.rs`.
- Add unit tests `read_last_var_trims_trailing_ifs_whitespace` and `read_last_var_trims_only_trailing_ifs_whitespace` to validate whitespace-only IFS trimming and non-IFS trailing-space preservation.
- Add bash spec cases to `crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh` that assert the final-variable tail trimming and non-IFS trailing-space behavior.

### Testing
- Ran `cargo test -p bashkit read_last_var --lib` and the new unit tests passed.
- Ran `cargo test -p bashkit builtins::read::tests::read_custom_ifs_last_var_preserves_original_delimiters --lib` and it passed.
- Ran the integration spec runner for the relevant cases (`spec_tests::bash_spec_tests`) and the spec cases covering the tail behavior passed.
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --lib -- -D warnings` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b64f31f44832bb6b3415e9bc2d204)