### PR TITLE
feat(site): link skill source and enrich llms.txt for agents

### DIFF
--- a/docs/llm-tools.md
+++ b/docs/llm-tools.md
@@ -95,6 +95,16 @@ limits on commands and output, and a default-deny network allowlist. The model
 cannot escape to the host unless you explicitly mount a real filesystem or
 allow a domain.
 
+## Agent skill
+
+Give your coding agent Bashkit-specific context with the published skill:
+
+```sh
+npx skills add everruns/bashkit
+```
+
+[View skill contents](https://github.com/everruns/bashkit/tree/main/skills/bashkit) — the `SKILL.md` and reference files (CLI, Rust/Python/TS APIs, builtins, LLM tools, examples) the skill installs.
+
 ## Next steps
 
 - [Hooks](hooks.md) — observe, rewrite, or cancel tool calls and HTTP requests.

--- a/site/scripts/verify-llms.mjs
+++ b/site/scripts/verify-llms.mjs
@@ -32,6 +32,14 @@ if (!/\n> /.test(llms)) {
 if (!llms.includes("https://bashkit.sh/llms-full.txt")) {
   throw new Error("llms.txt must link to llms-full.txt.");
 }
+// Agent-friendly ingredients: a link to the human-readable skill source and a
+// ready-to-paste prompts section.
+if (!llms.includes("github.com/everruns/bashkit/tree/main/skills/bashkit")) {
+  throw new Error("llms.txt must link to the skill source (View skill contents).");
+}
+if (!llms.includes("## Common prompts")) {
+  throw new Error("llms.txt must include a `## Common prompts` section.");
+}
 
 // Every doc must be discoverable from both entry points.
 const metaSource = readFileSync(metaPath, "utf8");

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -14,6 +14,7 @@ const currentYear = new Date().getFullYear();
         <a href="https://crates.io/crates/bashkit" target="_blank" rel="noopener noreferrer">crates.io</a>
         <a href="https://pypi.org/project/bashkit/" target="_blank" rel="noopener noreferrer">PyPI</a>
         <a href="https://www.npmjs.com/package/@everruns/bashkit" target="_blank" rel="noopener noreferrer">npm</a>
+        <a href="https://github.com/everruns/bashkit/tree/main/skills/bashkit" target="_blank" rel="noopener noreferrer">Skill</a>
         <a href="/llms.txt">llms.txt</a>
         <a
           href="https://github.com/everruns/bashkit"

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,4 +1,6 @@
 ---
+import { skillRepoUrl } from "../content/home";
+
 const currentYear = new Date().getFullYear();
 ---
 
@@ -14,7 +16,7 @@ const currentYear = new Date().getFullYear();
         <a href="https://crates.io/crates/bashkit" target="_blank" rel="noopener noreferrer">crates.io</a>
         <a href="https://pypi.org/project/bashkit/" target="_blank" rel="noopener noreferrer">PyPI</a>
         <a href="https://www.npmjs.com/package/@everruns/bashkit" target="_blank" rel="noopener noreferrer">npm</a>
-        <a href="https://github.com/everruns/bashkit/tree/main/skills/bashkit" target="_blank" rel="noopener noreferrer">Skill</a>
+        <a href={skillRepoUrl} target="_blank" rel="noopener noreferrer">Skill</a>
         <a href="/llms.txt">llms.txt</a>
         <a
           href="https://github.com/everruns/bashkit"

--- a/site/src/content/home.ts
+++ b/site/src/content/home.ts
@@ -53,6 +53,18 @@ export const evalSnapshot = {
 
 export const benchesHref = "/benches";
 
+// Human-readable skill source (SKILL.md + references) for "View skill contents".
+export const skillRepoUrl =
+  "https://github.com/everruns/bashkit/tree/main/skills/bashkit";
+
+// Ready-to-paste prompts for driving a coding agent that has the skill installed.
+export const commonPrompts = [
+  "Using bashkit, add a sandboxed bash tool to my agent.",
+  "Embed bashkit in my Rust service to run untrusted shell scripts in-memory.",
+  "Run this bash script in bashkit and return stdout, stderr, and the exit code.",
+  "Add a custom builtin to bashkit that calls my internal HTTP API.",
+];
+
 export const heroStats = [
   { label: "Built-in commands", value: String(builtinCount), href: "/builtins" },
   {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -18,6 +18,7 @@ import {
   quickStarts,
   resources,
   signals,
+  skillRepoUrl,
   surfaces,
 } from "../content/home";
 
@@ -155,6 +156,7 @@ import {
             sandbox model, package APIs, builtins, examples, and agent-tool
             patterns. Install it first, then add Bashkit to the host project.
           </p>
+          <a href={skillRepoUrl} class="atlas-inline-link" target="_blank" rel="noopener noreferrer">View skill contents</a>
         </div>
 
         <div class="atlas-agent-steps">

--- a/site/src/pages/index.md.ts
+++ b/site/src/pages/index.md.ts
@@ -13,6 +13,7 @@ import {
   languages,
   resources,
   signals,
+  skillRepoUrl,
   surfaces,
 } from "../content/home";
 import { DOC_META } from "./docs/_meta";
@@ -57,6 +58,8 @@ export const GET: APIRoute = () => {
       ...(step.command ? ["", "```sh", step.command, "```"] : []),
       "",
     ]),
+    `- [View skill contents](${skillRepoUrl}) - the SKILL.md and reference files the skill installs.`,
+    "",
     "## Product surface",
     "",
     ...surfaces.map((item) => `- **${item.title}** - ${item.detail}`),

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -5,9 +5,11 @@
 import type { APIRoute } from "astro";
 import {
   agentSteps,
+  commonPrompts,
   homeHero,
   languages,
   resources,
+  skillRepoUrl,
 } from "../content/home";
 import { DOC_META } from "./docs/_meta";
 
@@ -53,10 +55,18 @@ export const GET: APIRoute = () => {
     "",
     "## Quickstarts",
     "",
-    ...languages.map(
-      (lang) => `- [${lang.eyebrow}: ${lang.title}](${SITE}/index.md): \`${lang.install}\``,
-    ),
-    "",
+    ...languages.flatMap((lang) => [
+      `### ${lang.eyebrow} — ${lang.title}`,
+      "",
+      "```sh",
+      lang.install,
+      "```",
+      "",
+      "```" + lang.lang,
+      lang.code,
+      "```",
+      "",
+    ]),
     "## Agent skill",
     "",
     ...agentSteps.map((step) =>
@@ -64,7 +74,14 @@ export const GET: APIRoute = () => {
         ? `- ${step.title}: ${step.detail} (\`${step.command}\`)`
         : `- ${step.title}: ${step.detail}`,
     ),
+    `- [View skill contents](${skillRepoUrl}): the SKILL.md and reference files the skill installs.`,
     `- [Agent Skills discovery index](${SITE}/.well-known/agent-skills/index.json): machine-readable skill manifest for coding agents.`,
+    "",
+    "## Common prompts",
+    "",
+    "Prompts to give a coding agent that has the skill installed:",
+    "",
+    ...commonPrompts.map((prompt) => `- ${prompt}`),
     "",
     ...docSections,
     "## Optional",


### PR DESCRIPTION
## Summary

Two related agent-friendliness improvements:

1. **Link to the skill source from the web + AI docs.** The site previously exposed only the `npx skills add everruns/bashkit` command and the machine-readable discovery JSON — there was no obvious "view the skill contents" link. Adds a **View skill contents** link (to `skills/bashkit/` on GitHub) on:
   - the homepage agent-development section (next to the npx command)
   - the footer
   - `/index.md` (markdown homepage)
   - `llms.txt` (Agent skill section)
   - `docs/llm-tools.md` (the most AI-oriented doc)

2. **Enrich `llms.txt`** toward the "exceptionally agent-friendly" checklist (install / skill contents / common prompts / minimal code / deeper docs):
   - **Minimal Rust/Python/TS code** in Quickstarts (was install-command-only)
   - A **Common prompts** section of ready-to-paste agent prompts
   - The skill-contents link above

The skill URL and prompt list live in `site/src/content/home.ts` as shared content. `verify-llms.mjs` now asserts the skill link and the Common prompts section so they can't silently drop.

## Verification

- `pnpm check` — 0 errors
- `pnpm build` — all postbuild verify scripts green: `Verified llms.txt and llms-full.txt (18 guides indexed) and /llms.txt back-links.`