### PR TITLE
fix(builtins): include special builtins in inventory

### DIFF
--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -327,8 +327,13 @@ pub(crate) struct ShellRef<'a> {
     pub(crate) execution_extensions: Arc<builtins::ExecutionExtensions>,
 }
 
-// Keep interpreter-dispatched builtins in the public inventory; these do not
-// live in the registered builtin map because they need parser/interpreter state.
+// Interpreter-dispatched "special" builtins, listed here so the public
+// inventory and special-builtin dispatch share one source of truth. Some names
+// (e.g. `eval`, `local`, `unset`) are also in the registered builtin map, but
+// the interpreter dispatches them ahead of it because they need parser/
+// interpreter state; others (e.g. `bash`, `command`, `exec`, `getopts`) live
+// only here. Listing every name guarantees inventory completeness regardless of
+// map membership.
 const SPECIAL_BUILTIN_NAMES: &[&str] = &[
     ".", "bash", "command", "declare", "eval", "exec", "getopts", "let", "local", "sh", "source",
     "typeset", "unset",

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -327,12 +327,21 @@ pub(crate) struct ShellRef<'a> {
     pub(crate) execution_extensions: Arc<builtins::ExecutionExtensions>,
 }
 
-/// Sorted, deduped union of baked-in/custom builtins and the host registry.
+// Keep interpreter-dispatched builtins in the public inventory; these do not
+// live in the registered builtin map because they need parser/interpreter state.
+const SPECIAL_BUILTIN_NAMES: &[&str] = &[
+    ".", "bash", "command", "declare", "eval", "exec", "getopts", "let", "local", "sh", "source",
+    "typeset", "unset",
+];
+
+/// Sorted, deduped union of baked-in/custom builtins, interpreter-special
+/// builtins, and the host registry.
 fn merged_builtin_names(
     builtins: &HashMap<String, Arc<dyn Builtin>>,
     host_builtins: Option<&crate::builtins::BuiltinRegistry>,
 ) -> Vec<String> {
     let mut names: Vec<String> = builtins.keys().cloned().collect();
+    names.extend(SPECIAL_BUILTIN_NAMES.iter().map(|name| (*name).to_string()));
     if let Some(reg) = host_builtins {
         names.extend(reg.names());
     }
@@ -352,7 +361,7 @@ impl ShellRef<'_> {
         self.builtins.contains_key(name)
     }
 
-    /// Sorted names of all registered builtins (baked-in + custom + host
+    /// Sorted names of all dispatchable builtins (registered + special + host
     /// registry) — same contract as [`crate::Bash::builtin_names`].
     pub(crate) fn builtin_names(&self) -> Vec<String> {
         merged_builtin_names(self.builtins, self.host_builtins)
@@ -5899,22 +5908,7 @@ impl Interpreter {
     }
 
     fn is_special_builtin_name(name: &str) -> bool {
-        matches!(
-            name,
-            "exec"
-                | "local"
-                | "bash"
-                | "sh"
-                | "source"
-                | "."
-                | "eval"
-                | "command"
-                | "declare"
-                | "typeset"
-                | "let"
-                | "unset"
-                | "getopts"
-        )
+        SPECIAL_BUILTIN_NAMES.contains(&name)
     }
 
     async fn execute_special_builtin_with_hooks(
@@ -5990,7 +5984,7 @@ impl Interpreter {
             .is_some_and(|reg| reg.lookup(name).is_some())
     }
 
-    /// Sorted names of all registered builtins (baked-in + custom + host
+    /// Sorted names of all dispatchable builtins (registered + special + host
     /// registry). See [`crate::Bash::builtin_names`].
     pub(crate) fn builtin_names(&self) -> Vec<String> {
         merged_builtin_names(&self.builtins, self.host_builtins.as_ref())

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -1311,12 +1311,13 @@ impl Bash {
         self.interpreter.restore_shell_state(state);
     }
 
-    /// Names of all builtins registered in this instance, sorted.
+    /// Names of all builtins dispatchable in this instance, sorted.
     ///
     /// Reflects what this build + configuration actually dispatches:
     /// baked-in builtins (including compile-feature-gated ones like `jq`,
-    /// `git`, `ssh`), custom builtins registered at construction, and
-    /// host-registry builtins. Canonical source for the generated builtins
+    /// `git`, `ssh`), interpreter-special builtins like `exec`, custom
+    /// builtins registered at construction, and host-registry builtins.
+    /// Canonical source for the generated builtins
     /// status (`just regen-builtins`, `specs/status/builtins.json`).
     pub fn builtin_names(&self) -> Vec<String> {
         self.interpreter.builtin_names()

--- a/crates/bashkit/tests/integration/builtin_registry_tests.rs
+++ b/crates/bashkit/tests/integration/builtin_registry_tests.rs
@@ -215,6 +215,15 @@ async fn builtin_names_lists_baked_in_and_host_builtins() {
     for expected in ["echo", "cd", "grep", "awk", "sed"] {
         assert!(names.iter().any(|n| n == expected), "missing {expected}");
     }
+    for special in [
+        ".", "bash", "command", "declare", "eval", "exec", "getopts", "let", "local", "sh",
+        "source", "typeset", "unset",
+    ] {
+        assert!(
+            names.iter().any(|n| n == special),
+            "missing special builtin {special}"
+        );
+    }
     let mut sorted = names.clone();
     sorted.sort();
     sorted.dedup();

--- a/specs/status/builtins.json
+++ b/specs/status/builtins.json
@@ -35,6 +35,10 @@
     },
     {
       "feature": null,
+      "name": "bash"
+    },
+    {
+      "feature": null,
       "name": "bc"
     },
     {
@@ -79,6 +83,10 @@
     },
     {
       "feature": null,
+      "name": "command"
+    },
+    {
+      "feature": null,
       "name": "compgen"
     },
     {
@@ -104,6 +112,10 @@
     {
       "feature": null,
       "name": "date"
+    },
+    {
+      "feature": null,
+      "name": "declare"
     },
     {
       "feature": "typescript",
@@ -151,6 +163,10 @@
     },
     {
       "feature": null,
+      "name": "exec"
+    },
+    {
+      "feature": null,
       "name": "exit"
     },
     {
@@ -184,6 +200,10 @@
     {
       "feature": null,
       "name": "fold"
+    },
+    {
+      "feature": null,
+      "name": "getopts"
     },
     {
       "feature": "git",
@@ -260,6 +280,10 @@
     {
       "feature": null,
       "name": "less"
+    },
+    {
+      "feature": null,
+      "name": "let"
     },
     {
       "feature": null,
@@ -427,6 +451,10 @@
     },
     {
       "feature": null,
+      "name": "sh"
+    },
+    {
+      "feature": null,
       "name": "sha1sum"
     },
     {
@@ -555,6 +583,10 @@
     },
     {
       "feature": null,
+      "name": "typeset"
+    },
+    {
+      "feature": null,
       "name": "unalias"
     },
     {
@@ -626,5 +658,5 @@
       "name": "zip"
     }
   ],
-  "count": 156
+  "count": 164
 }


### PR DESCRIPTION
### Motivation
- The generated builtin inventory omitted interpreter-level special builtins (e.g. `bash`, `command`, `exec`, `getopts`, `let`, `sh`, `typeset`), making the public `Bash::builtin_names()` API and `specs/status/builtins.json` incomplete.
- Centralize the source of truth for special builtins to avoid future drift between dispatch logic and the inventory used by the site and tooling.

### Description
- Add a `SPECIAL_BUILTIN_NAMES` constant and include it in the merged inventory via `merged_builtin_names(...)` so `Bash::builtin_names()` returns registered + special + host names (`crates/bashkit/src/interpreter/mod.rs`).
- Replace the ad-hoc `matches!(...)` in `is_special_builtin_name` with a reference to `SPECIAL_BUILTIN_NAMES` to keep dispatch and inventory in sync (`crates/bashkit/src/interpreter/mod.rs`).
- Update the public docstring in `Bash::builtin_names()` to state it returns all dispatchable builtins, including interpreter-special ones (`crates/bashkit/src/lib.rs`).
- Add a regression assertion that the special builtin names appear in `builtin_names()` (`crates/bashkit/tests/integration/builtin_registry_tests.rs`) and regenerate `specs/status/builtins.json` (count updated to 164).

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran the targeted integration tests `builtin_names_lists_baked_in_and_host_builtins` and `compgen_b_matches_builtin_names` via `cargo test -p bashkit --test integration`, both passed. 
- Ran `just regen-builtins` to regenerate `specs/status/builtins.json` and committed the updated JSON, which includes the previously-missing special builtins. 
- Ran `git diff --check` with no whitespace issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347496af6c832ba0264b3deaabf44d)