### PR TITLE
feat(tool): gate BashTool wrapper behind default `bash_tool` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+      - name: Clippy without default features (lean build, no bash_tool)
+        run: cargo clippy -p bashkit --no-default-features --lib --tests -- -D warnings
+
       - name: Build documentation
         run: cargo doc --no-deps --all-features
         env:

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -32,8 +32,8 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
-# `BashTool` wrapper, so it opts out of the default `tool` feature to avoid
-# pulling in tower / futures-core.
+# `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
+# avoid pulling in tower / futures-core.
 bashkit = { path = "../bashkit", version = "0.11.0", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -31,7 +31,10 @@ scripted_tool = ["bashkit/scripted_tool"]
 interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 
 [dependencies]
-bashkit = { path = "../bashkit", version = "0.11.0", features = ["http_client", "git", "jq"] }
+# The CLI drives the `Bash` interpreter directly and never touches the LLM
+# `BashTool` wrapper, so it opts out of the default `tool` feature to avoid
+# pulling in tower / futures-core.
+bashkit = { path = "../bashkit", version = "0.11.0", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -17,9 +17,11 @@ readme = "../../README.md"
 # Async runtime
 tokio = { workspace = true }
 async-trait = { workspace = true }
-futures-core = { workspace = true }
+# futures-core / tower are only pulled in by the LLM `BashTool` wrapper
+# (and the `scripted_tool` layer on top of it). Optional, gated under `tool`.
+futures-core = { workspace = true, optional = true }
 futures-util = { workspace = true }
-tower = { workspace = true }
+tower = { workspace = true, optional = true }
 
 # Error handling
 thiserror = { workspace = true }
@@ -108,7 +110,13 @@ zapcode-core = { version = "1.5", optional = true }
 turso_core = { workspace = true, optional = true }
 
 [features]
-default = []
+default = ["tool"]
+# Enable the LLM-facing `BashTool` wrapper: the `Tool` trait, `ToolExecution`,
+# OpenAI tool-definition/JSON-schema helpers, and the `tower::Service` bridge.
+# On by default. Disable with `--no-default-features` to compile just the
+# embeddable `Bash` interpreter and drop the `tower` / `futures-core` deps.
+# Usage: cargo build --no-default-features [--features <others>]
+tool = ["dep:tower", "dep:futures-core"]
 # Enable jq builtin via embedded jaq interpreter
 # Usage: cargo build --features jq
 jq = ["dep:jaq-core", "dep:jaq-std", "dep:jaq-json"]
@@ -130,8 +138,9 @@ git = []
 # Usage: cargo build --features ssh
 ssh = ["russh"]
 # Enable ScriptedTool: compose ToolDef+callback pairs into a single Tool
+# Builds on the `BashTool` contract, so it pulls in the `tool` feature.
 # Usage: cargo build --features scripted_tool
-scripted_tool = []
+scripted_tool = ["tool"]
 # Enable python/python3 builtins via embedded Monty interpreter
 # Monty is a git dep (not yet on crates.io) — feature unavailable from registry
 python = ["dep:monty"]
@@ -209,6 +218,10 @@ required-features = ["git"]
 [[example]]
 name = "ssh_supabase"
 required-features = ["ssh"]
+
+[[example]]
+name = "show_tool_output"
+required-features = ["tool"]
 
 [[example]]
 name = "scripted_tool"

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -110,13 +110,13 @@ zapcode-core = { version = "1.5", optional = true }
 turso_core = { workspace = true, optional = true }
 
 [features]
-default = ["tool"]
+default = ["bash_tool"]
 # Enable the LLM-facing `BashTool` wrapper: the `Tool` trait, `ToolExecution`,
 # OpenAI tool-definition/JSON-schema helpers, and the `tower::Service` bridge.
 # On by default. Disable with `--no-default-features` to compile just the
 # embeddable `Bash` interpreter and drop the `tower` / `futures-core` deps.
 # Usage: cargo build --no-default-features [--features <others>]
-tool = ["dep:tower", "dep:futures-core"]
+bash_tool = ["dep:tower", "dep:futures-core"]
 # Enable jq builtin via embedded jaq interpreter
 # Usage: cargo build --features jq
 jq = ["dep:jaq-core", "dep:jaq-std", "dep:jaq-json"]
@@ -138,9 +138,9 @@ git = []
 # Usage: cargo build --features ssh
 ssh = ["russh"]
 # Enable ScriptedTool: compose ToolDef+callback pairs into a single Tool
-# Builds on the `BashTool` contract, so it pulls in the `tool` feature.
+# Builds on the `BashTool` contract, so it pulls in the `bash_tool` feature.
 # Usage: cargo build --features scripted_tool
-scripted_tool = ["tool"]
+scripted_tool = ["bash_tool"]
 # Enable python/python3 builtins via embedded Monty interpreter
 # Monty is a git dep (not yet on crates.io) — feature unavailable from registry
 python = ["dep:monty"]
@@ -221,7 +221,7 @@ required-features = ["ssh"]
 
 [[example]]
 name = "show_tool_output"
-required-features = ["tool"]
+required-features = ["bash_tool"]
 
 [[example]]
 name = "scripted_tool"

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../../README.md"
 tokio = { workspace = true }
 async-trait = { workspace = true }
 # futures-core / tower are only pulled in by the LLM `BashTool` wrapper
-# (and the `scripted_tool` layer on top of it). Optional, gated under `tool`.
+# (and the `scripted_tool` layer on top of it). Optional, gated under `bash_tool`.
 futures-core = { workspace = true, optional = true }
 futures-util = { workspace = true }
 tower = { workspace = true, optional = true }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -429,8 +429,8 @@ mod snapshot;
 #[doc(hidden)]
 pub mod testing;
 /// Tool contract for LLM integration.
-/// Requires the `tool` feature (enabled by default).
-#[cfg(feature = "tool")]
+/// Requires the `bash_tool` feature (enabled by default).
+#[cfg(feature = "bash_tool")]
 pub mod tool;
 /// Reusable tool primitives: ToolDef, ToolArgs, ToolImpl, exec types.
 #[cfg(feature = "scripted_tool")]
@@ -465,9 +465,9 @@ pub use limits::{
 };
 pub use network::NetworkAllowlist;
 pub use snapshot::{Snapshot, SnapshotOptions};
-#[cfg(feature = "tool")]
+#[cfg(feature = "bash_tool")]
 pub use tool::BashToolBuilder as ToolBuilder;
-#[cfg(feature = "tool")]
+#[cfg(feature = "bash_tool")]
 pub use tool::{
     BashTool, BashToolBuilder, Tool, ToolError, ToolExecution, ToolImage, ToolOutput,
     ToolOutputChunk, ToolOutputMetadata, ToolRequest, ToolResponse, ToolService, ToolStatus,

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -428,7 +428,9 @@ mod snapshot;
 /// invariants enforced (TM-INF-013, TM-INF-016, TM-INF-022).
 #[doc(hidden)]
 pub mod testing;
-/// Tool contract for LLM integration
+/// Tool contract for LLM integration.
+/// Requires the `tool` feature (enabled by default).
+#[cfg(feature = "tool")]
 pub mod tool;
 /// Reusable tool primitives: ToolDef, ToolArgs, ToolImpl, exec types.
 #[cfg(feature = "scripted_tool")]
@@ -463,7 +465,9 @@ pub use limits::{
 };
 pub use network::NetworkAllowlist;
 pub use snapshot::{Snapshot, SnapshotOptions};
+#[cfg(feature = "tool")]
 pub use tool::BashToolBuilder as ToolBuilder;
+#[cfg(feature = "tool")]
 pub use tool::{
     BashTool, BashToolBuilder, Tool, ToolError, ToolExecution, ToolImage, ToolOutput,
     ToolOutputChunk, ToolOutputMetadata, ToolRequest, ToolResponse, ToolService, ToolStatus,

--- a/specs/tool-contract.md
+++ b/specs/tool-contract.md
@@ -14,6 +14,18 @@ ToolBuilder (config) -> Tool (metadata) -> ToolExecution (single-use runtime)
 `BashToolBuilder` is the primary builder. `ScriptedToolBuilder` and
 `ScriptingToolSetBuilder` mirror the same contract for orchestration tools.
 
+## Feature gating
+
+The entire tool layer (`tool` module: `Tool` trait, `BashTool*`,
+`ToolExecution`, `ToolService`, schema/OpenAI helpers) is gated behind the
+`tool` feature, which is **on by default**. Building with
+`--no-default-features` drops the module and its exclusive dependencies
+(`tower`, `futures-core`), leaving just the embeddable `Bash` interpreter.
+
+- `scripted_tool` builds on this layer and so enables `tool`.
+- Consumers that only drive `Bash` directly (e.g. `bashkit-cli`) set
+  `default-features = false` to avoid pulling in the tool dependencies.
+
 ## Public API
 
 `Tool` trait, builders, `ToolExecution`, `ToolOutput`, `ToolOutputChunk`,

--- a/specs/tool-contract.md
+++ b/specs/tool-contract.md
@@ -18,11 +18,11 @@ ToolBuilder (config) -> Tool (metadata) -> ToolExecution (single-use runtime)
 
 The entire tool layer (`tool` module: `Tool` trait, `BashTool*`,
 `ToolExecution`, `ToolService`, schema/OpenAI helpers) is gated behind the
-`tool` feature, which is **on by default**. Building with
+`bash_tool` feature, which is **on by default**. Building with
 `--no-default-features` drops the module and its exclusive dependencies
 (`tower`, `futures-core`), leaving just the embeddable `Bash` interpreter.
 
-- `scripted_tool` builds on this layer and so enables `tool`.
+- `scripted_tool` builds on this layer and so enables `bash_tool`.
 - Consumers that only drive `Bash` directly (e.g. `bashkit-cli`) set
   `default-features = false` to avoid pulling in the tool dependencies.
 


### PR DESCRIPTION
## What

Put the LLM-facing tool layer behind a new `bash_tool` Cargo feature, **enabled by default**. The gated surface is the entire `tool` module: the `Tool` trait, `BashTool`/`BashToolBuilder`, `ToolExecution`, `ToolService`, and the JSON-schema / OpenAI tool-definition helpers.

Building with `--no-default-features` now compiles just the embeddable `Bash` interpreter and drops the tool-only dependencies.

## Why

Consumers that only drive the `Bash` interpreter directly (e.g. `bashkit-cli`) had no way to avoid compiling the tool wrapper or pulling in its dependencies. The `bash_tool` feature makes the wrapper optional so those builds stay lean.

## How

- `bash_tool = ["dep:tower", "dep:futures-core"]`; added to `default`. `tower` and `futures-core` are now `optional` — they were direct dependencies of the tool module only (`async-trait` / `futures-util` are used crate-wide and stay non-optional).
- `tower` (and its tree) is dropped entirely from the dependency graph under `--no-default-features`; `futures-core` remains only transitively via `futures-util`, so no direct edge from the tool module survives.
- `scripted_tool` builds on this contract, so it now enables `bash_tool`.
- `bashkit-cli` sets `default-features = false` (it never uses the wrapper), realizing the dependency savings.
- `pub mod tool` and its re-exports in `lib.rs` are gated on `#[cfg(feature = "bash_tool")]`.
- Documented the gate in `specs/tool-contract.md`.

## Tests / verification

- New CI step guards the lean build so it can't silently break: `cargo clippy -p bashkit --no-default-features --lib --tests -- -D warnings`.
- Compiles in all configs: default, `--no-default-features`, `--features scripted_tool`; consumers `bashkit-cli` and `bashkit-eval` build.
- `cargo fmt --check`, clippy (default all-targets + lean) clean.
- Tests green: bashkit lib `2549 passed`, `bashkit-cli` `80 passed` (incl. the existing 36 `tool::` tests under default features).
- Smoke tested end-to-end: lean CLI runs (`expr 6 * 7` -> `42`) and the `show_tool_output` example emits schemas / tool definition under default features.

The tool module path (`bashkit::tool::…`, `BashTool`) is unchanged — only the Cargo feature name is new.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfRMjgo3KhEtEN7zWT9wLL)_