### PR TITLE
feat(lib): add ExecOptions request struct + exec_with_options entry point

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -579,6 +579,66 @@ impl Drop for OutputCallbackGuard {
     }
 }
 
+/// Per-call options for [`Bash::exec_with_options`].
+///
+/// Bundles the optional inputs to a single execution — streaming output and
+/// per-call builtin extensions — into one request value so new options can be
+/// added as fields without multiplying the number of `exec*` methods. The
+/// convenience methods ([`Bash::exec`], [`Bash::exec_with_extensions`],
+/// [`Bash::exec_streaming`], [`Bash::exec_streaming_with_extensions`]) are thin
+/// wrappers over `exec_with_options`.
+///
+/// # Example
+///
+/// ```rust
+/// use bashkit::{Bash, ExecOptions};
+/// use std::sync::{Arc, Mutex};
+///
+/// # #[tokio::main]
+/// # async fn main() -> bashkit::Result<()> {
+/// let chunks: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+/// let chunks_cb = chunks.clone();
+/// let mut bash = Bash::new();
+/// let result = bash
+///     .exec_with_options(
+///         "for i in 1 2 3; do echo $i; done",
+///         ExecOptions::new().streaming(Box::new(move |stdout, _stderr| {
+///             chunks_cb.lock().unwrap().push(stdout.to_string());
+///         })),
+///     )
+///     .await?;
+/// assert_eq!(result.stdout, "1\n2\n3\n");
+/// assert_eq!(*chunks.lock().unwrap(), vec!["1\n", "2\n", "3\n"]);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Default)]
+pub struct ExecOptions {
+    extensions: ExecutionExtensions,
+    output_callback: Option<OutputCallback>,
+}
+
+impl ExecOptions {
+    /// Create an empty set of options (no streaming, no extensions).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stream incremental `(stdout_chunk, stderr_chunk)` output to `callback`
+    /// as it is produced. See [`Bash::exec_streaming`] for callback semantics.
+    pub fn streaming(mut self, callback: OutputCallback) -> Self {
+        self.output_callback = Some(callback);
+        self
+    }
+
+    /// Attach per-execution builtin extensions (request-scoped typed data read
+    /// by builtins via `ctx.execution_extension::<T>()`).
+    pub fn extensions(mut self, extensions: ExecutionExtensions) -> Self {
+        self.extensions = extensions;
+        self
+    }
+}
+
 /// Main entry point for Bashkit.
 ///
 /// Provides a virtual bash interpreter with an in-memory virtual filesystem.
@@ -675,6 +735,31 @@ impl Bash {
         let _ = extensions.insert(builtins::SqliteInprocessOptIn(self.sqlite_inprocess_opt_in));
         let _extensions_guard = self.interpreter.scoped_execution_extensions(extensions);
         self.exec_impl(script).await
+    }
+
+    /// Execute a bash script with a single [`ExecOptions`] request value.
+    ///
+    /// This is the canonical entry point: streaming output and per-call builtin
+    /// extensions are carried as fields of [`ExecOptions`] rather than as
+    /// separate method overloads, so future per-call options can be added
+    /// without multiplying `exec*` methods. The other `exec*` methods are thin
+    /// wrappers over this one.
+    pub async fn exec_with_options(
+        &mut self,
+        script: &str,
+        options: ExecOptions,
+    ) -> Result<ExecResult> {
+        let ExecOptions {
+            extensions,
+            output_callback,
+        } = options;
+        // Install the streaming callback for the duration of this execution, if
+        // any. The guard holds a raw pointer (not a borrow), so the mutable
+        // interpreter borrow is released before `exec_with_extensions` runs and
+        // the callback is cleared on drop after the await completes.
+        let _stream_guard =
+            output_callback.map(|cb| OutputCallbackGuard::install(&mut self.interpreter, cb));
+        self.exec_with_extensions(script, extensions).await
     }
 
     async fn exec_impl(&mut self, script: &str) -> Result<ExecResult> {
@@ -1006,8 +1091,13 @@ impl Bash {
         output_callback: OutputCallback,
         extensions: ExecutionExtensions,
     ) -> Result<ExecResult> {
-        let _guard = OutputCallbackGuard::install(&mut self.interpreter, output_callback);
-        self.exec_with_extensions(script, extensions).await
+        self.exec_with_options(
+            script,
+            ExecOptions::new()
+                .streaming(output_callback)
+                .extensions(extensions),
+        )
+        .await
     }
 
     /// Return a shared cancellation token.

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -714,27 +714,19 @@ impl Bash {
     /// input size, then parses the script with a timeout, AST depth limit, and fuel limit,
     /// then executes the resulting AST.
     pub async fn exec(&mut self, script: &str) -> Result<ExecResult> {
-        self.exec_with_extensions(script, ExecutionExtensions::new())
-            .await
+        self.exec_with_options(script, ExecOptions::new()).await
     }
 
     /// Execute a bash script with per-execution builtin extensions.
+    ///
+    /// Convenience wrapper over [`exec_with_options`](Self::exec_with_options).
     pub async fn exec_with_extensions(
         &mut self,
         script: &str,
-        mut extensions: ExecutionExtensions,
+        extensions: ExecutionExtensions,
     ) -> Result<ExecResult> {
-        // Expose active execution limits and deadline to builtins that need to
-        // honor per-execution sandbox settings inside synchronous VM sections.
-        let active_limits = self.interpreter.limits().clone();
-        let _ = extensions.insert(active_limits.clone());
-        let _ = extensions.insert(builtins::ExecutionDeadline::new(active_limits.timeout));
-        #[cfg(feature = "python")]
-        let _ = extensions.insert(builtins::PythonInprocessOptIn(self.python_inprocess_opt_in));
-        #[cfg(feature = "sqlite")]
-        let _ = extensions.insert(builtins::SqliteInprocessOptIn(self.sqlite_inprocess_opt_in));
-        let _extensions_guard = self.interpreter.scoped_execution_extensions(extensions);
-        self.exec_impl(script).await
+        self.exec_with_options(script, ExecOptions::new().extensions(extensions))
+            .await
     }
 
     /// Execute a bash script with a single [`ExecOptions`] request value.
@@ -750,16 +742,26 @@ impl Bash {
         options: ExecOptions,
     ) -> Result<ExecResult> {
         let ExecOptions {
-            extensions,
+            mut extensions,
             output_callback,
         } = options;
+        // Expose active execution limits and deadline to builtins that need to
+        // honor per-execution sandbox settings inside synchronous VM sections.
+        let active_limits = self.interpreter.limits().clone();
+        let _ = extensions.insert(active_limits.clone());
+        let _ = extensions.insert(builtins::ExecutionDeadline::new(active_limits.timeout));
+        #[cfg(feature = "python")]
+        let _ = extensions.insert(builtins::PythonInprocessOptIn(self.python_inprocess_opt_in));
+        #[cfg(feature = "sqlite")]
+        let _ = extensions.insert(builtins::SqliteInprocessOptIn(self.sqlite_inprocess_opt_in));
         // Install the streaming callback for the duration of this execution, if
         // any. The guard holds a raw pointer (not a borrow), so the mutable
-        // interpreter borrow is released before `exec_with_extensions` runs and
-        // the callback is cleared on drop after the await completes.
+        // interpreter borrow is released before `exec_impl` runs and the
+        // callback is cleared on drop after the await completes.
         let _stream_guard =
             output_callback.map(|cb| OutputCallbackGuard::install(&mut self.interpreter, cb));
-        self.exec_with_extensions(script, extensions).await
+        let _extensions_guard = self.interpreter.scoped_execution_extensions(extensions);
+        self.exec_impl(script).await
     }
 
     async fn exec_impl(&mut self, script: &str) -> Result<ExecResult> {
@@ -1080,11 +1082,13 @@ impl Bash {
         script: &str,
         output_callback: OutputCallback,
     ) -> Result<ExecResult> {
-        self.exec_streaming_with_extensions(script, output_callback, ExecutionExtensions::new())
+        self.exec_with_options(script, ExecOptions::new().streaming(output_callback))
             .await
     }
 
     /// Execute a bash script with streaming output and per-execution builtin extensions.
+    ///
+    /// Convenience wrapper over [`exec_with_options`](Self::exec_with_options).
     pub async fn exec_streaming_with_extensions(
         &mut self,
         script: &str,

--- a/crates/bashkit/tests/integration/exec_options_tests.rs
+++ b/crates/bashkit/tests/integration/exec_options_tests.rs
@@ -1,0 +1,73 @@
+//! Tests for the unified `Bash::exec_with_options` entry point.
+//!
+//! `exec_with_options` carries streaming + per-call extensions as fields of a
+//! single `ExecOptions` request, and the older `exec*` methods are thin wrappers
+//! over it. These tests pin that the request struct is wired through correctly.
+
+use bashkit::{Bash, ExecOptions};
+use std::sync::{Arc, Mutex};
+
+#[tokio::test]
+async fn exec_with_options_default_matches_exec() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec_with_options("echo hello", ExecOptions::new())
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.stdout, "hello\n");
+}
+
+#[tokio::test]
+async fn exec_with_options_streams_output() {
+    let chunks: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let chunks_cb = chunks.clone();
+    let mut bash = Bash::new();
+
+    let result = bash
+        .exec_with_options(
+            "for i in 1 2 3; do echo $i; done",
+            ExecOptions::new().streaming(Box::new(move |stdout, _stderr| {
+                if !stdout.is_empty() {
+                    chunks_cb.lock().unwrap().push(stdout.to_string());
+                }
+            })),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout, "1\n2\n3\n");
+    assert_eq!(*chunks.lock().unwrap(), vec!["1\n", "2\n", "3\n"]);
+}
+
+#[tokio::test]
+async fn exec_with_options_callback_cleared_after_call() {
+    let count = Arc::new(Mutex::new(0usize));
+    let count_cb = count.clone();
+    let mut bash = Bash::new();
+
+    bash.exec_with_options(
+        "echo streamed",
+        ExecOptions::new().streaming(Box::new(move |stdout, _stderr| {
+            if !stdout.is_empty() {
+                *count_cb.lock().unwrap() += 1;
+            }
+        })),
+    )
+    .await
+    .unwrap();
+
+    let before = *count.lock().unwrap();
+    assert!(
+        before > 0,
+        "callback should have fired during streaming call"
+    );
+
+    // A subsequent plain exec must not invoke the previous call's callback.
+    bash.exec("echo after").await.unwrap();
+    assert_eq!(
+        *count.lock().unwrap(),
+        before,
+        "streaming callback must not persist past its exec_with_options call"
+    );
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -36,6 +36,7 @@ pub mod credential_injection_tests;
 pub mod custom_builtins_tests;
 pub mod custom_fs_tests;
 pub mod dev_null_tests;
+pub mod exec_options_tests;
 pub mod final_env_tests;
 pub mod find_multi_path_tests;
 pub mod git_advanced_tests;


### PR DESCRIPTION
## Why

Architectural item #2: the per-call `exec` surface was a 2×2 method matrix —

|  | no extensions | with extensions |
|--|--|--|
| **no streaming** | `exec` | `exec_with_extensions` |
| **streaming** | `exec_streaming` | `exec_streaming_with_extensions` |

Every new per-call option (timeout, mode, …) would *double* the method count. That combinatorial growth is the smell of a missing request abstraction.

## What

- New `ExecOptions` request struct carrying streaming output + per-call builtin extensions as **fields** (builder-style `.streaming(cb)` / `.extensions(ext)`).
- New canonical `Bash::exec_with_options(script, options)` entry point. Future per-call options become fields here, not new methods.
- The four existing methods stay as thin convenience wrappers; `exec_streaming_with_extensions` now delegates to `exec_with_options`, so there is **one** execution path (streaming-guard install + extension setup).
- `ExecOptions` is a crate-root `pub struct` (`bashkit::ExecOptions`). Public API and bindings are **unchanged** — purely additive.

## Tests

- `exec_options_tests` (3): default-options parity with `exec`, streaming via options, and that the streaming callback is cleared after the call (doesn't leak into a later `exec`).
- Doctests on `ExecOptions` and `exec_streaming` pass; `coproc_tests` (which exercise the re-pointed `exec_streaming` path) green. `bash_tool` + CLI build clean. fmt + clippy clean.

## Series

First slice of item #2. Follow-ups (separate PRs): (a) make `BashTool`/`BashToolBuilder` a thin adapter over `Bash`/`BashBuilder` to remove the ~70% duplicated builder surface; (b) fix the self-contradicting `restore_shell_state` on the tool path (stateless `BashTool` builds a fresh `Bash` per call) and unify shell+VFS session snapshotting.