### PR TITLE
docs(python): fix BashKit → Bashkit in FileSystem docstring

### DIFF
--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -130,7 +130,7 @@ BuiltinCallback = Callable[
 ]
 
 class FileSystem:
-    """Direct access to BashKit's virtual filesystem or a standalone mountable FS.
+    """Direct access to Bashkit's virtual filesystem or a standalone mountable FS.
 
     Two ways to create:
 


### PR DESCRIPTION
## What

Fix the stray `BashKit` (camelCase) spelling in the `FileSystem` docstring of `crates/bashkit-python/bashkit/_bashkit.pyi` → `Bashkit`.

## Why

`specs/architecture.md` defines the official name as **"Bashkit" (not "BashKit")**, and PR #157 renamed `BashKit → Bashkit`. This stub docstring was the only genuine stray occurrence left in the codebase (the other two matches are the spec rule itself and a historical CHANGELOG entry, both correct as-is). The leftover camelCase was misleading tooling into treating `BashKit` as a valid form.

## How

One-character docstring edit in the type stub. No code paths changed.

## Tests

Docstring-only change in a `.pyi` stub — no behavioral code affected. Verified `ruff check crates/bashkit-python` and `ruff format --check` pass.