### PR TITLE
fix(expansion): fail closed on quote marker collision

### DIFF
--- a/crates/bashkit/src/interpreter/expansion.rs
+++ b/crates/bashkit/src/interpreter/expansion.rs
@@ -1125,20 +1125,10 @@ impl Interpreter {
             );
         }
 
-        // Important decision: all source-level candidates may appear only inside
-        // nested/lazy expansions. In that case one candidate is still safe for
-        // this top-level operand if parsed literal parts contain exactly the
-        // quote-boundary markers we inserted. This preserves quote semantics
-        // without returning to an unbounded Unicode search.
-        for &quote_mark in OPERAND_QUOTE_MARK_CANDIDATES {
-            let (stripped, inserted_marks) =
-                Self::strip_operand_quotes_with_count(operand, Some(quote_mark));
-            let word = Parser::parse_word_string_with_limits(&stripped, max_depth, max_fuel);
-            if Self::top_level_literal_mark_count(&word, quote_mark) == inserted_marks {
-                return (word, Some(quote_mark), false);
-            }
-        }
-
+        // Important decision: marker provenance is lost after parsing. If every
+        // bounded candidate appears in the source operand, a source literal can
+        // masquerade as an inserted quote-boundary marker. Fail closed instead
+        // of reparsing with an unsafe marker.
         // Fail-closed: no safe marker. Only force quoted handling when real
         // unescaped quotes were stripped (not escaped `\"` or NUL-marked quotes).
         let (stripped, unescaped_quotes) = Self::strip_operand_quotes_with_count(operand, None);
@@ -1147,16 +1137,6 @@ impl Interpreter {
             None,
             unescaped_quotes > 0,
         )
-    }
-
-    pub(super) fn top_level_literal_mark_count(word: &Word, quote_mark: char) -> usize {
-        word.parts
-            .iter()
-            .filter_map(|part| match part {
-                WordPart::Literal(s) => Some(s.chars().filter(|&ch| ch == quote_mark).count()),
-                _ => None,
-            })
-            .sum()
     }
 
     pub(super) fn push_marked_literal(

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -11498,6 +11498,18 @@ echo "count=$COUNT"
         assert_eq!(result.stdout.trim(), "axxxb");
     }
 
+    #[tokio::test]
+    async fn test_quoted_remove_prefix_operand_rejects_colliding_source_marker() {
+        let quote_mark = OPERAND_QUOTE_MARK_CANDIDATES[0];
+        let dead_candidates: String = OPERAND_QUOTE_MARK_CANDIDATES[1..].iter().collect();
+        let script = format!(
+            "val=\"axxxb\"; pat=\"a*\"; echo \"${{val#${{unset+{dead_candidates}}}{quote_mark}\\\"$pat\\\"{quote_mark}${{unset+\\\"\\\"}}}}\""
+        );
+        let result = run_script(&script).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "axxxb");
+    }
+
     #[test]
     fn test_command_not_found_suggestions_use_stable_tie_break() {
         let msg = command_not_found_message("grpe", &["type", "true", "tree", "grep"]);


### PR DESCRIPTION
### Motivation
- Prevent a reparsing/count heuristic from misidentifying source literal marker characters as inserted quote-boundary markers and thereby flipping quote state for pattern-removal operands.

### Description
- Remove the unsafe fallback loop that reparsed the operand for each bounded quote-marker candidate and the associated top-level literal count helper.
- Change `parse_marked_operand` to fail-closed when all bounded marker candidates appear in the source operand, returning no marker and using `force_quoted` only when real unescaped quotes were stripped.
- Add a regression test `test_quoted_remove_prefix_operand_rejects_colliding_source_marker` that reproduces the colliding-source-marker case and asserts the quoted operand remains literal.

### Testing
- Ran `cargo fmt --check` which passed.
- Ran targeted unit tests with `cargo test -p bashkit quoted_remove_prefix_operand` and `cargo test -p bashkit test_parse_marked_operand_escaped_quotes_do_not_force_quoting` and the new regression test, and all passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3472886830832b9119b304248bc00b)