### PR TITLE
refactor(builtins): share RuntimeLimits core across Python/TypeScript VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- **`PythonLimits` / `TypeScriptLimits` fields moved under a shared `common: RuntimeLimits`.**
+  The two embedded-VM limit types now share a `RuntimeLimits` core (duration,
+  memory, allocations, call depth). The fluent builder API is unchanged
+  (`.max_duration()`, `.max_memory()`, `.max_recursion()` / `.max_stack_depth()`,
+  `default()`), but code that read the `pub max_*` fields directly must now go
+  through `.common` (e.g. `limits.common.max_memory`). SQLite is unaffected.
+
 ## [0.11.0] - 2026-06-16
 
 ### Highlights

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -122,6 +122,9 @@ pub(crate) mod git;
 
 pub(crate) mod ssh;
 
+#[cfg(any(feature = "python", feature = "typescript"))]
+mod runtime_limits;
+
 #[cfg(feature = "python")]
 mod python;
 
@@ -224,6 +227,9 @@ pub use git::Git;
 
 #[cfg(feature = "ssh")]
 pub use ssh::{Scp, Sftp, Ssh};
+
+#[cfg(any(feature = "python", feature = "typescript"))]
+pub use runtime_limits::RuntimeLimits;
 
 #[cfg(feature = "python")]
 pub(crate) use python::PythonInprocessOptIn;

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -32,15 +32,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use super::{Builtin, Context, ExecutionDeadline, resolve_path};
+use super::{Builtin, Context, ExecutionDeadline, RuntimeLimits, resolve_path};
 use crate::error::Result;
 use crate::fs::{FileSystem, FileType};
 use crate::interpreter::ExecResult;
 
-/// Default resource limits for virtual Python execution.
-const DEFAULT_MAX_ALLOCATIONS: usize = 1_000_000;
-const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(30);
-const DEFAULT_MAX_MEMORY: usize = 64 * 1024 * 1024; // 64 MB
+/// Python's default recursion-depth cap. The other VM limits (duration,
+/// memory, allocations) default via [`RuntimeLimits::default`].
 const DEFAULT_MAX_RECURSION: usize = 200;
 // Security hard-stop: catastrophic regex backtracking can bypass cooperative
 // interpreter budget checks, so disable regex stdlib module in untrusted code.
@@ -96,23 +94,18 @@ fn python_inprocess_enabled(ctx: &Context<'_>) -> bool {
 /// ```
 #[derive(Debug, Clone)]
 pub struct PythonLimits {
-    /// Maximum heap allocations (default: 1,000,000).
-    pub max_allocations: usize,
-    /// Maximum execution time (default: 30s).
-    pub max_duration: Duration,
-    /// Maximum memory in bytes (default: 64 MB).
-    pub max_memory: usize,
-    /// Maximum recursion depth (default: 200).
-    pub max_recursion: usize,
+    /// Shared VM resource limits (duration, memory, allocations, call depth).
+    pub common: RuntimeLimits,
 }
 
 impl Default for PythonLimits {
     fn default() -> Self {
         Self {
-            max_allocations: DEFAULT_MAX_ALLOCATIONS,
-            max_duration: DEFAULT_MAX_DURATION,
-            max_memory: DEFAULT_MAX_MEMORY,
-            max_recursion: DEFAULT_MAX_RECURSION,
+            common: RuntimeLimits {
+                // Python defaults to a recursion depth of 200.
+                max_call_depth: DEFAULT_MAX_RECURSION,
+                ..RuntimeLimits::default()
+            },
         }
     }
 }
@@ -121,28 +114,28 @@ impl PythonLimits {
     /// Set max heap allocations.
     #[must_use]
     pub fn max_allocations(mut self, n: usize) -> Self {
-        self.max_allocations = n;
+        self.common.max_allocations = n;
         self
     }
 
     /// Set max execution duration.
     #[must_use]
     pub fn max_duration(mut self, d: Duration) -> Self {
-        self.max_duration = d;
+        self.common.max_duration = d;
         self
     }
 
     /// Set max memory in bytes.
     #[must_use]
     pub fn max_memory(mut self, bytes: usize) -> Self {
-        self.max_memory = bytes;
+        self.common.max_memory = bytes;
         self
     }
 
     /// Set max recursion depth.
     #[must_use]
     pub fn max_recursion(mut self, depth: usize) -> Self {
-        self.max_recursion = depth;
+        self.common.max_call_depth = depth;
         self
     }
 }
@@ -450,7 +443,7 @@ impl Builtin for Python {
             .execution_extension::<ExecutionDeadline>()
             .map(ExecutionDeadline::remaining)
         {
-            limits.max_duration = limits.max_duration.min(remaining);
+            limits.common.max_duration = limits.common.max_duration.min(remaining);
         }
 
         run_python(
@@ -495,15 +488,15 @@ async fn run_python(
     };
 
     let limits = ResourceLimits::new()
-        .max_allocations(py_limits.max_allocations)
-        .max_duration(py_limits.max_duration)
-        .max_memory(py_limits.max_memory)
-        .max_recursion_depth(Some(py_limits.max_recursion));
+        .max_allocations(py_limits.common.max_allocations)
+        .max_duration(py_limits.common.max_duration)
+        .max_memory(py_limits.common.max_memory)
+        .max_recursion_depth(Some(py_limits.common.max_call_depth));
 
     let tracker = LimitedTracker::new(limits);
     // Important security decision: cap awaited host callbacks with the same wall-clock
     // budget as Monty so external functions cannot pin execution between VM steps.
-    let python_deadline = Instant::now().checked_add(py_limits.max_duration);
+    let python_deadline = Instant::now().checked_add(py_limits.common.max_duration);
 
     // Run the synchronous start() phase, then extract collected output.
     // PrintWriter::CollectString is not Send, so we scope it to avoid holding across .await.
@@ -1514,19 +1507,19 @@ mod tests {
             .max_duration(Duration::from_secs(10))
             .max_memory(1024)
             .max_recursion(50);
-        assert_eq!(limits.max_allocations, 500);
-        assert_eq!(limits.max_duration, Duration::from_secs(10));
-        assert_eq!(limits.max_memory, 1024);
-        assert_eq!(limits.max_recursion, 50);
+        assert_eq!(limits.common.max_allocations, 500);
+        assert_eq!(limits.common.max_duration, Duration::from_secs(10));
+        assert_eq!(limits.common.max_memory, 1024);
+        assert_eq!(limits.common.max_call_depth, 50);
     }
 
     #[test]
     fn test_python_limits_default() {
         let limits = PythonLimits::default();
-        assert_eq!(limits.max_allocations, 1_000_000);
-        assert_eq!(limits.max_duration, Duration::from_secs(30));
-        assert_eq!(limits.max_memory, 64 * 1024 * 1024);
-        assert_eq!(limits.max_recursion, 200);
+        assert_eq!(limits.common.max_allocations, 1_000_000);
+        assert_eq!(limits.common.max_duration, Duration::from_secs(30));
+        assert_eq!(limits.common.max_memory, 64 * 1024 * 1024);
+        assert_eq!(limits.common.max_call_depth, 200);
     }
 
     // --- External function tests ---

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -92,6 +92,9 @@ fn python_inprocess_enabled(ctx: &Context<'_>) -> bool {
 ///
 /// let bash = Bash::builder().python_with_limits(limits).build();
 /// ```
+/// The individual limit axes live on [`common`](Self::common) (a shared
+/// [`RuntimeLimits`]); read them as e.g. `limits.common.max_memory`. The fluent
+/// setters below configure them directly.
 #[derive(Debug, Clone)]
 pub struct PythonLimits {
     /// Shared VM resource limits (duration, memory, allocations, call depth).

--- a/crates/bashkit/src/builtins/runtime_limits.rs
+++ b/crates/bashkit/src/builtins/runtime_limits.rs
@@ -1,0 +1,110 @@
+//! Shared resource limits for embedded language runtimes.
+//!
+//! The embedded VM builtins (Python via Monty, TypeScript via ZapCode) each
+//! need the same core sandbox knobs: a wall-clock budget, a memory cap, an
+//! allocation cap, and a call-depth cap. Rather than each runtime re-declaring
+//! those four axes, their defaults, and their fluent setters, they share this
+//! [`RuntimeLimits`] core and add only runtime-specific naming/defaults on top
+//! (e.g. Python calls the depth knob `max_recursion`, TypeScript calls it
+//! `max_stack_depth`).
+//!
+//! This is intentionally scoped to *general-purpose VM* runtimes. SQLite is a
+//! query engine, not a VM — its limits (rows, statements, PRAGMAs, db size)
+//! don't map onto these axes — so it keeps its own `SqliteLimits` and is not
+//! forced into this shape.
+
+use std::time::Duration;
+
+/// Default wall-clock budget for one embedded-runtime invocation.
+pub(crate) const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(30);
+/// Default memory cap (64 MB).
+pub(crate) const DEFAULT_MAX_MEMORY: usize = 64 * 1024 * 1024;
+/// Default heap-allocation cap.
+pub(crate) const DEFAULT_MAX_ALLOCATIONS: usize = 1_000_000;
+/// Neutral default call-depth cap; each runtime overrides with its own default.
+pub(crate) const DEFAULT_MAX_CALL_DEPTH: usize = 256;
+
+/// Core resource limits shared by embedded language-VM runtimes.
+///
+/// Carried as the `common` field of `PythonLimits` / `TypeScriptLimits`. Use
+/// the runtime-specific limit types and their fluent setters to configure these
+/// — they delegate here.
+#[derive(Debug, Clone)]
+pub struct RuntimeLimits {
+    /// Maximum execution time for one invocation (default: 30s).
+    pub max_duration: Duration,
+    /// Maximum memory in bytes (default: 64 MB).
+    pub max_memory: usize,
+    /// Maximum heap allocations (default: 1,000,000).
+    pub max_allocations: usize,
+    /// Maximum call/recursion depth. Defaults vary per runtime.
+    pub max_call_depth: usize,
+}
+
+impl Default for RuntimeLimits {
+    fn default() -> Self {
+        Self {
+            max_duration: DEFAULT_MAX_DURATION,
+            max_memory: DEFAULT_MAX_MEMORY,
+            max_allocations: DEFAULT_MAX_ALLOCATIONS,
+            max_call_depth: DEFAULT_MAX_CALL_DEPTH,
+        }
+    }
+}
+
+impl RuntimeLimits {
+    /// Set the wall-clock budget.
+    #[must_use]
+    pub fn max_duration(mut self, d: Duration) -> Self {
+        self.max_duration = d;
+        self
+    }
+
+    /// Set the memory cap in bytes.
+    #[must_use]
+    pub fn max_memory(mut self, bytes: usize) -> Self {
+        self.max_memory = bytes;
+        self
+    }
+
+    /// Set the heap-allocation cap.
+    #[must_use]
+    pub fn max_allocations(mut self, n: usize) -> Self {
+        self.max_allocations = n;
+        self
+    }
+
+    /// Set the call/recursion-depth cap.
+    #[must_use]
+    pub fn max_call_depth(mut self, depth: usize) -> Self {
+        self.max_call_depth = depth;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_uses_shared_constants() {
+        let limits = RuntimeLimits::default();
+        assert_eq!(limits.max_duration, DEFAULT_MAX_DURATION);
+        assert_eq!(limits.max_memory, DEFAULT_MAX_MEMORY);
+        assert_eq!(limits.max_allocations, DEFAULT_MAX_ALLOCATIONS);
+        assert_eq!(limits.max_call_depth, DEFAULT_MAX_CALL_DEPTH);
+    }
+
+    #[test]
+    fn fluent_setters_override_each_axis() {
+        let limits = RuntimeLimits::default()
+            .max_duration(Duration::from_secs(7))
+            .max_memory(2048)
+            .max_allocations(99)
+            .max_call_depth(33);
+        assert_eq!(limits.max_duration, Duration::from_secs(7));
+        assert_eq!(limits.max_memory, 2048);
+        assert_eq!(limits.max_allocations, 99);
+        assert_eq!(limits.max_call_depth, 33);
+    }
+}

--- a/crates/bashkit/src/builtins/typescript.rs
+++ b/crates/bashkit/src/builtins/typescript.rs
@@ -53,6 +53,9 @@ const DEFAULT_MAX_STACK_DEPTH: usize = 512;
 /// assert_eq!(limits.common.max_duration, Duration::from_secs(5));
 /// assert_eq!(limits.common.max_memory, 16 * 1024 * 1024);
 /// ```
+/// The individual limit axes live on [`common`](Self::common) (a shared
+/// [`RuntimeLimits`]); read them as e.g. `limits.common.max_memory`. The fluent
+/// setters below configure them directly.
 #[derive(Debug, Clone)]
 pub struct TypeScriptLimits {
     /// Shared VM resource limits (duration, memory, allocations, call depth).

--- a/crates/bashkit/src/builtins/typescript.rs
+++ b/crates/bashkit/src/builtins/typescript.rs
@@ -23,16 +23,14 @@ use std::sync::Arc;
 use std::time::Duration;
 use zapcode_core::{ResourceLimits, RunResult, Value, VmState, ZapcodeRun};
 
-use super::{Builtin, Context, ExecutionDeadline, Extension, resolve_path};
+use super::{Builtin, Context, ExecutionDeadline, Extension, RuntimeLimits, resolve_path};
 use crate::error::Result;
 use crate::fs::FileSystem;
 use crate::interpreter::ExecResult;
 
-/// Default resource limits for virtual TypeScript execution.
-const DEFAULT_MAX_DURATION: Duration = Duration::from_secs(30);
-const DEFAULT_MAX_MEMORY: usize = 64 * 1024 * 1024; // 64 MB
+/// TypeScript's default call-stack-depth cap. The other VM limits (duration,
+/// memory, allocations) default via [`RuntimeLimits::default`].
 const DEFAULT_MAX_STACK_DEPTH: usize = 512;
-const DEFAULT_MAX_ALLOCATIONS: usize = 1_000_000;
 
 /// Resource limits for the embedded TypeScript (ZapCode) interpreter.
 ///
@@ -52,28 +50,23 @@ const DEFAULT_MAX_ALLOCATIONS: usize = 1_000_000;
 ///     .max_duration(Duration::from_secs(5))
 ///     .max_memory(16 * 1024 * 1024);
 ///
-/// assert_eq!(limits.max_duration, Duration::from_secs(5));
-/// assert_eq!(limits.max_memory, 16 * 1024 * 1024);
+/// assert_eq!(limits.common.max_duration, Duration::from_secs(5));
+/// assert_eq!(limits.common.max_memory, 16 * 1024 * 1024);
 /// ```
 #[derive(Debug, Clone)]
 pub struct TypeScriptLimits {
-    /// Maximum execution time (default: 30s).
-    pub max_duration: Duration,
-    /// Maximum memory in bytes (default: 64 MB).
-    pub max_memory: usize,
-    /// Maximum call stack depth (default: 512).
-    pub max_stack_depth: usize,
-    /// Maximum heap allocations (default: 1,000,000).
-    pub max_allocations: usize,
+    /// Shared VM resource limits (duration, memory, allocations, call depth).
+    pub common: RuntimeLimits,
 }
 
 impl Default for TypeScriptLimits {
     fn default() -> Self {
         Self {
-            max_duration: DEFAULT_MAX_DURATION,
-            max_memory: DEFAULT_MAX_MEMORY,
-            max_stack_depth: DEFAULT_MAX_STACK_DEPTH,
-            max_allocations: DEFAULT_MAX_ALLOCATIONS,
+            common: RuntimeLimits {
+                // TypeScript defaults to a call-stack depth of 512.
+                max_call_depth: DEFAULT_MAX_STACK_DEPTH,
+                ..RuntimeLimits::default()
+            },
         }
     }
 }
@@ -82,38 +75,38 @@ impl TypeScriptLimits {
     /// Set max execution duration.
     #[must_use]
     pub fn max_duration(mut self, d: Duration) -> Self {
-        self.max_duration = d;
+        self.common.max_duration = d;
         self
     }
 
     /// Set max memory in bytes.
     #[must_use]
     pub fn max_memory(mut self, bytes: usize) -> Self {
-        self.max_memory = bytes;
+        self.common.max_memory = bytes;
         self
     }
 
     /// Set max call stack depth.
     #[must_use]
     pub fn max_stack_depth(mut self, depth: usize) -> Self {
-        self.max_stack_depth = depth;
+        self.common.max_call_depth = depth;
         self
     }
 
     /// Set max heap allocations.
     #[must_use]
     pub fn max_allocations(mut self, n: usize) -> Self {
-        self.max_allocations = n;
+        self.common.max_allocations = n;
         self
     }
 
     /// Convert to ZapCode's `ResourceLimits`.
     fn to_zapcode_limits(&self) -> ResourceLimits {
         ResourceLimits {
-            memory_limit_bytes: self.max_memory,
-            time_limit_ms: self.max_duration.as_millis() as u64,
-            max_stack_depth: self.max_stack_depth,
-            max_allocations: self.max_allocations,
+            memory_limit_bytes: self.common.max_memory,
+            time_limit_ms: self.common.max_duration.as_millis() as u64,
+            max_stack_depth: self.common.max_call_depth,
+            max_allocations: self.common.max_allocations,
         }
     }
 }
@@ -188,7 +181,7 @@ const VFS_FUNCTIONS: &[&str] = &[
 ///     .limits(TypeScriptLimits::default().max_duration(Duration::from_secs(5)))
 ///     .compat_aliases(false)
 ///     .unsupported_mode_hint(false);
-/// assert_eq!(config.limits.max_duration, Duration::from_secs(5));
+/// assert_eq!(config.limits.common.max_duration, Duration::from_secs(5));
 /// assert!(!config.enable_compat_aliases);
 /// assert!(!config.enable_unsupported_mode_hint);
 /// ```
@@ -402,7 +395,7 @@ impl TypeScript {
     fn effective_limits(&self, deadline: Option<&ExecutionDeadline>) -> TypeScriptLimits {
         let mut limits = self.limits.clone();
         if let Some(deadline) = deadline {
-            limits.max_duration = limits.max_duration.min(deadline.remaining());
+            limits.common.max_duration = limits.common.max_duration.min(deadline.remaining());
         }
         limits
     }
@@ -1238,10 +1231,10 @@ mod tests {
     #[test]
     fn test_limits_default() {
         let limits = TypeScriptLimits::default();
-        assert_eq!(limits.max_duration, Duration::from_secs(30));
-        assert_eq!(limits.max_memory, 64 * 1024 * 1024);
-        assert_eq!(limits.max_stack_depth, 512);
-        assert_eq!(limits.max_allocations, 1_000_000);
+        assert_eq!(limits.common.max_duration, Duration::from_secs(30));
+        assert_eq!(limits.common.max_memory, 64 * 1024 * 1024);
+        assert_eq!(limits.common.max_call_depth, 512);
+        assert_eq!(limits.common.max_allocations, 1_000_000);
     }
 
     #[test]
@@ -1251,10 +1244,10 @@ mod tests {
             .max_memory(1024)
             .max_stack_depth(100)
             .max_allocations(500);
-        assert_eq!(limits.max_duration, Duration::from_secs(5));
-        assert_eq!(limits.max_memory, 1024);
-        assert_eq!(limits.max_stack_depth, 100);
-        assert_eq!(limits.max_allocations, 500);
+        assert_eq!(limits.common.max_duration, Duration::from_secs(5));
+        assert_eq!(limits.common.max_memory, 1024);
+        assert_eq!(limits.common.max_call_depth, 100);
+        assert_eq!(limits.common.max_allocations, 500);
     }
 
     #[test]
@@ -1282,7 +1275,7 @@ mod tests {
             .limits(TypeScriptLimits::default().max_duration(Duration::from_secs(5)));
         assert!(!config.enable_compat_aliases);
         assert!(!config.enable_unsupported_mode_hint);
-        assert_eq!(config.limits.max_duration, Duration::from_secs(5));
+        assert_eq!(config.limits.common.max_duration, Duration::from_secs(5));
     }
 
     // --- Unsupported mode hint tests ---

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -506,6 +506,10 @@ pub use builtins::ssh::{SshClient, SshHandler, SshOutput, SshTarget};
 #[cfg(feature = "python")]
 pub use builtins::{PythonExternalFnHandler, PythonExternalFns, PythonLimits};
 
+// Shared resource-limit core for embedded language VMs (Python, TypeScript).
+#[cfg(any(feature = "python", feature = "typescript"))]
+pub use builtins::RuntimeLimits;
+
 #[cfg(feature = "sqlite")]
 pub use builtins::{Sqlite, SqliteBackend, SqliteLimits};
 // Re-export monty types needed by external handler consumers.


### PR DESCRIPTION
## Why

Architectural item #3 (YAGNI / scope creep), the "unify the limits, modestly" piece. `PythonLimits` and `TypeScriptLimits` were two **near-identical 4-field structs** — `max_duration`, `max_memory`, `max_allocations`, and a call-depth knob — each independently re-declaring the fields, their defaults, and their fluent setters. The only real differences: the depth knob's name (`max_recursion` vs `max_stack_depth`) and its default (200 vs 512). That's the "each runtime reinvents its own limits" smell.

## What

- New shared **`RuntimeLimits`** core (`builtins/runtime_limits.rs`): the four common VM axes + canonical defaults + fluent setters, in one place.
- `PythonLimits` and `TypeScriptLimits` now embed it as a `pub common: RuntimeLimits` field. Each keeps its **domain-named** setter (`max_recursion` / `max_stack_depth`, delegating to `common.max_call_depth`) and its own call-depth default.
- The public **fluent builder API is unchanged** — `.max_duration()`, `.max_memory()`, `.max_recursion()`/`.max_stack_depth()`, `default()` — which is exactly what bindings, examples, and docs use (verified). Internal field *reads* moved to `…common.…`.

### Deliberately scoped to language VMs

SQLite is a **query engine, not a VM** — its limits are rows/statements/PRAGMAs/db-size and it has no `max_memory`/`max_allocations`. Forcing it into a shared VM-limits struct would be over-abstraction (the YAGNI trap in the other direction), so `SqliteLimits` is left as-is.

## Tests

- New `runtime_limits` unit tests (defaults + each fluent setter).
- `python` integration/security suite (**280**) and `typescript` suite (**75**) green; Python/TS limits unit tests green. `cargo clippy` clean on both features; fmt clean. Builds verified with each VM feature separately.

## Series

This is the "unify limits" slice of item #3. The other half of Option A — isolating the unstable monty/zapcode value types (`MontyObject`, `ExtFunctionResult`, `ZapcodeValue`, …) out of bashkit's public callback API so the crate's semver detaches from those pre-1.0 git deps — is a larger, separate change (it means wrapping rich foreign value types used in external-function handler signatures). Flagging it as a follow-up rather than half-doing it.