### PR TITLE
refactor(interpreter): move getopts cluster cursor to typed state

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1001,6 +1001,7 @@ struct SubshellSnapshot {
     memory_budget: crate::limits::MemoryBudget,
     exec_fd_table: HashMap<i32, FdTarget>,
     random_state: u32,
+    getopts_char_idx: usize,
 }
 
 /// Interpreter state.
@@ -8213,6 +8214,7 @@ impl Interpreter {
             memory_budget: self.memory_budget.clone(),
             exec_fd_table: self.exec_fd_table.clone(),
             random_state: self.random_state.load(Ordering::Relaxed),
+            getopts_char_idx: self.getopts_char_idx,
         }
     }
 
@@ -8224,6 +8226,7 @@ impl Interpreter {
         self.exec_fd_table = snap.exec_fd_table;
         self.random_state
             .store(snap.random_state, Ordering::Relaxed);
+        self.getopts_char_idx = snap.getopts_char_idx;
     }
 
     fn execute_cmd_subst<'a>(

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -593,7 +593,6 @@ pub(crate) fn is_internal_variable(name: &str) -> bool {
         || name.starts_with("_BG_EXIT_")
         || name.starts_with("_LAST_BG_")
         || name.starts_with("_DIRSTACK_")
-        || name.starts_with("_OPTCHAR_")
         || name == "_SHIFT_COUNT"
         || name == "_SET_POSITIONAL"
 }
@@ -1066,6 +1065,11 @@ pub struct Interpreter {
     /// Stdin inherited from pipeline for compound commands (while read, etc.)
     /// Each read operation consumes one line, advancing through the data.
     pipeline_stdin: Option<String>,
+    /// Position within the current argument while `getopts` walks a clustered
+    /// short-option group (e.g. `-abc`). Interpreter-internal working state for
+    /// `execute_getopts`; `0` means "at the start of the next option group".
+    /// Previously stored in the user variable namespace as `_OPTCHAR_IDX`.
+    getopts_char_idx: usize,
     /// Optional callback for streaming output chunks during execution.
     /// When set, output is emitted incrementally via this callback in addition
     /// to being accumulated in the returned ExecResult.
@@ -1521,6 +1525,7 @@ impl Interpreter {
             #[cfg(feature = "ssh")]
             ssh_client: None,
             pipeline_stdin: None,
+            getopts_char_idx: 0,
             output_callback: None,
             execution_extensions: Arc::new(StdMutex::new(Arc::new(
                 builtins::ExecutionExtensions::new(),
@@ -4292,7 +4297,7 @@ impl Interpreter {
             self.insert_variable_checked(var.to_string(), val.to_string());
         }
         self.insert_variable_checked("OPTIND".to_string(), "1".to_string());
-        self.vars_mut().remove("_OPTCHAR_IDX");
+        self.getopts_char_idx = 0;
 
         // Forward piped stdin to child when executing a script file or -c command
         let saved_stdin = self.pipeline_stdin.take();
@@ -7283,18 +7288,13 @@ impl Interpreter {
         let opt_chars: Vec<char> = current_arg[1..].chars().collect();
 
         // Track position within the current argument for multi-char options
-        let char_idx: usize = self
-            .scoped
-            .variables
-            .get("_OPTCHAR_IDX")
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0);
+        let char_idx: usize = self.getopts_char_idx;
 
         if char_idx >= opt_chars.len() {
             // Should not happen, but advance
             self.vars_mut()
                 .insert("OPTIND".to_string(), (optind + 1).to_string());
-            self.vars_mut().remove("_OPTCHAR_IDX");
+            self.getopts_char_idx = 0;
             self.insert_variable_checked(varname.clone(), "?".to_string());
             return Ok(ExecResult {
                 stdout: String::new(),
@@ -7322,20 +7322,20 @@ impl Interpreter {
                     self.insert_variable_checked("OPTARG".to_string(), arg_val);
                     self.vars_mut()
                         .insert("OPTIND".to_string(), (optind + 1).to_string());
-                    self.vars_mut().remove("_OPTCHAR_IDX");
+                    self.getopts_char_idx = 0;
                 } else if optind < parse_args.len() {
                     // Next arg is the argument
                     self.vars_mut()
                         .insert("OPTARG".to_string(), parse_args[optind].clone());
                     self.vars_mut()
                         .insert("OPTIND".to_string(), (optind + 2).to_string());
-                    self.vars_mut().remove("_OPTCHAR_IDX");
+                    self.getopts_char_idx = 0;
                 } else {
                     // Missing argument
                     self.vars_mut().remove("OPTARG");
                     self.vars_mut()
                         .insert("OPTIND".to_string(), (optind + 1).to_string());
-                    self.vars_mut().remove("_OPTCHAR_IDX");
+                    self.getopts_char_idx = 0;
                     if silent {
                         self.insert_variable_checked(varname.clone(), ":".to_string());
                         self.vars_mut()
@@ -7356,25 +7356,23 @@ impl Interpreter {
                 self.vars_mut().remove("OPTARG");
                 if char_idx + 1 < opt_chars.len() {
                     // More chars in this arg
-                    self.vars_mut()
-                        .insert("_OPTCHAR_IDX".to_string(), (char_idx + 1).to_string());
+                    self.getopts_char_idx = char_idx + 1;
                 } else {
                     // Move to next arg
                     self.vars_mut()
                         .insert("OPTIND".to_string(), (optind + 1).to_string());
-                    self.vars_mut().remove("_OPTCHAR_IDX");
+                    self.getopts_char_idx = 0;
                 }
             }
         } else {
             // Unknown option
             self.vars_mut().remove("OPTARG");
             if char_idx + 1 < opt_chars.len() {
-                self.vars_mut()
-                    .insert("_OPTCHAR_IDX".to_string(), (char_idx + 1).to_string());
+                self.getopts_char_idx = char_idx + 1;
             } else {
                 self.vars_mut()
                     .insert("OPTIND".to_string(), (optind + 1).to_string());
-                self.vars_mut().remove("_OPTCHAR_IDX");
+                self.getopts_char_idx = 0;
             }
 
             if silent {
@@ -11966,7 +11964,6 @@ cat /tmp/test_fd_exec_public.txt"#,
             "_LAST_BG_PID",
             "_DIRSTACK_SIZE",
             "_DIRSTACK_0",
-            "_OPTCHAR_IDX",
             "SHOPT_e",
             "SHOPT_x",
             "SHOPT_expand_aliases",

--- a/crates/bashkit/tests/spec_cases/bash/getopts.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/getopts.test.sh
@@ -97,6 +97,18 @@ echo "exit=$?"
 exit=1
 ### end
 
+### getopts_cursor_isolated_across_subshell
+# A $(...) subshell running its own getopts must not clobber the parent's
+# position within a clustered -abc group (parent resumes at 'b', like real bash).
+OPTIND=1
+getopts "abc" p -abc
+junk=$(OPTIND=1; while getopts "xy" q -xy; do :; done)
+getopts "abc" p2 -abc
+echo "$p $p2"
+### expect
+a b
+### end
+
 ### getopts_optchar_idx_is_ordinary_var
 ### bash_diff: real bash has no _OPTCHAR_IDX internal at all; this pins that bashkit's clustered-option cursor is interpreter state, not a shell variable
 # The cluster cursor that walks -abc is interpreter-internal state, not the

--- a/crates/bashkit/tests/spec_cases/bash/getopts.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/getopts.test.sh
@@ -96,3 +96,21 @@ echo "exit=$?"
 ### expect
 exit=1
 ### end
+
+### getopts_optchar_idx_is_ordinary_var
+### bash_diff: real bash has no _OPTCHAR_IDX internal at all; this pins that bashkit's clustered-option cursor is interpreter state, not a shell variable
+# The cluster cursor that walks -abc is interpreter-internal state, not the
+# user-visible _OPTCHAR_IDX variable. Setting that name must not affect getopts,
+# and it stays an ordinary variable throughout.
+OPTIND=1
+_OPTCHAR_IDX=hijack
+while getopts "abc" opt -abc; do
+  echo "$opt"
+done
+echo "var=$_OPTCHAR_IDX"
+### expect
+a
+b
+c
+var=hijack
+### end


### PR DESCRIPTION
## Why

Follow-up in the #1 series (de-leaking the interpreter↔variable-namespace boundary). After #2092 removed the `_EVAL_CMD` magic-variable channel, the remaining `_`-prefixed markers fall into two buckets: already-migrated defense-in-depth blocklist entries, and a few cases where **state still lives in the user variable namespace**. `_OPTCHAR_IDX` is one of the latter.

`getopts` tracks its cursor *within* a clustered short-option group (e.g. `-abc`) so successive calls in a `while getopts` loop advance through `a`, `b`, `c`. That cursor was stored as a `_OPTCHAR_IDX` shell variable and guarded by `is_internal_variable()` — but it's purely **interpreter-internal transient working state**, not a shell variable.

## What

- Move the cursor to a typed `getopts_char_idx: usize` field on the interpreter (read/write/clear in `execute_getopts`; `0` = start of the next group).
- Drop `_OPTCHAR_` from the `is_internal_variable()` blocklist (and its unit-test entry). With nothing reading it, `_OPTCHAR_IDX` is now an ordinary variable.
- Include `getopts_char_idx` in `SubshellSnapshot` so it's saved/restored across `$(...)` / subshell / child-shell isolation boundaries — preserving the isolation the variable previously got for free from `scoped` snapshotting.

## Tests

- `getopts_cursor_isolated_across_subshell`: a `$(...)` subshell's getopts must not move the parent's position in a `-abc` group (matches real bash).
- `getopts_optchar_idx_is_ordinary_var`: clustered parsing works while a user `_OPTCHAR_IDX=hijack` is untouched.
- Existing clustered-option spec cases (`-abc`, `-af myfile`) still pass; `bash_spec_tests`, `is_internal_variable` unit test, 2489 lib unit tests, and 44 snapshot tests green. fmt + clippy clean.