### PR TITLE
docs(site): add LLM tools guide

### DIFF
--- a/docs/llm-tools.md
+++ b/docs/llm-tools.md
@@ -13,7 +13,7 @@ it a real host shell.
 
 ```rust
 use bashkit::{BashTool, Tool};
-use futures::StreamExt;
+use futures_util::StreamExt;
 
 # #[tokio::main]
 # async fn main() -> anyhow::Result<()> {

--- a/docs/llm-tools.md
+++ b/docs/llm-tools.md
@@ -1,0 +1,103 @@
+# Bashkit as an LLM Tool
+
+`BashTool` wraps the Bashkit sandbox as a ready-made tool for agent frameworks.
+It exposes everything a model needs to call a shell safely: discovery metadata
+(name, description, input schema), a system prompt describing the sandbox,
+streaming output, and execution that runs against the same in-process virtual
+filesystem and resource limits as the rest of Bashkit.
+
+Use this when you want an agent or LLM app to run shell commands without giving
+it a real host shell.
+
+## Rust tool contract
+
+```rust
+use bashkit::{BashTool, Tool};
+use futures::StreamExt;
+
+# #[tokio::main]
+# async fn main() -> anyhow::Result<()> {
+let tool = BashTool::builder()
+    .username("agent")
+    .hostname("sandbox")
+    .build();
+
+println!("{}", tool.description());
+println!("{}", tool.system_prompt());
+
+let execution = tool.execution(serde_json::json!({
+    "commands": "printf 'hello\nworld\n'"
+}))?;
+let mut stream = execution.output_stream().expect("stream available");
+
+let handle = tokio::spawn(async move { execution.execute().await });
+while let Some(chunk) = stream.next().await {
+    println!("{}: {}", chunk.kind, chunk.data);
+}
+
+let output = handle.await??;
+assert_eq!(output.result["stdout"], "hello\nworld\n");
+# Ok(())
+# }
+```
+
+The `Tool` trait gives you the pieces a framework needs: `description()` and
+`system_prompt()` for prompting, an input schema for tool-call validation, and
+streaming `chunk.kind` / `chunk.data` events while the command runs.
+
+## Python
+
+```python
+from bashkit import BashTool
+
+tool = BashTool()
+print(tool.input_schema())
+print(tool.description())
+print(tool.system_prompt())
+
+result = tool.execute_sync("echo 'Hello!'")
+print(result.stdout)
+```
+
+The Python package ships optional extras with adapters for popular frameworks:
+
+```bash
+pip install 'bashkit[langchain]'
+pip install 'bashkit[pydantic-ai]'
+pip install 'bashkit[deepagents]'
+```
+
+## TypeScript / JavaScript
+
+```typescript
+import { BashTool } from "@everruns/bashkit";
+
+const tool = new BashTool();
+console.log(tool.description());
+console.log(tool.systemPrompt());
+
+const result = await tool.execute("echo 'Hello!'");
+console.log(result.stdout);
+```
+
+Framework adapters are exported as subpaths of `@everruns/bashkit`:
+
+- OpenAI adapter: `@everruns/bashkit/openai`
+- Anthropic adapter: `@everruns/bashkit/anthropic`
+- Vercel AI SDK adapter: `@everruns/bashkit/ai`
+- LangChain adapter: `@everruns/bashkit/langchain`
+
+## Sandbox guarantees
+
+A `BashTool` runs in the same sandbox as the core interpreter, so tool calls
+inherit Bashkit's safety model: an in-memory virtual filesystem, resource
+limits on commands and output, and a default-deny network allowlist. The model
+cannot escape to the host unless you explicitly mount a real filesystem or
+allow a domain.
+
+## Next steps
+
+- [Hooks](hooks.md) — observe, rewrite, or cancel tool calls and HTTP requests.
+- [Security](security.md) — the sandbox boundaries every tool call runs inside.
+- Examples: [agent and tool flows](https://github.com/everruns/bashkit/tree/main/examples).
+- Full API reference: [docs.rs/bashkit](https://docs.rs/bashkit/latest/bashkit/).

--- a/site/src/pages/docs/_meta.ts
+++ b/site/src/pages/docs/_meta.ts
@@ -35,6 +35,16 @@ export const DOC_META: DocMeta[] = [
     editPath: "docs/embedding.md",
   },
   {
+    slug: "llm-tools",
+    title: "LLM tools",
+    summary: "Expose Bashkit as a sandboxed tool for agent frameworks.",
+    seoTitle: "Use Bashkit as an LLM tool for agent frameworks",
+    seoDescription:
+      "Expose Bashkit as an LLM tool with BashTool: discovery metadata, system prompts, streaming output, and sandboxed execution for Rust, Python, and JS agents.",
+    section: "Getting started",
+    editPath: "docs/llm-tools.md",
+  },
+  {
     slug: "security",
     title: "Security",
     summary: "Sandbox boundaries, threat model, and what scripts cannot do.",


### PR DESCRIPTION
## Summary

Adds a dedicated **LLM tools** guide to the docs site (under **Getting Started**) covering `BashTool` — how to expose the Bashkit sandbox as a tool for agent frameworks.

The homepage tagline promises *"tool interfaces for agent frameworks"* and the homepage lists an *"LLM tool contract"* surface, but the docs nav had no page for it. This is the product's headline use case, so it deserves a front-door guide.

## Contents (`docs/llm-tools.md`)

- Rust tool contract: `BashTool::builder()`, `description()`, `system_prompt()`, input schema, and streaming output chunks
- Python quickstart + framework extras (`langchain`, `pydantic-ai`, `deepagents`)
- TypeScript/JavaScript quickstart + adapter subpaths (`openai`, `anthropic`, `ai`, `langchain`)
- Sandbox guarantees that every tool call inherits
- Next-steps links to Hooks, Security, examples, and docs.rs

Code examples reuse the vetted snippets from `skills/bashkit/references/llm-tools.md`, so they stay consistent with the published agent skill.

## Verification

- `pnpm check` — 0 errors
- `pnpm build` — all postbuild verify scripts green (17 doc routes, sitemap, link headers, agent skills)

## Note

Placed under **Getting Started** alongside CLI (and, if #2100 merges first, Embedding) to give the three primary ways to use Bashkit — CLI, library, agent tool — a shared front door. Trivial `_meta.ts` rebase expected against #2100 since both add a Getting Started entry.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REeg3GwFYYDRZJPUVJJJ8Q)_