### PR TITLE
docs(skills): list http_client, ssh, jq, bot-auth in rust install features

### DIFF
--- a/skills/bashkit/references/rust.md
+++ b/skills/bashkit/references/rust.md
@@ -11,7 +11,11 @@ cargo add bashkit
 Optional features:
 
 ```bash
+cargo add bashkit --features http_client
 cargo add bashkit --features git
+cargo add bashkit --features ssh
+cargo add bashkit --features jq
+cargo add bashkit --features bot-auth
 cargo add bashkit --features python
 cargo add bashkit --features typescript
 cargo add bashkit --features sqlite


### PR DESCRIPTION
## What
Add `http_client`, `ssh`, `jq`, and `bot-auth` to the "Optional features" list in `skills/bashkit/references/rust.md`.

## Why
The install feature list previously omitted `http_client`, even though the same file's Network Allowlist section states HTTP access requires the `http_client` feature — a reader scanning only the install block had no way to enable it. `ssh`, `jq`, and `bot-auth` were similarly missing despite being real, user-facing features in `crates/bashkit/Cargo.toml`.

## How
Added the four `cargo add bashkit --features <name>` lines. All listed features were verified against `crates/bashkit/Cargo.toml`.

## Tests
Docs-only change to a skill reference file. No test covers the reference markdown content (the skills publication test validates only `SKILL.md` frontmatter), and no compiled code is affected. Verified feature names against the crate manifest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8Bfov6tDpwmVZx8XzEtut)_