### PR TITLE
refactor(interpreter): move $! to typed state, drop dead _BG_EXIT_CODE

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -590,8 +590,6 @@ pub(crate) fn is_internal_variable(name: &str) -> bool {
         || name.starts_with("_LOWER_")
         || name.starts_with("_INTEGER_")
         || name.starts_with("_ARRAY_READ_")
-        || name.starts_with("_BG_EXIT_")
-        || name.starts_with("_LAST_BG_")
         || name.starts_with("_DIRSTACK_")
         || name == "_SHIFT_COUNT"
         || name == "_SET_POSITIONAL"
@@ -1002,6 +1000,7 @@ struct SubshellSnapshot {
     exec_fd_table: HashMap<i32, FdTarget>,
     random_state: u32,
     getopts_char_idx: usize,
+    last_bg_pid: Option<String>,
 }
 
 /// Interpreter state.
@@ -1071,6 +1070,10 @@ pub struct Interpreter {
     /// `execute_getopts`; `0` means "at the start of the next option group".
     /// Previously stored in the user variable namespace as `_OPTCHAR_IDX`.
     getopts_char_idx: usize,
+    /// Sandboxed PID/job id of the most recent background command, surfaced as
+    /// `$!`. Interpreter-internal state (not a host PID); subshell-isolated like
+    /// any other shell state. Previously stored as the `_LAST_BG_PID` variable.
+    last_bg_pid: Option<String>,
     /// Optional callback for streaming output chunks during execution.
     /// When set, output is emitted incrementally via this callback in addition
     /// to being accumulated in the returned ExecResult.
@@ -1527,6 +1530,7 @@ impl Interpreter {
             ssh_client: None,
             pipeline_stdin: None,
             getopts_char_idx: 0,
+            last_bg_pid: None,
             output_callback: None,
             execution_extensions: Arc::new(StdMutex::new(Arc::new(
                 builtins::ExecutionExtensions::new(),
@@ -3948,8 +3952,7 @@ impl Interpreter {
             .insert(format!("{}_PID", name), virtual_pid.to_string());
 
         // Also set $! (last background PID)
-        self.vars_mut()
-            .insert("_LAST_BG_PID".to_string(), virtual_pid.to_string());
+        self.last_bg_pid = Some(virtual_pid.to_string());
 
         // Coproc itself returns success with empty output (stdout was captured)
         Ok(ExecResult::ok(String::new()))
@@ -4686,14 +4689,11 @@ impl Interpreter {
         let job_result = ExecResult::with_code(String::new(), exit_code);
         let handle = tokio::spawn(async move { job_result });
         let job_id = self.jobs.lock().await.spawn(handle);
-        self.vars_mut()
-            .insert("_LAST_BG_PID".to_string(), job_id.to_string());
+        self.last_bg_pid = Some(job_id.to_string());
 
-        // Background commands always return exit code 0 to the parent
+        // Background commands always return exit code 0 to the parent.
+        // The real exit code lives in the job table for `wait` to read.
         self.last_exit_code = 0;
-        // But store the real exit code for $? after wait
-        self.vars_mut()
-            .insert("_BG_EXIT_CODE".to_string(), exit_code.to_string());
         Ok(())
     }
 
@@ -8215,6 +8215,7 @@ impl Interpreter {
             exec_fd_table: self.exec_fd_table.clone(),
             random_state: self.random_state.load(Ordering::Relaxed),
             getopts_char_idx: self.getopts_char_idx,
+            last_bg_pid: self.last_bg_pid.clone(),
         }
     }
 
@@ -8227,6 +8228,7 @@ impl Interpreter {
         self.random_state
             .store(snap.random_state, Ordering::Relaxed);
         self.getopts_char_idx = snap.getopts_char_idx;
+        self.last_bg_pid = snap.last_bg_pid;
     }
 
     fn execute_cmd_subst<'a>(
@@ -8912,7 +8914,7 @@ impl Interpreter {
                 // $! - PID of most recent background command
                 // In Bashkit's virtual environment, background jobs run synchronously
                 // Return empty string or last job ID placeholder
-                if let Some(last_bg_pid) = self.scoped.variables.get("_LAST_BG_PID") {
+                if let Some(last_bg_pid) = &self.last_bg_pid {
                     return last_bg_pid.clone();
                 }
                 return String::new();
@@ -11963,8 +11965,6 @@ cat /tmp/test_fd_exec_public.txt"#,
             "_ARRAY_READ_a",
             "_SHIFT_COUNT",
             "_SET_POSITIONAL",
-            "_BG_EXIT_CODE",
-            "_LAST_BG_PID",
             "_DIRSTACK_SIZE",
             "_DIRSTACK_0",
             "SHOPT_e",

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -720,6 +720,10 @@ pub struct ShellState {
     pub cwd: PathBuf,
     /// Last exit code
     pub last_exit_code: i32,
+    /// PID/job id of the most recent background command, surfaced as `$!`.
+    /// `Option` so older snapshots without the field deserialize cleanly.
+    #[serde(default)]
+    pub last_bg_pid: Option<String>,
     /// Defined shell functions
     #[serde(
         default,
@@ -2074,6 +2078,7 @@ impl Interpreter {
             assoc_arrays: (*self.scoped.assoc_arrays).clone(),
             cwd: self.cwd.clone(),
             last_exit_code: self.last_exit_code,
+            last_bg_pid: self.last_bg_pid.clone(),
             functions: if options.include_functions {
                 (*self.scoped.functions).clone()
             } else {
@@ -2121,6 +2126,7 @@ impl Interpreter {
         self.scoped.assoc_arrays = Arc::new(state.assoc_arrays.clone());
         self.cwd = state.cwd.clone();
         self.last_exit_code = state.last_exit_code;
+        self.last_bg_pid = state.last_bg_pid.clone();
         // THREAT[TM-DOS-061]: Re-parse and budget-check restored functions so
         // snapshots cannot bypass parser/memory limits via serialized AST.
         let mut restored_functions = HashMap::new();
@@ -12019,6 +12025,24 @@ cat /tmp/test_fd_exec_public.txt"#,
     }
 
     #[tokio::test]
+    async fn test_shell_state_roundtrips_last_bg_pid() {
+        let mut interp = Interpreter::new(Arc::new(InMemoryFs::new()));
+        let ast = Parser::new("true &").parse().unwrap();
+        interp.execute(&ast).await.unwrap();
+        let bang = interp.last_bg_pid.clone();
+        assert!(bang.is_some(), "$! should be set after backgrounding");
+
+        let state = interp.shell_state();
+        assert_eq!(state.last_bg_pid, bang);
+
+        let mut restored = Interpreter::new(Arc::new(InMemoryFs::new()));
+        restored.restore_shell_state(&state);
+        let echo = Parser::new("echo $!").parse().unwrap();
+        let out = restored.execute(&echo).await.unwrap();
+        assert_eq!(out.stdout.trim(), bang.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_restore_shell_state_migrates_legacy_nameref_targets() {
         let state = ShellState {
             env: HashMap::new(),
@@ -12033,6 +12057,7 @@ cat /tmp/test_fd_exec_public.txt"#,
             assoc_arrays: HashMap::new(),
             cwd: PathBuf::from("/"),
             last_exit_code: 0,
+            last_bg_pid: None,
             functions: HashMap::new(),
             aliases: HashMap::new(),
             traps: HashMap::new(),
@@ -12070,6 +12095,7 @@ cat /tmp/test_fd_exec_public.txt"#,
             assoc_arrays: HashMap::new(),
             cwd: PathBuf::from("/"),
             last_exit_code: 0,
+            last_bg_pid: None,
             functions: HashMap::new(),
             aliases: HashMap::new(),
             traps: HashMap::new(),

--- a/crates/bashkit/tests/spec_cases/bash/wait.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/wait.test.sh
@@ -17,3 +17,36 @@ echo $?
 hello
 0
 ### end
+
+### bang_var_basic
+# $! is set to the most recent background job id (non-empty)
+true &
+[ -n "$!" ] && echo set || echo unset
+### expect
+set
+### end
+
+### bang_var_isolated_across_subshell
+### bash_diff: VFS runs background jobs synchronously
+# A $(...) subshell starting its own background job must not change the
+# parent's $! (last background PID is per-shell state, like real bash).
+true &
+parent=$!
+junk=$(true & true)
+[ "$!" = "$parent" ] && echo isolated || echo leaked
+### expect
+isolated
+### end
+
+### bg_internal_names_are_ordinary_vars
+### bash_diff: VFS runs background jobs synchronously
+# _LAST_BG_PID / _BG_EXIT_CODE are no longer interpreter channels in the
+# variable namespace; backgrounding tracks $! in typed state and leaves these
+# user variables untouched.
+_LAST_BG_PID=hijack
+_BG_EXIT_CODE=hijack2
+true &
+echo "$_LAST_BG_PID $_BG_EXIT_CODE"
+### expect
+hijack hijack2
+### end


### PR DESCRIPTION
## Why

Continues the #1 series (moving interpreter-internal state out of the user variable namespace), the same pattern as #2096's getopts cursor. Two more `_`-prefixed magic variables backing background-job state:

- **`_LAST_BG_PID`** — live: backs `$!` (most recent background PID). Interpreter-internal sandboxed state, not a shell variable, guarded by `is_internal_variable()`.
- **`_BG_EXIT_CODE`** — dead: written by the background-command path but **never read** (`wait` reads the job table). Its "store the real exit code for `$?` after wait" comment was stale.

## What

- Move `$!` to a typed `last_bg_pid: Option<String>` field. Producers (background `&`, coproc) set the field; `$!` expansion reads it.
- Include `last_bg_pid` in `SubshellSnapshot` (snapshot + restore) so it stays subshell-isolated — preserving the isolation the variable previously got for free from `scoped` snapshotting (this was the review catch on #2096, applied up front here).
- Include `last_bg_pid` in `ShellState` (serde default) so `$!` still roundtrips through `shell_state()` / `restore_shell_state()` session snapshots (review catch on this PR).
- Remove the dead `_BG_EXIT_CODE` write and fix the stale comment (the real exit code already lives in the job table for `wait`).
- Drop `_LAST_BG_` and `_BG_EXIT_` from the `is_internal_variable()` blocklist and its test list; both names are now ordinary variables.

## Tests

- `bang_var_basic`: `$!` is set by backgrounding.
- `bang_var_isolated_across_subshell`: a `$(...)` subshell's background job does not change the parent's `$!` (matches real-bash per-shell semantics).
- `bg_internal_names_are_ordinary_vars`: `_LAST_BG_PID` / `_BG_EXIT_CODE` user variables are untouched by backgrounding.
- `test_shell_state_roundtrips_last_bg_pid`: `$!` survives `shell_state()` + `restore_shell_state()`.
- Existing `wait.test.sh` (`wait $!`) and `background_exec` (8) still pass; `is_internal_variable` unit test, 2489 lib unit tests, 44 snapshot tests green. fmt + clippy clean.