### PR TITLE
docs(site): cross-link Markdown surfaces to llms.txt + document contract

### DIFF
--- a/site/scripts/verify-llms.mjs
+++ b/site/scripts/verify-llms.mjs
@@ -43,7 +43,7 @@ function extractString(block, key) {
   return new RegExp(`${key}:\\s*"([^"]+)"`).exec(block)?.[1];
 }
 
-let count = 0;
+const slugs = [];
 let match;
 while ((match = objectPattern.exec(metaSource)) !== null) {
   const block = match[0];
@@ -57,11 +57,31 @@ while ((match = objectPattern.exec(metaSource)) !== null) {
   if (!llmsFull.includes(`# ${title}\n`)) {
     throw new Error(`llms-full.txt missing inlined guide: ${title}`);
   }
-  count += 1;
+  slugs.push(slug);
 }
 
-if (count === 0) {
+if (slugs.length === 0) {
   throw new Error("No docs parsed from _meta.ts; verify-llms is misconfigured.");
 }
 
-console.log(`Verified llms.txt and llms-full.txt (${count} guides indexed).`);
+// The Markdown-negotiated surfaces (consumed by agents) must point back at the
+// curated index, so an agent landing on any .md page can find /llms.txt.
+function assertLinksToLlms(relPath) {
+  const filePath = path.join(distRoot, relPath);
+  if (!existsSync(filePath)) {
+    throw new Error(`Missing Markdown route for llms.txt back-link check: ${relPath}`);
+  }
+  if (!readFileSync(filePath, "utf8").includes("/llms.txt")) {
+    throw new Error(`${relPath} does not link back to /llms.txt`);
+  }
+}
+
+assertLinksToLlms("index.md");
+assertLinksToLlms("docs.md");
+for (const slug of slugs) {
+  assertLinksToLlms(path.join("docs", `${slug}.md`));
+}
+
+console.log(
+  `Verified llms.txt and llms-full.txt (${slugs.length} guides indexed) and /llms.txt back-links.`,
+);

--- a/site/scripts/verify-llms.mjs
+++ b/site/scripts/verify-llms.mjs
@@ -71,8 +71,9 @@ function assertLinksToLlms(relPath) {
   if (!existsSync(filePath)) {
     throw new Error(`Missing Markdown route for llms.txt back-link check: ${relPath}`);
   }
-  if (!readFileSync(filePath, "utf8").includes("/llms.txt")) {
-    throw new Error(`${relPath} does not link back to /llms.txt`);
+  // Require an actual Markdown link target, not just a mention of the path.
+  if (!readFileSync(filePath, "utf8").includes("](/llms.txt)")) {
+    throw new Error(`${relPath} does not contain a Markdown link to /llms.txt`);
   }
 }
 

--- a/site/src/pages/docs.md.ts
+++ b/site/src/pages/docs.md.ts
@@ -38,6 +38,10 @@ export const GET: APIRoute = () => {
         "",
       ];
     }),
+    "---",
+    "",
+    "For a curated, machine-readable index of the whole site, see [llms.txt](/llms.txt) (full text: [llms-full.txt](/llms-full.txt)).",
+    "",
   ].join("\n");
 
   return new Response(markdown, {

--- a/site/src/pages/docs/[slug].md.ts
+++ b/site/src/pages/docs/[slug].md.ts
@@ -93,6 +93,8 @@ function renderNavigation(previous?: DocMeta, next?: DocMeta): string {
     links.push(`- [Next: ${next.title}](/docs/${next.slug}/)`);
   }
 
+  links.push("- [llms.txt](/llms.txt) - curated index of this site for agents");
+
   return ["---", "", "## Navigation", "", ...links].join("\n");
 }
 

--- a/site/src/pages/index.md.ts
+++ b/site/src/pages/index.md.ts
@@ -33,6 +33,8 @@ export const GET: APIRoute = () => {
     "## Navigation",
     "",
     ...homeNavigation.map((item) => `- [${item.label}](${item.href}) - ${item.detail}`),
+    "- [llms.txt](/llms.txt) - Curated, machine-readable index of this site for coding agents.",
+    "- [llms-full.txt](/llms-full.txt) - Every guide inlined into one document.",
     "",
     "## Quick starts",
     "",

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -35,3 +35,35 @@ boilerplate from rendered docs with `# ` line prefixes.
 Doc modules behind `#[cfg(feature = "...")]` (e.g., `python_guide`) may use
 feature-gated APIs freely. Non-gated modules (e.g., `threat_model`,
 `compatibility_scorecard`) must NOT — use `rust,ignore` there.
+
+## Agent-facing site surfaces
+
+The `bashkit.sh` site (`site/`) exposes machine-readable surfaces for coding
+agents. All are **generated**, not hand-maintained, so they cannot drift from
+the canonical docs/content:
+
+- **Markdown routes** — every page has a `text/markdown` representation via
+  content negotiation (the Worker) or a direct `.md` URL: `/index.md`,
+  `/docs.md`, `/docs/<slug>.md`. The per-doc route serves the raw canonical
+  source plus a generated navigation footer.
+- **`/llms.txt` + `/llms-full.txt`** ([llmstxt.org](https://llmstxt.org)) — the
+  curated agent entry point and the full-text inline of every guide. Both are
+  generated from `DOC_META` (`site/src/pages/docs/_meta.ts`) and the content
+  tables in `site/src/content/home.ts`.
+- **Agent Skills discovery index** — `/.well-known/agent-skills/index.json`
+  plus the `bashkit.tar.gz` skill archive. Unlike the above, this is a separate
+  digest-locked artifact built from `skills/bashkit/` via `rosie-skills`, **not**
+  regenerated at site build; refresh it when `skills/bashkit/` changes.
+
+### Contract
+
+- A new public guide needs a `DOC_META` entry (slug, title, summary, SEO
+  fields, section). `verify-doc-routes.mjs` rejects any `docs/*.md` without a
+  route; `verify-llms.mjs` rejects any `DOC_META` doc missing from `/llms.txt`
+  or `/llms-full.txt`.
+- The Markdown surfaces (`/index.md`, `/docs.md`, every `/docs/<slug>.md`) must
+  link back to `/llms.txt` — enforced by `verify-llms.mjs`.
+- `/llms.txt` is advertised via the homepage HTTP `Link` header
+  (`site/public/_headers`), `robots.txt`, and a footer link.
+- All site verify scripts run in the `postbuild` chain (CI **Site Build** job),
+  so these guarantees hold on every build.

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -68,6 +68,7 @@ dependency rot, or security gaps ship in a release.
 - Python docstrings match behavior
 - `README.md` feature list matches implemented builtins
 - Public docs (`docs/`) match current code: CLI flags, security boundaries, feature descriptions, test counts, and examples all reflect reality
+- Agent surfaces (`/llms.txt`, `/llms-full.txt`, Markdown routes) regenerate and pass `verify-llms` (auto-enforced in CI); refresh the agent-skills tarball/`index.json` digest if `skills/bashkit/` changed (see `specs/documentation.md` § Agent-facing site surfaces)
 - `CONTRIBUTING.md` instructions accurate
 - `CHANGELOG.md` has entries for all changes since last release
 


### PR DESCRIPTION
## Summary

Makes the Markdown-negotiated site surfaces (consumed almost entirely by coding agents — the exact `llms.txt` audience) point **back** at `/llms.txt`. Discovery was previously one-directional: `llms.txt` to the `.md` pages, but never the reverse. Also documents the previously-undocumented agent surfaces and their generation/verify contract.

## Cross-links added

- `/index.md` — `llms.txt` + `llms-full.txt` in the Navigation section (markdown-only; not added to the shared HTML nav table).
- `/docs.md` — footer pointer to `llms.txt` / `llms-full.txt`.
- per-doc markdown route — a `- [llms.txt](/llms.txt)` line in the generated Navigation footer, so every doc an agent fetches points home.
- `verify-llms.mjs` — asserts every `.md` surface back-links `/llms.txt` (via a real Markdown link target), so these can't silently drop.

## Specs (closing the governance gap)

`llms.txt` / the agent surfaces had no spec coverage at all. This adds:

- `specs/documentation.md` — new "Agent-facing site surfaces" section documenting the Markdown routes, `/llms.txt` + `/llms-full.txt`, the agent-skills index, and the contract: all generated from `DOC_META`/`home.ts`, enforced by `verify-llms` in CI's Site Build job. Also notes the agent-skill tarball is a separate digest-locked artifact (built via `rosie-skills`, not at site build).
- `specs/maintenance.md` — a bullet in the Documentation checklist covering the agent surfaces + the skill tarball/digest refresh.

## Deliberately skipped

The HTML head `link` tag — it targets HTML crawlers and is not a recognized `llms.txt` signal (cosmetic), whereas these `.md` back-links target real agent traffic.

## Verification

- `pnpm check` — 0 errors
- `pnpm build` — all postbuild verify scripts green: `Verified llms.txt and llms-full.txt (18 guides indexed) and /llms.txt back-links.`