### PR TITLE
feat(site): self-host Python + TypeScript API references at /api

### DIFF
--- a/.github/workflows/apidocs-drift.yml
+++ b/.github/workflows/apidocs-drift.yml
@@ -1,0 +1,110 @@
+name: API Reference Drift
+
+# Fails when a committed self-hosted API reference no longer matches what its
+# generator produces from the package's source of truth. The markdown lives in
+# site/src/content/apidocs/*.md and feeds the /api/{python,typescript} pages;
+# the node-only site build just renders it, so it must be regenerated and
+# committed on release — fix drift by running `just apidocs` and committing.
+# See specs/documentation.md ("API reference hosting").
+#
+# Per AGENTS.md commit-attribution rules this workflow never auto-commits; it
+# only fails so a human regenerates and commits under a real identity.
+#
+# Two jobs, two cost profiles:
+#   python      — griffe statically parses the type stubs; no build needed, so
+#                 it runs on every PR that can change the surface.
+#   typescript  — the .ts wrappers import types from the napi-generated
+#                 index.d.ts, so regeneration needs a Rust build. Too heavy for
+#                 per-PR; runs on the weekly schedule and on demand only.
+
+on:
+  pull_request:
+    paths:
+      - 'crates/bashkit-python/bashkit/**'
+      - 'scripts/gen_python_apidocs.py'
+      - 'site/src/content/apidocs/python.md'
+      - '.github/workflows/apidocs-drift.yml'
+  schedule:
+    # Weekly Mondays 06:00 UTC, after the builtins (05:30) and coreutils (05:00) runs.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: Regenerate and diff Python API reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      # Pinned: griffe parses the stubs; an upgrade could shift the parsed
+      # surface and flag false drift. Bump deliberately, then regenerate.
+      - name: Install griffe
+        run: pip install "griffe==2.1.0"
+
+      - name: Regenerate Python API reference
+        run: python3 scripts/gen_python_apidocs.py
+
+      - name: Fail on drift
+        run: |
+          if ! git diff --exit-code -- site/src/content/apidocs/python.md; then
+            echo "::error::site/src/content/apidocs/python.md is stale — run 'just apidocs-python' and commit the result"
+            exit 1
+          fi
+
+  typescript:
+    name: Regenerate and diff TypeScript API reference
+    # Needs a Rust napi build to materialize index.d.ts; keep it off per-PR.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: crates/bashkit-js
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: crates/bashkit-js/pnpm-lock.yaml
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+        working-directory: crates/bashkit-js
+
+      - name: Build napi addon (generates index.d.ts)
+        run: pnpm exec napi build --platform
+        working-directory: crates/bashkit-js
+
+      - name: Regenerate TypeScript API reference
+        # npx fetches the pinned typedoc at generation time (network required).
+        run: node scripts/gen_ts_apidocs.mjs
+
+      - name: Fail on drift
+        run: |
+          if ! git diff --exit-code -- site/src/content/apidocs/typescript.md; then
+            echo "::error::site/src/content/apidocs/typescript.md is stale — run 'just apidocs-ts' and commit the result"
+            exit 1
+          fi

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -458,7 +458,7 @@ class Bash:
         ...     external_functions=["api_request"],
         ...     external_handler=handler,
         ... )
-        >>> result = await bash.execute("python3 -c 'print(api_request(url=\"/data\"))'")
+        >>> result = await bash.execute("python3 -c 'print(api_request())'")
     """
 
     def __init__(

--- a/justfile
+++ b/justfile
@@ -69,6 +69,12 @@ fuzz-diff-deep:
 clean:
     cargo clean
 
+# Regenerate the self-hosted Python API reference (docs.rs analog for PyPI).
+# Output committed at site/src/content/apidocs/python.md; refresh on release.
+# Needs griffe: pip install griffe. See specs/documentation.md.
+apidocs-python:
+    python3 scripts/gen_python_apidocs.py
+
 # Regenerate the canonical builtin inventory consumed by the site's
 # builtins page. Committed output; the builtins-drift workflow fails on diff.
 regen-builtins:

--- a/justfile
+++ b/justfile
@@ -75,6 +75,17 @@ clean:
 apidocs-python:
     python3 scripts/gen_python_apidocs.py
 
+# Regenerate the self-hosted TypeScript API reference (docs.rs analog for npm).
+# Output committed at site/src/content/apidocs/typescript.md; refresh on release.
+# Requires `napi build` first (generates index.d.ts the .ts wrappers import).
+# Needs network for `npx typedoc`. See specs/documentation.md.
+apidocs-ts:
+    cd crates/bashkit-js && pnpm exec napi build --platform
+    node scripts/gen_ts_apidocs.mjs
+
+# Regenerate all self-hosted package API references.
+apidocs: apidocs-python apidocs-ts
+
 # Regenerate the canonical builtin inventory consumed by the site's
 # builtins page. Committed output; the builtins-drift workflow fails on diff.
 regen-builtins:

--- a/scripts/gen_python_apidocs.py
+++ b/scripts/gen_python_apidocs.py
@@ -50,10 +50,6 @@ INTEGRATIONS = [
 ]
 
 
-def slugify(name: str) -> str:
-    return name.replace("_", "-").lower()
-
-
 def annotation_str(ann) -> str:
     if ann is None:
         return ""

--- a/scripts/gen_python_apidocs.py
+++ b/scripts/gen_python_apidocs.py
@@ -86,6 +86,104 @@ def docstring_of(obj) -> str:
     return ""
 
 
+def _format_text(text: str) -> str:
+    """Render a free-text docstring section to markdown.
+
+    griffe hands us the dedented docstring verbatim. Doctest/example blocks are
+    indented under a label line (e.g. ``Example (basic):``) with no blank line
+    between, so Markdown folds them into the preceding paragraph as run-on
+    prose. Fence each indented block as a ```python``` code block and turn rST
+    ``::`` literal-block markers back into a plain colon.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        # rST literal-block marker on a label line: "Example::" -> "Example:".
+        if line.strip() and not line.startswith(" ") and line.rstrip().endswith("::"):
+            out.append(line.rstrip()[:-1])
+            i += 1
+            continue
+        if line.startswith(" ") and line.strip():
+            block: list[str] = []
+            while i < n:
+                cur = lines[i]
+                if not cur.strip():
+                    # Keep an interior blank line only if more indented
+                    # content follows; otherwise the block has ended.
+                    j = i + 1
+                    while j < n and not lines[j].strip():
+                        j += 1
+                    if j < n and lines[j].startswith(" "):
+                        block.append("")
+                        i += 1
+                        continue
+                    break
+                if cur.startswith(" "):
+                    block.append(cur)
+                    i += 1
+                else:
+                    break
+            indents = [len(b) - len(b.lstrip()) for b in block if b.strip()]
+            dedent = min(indents) if indents else 0
+            block = [b[dedent:] if len(b) >= dedent else b for b in block]
+            if out and out[-1].strip():
+                out.append("")
+            out.append("```python")
+            out.extend(block)
+            out.append("```")
+            out.append("")
+        else:
+            out.append(line)
+            i += 1
+    return "\n".join(out).strip()
+
+
+def _section_kind(sec) -> str:
+    return sec.kind.value if hasattr(sec.kind, "value") else str(sec.kind)
+
+
+def render_doc_sections(obj) -> list[str]:
+    """Parse a docstring into Google-style sections and render each as markdown.
+
+    Parameters/returns become real lists instead of indented blocks that
+    Markdown would otherwise collapse into a single run-on paragraph.
+    """
+    if not (obj.docstring and obj.docstring.value):
+        return []
+    out: list[str] = []
+    for sec in obj.docstring.parse("google"):
+        kind = _section_kind(sec)
+        if kind == "text":
+            out += [_format_text(sec.value), ""]
+        elif kind == "parameters":
+            out += ["**Parameters:**", ""]
+            for p in sec.value:
+                desc = " ".join((p.description or "").split())
+                out.append(f"- **`{p.name}`** — {desc}" if desc else f"- **`{p.name}`**")
+            out.append("")
+        elif kind == "returns":
+            desc = " ".join(
+                " ".join((r.description or "").split()) for r in sec.value
+            ).strip()
+            if desc:
+                out += [f"**Returns:** {desc}", ""]
+        elif kind == "raises":
+            out += ["**Raises:**", ""]
+            for r in sec.value:
+                ann = annotation_str(getattr(r, "annotation", None))
+                desc = " ".join((r.description or "").split())
+                label = f"`{ann}`" if ann else "error"
+                out.append(f"- **{label}** — {desc}" if desc else f"- **{label}**")
+            out.append("")
+        elif isinstance(sec.value, str):
+            out += [_format_text(sec.value), ""]
+    while out and not out[-1].strip():
+        out.pop()
+    return out + [""] if out else out
+
+
 def own_members(obj):
     return {n: m for n, m in obj.members.items() if not m.is_alias}
 
@@ -96,19 +194,13 @@ def render_function(name: str, func, *, heading: str, level: int) -> list[str]:
     lines.append(render_signature(name, func))
     lines.append("```")
     lines.append("")
-    doc = docstring_of(func)
-    if doc:
-        lines.append(doc)
-        lines.append("")
+    lines += render_doc_sections(func)
     return lines
 
 
 def render_class(name: str, cls) -> list[str]:
     lines = [f"## {name}", ""]
-    doc = docstring_of(cls)
-    if doc:
-        lines.append(doc)
-        lines.append("")
+    lines += render_doc_sections(cls)
 
     members = own_members(cls)
     methods = [

--- a/scripts/gen_python_apidocs.py
+++ b/scripts/gen_python_apidocs.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Generate the Python API reference markdown for bashkit.sh.
+
+Decision: we have no docs.rs equivalent for the PyPI package, so we self-host
+an API reference on bashkit.sh. To stay on-brand we emit plain markdown and let
+the Astro `DocsLayout` render it (same colors/typography/Shiki theme as every
+other doc page) instead of shipping a foreign pdoc/Sphinx theme.
+
+Source of truth: the PEP 561 type stubs in `crates/bashkit-python/bashkit`
+(`_bashkit.pyi` + the pure-Python integration modules). We use `griffe` to
+statically parse them (no compiled extension or third-party deps required,
+`allow_inspection=False`), then render markdown. Latest-only: regenerated on
+release, output committed to the repo so the node-only site build just renders
+it. See specs/documentation.md ("API reference hosting").
+
+Usage: python3 scripts/gen_python_apidocs.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import griffe
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_SEARCH_PATH = REPO_ROOT / "crates" / "bashkit-python"
+OUT_PATH = REPO_ROOT / "site" / "src" / "content" / "apidocs" / "python.md"
+
+# Curated public surface, in rendering order. Mirrors bashkit.__all__ plus the
+# framework integration modules that ship in the package.
+CORE_ORDER = [
+    "Bash",
+    "BashTool",
+    "ScriptedTool",
+    "FileSystem",
+    "ExecResult",
+    "ShellState",
+    "BuiltinContext",
+    "BuiltinResult",
+    "BashError",
+    "create_langchain_tool_spec",
+    "get_version",
+]
+
+INTEGRATIONS = [
+    ("bashkit.langchain", "bashkit.langchain"),
+    ("bashkit.pydantic_ai", "bashkit.pydantic_ai"),
+    ("bashkit.deepagents", "bashkit.deepagents"),
+]
+
+
+def slugify(name: str) -> str:
+    return name.replace("_", "-").lower()
+
+
+def annotation_str(ann) -> str:
+    if ann is None:
+        return ""
+    return str(ann)
+
+
+def render_signature(name: str, func) -> str:
+    """Build a Python-style signature string for a function/method."""
+    parts = []
+    for p in func.parameters:
+        if p.name == "self":
+            continue
+        kind = getattr(p.kind, "value", "")
+        prefix = ""
+        if kind == "variadic positional":
+            prefix = "*"
+        elif kind == "variadic keyword":
+            prefix = "**"
+        piece = f"{prefix}{p.name}"
+        ann = annotation_str(p.annotation)
+        if ann:
+            piece += f": {ann}"
+        if p.default is not None and not prefix:
+            piece += f" = {p.default}"
+        parts.append(piece)
+    ret = annotation_str(func.returns)
+    arrow = f" -> {ret}" if ret else ""
+    return f"{name}({', '.join(parts)}){arrow}"
+
+
+def docstring_of(obj) -> str:
+    if obj.docstring and obj.docstring.value:
+        return obj.docstring.value.strip()
+    return ""
+
+
+def own_members(obj):
+    return {n: m for n, m in obj.members.items() if not m.is_alias}
+
+
+def render_function(name: str, func, *, heading: str, level: int) -> list[str]:
+    lines = [f"{'#' * level} {heading}", ""]
+    lines.append("```python")
+    lines.append(render_signature(name, func))
+    lines.append("```")
+    lines.append("")
+    doc = docstring_of(func)
+    if doc:
+        lines.append(doc)
+        lines.append("")
+    return lines
+
+
+def render_class(name: str, cls) -> list[str]:
+    lines = [f"## {name}", ""]
+    doc = docstring_of(cls)
+    if doc:
+        lines.append(doc)
+        lines.append("")
+
+    members = own_members(cls)
+    methods = [
+        (n, m)
+        for n, m in members.items()
+        if m.is_function and (n == "__init__" or not n.startswith("_"))
+    ]
+    attributes = [
+        (n, m)
+        for n, m in members.items()
+        if m.is_attribute and not n.startswith("_")
+    ]
+
+    if attributes:
+        lines.append("### Fields")
+        lines.append("")
+        for n, attr in attributes:
+            ann = annotation_str(attr.annotation)
+            suffix = f" — `{ann}`" if ann else ""
+            adoc = docstring_of(attr)
+            adoc = f" {adoc}" if adoc else ""
+            lines.append(f"- **`{n}`**{suffix}{adoc}")
+        lines.append("")
+
+    for n, meth in methods:
+        heading = "Constructor" if n == "__init__" else f"`{n}`"
+        sig_name = name if n == "__init__" else f"{name}.{n}"
+        lines += render_function(sig_name, meth, heading=heading, level=3)
+
+    return lines
+
+
+def main() -> int:
+    pkg = griffe.load(
+        "bashkit",
+        search_paths=[str(PKG_SEARCH_PATH)],
+        allow_inspection=False,
+    )
+    native = pkg["_bashkit"]
+
+    out: list[str] = []
+    out.append("# Python API reference")
+    out.append("")
+    out.append(
+        "Auto-generated reference for the [`bashkit`](https://pypi.org/project/bashkit/) "
+        "PyPI package, covering the public classes and functions exported from "
+        "`bashkit`. Reflects the latest published release."
+    )
+    out.append("")
+    out.append(
+        "> Install with `pip install bashkit`. See the "
+        "[Embedding guide](/docs/embedding/) and "
+        "[LLM tools guide](/docs/llm-tools/) for task-oriented walkthroughs."
+    )
+    out.append("")
+
+    for name in CORE_ORDER:
+        member = native.members.get(name)
+        if member is None:
+            print(f"warning: {name} not found in stubs", file=sys.stderr)
+            continue
+        if member.is_class:
+            out += render_class(name, member)
+        elif member.is_function:
+            out += render_function(
+                name, member, heading=f"{name}()", level=2
+            )
+
+    # Framework integration modules (pure-Python).
+    integ_lines: list[str] = []
+    for mod_path, title in INTEGRATIONS:
+        try:
+            mod = pkg
+            for part in mod_path.split(".")[1:]:
+                mod = mod[part]
+        except KeyError:
+            continue
+        funcs = [
+            (n, m)
+            for n, m in own_members(mod).items()
+            if m.is_function and not n.startswith("_")
+        ]
+        if not funcs:
+            continue
+        integ_lines.append(f"## `{title}`")
+        integ_lines.append("")
+        mdoc = docstring_of(mod)
+        if mdoc:
+            integ_lines.append(mdoc.splitlines()[0])
+            integ_lines.append("")
+        for n, fn in funcs:
+            integ_lines += render_function(
+                f"{title}.{n}", fn, heading=f"`{n}`", level=3
+            )
+
+    if integ_lines:
+        out.append("---")
+        out.append("")
+        out.append("# Framework integrations")
+        out.append("")
+        out += integ_lines
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    text = "\n".join(out).rstrip() + "\n"
+    OUT_PATH.write_text(text, encoding="utf-8")
+    print(f"wrote {OUT_PATH.relative_to(REPO_ROOT)} ({len(text)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_ts_apidocs.mjs
+++ b/scripts/gen_ts_apidocs.mjs
@@ -198,6 +198,12 @@ function renderComment(comment, lines) {
 
 // ---- member rendering ------------------------------------------------------
 
+// Lowercase the leading character so a class name reads as an instance
+// receiver: `Bash` -> `bash`, `BashTool` -> `bashTool`.
+function instanceName(className) {
+  return className.charAt(0).toLowerCase() + className.slice(1);
+}
+
 // A field bullet: `- **name** — `type`` with the description as an indented
 // continuation paragraph. Multi-paragraph summaries must be indented under the
 // bullet, otherwise their blank lines terminate the list and the trailing
@@ -266,7 +272,10 @@ function renderClass(refl) {
     }
   }
   for (const m of methods) {
-    lines.push(...renderCallable(`${refl.name}.${m.name}`, m, 3, `\`${m.name}\``));
+    // Static methods are class-level (`Bash.create`); instance methods read as
+    // a call on an instance (`bash.addBuiltin`), not a static `Bash.addBuiltin`.
+    const receiver = m.flags?.isStatic ? refl.name : instanceName(refl.name);
+    lines.push(...renderCallable(`${receiver}.${m.name}`, m, 3, `\`${m.name}\``));
   }
   return lines;
 }

--- a/scripts/gen_ts_apidocs.mjs
+++ b/scripts/gen_ts_apidocs.mjs
@@ -198,6 +198,20 @@ function renderComment(comment, lines) {
 
 // ---- member rendering ------------------------------------------------------
 
+// A field bullet: `- **name** — `type`` with the description as an indented
+// continuation paragraph. Multi-paragraph summaries must be indented under the
+// bullet, otherwise their blank lines terminate the list and the trailing
+// paragraphs render dedented (one `<ul><li>` per field + orphaned `<p>`s).
+function fieldEntry(label, typeStr, summary) {
+  const head = `- **\`${label}\`** — \`${typeStr}\``;
+  if (!summary) return [head];
+  const body = summary
+    .split("\n")
+    .map((l) => (l.length ? `  ${l}` : ""))
+    .join("\n");
+  return [head, "", body];
+}
+
 function signatureString(name, sig) {
   const params = (sig.parameters ?? [])
     .map((p) => {
@@ -235,8 +249,7 @@ function renderClass(refl) {
     lines.push("### Properties", "");
     for (const p of props) {
       const { summary } = commentToMarkdown(p.comment);
-      const doc = summary ? ` ${summary}` : "";
-      lines.push(`- **\`${p.name}\`** — \`${typeToString(p.type)}\`${doc}`);
+      lines.push(...fieldEntry(p.name, typeToString(p.type), summary));
     }
     lines.push("");
   }
@@ -269,8 +282,7 @@ function renderInterface(refl) {
     for (const p of props) {
       const opt = p.flags?.isOptional ? "?" : "";
       const { summary } = commentToMarkdown(p.comment);
-      const doc = summary ? ` ${summary}` : "";
-      lines.push(`- **\`${p.name}${opt}\`** — \`${typeToString(p.type)}\`${doc}`);
+      lines.push(...fieldEntry(`${p.name}${opt}`, typeToString(p.type), summary));
     }
     lines.push("");
   }

--- a/scripts/gen_ts_apidocs.mjs
+++ b/scripts/gen_ts_apidocs.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+// Generate the TypeScript API reference markdown for bashkit.sh.
+//
+// Decision: mirror the Python generator (scripts/gen_python_apidocs.py). We
+// emit plain markdown and let the Astro DocsLayout render it on-brand, instead
+// of shipping TypeDoc's stock HTML theme. Source of truth is the package's own
+// TypeScript wrappers (wrapper.ts + subpath modules), parsed by TypeDoc to JSON
+// and rendered here for full control over headings, anchors, and links (no
+// local .md links — verify-public-links forbids them).
+//
+// Prerequisite: the .ts wrappers import types from the napi-generated, gitignored
+// `index.d.ts`, so `napi build` MUST have run in crates/bashkit-js first. That's
+// a Rust compile, so this can't run in the node-only site.yml — run it in a
+// Rust-capable release job, then commit the output.
+//
+// Usage: node scripts/gen_ts_apidocs.mjs   (or: just apidocs-ts)
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TYPEDOC_VERSION = "0.28.1";
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const jsDir = path.join(repoRoot, "crates", "bashkit-js");
+const outPath = path.join(repoRoot, "site", "src", "content", "apidocs", "typescript.md");
+
+const ENTRY_POINTS = ["wrapper.ts", "langchain.ts", "anthropic.ts", "openai.ts", "ai.ts"];
+
+// Friendly module titles + import specifiers, in render order.
+const MODULES = {
+  wrapper: { title: null, specifier: "@everruns/bashkit", core: true },
+  langchain: { title: "@everruns/bashkit/langchain", specifier: "@everruns/bashkit/langchain" },
+  anthropic: { title: "@everruns/bashkit/anthropic", specifier: "@everruns/bashkit/anthropic" },
+  openai: { title: "@everruns/bashkit/openai", specifier: "@everruns/bashkit/openai" },
+  ai: { title: "@everruns/bashkit/ai", specifier: "@everruns/bashkit/ai" },
+};
+
+// TypeDoc ReflectionKind values we care about.
+const Kind = {
+  Module: 2,
+  Variable: 32,
+  Function: 64,
+  Class: 128,
+  Interface: 256,
+  Constructor: 512,
+  Property: 1024,
+  Method: 2048,
+  Accessor: 262144,
+  TypeAlias: 2097152,
+};
+
+// Preferred ordering for the core module's classes.
+const CLASS_ORDER = ["Bash", "BashTool", "ScriptedTool", "FileSystem", "BashError"];
+
+function runTypedoc() {
+  const tmp = mkdtempSync(path.join(tmpdir(), "bashkit-tsdoc-"));
+  const jsonPath = path.join(tmp, "api.json");
+  execFileSync(
+    "npx",
+    [
+      "--yes",
+      `typedoc@${TYPEDOC_VERSION}`,
+      "--json",
+      jsonPath,
+      "--tsconfig",
+      path.join(jsDir, "tsconfig.json"),
+      "--excludePrivate",
+      "--excludeProtected",
+      "--excludeExternals",
+      "--readme",
+      "none",
+      "--entryPoints",
+      ...ENTRY_POINTS.map((e) => path.join(jsDir, e)),
+    ],
+    { cwd: jsDir, stdio: ["ignore", "inherit", "inherit"] },
+  );
+  return JSON.parse(readFileSync(jsonPath, "utf8"));
+}
+
+// ---- type stringification --------------------------------------------------
+
+function typeToString(t) {
+  if (!t) return "";
+  switch (t.type) {
+    case "intrinsic":
+      return t.name;
+    case "literal":
+      return typeof t.value === "string" ? `"${t.value}"` : String(t.value);
+    case "reference": {
+      const args = t.typeArguments?.length
+        ? `<${t.typeArguments.map(typeToString).join(", ")}>`
+        : "";
+      return `${t.name}${args}`;
+    }
+    case "array":
+      return `${wrapIfComplex(t.elementType)}[]`;
+    case "union":
+      return t.types.map(typeToString).join(" | ");
+    case "intersection":
+      return t.types.map(typeToString).join(" & ");
+    case "tuple":
+      return `[${(t.elements ?? []).map(typeToString).join(", ")}]`;
+    case "named-tuple-member":
+      return `${t.name}${t.isOptional ? "?" : ""}: ${typeToString(t.element)}`;
+    case "optional":
+      return `${typeToString(t.elementType)}?`;
+    case "rest":
+      return `...${typeToString(t.elementType)}`;
+    case "indexedAccess":
+      return `${typeToString(t.objectType)}[${typeToString(t.indexType)}]`;
+    case "typeOperator":
+      return `${t.operator} ${typeToString(t.target)}`;
+    case "query":
+      return `typeof ${typeToString(t.queryType)}`;
+    case "predicate":
+      return `${t.name} is ${typeToString(t.targetType)}`;
+    case "templateLiteral":
+      return "`template`";
+    case "reflection":
+      return reflectionTypeToString(t.declaration);
+    case "mapped":
+    case "conditional":
+      return t.name ?? "object";
+    case "unknown":
+      return t.name ?? "unknown";
+    default:
+      return t.name ?? "unknown";
+  }
+}
+
+function wrapIfComplex(t) {
+  const s = typeToString(t);
+  return /[ |&]/.test(s) ? `(${s})` : s;
+}
+
+function reflectionTypeToString(decl) {
+  if (!decl) return "object";
+  if (decl.signatures?.length) {
+    const sig = decl.signatures[0];
+    const params = (sig.parameters ?? [])
+      .map((p) => `${p.name}: ${typeToString(p.type)}`)
+      .join(", ");
+    return `(${params}) => ${typeToString(sig.type)}`;
+  }
+  if (decl.children?.length) {
+    const props = decl.children
+      .map((c) => `${c.name}${c.flags?.isOptional ? "?" : ""}: ${typeToString(c.type)}`)
+      .join("; ");
+    return `{ ${props} }`;
+  }
+  return "object";
+}
+
+// ---- comment rendering -----------------------------------------------------
+
+function partsToText(parts) {
+  if (!parts) return "";
+  return parts
+    .map((p) => {
+      if (p.kind === "inline-tag" && (p.tag === "@link" || p.tag === "@linkcode")) {
+        return `\`${p.tsLinkText || p.text}\``;
+      }
+      return p.text;
+    })
+    .join("");
+}
+
+function commentToMarkdown(comment) {
+  if (!comment) return { summary: "", examples: [], remarks: "" };
+  const summary = partsToText(comment.summary).trim();
+  const examples = [];
+  let remarks = "";
+  for (const tag of comment.blockTags ?? []) {
+    if (tag.tag === "@example") {
+      examples.push(partsToText(tag.content).trim());
+    } else if (tag.tag === "@remarks") {
+      remarks = partsToText(tag.content).trim();
+    }
+  }
+  return { summary, examples, remarks };
+}
+
+function renderComment(comment, lines) {
+  const { summary, examples, remarks } = commentToMarkdown(comment);
+  if (summary) {
+    lines.push(summary, "");
+  }
+  if (remarks) {
+    lines.push(remarks, "");
+  }
+  for (const ex of examples) {
+    // @example content already contains fenced code in our JSDoc.
+    lines.push(ex, "");
+  }
+}
+
+// ---- member rendering ------------------------------------------------------
+
+function signatureString(name, sig) {
+  const params = (sig.parameters ?? [])
+    .map((p) => {
+      const rest = p.flags?.isRest ? "..." : "";
+      const opt = p.flags?.isOptional ? "?" : "";
+      return `${rest}${p.name}${opt}: ${typeToString(p.type)}`;
+    })
+    .join(", ");
+  return `${name}(${params}): ${typeToString(sig.type)}`;
+}
+
+function renderCallable(name, refl, level, heading) {
+  const lines = [`${"#".repeat(level)} ${heading}`, ""];
+  const sig = refl.signatures?.[0];
+  if (sig) {
+    lines.push("```typescript", signatureString(name, sig), "```", "");
+    renderComment(sig.comment ?? refl.comment, lines);
+  } else {
+    renderComment(refl.comment, lines);
+  }
+  return lines;
+}
+
+function renderClass(refl) {
+  const lines = [`## ${refl.name}`, ""];
+  renderComment(refl.comment, lines);
+
+  const children = refl.children ?? [];
+  const ctor = children.find((c) => c.kind === Kind.Constructor);
+  const methods = children.filter((c) => c.kind === Kind.Method);
+  const accessors = children.filter((c) => c.kind === Kind.Accessor);
+  const props = children.filter((c) => c.kind === Kind.Property);
+
+  if (props.length) {
+    lines.push("### Properties", "");
+    for (const p of props) {
+      const { summary } = commentToMarkdown(p.comment);
+      const doc = summary ? ` ${summary}` : "";
+      lines.push(`- **\`${p.name}\`** — \`${typeToString(p.type)}\`${doc}`);
+    }
+    lines.push("");
+  }
+
+  if (ctor?.signatures?.length) {
+    lines.push(...renderCallable(`new ${refl.name}`, ctor, 3, "Constructor"));
+  }
+  for (const a of accessors) {
+    const getter = a.getSignature;
+    if (getter) {
+      lines.push(`### \`${a.name}\``, "");
+      lines.push("```typescript", `${a.name}: ${typeToString(getter.type)}`, "```", "");
+      renderComment(getter.comment ?? a.comment, lines);
+    }
+  }
+  for (const m of methods) {
+    lines.push(...renderCallable(`${refl.name}.${m.name}`, m, 3, `\`${m.name}\``));
+  }
+  return lines;
+}
+
+function renderInterface(refl) {
+  const lines = [`## ${refl.name}`, ""];
+  renderComment(refl.comment, lines);
+  const children = refl.children ?? [];
+  const props = children.filter((c) => c.kind === Kind.Property);
+  const methods = children.filter((c) => c.kind === Kind.Method);
+  if (props.length) {
+    lines.push("### Fields", "");
+    for (const p of props) {
+      const opt = p.flags?.isOptional ? "?" : "";
+      const { summary } = commentToMarkdown(p.comment);
+      const doc = summary ? ` ${summary}` : "";
+      lines.push(`- **\`${p.name}${opt}\`** — \`${typeToString(p.type)}\`${doc}`);
+    }
+    lines.push("");
+  }
+  for (const m of methods) {
+    lines.push(...renderCallable(m.name, m, 3, `\`${m.name}\``));
+  }
+  return lines;
+}
+
+function renderTypeAlias(refl) {
+  const lines = [`## ${refl.name}`, ""];
+  renderComment(refl.comment, lines);
+  lines.push("```typescript", `type ${refl.name} = ${typeToString(refl.type)}`, "```", "");
+  return lines;
+}
+
+function renderModuleMembers(mod, out) {
+  const children = mod.children ?? [];
+  const byKind = (k) => children.filter((c) => c.kind === k);
+
+  const classes = byKind(Kind.Class).sort((a, b) => {
+    const ia = CLASS_ORDER.indexOf(a.name);
+    const ib = CLASS_ORDER.indexOf(b.name);
+    return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  });
+  for (const c of classes) out.push(...renderClass(c));
+  for (const f of byKind(Kind.Function)) {
+    out.push(...renderCallable(f.name, f, 2, `${f.name}()`));
+  }
+  for (const i of byKind(Kind.Interface)) out.push(...renderInterface(i));
+  for (const t of byKind(Kind.TypeAlias)) out.push(...renderTypeAlias(t));
+}
+
+// ---- main ------------------------------------------------------------------
+
+function main() {
+  const project = runTypedoc();
+  // With multiple entry points, project.children are the modules. With one it
+  // flattens — normalize to a module map keyed by entry basename.
+  const modules = new Map();
+  if ((project.children ?? []).some((c) => c.kind === Kind.Module)) {
+    for (const m of project.children) modules.set(m.name, m);
+  } else {
+    modules.set("wrapper", project);
+  }
+
+  const out = [];
+  out.push("# TypeScript API reference", "");
+  out.push(
+    "Auto-generated reference for the " +
+      "[`@everruns/bashkit`](https://www.npmjs.com/package/@everruns/bashkit) " +
+      "npm package. Reflects the latest published release.",
+    "",
+  );
+  out.push(
+    "> Install with `npm install @everruns/bashkit`. See the " +
+      "[Embedding guide](/docs/embedding/) and " +
+      "[LLM tools guide](/docs/llm-tools/) for task-oriented walkthroughs.",
+    "",
+  );
+
+  // Core module first.
+  const core = modules.get("wrapper");
+  if (core) renderModuleMembers(core, out);
+
+  // Integration subpath modules.
+  const integ = [];
+  for (const [key, meta] of Object.entries(MODULES)) {
+    if (meta.core) continue;
+    const mod = modules.get(key);
+    if (!mod || !(mod.children ?? []).length) continue;
+    integ.push(`## \`${meta.title}\``, "");
+    renderComment(mod.comment, integ);
+    const sub = [];
+    renderModuleMembers(mod, sub);
+    // Demote H2s from members to H3s under the module section.
+    for (const line of sub) {
+      integ.push(line.startsWith("## ") ? `###${line.slice(2)}` : line);
+    }
+  }
+  if (integ.length) {
+    out.push("---", "", "# Framework integrations", "", ...integ);
+  }
+
+  mkdirSync(path.dirname(outPath), { recursive: true });
+  const text = out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+  writeFileSync(outPath, text, "utf8");
+  console.log(`wrote ${path.relative(repoRoot, outPath)} (${text.length} bytes)`);
+}
+
+main();

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -46,11 +46,7 @@
       <a href="/#install">Install</a>
       <a href="/benches">Benches</a>
       <a href="/docs">Docs</a>
-      <a
-        href="https://docs.rs/bashkit"
-        target="_blank"
-        rel="noopener noreferrer">API</a
-      >
+      <a href="/api">API</a>
       <a
         href="https://github.com/everruns/bashkit"
         target="_blank"

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -12,4 +12,11 @@ const rustdocs = defineCollection({
   loader: glob({ pattern: "*.md", base: "../crates/bashkit/docs" }),
 });
 
-export const collections = { docs, rustdocs };
+// API references for the PyPI/npm packages — the self-hosted analog to docs.rs
+// for Rust. Generated markdown (committed, regenerated on release) so the site
+// build stays node-only. See specs/documentation.md ("API reference hosting").
+const apidocs = defineCollection({
+  loader: glob({ pattern: "*.md", base: "./src/content/apidocs" }),
+});
+
+export const collections = { docs, rustdocs, apidocs };

--- a/site/src/content/apidocs/python.md
+++ b/site/src/content/apidocs/python.md
@@ -1,0 +1,1811 @@
+# Python API reference
+
+Auto-generated reference for the [`bashkit`](https://pypi.org/project/bashkit/) PyPI package, covering the public classes and functions exported from `bashkit`. Reflects the latest published release.
+
+> Install with `pip install bashkit`. See the [Embedding guide](/docs/embedding/) and [LLM tools guide](/docs/llm-tools/) for task-oriented walkthroughs.
+
+## Bash
+
+Core bash interpreter with virtual filesystem.
+
+State persists between calls — files created in one execute() are
+available in subsequent calls.
+
+Example (basic):
+    >>> bash = Bash()
+    >>> result = await bash.execute("echo 'Hello!'")
+    >>> print(result.stdout)
+    Hello!
+
+Example (Python execution with external function handler):
+    >>> async def handler(fn_name: str, args: list, kwargs: dict) -> Any:
+    ...     return await tool_executor.call(fn_name, kwargs)
+    >>> bash = Bash(
+    ...     python=True,
+    ...     external_functions=["api_request"],
+    ...     external_handler=handler,
+    ... )
+    >>> result = await bash.execute("python3 -c 'print(api_request(url="/data"))'")
+
+### Constructor
+
+```python
+Bash(username: str | None = None, hostname: str | None = None, cwd: str | None = None, env: Mapping[str, str] | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, max_memory: int | None = None, timeout_seconds: float | None = None, python: bool = False, sqlite: bool = False, external_functions: list[str] | None = None, external_handler: ExternalHandler | None = None, files: dict[str, str | Callable[[], str]] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, custom_builtins: Mapping[str, BuiltinCallback] | None = None, network: NetworkConfig | None = None) -> None
+```
+
+Create a new Bash interpreter.
+
+Args:
+    username: Custom username (default ``"user"``).
+    hostname: Custom hostname (default ``"bashkit"``).
+    cwd: Initial working directory for the shell. Sets the starting
+        directory directly instead of running a leading ``cd``.
+    env: Initial environment variables applied before execution, so
+        scripts see them without an ``export`` prelude.
+    max_commands: Limit total commands executed.
+    max_loop_iterations: Limit iterations per loop.
+    max_memory: Memory limit in bytes for the VFS.
+    timeout_seconds: Abort execution after this duration.
+    python: Enable embedded Python (``python3`` builtin).
+    sqlite: Enable embedded SQLite (``sqlite``/``sqlite3`` builtin).
+        Defaults to ``False``. When ``True``, the Turso-backed engine
+        is registered and ``BASHKIT_ALLOW_INPROCESS_SQLITE=1`` is
+        injected automatically. Default ``SqliteLimits`` apply: 4 MiB
+        script cap, 256 MiB DB cap, 30 s wall-clock budget,
+        resource-affecting PRAGMAs (`cache_size`, `mmap_size`, …)
+        rejected, ``ATTACH``/``DETACH`` rejected.
+    external_functions: Function names callable from Python code.
+    external_handler: Async callback for external function calls.
+        The callback must not call back into the same ``Bash`` instance
+        via live methods like ``read_file()``, ``fs()``, or
+        ``execute()``; those re-entrant calls are rejected.
+    files: Dict mapping VFS paths to file contents or lazy callables.
+    mounts: List of real host directory mount configs.
+    allowed_mount_paths: Host path prefixes allowed for real filesystem
+        mounts. Required when mounting sensitive host locations such as
+        paths under a user home directory.
+    readonly_filesystem: Deny all filesystem mutations after configured
+        files and mounts are applied.
+    custom_builtins: Constructor-time Python callbacks exposed as
+        bash builtins. Each callback receives a ``BuiltinContext``
+        with raw ``argv`` tokens, optional pipeline ``stdin``, and a
+        live ``fs`` handle to the virtual filesystem, and must return a
+        stdout string, a ``BuiltinResult``, or await either. Async
+        callbacks run on the caller's active asyncio loop for
+        ``await execute()`` and on a private loop for
+        ``execute_sync()``.
+    network: Optional outbound HTTP / network configuration. Pass
+        ``{"allow": [...]}`` for an explicit allowlist or
+        ``{"allow_all": True}`` to allow every URL (mirrors
+        ``NetworkAllowlist::allow_all()`` in the Rust core). Set
+        ``"block_private_ips": False`` to relax the SSRF guard.
+        Add ``"credentials": [...]`` to inject headers transparently
+        for matching URLs and ``"credential_placeholders": [...]``
+        to expose opaque placeholder env vars that are replaced with
+        the real secret on the wire. When omitted, network access
+        is disabled (current default). Preserved across ``reset()``
+        and ``from_snapshot()`` — placeholder env vars are
+        regenerated on each rebuild.
+
+Example::
+
+    >>> bash = Bash(
+    ...     timeout_seconds=30,
+    ...     files={"/input.txt": "some data"},
+    ...     custom_builtins={"ping": lambda ctx: "pong\n"},
+    ...     network={
+    ...         "allow": ["https://api.github.com"],
+    ...         "credentials": [
+    ...             {
+    ...                 "pattern": "https://api.github.com",
+    ...                 "kind": "bearer",
+    ...                 "token": "ghp_xxx",
+    ...             }
+    ...         ],
+    ...     },
+    ... )
+
+### `execute`
+
+```python
+Bash.execute(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute bash commands asynchronously.
+
+Args:
+    commands: Bash script to run (like ``bash -c "commands"``).
+    on_output: Optional callback receiving chunked ``(stdout, stderr)``
+        pairs during execution. Must be synchronous.
+
+Async ``custom_builtins`` callbacks run on the caller's active asyncio
+loop.
+
+Returns:
+    ExecResult with stdout, stderr, exit_code.
+
+Example::
+
+    >>> bash = Bash()
+    >>> result = await bash.execute("echo hello && echo world")
+    >>> print(result.stdout)
+    hello
+    world
+
+### `execute_sync`
+
+```python
+Bash.execute_sync(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute bash commands synchronously (blocking).
+
+Not supported when ``external_handler`` is configured — use
+``execute()`` (async) instead. ``on_output`` must be synchronous.
+Async ``custom_builtins`` callbacks run on a private loop here.
+When called from inside a running event loop (e.g. Jupyter / IPython),
+callbacks are dispatched to a background thread with their own loop so
+that asyncio's "cannot run while another loop is running" restriction
+is not triggered.
+
+Example::
+
+    >>> bash = Bash()
+    >>> result = bash.execute_sync("date +%Y")
+    >>> print(result.exit_code)
+    0
+
+### `execute_or_throw`
+
+```python
+Bash.execute_or_throw(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute commands asynchronously; raise ``BashError`` on non-zero exit.
+
+``on_output`` must be synchronous.
+
+Example::
+
+    >>> bash = Bash()
+    >>> result = await bash.execute_or_throw("echo ok")
+    >>> # Raises BashError if the command fails:
+    >>> await bash.execute_or_throw("false")  # doctest: +SKIP
+    Traceback (most recent call last):
+        ...
+    BashError: ...
+
+### `execute_sync_or_throw`
+
+```python
+Bash.execute_sync_or_throw(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute commands synchronously; raise ``BashError`` on non-zero exit.
+
+``on_output`` must be synchronous.
+
+Example::
+
+    >>> bash = Bash()
+    >>> result = bash.execute_sync_or_throw("echo ok")
+    >>> print(result.stdout.strip())
+    ok
+
+### `cancel`
+
+```python
+Bash.cancel() -> None
+```
+
+Cancel the currently running execution.
+
+Safe to call from any thread. Execution aborts at the next
+command boundary.
+
+Example::
+
+    >>> import threading
+    >>> bash = Bash()
+    >>> threading.Timer(1.0, bash.cancel).start()
+    >>> # Long-running command will be cancelled after 1 second
+
+### `clear_cancel`
+
+```python
+Bash.clear_cancel() -> None
+```
+
+Clear the cancellation flag so subsequent executions proceed normally.
+
+Call this after a ``cancel()`` once the in-flight execution has
+finished and you want to reuse the same ``Bash`` instance
+(preserving VFS state). Without this, every future ``execute()``
+will immediately fail with ``"execution cancelled"``.
+
+**Note:** Calling this while an execution is still in-flight may
+allow that execution to continue past the cancellation point.
+Wait for the cancelled execution to finish before clearing
+(await the async call or let ``execute_sync`` return).
+
+Example::
+
+    >>> bash = Bash()
+    >>> bash.cancel()
+    >>> bash.clear_cancel()
+    >>> result = bash.execute_sync("echo ok")
+    >>> result.exit_code
+    0
+
+### `reset`
+
+```python
+Bash.reset() -> None
+```
+
+Reset interpreter to initial state.
+
+Clears all VFS contents, environment variables, and shell state.
+Re-applies the original ``files``, ``mounts``, and
+``custom_builtins`` configuration.
+
+Example::
+
+    >>> bash = Bash()
+    >>> bash.execute_sync("echo hi > /tmp/file.txt")
+    >>> bash.reset()
+    >>> result = bash.execute_sync("cat /tmp/file.txt")
+    >>> result.exit_code  # file is gone after reset
+    1
+
+### `snapshot`
+
+```python
+Bash.snapshot(exclude_filesystem: bool = False, exclude_functions: bool = False) -> bytes
+```
+
+Serialize interpreter state to bytes.
+
+### `snapshot_keyed`
+
+```python
+Bash.snapshot_keyed(key: bytes, exclude_filesystem: bool = False, exclude_functions: bool = False) -> bytes
+```
+
+Serialize interpreter state to HMAC-protected bytes.
+
+### `shell_state`
+
+```python
+Bash.shell_state() -> ShellState
+```
+
+Capture a read-only shell-state snapshot.
+
+### `restore_snapshot`
+
+```python
+Bash.restore_snapshot(data: bytes) -> None
+```
+
+Restore interpreter state from bytes produced by ``snapshot()``.
+
+### `restore_snapshot_keyed`
+
+```python
+Bash.restore_snapshot_keyed(data: bytes, key: bytes) -> None
+```
+
+Restore interpreter state from bytes produced by ``snapshot_keyed()``.
+
+### `from_snapshot`
+
+```python
+Bash.from_snapshot(data: bytes, username: str | None = None, hostname: str | None = None, cwd: str | None = None, env: Mapping[str, str] | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, max_memory: int | None = None, timeout_seconds: float | None = None, python: bool = False, sqlite: bool = False, external_functions: list[str] | None = None, external_handler: ExternalHandler | None = None, files: dict[str, str] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, custom_builtins: Mapping[str, BuiltinCallback] | None = None, network: NetworkConfig | None = None) -> Bash
+```
+
+Create a new ``Bash`` from snapshot bytes and optional constructor kwargs.
+
+### `from_snapshot_keyed`
+
+```python
+Bash.from_snapshot_keyed(data: bytes, key: bytes, username: str | None = None, hostname: str | None = None, cwd: str | None = None, env: Mapping[str, str] | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, max_memory: int | None = None, timeout_seconds: float | None = None, python: bool = False, sqlite: bool = False, external_functions: list[str] | None = None, external_handler: ExternalHandler | None = None, files: dict[str, str] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, custom_builtins: Mapping[str, BuiltinCallback] | None = None, network: NetworkConfig | None = None) -> Bash
+```
+
+Create a new ``Bash`` from HMAC-protected snapshot bytes.
+
+### `read_file`
+
+```python
+Bash.read_file(path: str) -> str
+```
+
+Read a VFS file as UTF-8 text.
+
+### `write_file`
+
+```python
+Bash.write_file(path: str, content: str) -> None
+```
+
+Write UTF-8 text into the VFS.
+
+### `append_file`
+
+```python
+Bash.append_file(path: str, content: str) -> None
+```
+
+Append UTF-8 text to a VFS file.
+
+### `mkdir`
+
+```python
+Bash.mkdir(path: str, recursive: bool = False) -> None
+```
+
+Create a directory in the VFS.
+
+### `exists`
+
+```python
+Bash.exists(path: str) -> bool
+```
+
+Return whether a VFS path exists.
+
+### `remove`
+
+```python
+Bash.remove(path: str, recursive: bool = False) -> None
+```
+
+Remove a VFS file or directory.
+
+### `stat`
+
+```python
+Bash.stat(path: str) -> dict[str, Any]
+```
+
+Return metadata for a VFS path.
+
+### `chmod`
+
+```python
+Bash.chmod(path: str, mode: int) -> None
+```
+
+Change VFS permissions for a path.
+
+### `symlink`
+
+```python
+Bash.symlink(target: str, link: str) -> None
+```
+
+Create a symlink in the VFS.
+
+### `read_link`
+
+```python
+Bash.read_link(path: str) -> str
+```
+
+Return the symlink target for a VFS path.
+
+### `read_dir`
+
+```python
+Bash.read_dir(path: str) -> list[dict[str, Any]]
+```
+
+Return directory entries with metadata.
+
+### `ls`
+
+```python
+Bash.ls(path: str = '.') -> list[str]
+```
+
+Return entry names for a directory, or an empty list if it is missing.
+
+### `glob`
+
+```python
+Bash.glob(pattern: str) -> list[str]
+```
+
+Return file paths matching a safe glob pattern.
+
+### `fs`
+
+```python
+Bash.fs() -> FileSystem
+```
+
+Return a live filesystem handle.
+
+Each operation acquires the interpreter lock, so the handle always
+reflects the latest state (including after ``reset()``).
+
+Example::
+
+    >>> bash = Bash()
+    >>> bash.execute_sync("echo hello > /greeting.txt")
+    >>> fs = bash.fs()
+    >>> fs.read_file("/greeting.txt")
+    b'hello\n'
+
+### `mount`
+
+```python
+Bash.mount(vfs_path: str, fs: FileSystem) -> None
+```
+
+Mount an external filesystem at the given VFS path.
+
+Args:
+    vfs_path: Mount point inside the VFS.
+    fs: FileSystem instance to mount.
+
+Example::
+
+    >>> bash = Bash()
+    >>> overlay = FileSystem()
+    >>> overlay.write_file("/data.csv", b"a,b,c")
+    >>> bash.mount("/mnt/data", overlay)
+    >>> result = bash.execute_sync("cat /mnt/data/data.csv")
+    >>> print(result.stdout)
+    a,b,c
+
+### `unmount`
+
+```python
+Bash.unmount(vfs_path: str) -> None
+```
+
+Unmount a previously mounted filesystem.
+
+Example::
+
+    >>> bash = Bash()
+    >>> overlay = FileSystem()
+    >>> bash.mount("/mnt/ext", overlay)
+    >>> bash.unmount("/mnt/ext")
+
+## BashTool
+
+Sandboxed bash interpreter for AI agents.
+
+BashTool provides a safe execution environment for running bash commands
+with a virtual filesystem. All file operations are contained within the
+sandbox - no access to the real filesystem.
+
+Adds LLM-facing contract metadata (``description``, ``system_prompt``,
+``input_schema``, ``output_schema``) on top of the core interpreter.
+
+Example:
+    >>> tool = BashTool()
+    >>> result = await tool.execute("echo 'Hello!'")
+    >>> print(result.stdout)
+    Hello!
+
+### Fields
+
+- **`name`** — `str`
+- **`short_description`** — `str`
+- **`version`** — `str`
+
+### Constructor
+
+```python
+BashTool(username: str | None = None, hostname: str | None = None, cwd: str | None = None, env: Mapping[str, str] | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, max_memory: int | None = None, timeout_seconds: float | None = None, files: dict[str, str | Callable[[], str]] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, custom_builtins: Mapping[str, BuiltinCallback] | None = None, network: NetworkConfig | None = None) -> None
+```
+
+Create a new BashTool.
+
+Args:
+    username: Custom username (default ``"user"``).
+    hostname: Custom hostname (default ``"bashkit"``).
+    cwd: Initial working directory for the shell. Sets the starting
+        directory directly instead of running a leading ``cd``.
+    env: Initial environment variables applied before execution, so
+        scripts see them without an ``export`` prelude.
+    max_commands: Limit total commands executed.
+    max_loop_iterations: Limit iterations per loop.
+    max_memory: Memory limit in bytes for the VFS.
+    timeout_seconds: Abort execution after this duration.
+    files: Dict mapping VFS paths to file contents or lazy callables.
+    mounts: List of real host directory mount configs.
+    allowed_mount_paths: Host path prefixes allowed for real filesystem
+        mounts. Required when mounting sensitive host locations such as
+        paths under a user home directory.
+    readonly_filesystem: Deny all filesystem mutations after configured
+        files and mounts are applied.
+    custom_builtins: Constructor-time Python callbacks exposed as
+        bash builtins. Each callback receives a ``BuiltinContext``
+        (including a live ``fs`` handle to the virtual filesystem) and
+        must return a stdout string, a ``BuiltinResult``, or await
+        either. Async callbacks run on the caller's active asyncio
+        loop for ``await execute()`` and on a private loop for
+        ``execute_sync()``.
+    network: Optional outbound HTTP / network configuration. See
+        ``Bash.__init__`` for accepted keys. Preserved across
+        ``reset()`` and ``from_snapshot()``.
+
+Example::
+
+    >>> tool = BashTool(
+    ...     timeout_seconds=30,
+    ...     custom_builtins={"ping": lambda ctx: "pong\n"},
+    ...     network={"allow_all": True},
+    ... )
+    >>> print(tool.name)
+    bash
+
+### `execute`
+
+```python
+BashTool.execute(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute bash commands asynchronously.
+
+Async ``custom_builtins`` callbacks run on the caller's active asyncio
+loop.
+
+``on_output`` must be synchronous.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> result = await tool.execute("ls /")
+    >>> result.success
+    True
+
+### `execute_sync`
+
+```python
+BashTool.execute_sync(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute bash commands synchronously (blocking).
+
+Async ``custom_builtins`` callbacks run on a private loop here.
+When called from inside a running event loop (e.g. Jupyter / IPython),
+callbacks are dispatched to a background thread with their own loop so
+that asyncio's "cannot run while another loop is running" restriction
+is not triggered.
+
+``on_output`` must be synchronous.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> result = tool.execute_sync("echo 42")
+    >>> result.stdout.strip()
+    '42'
+
+### `execute_or_throw`
+
+```python
+BashTool.execute_or_throw(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute commands asynchronously; raise ``BashError`` on non-zero exit.
+
+``on_output`` must be synchronous.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> result = await tool.execute_or_throw("echo ok")
+    >>> result.success
+    True
+
+### `execute_sync_or_throw`
+
+```python
+BashTool.execute_sync_or_throw(commands: str, on_output: OutputHandler | None = None) -> ExecResult
+```
+
+Execute commands synchronously; raise ``BashError`` on non-zero exit.
+
+``on_output`` must be synchronous.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> result = tool.execute_sync_or_throw("echo ok")
+    >>> result.stdout.strip()
+    'ok'
+
+### `cancel`
+
+```python
+BashTool.cancel() -> None
+```
+
+Cancel the currently running execution.
+
+Safe to call from any thread.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> tool.cancel()  # no-op if nothing is running
+
+### `clear_cancel`
+
+```python
+BashTool.clear_cancel() -> None
+```
+
+Clear the cancellation flag so subsequent executions proceed normally.
+
+Call this after a ``cancel()`` once the in-flight execution has
+finished and you want to reuse the same ``BashTool`` instance
+(preserving VFS state). Without this, every future ``execute()``
+will immediately fail with ``"execution cancelled"``.
+
+**Note:** Calling this while an execution is still in-flight may
+allow that execution to continue past the cancellation point.
+Wait for the cancelled execution to finish before clearing
+(await the async call or let ``execute_sync`` return).
+
+Example::
+
+    >>> tool = BashTool()
+    >>> tool.cancel()
+    >>> tool.clear_cancel()
+    >>> result = tool.execute_sync("echo ok")
+    >>> result.exit_code
+    0
+
+### `description`
+
+```python
+BashTool.description() -> str
+```
+
+Return the tool description for LLM consumption.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> desc = tool.description()
+    >>> "bash" in desc.lower()
+    True
+
+### `help`
+
+```python
+BashTool.help() -> str
+```
+
+Return extended help text.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> help_text = tool.help()
+    >>> len(help_text) > 0
+    True
+
+### `system_prompt`
+
+```python
+BashTool.system_prompt() -> str
+```
+
+Return the system prompt for LLM agents.
+
+Includes tool description, usage guidelines, and capabilities.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> prompt = tool.system_prompt()
+    >>> "sandbox" in prompt.lower() or "bash" in prompt.lower()
+    True
+
+### `input_schema`
+
+```python
+BashTool.input_schema() -> str
+```
+
+Return the JSON Schema for tool input.
+
+Example::
+
+    >>> import json
+    >>> tool = BashTool()
+    >>> schema = json.loads(tool.input_schema())
+    >>> "commands" in str(schema)
+    True
+
+### `output_schema`
+
+```python
+BashTool.output_schema() -> str
+```
+
+Return the JSON Schema for tool output.
+
+Example::
+
+    >>> import json
+    >>> tool = BashTool()
+    >>> schema = json.loads(tool.output_schema())
+    >>> isinstance(schema, dict)
+    True
+
+### `reset`
+
+```python
+BashTool.reset() -> None
+```
+
+Reset the tool to initial state.
+
+Clears VFS, environment, and shell state while re-applying
+constructor-time ``custom_builtins``.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> tool.execute_sync("touch /tmp/file")
+    >>> tool.reset()
+    >>> result = tool.execute_sync("test -f /tmp/file")
+    >>> result.exit_code  # file is gone
+    1
+
+### `snapshot`
+
+```python
+BashTool.snapshot(exclude_filesystem: bool = False, exclude_functions: bool = False) -> bytes
+```
+
+Serialize interpreter state to bytes.
+
+### `snapshot_keyed`
+
+```python
+BashTool.snapshot_keyed(key: bytes, exclude_filesystem: bool = False, exclude_functions: bool = False) -> bytes
+```
+
+Serialize interpreter state to HMAC-protected bytes.
+
+### `shell_state`
+
+```python
+BashTool.shell_state() -> ShellState
+```
+
+Capture a read-only shell-state snapshot.
+
+### `restore_snapshot`
+
+```python
+BashTool.restore_snapshot(data: bytes) -> None
+```
+
+Restore interpreter state from bytes produced by ``snapshot()``.
+
+### `restore_snapshot_keyed`
+
+```python
+BashTool.restore_snapshot_keyed(data: bytes, key: bytes) -> None
+```
+
+Restore interpreter state from bytes produced by ``snapshot_keyed()``.
+
+### `from_snapshot`
+
+```python
+BashTool.from_snapshot(data: bytes, username: str | None = None, hostname: str | None = None, cwd: str | None = None, env: Mapping[str, str] | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, max_memory: int | None = None, timeout_seconds: float | None = None, files: dict[str, str] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, custom_builtins: Mapping[str, BuiltinCallback] | None = None, network: NetworkConfig | None = None) -> BashTool
+```
+
+Create a new ``BashTool`` from snapshot bytes and optional constructor kwargs.
+
+### `from_snapshot_keyed`
+
+```python
+BashTool.from_snapshot_keyed(data: bytes, key: bytes, username: str | None = None, hostname: str | None = None, cwd: str | None = None, env: Mapping[str, str] | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, max_memory: int | None = None, timeout_seconds: float | None = None, files: dict[str, str] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, custom_builtins: Mapping[str, BuiltinCallback] | None = None, network: NetworkConfig | None = None) -> BashTool
+```
+
+Create a new ``BashTool`` from HMAC-protected snapshot bytes.
+
+### `read_file`
+
+```python
+BashTool.read_file(path: str) -> str
+```
+
+Read a VFS file as UTF-8 text.
+
+### `write_file`
+
+```python
+BashTool.write_file(path: str, content: str) -> None
+```
+
+Write UTF-8 text into the VFS.
+
+### `append_file`
+
+```python
+BashTool.append_file(path: str, content: str) -> None
+```
+
+Append UTF-8 text to a VFS file.
+
+### `mkdir`
+
+```python
+BashTool.mkdir(path: str, recursive: bool = False) -> None
+```
+
+Create a directory in the VFS.
+
+### `exists`
+
+```python
+BashTool.exists(path: str) -> bool
+```
+
+Return whether a VFS path exists.
+
+### `remove`
+
+```python
+BashTool.remove(path: str, recursive: bool = False) -> None
+```
+
+Remove a VFS file or directory.
+
+### `stat`
+
+```python
+BashTool.stat(path: str) -> dict[str, Any]
+```
+
+Return metadata for a VFS path.
+
+### `chmod`
+
+```python
+BashTool.chmod(path: str, mode: int) -> None
+```
+
+Change VFS permissions for a path.
+
+### `symlink`
+
+```python
+BashTool.symlink(target: str, link: str) -> None
+```
+
+Create a symlink in the VFS.
+
+### `read_link`
+
+```python
+BashTool.read_link(path: str) -> str
+```
+
+Return the symlink target for a VFS path.
+
+### `read_dir`
+
+```python
+BashTool.read_dir(path: str) -> list[dict[str, Any]]
+```
+
+Return directory entries with metadata.
+
+### `ls`
+
+```python
+BashTool.ls(path: str = '.') -> list[str]
+```
+
+Return entry names for a directory, or an empty list if it is missing.
+
+### `glob`
+
+```python
+BashTool.glob(pattern: str) -> list[str]
+```
+
+Return file paths matching a safe glob pattern.
+
+### `fs`
+
+```python
+BashTool.fs() -> FileSystem
+```
+
+Return a live filesystem handle.
+
+Each operation acquires the interpreter lock, so the handle always
+reflects the latest state (including after ``reset()``).
+
+Example::
+
+    >>> tool = BashTool()
+    >>> tool.execute_sync("echo data > /out.txt")
+    >>> fs = tool.fs()
+    >>> fs.read_file("/out.txt")
+    b'data\n'
+
+### `mount`
+
+```python
+BashTool.mount(vfs_path: str, fs: FileSystem) -> None
+```
+
+Mount an external filesystem at the given VFS path.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> ext = FileSystem()
+    >>> ext.write_file("/info.txt", b"external")
+    >>> tool.mount("/mnt/ext", ext)
+    >>> result = tool.execute_sync("cat /mnt/ext/info.txt")
+    >>> result.stdout.strip()
+    'external'
+
+### `unmount`
+
+```python
+BashTool.unmount(vfs_path: str) -> None
+```
+
+Unmount a previously mounted filesystem.
+
+Example::
+
+    >>> tool = BashTool()
+    >>> ext = FileSystem()
+    >>> tool.mount("/mnt/ext", ext)
+    >>> tool.unmount("/mnt/ext")
+
+## ScriptedTool
+
+Compose Python callbacks as bash builtins for multi-tool orchestration.
+
+Each registered tool becomes a bash builtin command. An LLM (or user)
+writes a single bash script that pipes, loops, and branches across tools.
+
+Example:
+    >>> tool = ScriptedTool("api")
+    >>> tool.add_tool("greet", "Greet user",
+    ...     callback=lambda p, s=None: f"hello {p.get('name', 'world')}\n",
+    ...     schema={"type": "object", "properties": {"name": {"type": "string"}}})
+    >>> result = tool.execute_sync("greet --name Alice")
+    >>> print(result.stdout.strip())
+    hello Alice
+
+### Fields
+
+- **`name`** — `str`
+- **`short_description`** — `str`
+- **`version`** — `str`
+
+### Constructor
+
+```python
+ScriptedTool(name: str, short_description: str | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None) -> None
+```
+
+Create a new ScriptedTool.
+
+Args:
+    name: Tool name (used as the LLM tool identifier).
+    short_description: One-line description of the tool.
+    max_commands: Limit total commands per execution.
+    max_loop_iterations: Limit iterations per loop.
+
+Example::
+
+    >>> tool = ScriptedTool("data_pipeline", short_description="ETL tools")
+    >>> print(tool.name)
+    data_pipeline
+
+### `add_tool`
+
+```python
+ScriptedTool.add_tool(name: str, description: str, callback: Callable[[dict[str, Any], str | None], str], schema: dict[str, Any] | None = None) -> None
+```
+
+Register a Python callback as a bash builtin command.
+
+Args:
+    name: Command name (becomes a bash builtin).
+    description: Human-readable description of the sub-tool.
+    callback: ``(params_dict, stdin_or_none) -> output_string`` or
+        an async callback that resolves to one. Async callbacks run on
+        the caller's active asyncio loop for ``await execute()`` and on
+        a private loop for ``execute_sync()``.
+    schema: Optional JSON Schema for the tool's parameters.
+
+Example::
+
+    >>> tool = ScriptedTool("math")
+    >>> tool.add_tool(
+    ...     "add", "Add two numbers",
+    ...     callback=lambda p, s=None: str(int(p["a"]) + int(p["b"])) + "\n",
+    ...     schema={
+    ...         "type": "object",
+    ...         "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+    ...     },
+    ... )
+    >>> result = tool.execute_sync("add --a 2 --b 3")
+    >>> result.stdout.strip()
+    '5'
+
+### `env`
+
+```python
+ScriptedTool.env(key: str, value: str) -> None
+```
+
+Set an environment variable for subsequent executions.
+
+Example::
+
+    >>> tool = ScriptedTool("demo")
+    >>> tool.env("API_KEY", "secret-123")
+    >>> result = tool.execute_sync("echo $API_KEY")
+    >>> result.stdout.strip()
+    'secret-123'
+
+### `execute`
+
+```python
+ScriptedTool.execute(commands: str) -> ExecResult
+```
+
+Execute commands asynchronously.
+
+Async callbacks run on the caller's active asyncio loop.
+
+Example::
+
+    >>> tool = ScriptedTool("demo")
+    >>> tool.add_tool("hi", "Say hi", callback=lambda p, s=None: "hi\n")
+    >>> result = await tool.execute("hi")
+    >>> result.stdout.strip()
+    'hi'
+
+### `execute_sync`
+
+```python
+ScriptedTool.execute_sync(commands: str) -> ExecResult
+```
+
+Execute commands synchronously (blocking).
+
+Async callbacks run on a private loop here.
+
+Example::
+
+    >>> tool = ScriptedTool("demo")
+    >>> tool.add_tool("ping", "Ping", callback=lambda p, s=None: "pong\n")
+    >>> result = tool.execute_sync("ping")
+    >>> result.stdout.strip()
+    'pong'
+
+### `tool_count`
+
+```python
+ScriptedTool.tool_count() -> int
+```
+
+Return the number of registered sub-tools.
+
+Example::
+
+    >>> tool = ScriptedTool("demo")
+    >>> tool.tool_count()
+    0
+    >>> tool.add_tool("a", "A", callback=lambda p, s=None: "")
+    >>> tool.tool_count()
+    1
+
+### `description`
+
+```python
+ScriptedTool.description() -> str
+```
+
+Return the tool description for LLM consumption.
+
+Example::
+
+    >>> tool = ScriptedTool("api", short_description="API tools")
+    >>> desc = tool.description()
+    >>> len(desc) > 0
+    True
+
+### `help`
+
+```python
+ScriptedTool.help() -> str
+```
+
+Return extended help text listing all registered sub-tools.
+
+Example::
+
+    >>> tool = ScriptedTool("api")
+    >>> tool.add_tool("fetch", "Fetch URL", callback=lambda p, s=None: "")
+    >>> "fetch" in tool.help()
+    True
+
+### `system_prompt`
+
+```python
+ScriptedTool.system_prompt() -> str
+```
+
+Return the system prompt for LLM agents.
+
+Includes descriptions of all registered sub-tools and usage examples.
+
+Example::
+
+    >>> tool = ScriptedTool("api")
+    >>> tool.add_tool("fetch", "Fetch URL", callback=lambda p, s=None: "")
+    >>> prompt = tool.system_prompt()
+    >>> "fetch" in prompt.lower()
+    True
+
+### `input_schema`
+
+```python
+ScriptedTool.input_schema() -> str
+```
+
+Return the JSON Schema for tool input.
+
+Example::
+
+    >>> import json
+    >>> tool = ScriptedTool("api")
+    >>> schema = json.loads(tool.input_schema())
+    >>> "commands" in str(schema)
+    True
+
+### `output_schema`
+
+```python
+ScriptedTool.output_schema() -> str
+```
+
+Return the JSON Schema for tool output.
+
+Example::
+
+    >>> import json
+    >>> tool = ScriptedTool("api")
+    >>> schema = json.loads(tool.output_schema())
+    >>> isinstance(schema, dict)
+    True
+
+## FileSystem
+
+Direct access to Bashkit's virtual filesystem or a standalone mountable FS.
+
+Two ways to create:
+
+1. In-memory (default) — starts empty::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/hello.txt", b"hi")
+    >>> fs.read_file("/hello.txt")
+    b'hi'
+
+2. Backed by a real host directory::
+
+    >>> fs = FileSystem.real("/tmp/data", writable=False)
+    >>> fs.exists("/some-host-file.txt")
+    True
+
+### Constructor
+
+```python
+FileSystem() -> None
+```
+
+Create a new empty in-memory filesystem.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.exists("/anything")
+    False
+
+### `real`
+
+```python
+FileSystem.real(host_path: str, writable: bool = False) -> FileSystem
+```
+
+Create a filesystem backed by a real host directory.
+
+Args:
+    host_path: Absolute path on the host to expose.
+    writable: Allow write operations (default read-only).
+
+Example::
+
+    >>> fs = FileSystem.real("/tmp/project", writable=True)
+    >>> fs.write_file("/tmp/project/out.txt", b"data")
+
+### `from_capsule`
+
+```python
+FileSystem.from_capsule(capsule: Any) -> FileSystem
+```
+
+Create a filesystem from a ``PyCapsule`` exported by a native extension.
+
+The capsule must wrap a ``bashkit.FileSystem.v1`` stable ABI handle.
+
+### `to_capsule`
+
+```python
+FileSystem.to_capsule() -> Any
+```
+
+Export this filesystem as a stable-ABI ``PyCapsule`` for native extension interop.
+
+### `read_file`
+
+```python
+FileSystem.read_file(path: str) -> bytes
+```
+
+Read the entire contents of a file.
+
+Args:
+    path: Absolute path in the filesystem.
+
+Returns:
+    File contents as bytes.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/demo.txt", b"hello")
+    >>> fs.read_file("/demo.txt")
+    b'hello'
+
+### `write_file`
+
+```python
+FileSystem.write_file(path: str, content: bytes) -> None
+```
+
+Write content to a file, creating or overwriting it.
+
+Args:
+    path: Absolute path in the filesystem.
+    content: Data to write.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/output.txt", b"result data")
+
+### `append_file`
+
+```python
+FileSystem.append_file(path: str, content: bytes) -> None
+```
+
+Append content to an existing file.
+
+Args:
+    path: Absolute path in the filesystem.
+    content: Data to append.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/log.txt", b"line1\n")
+    >>> fs.append_file("/log.txt", b"line2\n")
+    >>> fs.read_file("/log.txt")
+    b'line1\nline2\n'
+
+### `mkdir`
+
+```python
+FileSystem.mkdir(path: str, recursive: bool = False) -> None
+```
+
+Create a directory.
+
+Args:
+    path: Absolute path for the new directory.
+    recursive: Create parent directories as needed.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.mkdir("/a/b/c", recursive=True)
+    >>> fs.exists("/a/b/c")
+    True
+
+### `remove`
+
+```python
+FileSystem.remove(path: str, recursive: bool = False) -> None
+```
+
+Remove a file or directory.
+
+Args:
+    path: Absolute path to remove.
+    recursive: Remove directory contents recursively.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/tmp.txt", b"x")
+    >>> fs.remove("/tmp.txt")
+    >>> fs.exists("/tmp.txt")
+    False
+
+### `stat`
+
+```python
+FileSystem.stat(path: str) -> dict[str, Any]
+```
+
+Get file metadata.
+
+Returns:
+    Dict with ``file_type``, ``size``, ``mode``, ``modified``, ``created``.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/f.txt", b"data")
+    >>> info = fs.stat("/f.txt")
+    >>> info["file_type"]
+    'file'
+    >>> info["size"]
+    4
+
+### `read_dir`
+
+```python
+FileSystem.read_dir(path: str) -> list[dict[str, Any]]
+```
+
+List directory entries.
+
+Returns:
+    List of dicts, each with ``name`` and ``metadata`` keys.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/dir/a.txt", b"a")
+    >>> entries = fs.read_dir("/dir")
+    >>> entries[0]["name"]
+    'a.txt'
+
+### `exists`
+
+```python
+FileSystem.exists(path: str) -> bool
+```
+
+Check whether a path exists.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.exists("/nope")
+    False
+    >>> fs.write_file("/yes.txt", b"")
+    >>> fs.exists("/yes.txt")
+    True
+
+### `rename`
+
+```python
+FileSystem.rename(from_path: str, to_path: str) -> None
+```
+
+Rename (move) a file or directory.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/old.txt", b"data")
+    >>> fs.rename("/old.txt", "/new.txt")
+    >>> fs.exists("/new.txt")
+    True
+
+### `copy`
+
+```python
+FileSystem.copy(from_path: str, to_path: str) -> None
+```
+
+Copy a file.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/src.txt", b"data")
+    >>> fs.copy("/src.txt", "/dst.txt")
+    >>> fs.read_file("/dst.txt")
+    b'data'
+
+### `symlink`
+
+```python
+FileSystem.symlink(target: str, link: str) -> None
+```
+
+Create a symbolic link.
+
+Args:
+    target: Path the symlink points to.
+    link: Path of the symlink itself.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/real.txt", b"data")
+    >>> fs.symlink("/real.txt", "/link.txt")
+    >>> fs.read_file("/link.txt")
+    b'data'
+
+### `chmod`
+
+```python
+FileSystem.chmod(path: str, mode: int) -> None
+```
+
+Change file permissions.
+
+Args:
+    path: Absolute path.
+    mode: Octal permission bits (e.g. ``0o755``).
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/script.sh", b"#!/bin/bash")
+    >>> fs.chmod("/script.sh", 0o755)
+
+### `read_link`
+
+```python
+FileSystem.read_link(path: str) -> str
+```
+
+Read the target of a symbolic link.
+
+Example::
+
+    >>> fs = FileSystem()
+    >>> fs.write_file("/target.txt", b"data")
+    >>> fs.symlink("/target.txt", "/link.txt")
+    >>> fs.read_link("/link.txt")
+    '/target.txt'
+
+## ExecResult
+
+Result from executing bash commands.
+
+Example::
+
+    >>> bash = Bash()
+    >>> result = bash.execute_sync("echo hello")
+    >>> result.success
+    True
+    >>> result.stdout
+    'hello\n'
+    >>> result.exit_code
+    0
+
+### Fields
+
+- **`stdout`** — `str`
+- **`stderr`** — `str`
+- **`exit_code`** — `int`
+- **`error`** — `str | None`
+- **`success`** — `bool`
+
+### `to_dict`
+
+```python
+ExecResult.to_dict() -> dict[str, Any]
+```
+
+Convert result to a plain dictionary.
+
+Returns:
+    Dict with ``stdout``, ``stderr``, ``exit_code``, ``error``,
+    ``stdout_truncated``, ``stderr_truncated``, ``final_env``.
+
+Example::
+
+    >>> bash = Bash()
+    >>> result = bash.execute_sync("echo hi")
+    >>> d = result.to_dict()
+    >>> d["stdout"]
+    'hi\n'
+    >>> d["exit_code"]
+    0
+
+## ShellState
+
+Read-only snapshot of shell state.
+
+Returned by ``Bash.shell_state()`` and ``BashTool.shell_state()`` for
+prompt rendering and state inspection. This is a Python-friendly
+inspection view, not a full-fidelity Rust ``ShellState`` mirror.
+Mapping fields are immutable views. Use
+``snapshot(exclude_filesystem=True)`` when you need shell-only restore
+bytes. Transient fields like ``last_exit_code`` and ``traps`` reflect the
+captured snapshot, but the next top-level ``execute()`` / ``execute_sync()``
+clears them before running a new command.
+
+### Fields
+
+- **`env`** — `Mapping[str, str]`
+- **`variables`** — `Mapping[str, str]`
+- **`arrays`** — `Mapping[str, Mapping[int, str]]`
+- **`assoc_arrays`** — `Mapping[str, Mapping[str, str]]`
+- **`cwd`** — `str`
+- **`last_exit_code`** — `int`
+- **`aliases`** — `Mapping[str, str]`
+- **`traps`** — `Mapping[str, str]`
+
+## BuiltinContext
+
+Invocation context for a custom builtin callback.
+
+Attributes:
+    name: Builtin command name.
+    argv: Raw argv tokens after shell parsing, excluding the command name.
+    stdin: Pipeline input from the previous command, if any.
+    env: Environment variables visible to the builtin.
+    cwd: Current working directory at invocation time.
+    fs: Live handle to the interpreter's virtual filesystem. Reads see
+        files created by earlier commands and writes are visible to later
+        ones. Same API as ``Bash.fs()`` — e.g. ``ctx.fs.read_file(path)``
+        returns ``bytes``. Operates directly on the interpreter's VFS, so
+        it is safe to use from inside the callback. Ops are synchronous and,
+        while a runtime is active, may run off-thread (relatively expensive
+        per call), so batch filesystem work rather than looping over many
+        tiny ops. May be retained past the callback: a stashed handle keeps
+        the VFS (and its runtime) alive even after the ``Bash`` is dropped.
+
+### Fields
+
+- **`name`** — `str`
+- **`argv`** — `list[str]`
+- **`stdin`** — `str | None`
+- **`env`** — `dict[str, str]`
+- **`cwd`** — `str`
+- **`fs`** — `FileSystem`
+
+## BuiltinResult
+
+Shell-facing result for a custom builtin callback.
+
+Attributes:
+    stdout: Text written to stdout.
+    stderr: Text written to stderr.
+    exit_code: Shell exit status.
+
+### Fields
+
+- **`stdout`** — `str`
+- **`stderr`** — `str`
+- **`exit_code`** — `int`
+
+### Constructor
+
+```python
+BuiltinResult(stdout: str = '', stderr: str = '', exit_code: int = 0) -> None
+```
+
+## BashError
+
+Exception raised when a bash command exits with non-zero status.
+
+Example::
+
+    >>> bash = Bash()
+    >>> try:
+    ...     bash.execute_sync_or_throw("exit 42")
+    ... except BashError as e:
+    ...     print(e.exit_code)
+    42
+
+### Fields
+
+- **`exit_code`** — `int`
+- **`stderr`** — `str`
+- **`stdout`** — `str`
+
+## create_langchain_tool_spec()
+
+```python
+create_langchain_tool_spec() -> dict[str, Any]
+```
+
+Create a LangChain-compatible tool specification.
+
+Returns:
+    Dict with name, description, and args_schema.
+
+Example::
+
+    >>> spec = create_langchain_tool_spec()
+    >>> spec["name"]
+    'bash'
+
+## get_version()
+
+```python
+get_version() -> str
+```
+
+Get the bashkit version string.
+
+Example::
+
+    >>> version = get_version()
+    >>> isinstance(version, str)
+    True
+
+---
+
+# Framework integrations
+
+## `bashkit.langchain`
+
+LangChain integration for Bashkit.
+
+### `Field`
+
+```python
+bashkit.langchain.Field(*args, **kwargs)
+```
+
+### `PrivateAttr`
+
+```python
+bashkit.langchain.PrivateAttr(*args, **kwargs)
+```
+
+### `create_bash_tool`
+
+```python
+bashkit.langchain.create_bash_tool(username: str | None = None, hostname: str | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, timeout_seconds: float | None = None, files: dict[str, str | Callable[[], str]] | None = None, mounts: list[dict[str, Any]] | None = None, allowed_mount_paths: list[str] | None = None, readonly_filesystem: bool = False, max_output_length: int = 100000) -> BashkitTool
+```
+
+Create a LangChain-compatible Bashkit tool.
+
+Args:
+    username: Custom username for sandbox
+    hostname: Custom hostname for sandbox
+    max_commands: Max commands to execute
+    max_loop_iterations: Max loop iterations
+    timeout_seconds: Execution timeout in seconds. When set, commands
+        that exceed this duration are aborted with exit code 124.
+    files: Static VFS file mounts keyed by sandbox path.
+    mounts: Real host directory mounts exposed inside the sandbox.
+        Mounts are read-only by default; pass ``{"writable": True}``
+        on a mount config to allow writes.
+    allowed_mount_paths: Host path prefixes allowed for real filesystem
+        mounts. Required when mounting sensitive host locations such as
+        paths under a user home directory.
+    readonly_filesystem: Deny all filesystem mutations after configured
+        files and mounts are applied.
+    max_output_length: Maximum number of characters returned to the
+        LangChain agent from one bash tool call before truncation.
+
+Returns:
+    BashkitTool instance for use with LangChain agents
+
+Raises:
+    ImportError: If langchain-core is not installed
+
+Example:
+    >>> from bashkit.langchain import create_bash_tool
+    >>> tool = create_bash_tool(timeout_seconds=30)
+    >>> result = tool.invoke({"commands": "ls -la"})
+
+### `create_scripted_tool`
+
+```python
+bashkit.langchain.create_scripted_tool(scripted_tool: NativeScriptedTool) -> ScriptedToolLangChain
+```
+
+Create a LangChain-compatible tool from a configured ScriptedTool.
+
+Args:
+    scripted_tool: A ScriptedTool with registered tool callbacks
+
+Returns:
+    ScriptedToolLangChain instance for use with LangChain agents
+
+Raises:
+    ImportError: If langchain-core is not installed
+
+Example:
+    >>> from bashkit import ScriptedTool
+    >>> from bashkit.langchain import create_scripted_tool
+    >>>
+    >>> st = ScriptedTool("api")
+    >>> st.add_tool("get_data", "Fetch data", callback=my_fn)
+    >>> tool = create_scripted_tool(st)
+    >>> # Use with: create_react_agent(model, [tool])
+
+## `bashkit.pydantic_ai`
+
+PydanticAI integration for Bashkit.
+
+### `create_bash_tool`
+
+```python
+bashkit.pydantic_ai.create_bash_tool(username: str | None = None, hostname: str | None = None, max_commands: int | None = None, max_loop_iterations: int | None = None, timeout_seconds: float | None = None, max_output_length: int = 100000) -> Tool
+```
+
+Create a PydanticAI Tool wrapping Bashkit.
+
+Args:
+    username: Custom username for sandbox
+    hostname: Custom hostname for sandbox
+    max_commands: Max commands to execute
+    max_loop_iterations: Max loop iterations
+    timeout_seconds: Execution timeout in seconds. When set, commands
+        that exceed this duration are aborted with exit code 124.
+
+Returns:
+    Tool for use with ``Agent(tools=[...])``
+
+Raises:
+    ImportError: If pydantic-ai is not installed
+
+Example:
+    >>> from bashkit.pydantic_ai import create_bash_tool
+    >>> tool = create_bash_tool(timeout_seconds=30)
+    >>> from pydantic_ai import Agent
+    >>> agent = Agent('anthropic:claude-sonnet-4-20250514', tools=[tool])
+
+## `bashkit.deepagents`
+
+Deep Agents integration for Bashkit.
+
+### `create_bash_middleware`
+
+```python
+bashkit.deepagents.create_bash_middleware(**kwargs) -> BashkitMiddleware
+```
+
+Create BashkitMiddleware for Deep Agents.
+
+### `create_bashkit_backend`
+
+```python
+bashkit.deepagents.create_bashkit_backend(**kwargs) -> BashkitBackend
+```
+
+Create BashkitBackend for Deep Agents.

--- a/site/src/content/apidocs/python.md
+++ b/site/src/content/apidocs/python.md
@@ -12,20 +12,27 @@ State persists between calls — files created in one execute() are
 available in subsequent calls.
 
 Example (basic):
-    >>> bash = Bash()
-    >>> result = await bash.execute("echo 'Hello!'")
-    >>> print(result.stdout)
-    Hello!
+
+```python
+>>> bash = Bash()
+>>> result = await bash.execute("echo 'Hello!'")
+>>> print(result.stdout)
+Hello!
+```
+
 
 Example (Python execution with external function handler):
-    >>> async def handler(fn_name: str, args: list, kwargs: dict) -> Any:
-    ...     return await tool_executor.call(fn_name, kwargs)
-    >>> bash = Bash(
-    ...     python=True,
-    ...     external_functions=["api_request"],
-    ...     external_handler=handler,
-    ... )
-    >>> result = await bash.execute("python3 -c 'print(api_request())'")
+
+```python
+>>> async def handler(fn_name: str, args: list, kwargs: dict) -> Any:
+...     return await tool_executor.call(fn_name, kwargs)
+>>> bash = Bash(
+...     python=True,
+...     external_functions=["api_request"],
+...     external_handler=handler,
+... )
+>>> result = await bash.execute("python3 -c 'print(api_request())'")
+```
 
 ### Constructor
 
@@ -35,75 +42,46 @@ Bash(username: str | None = None, hostname: str | None = None, cwd: str | None =
 
 Create a new Bash interpreter.
 
-Args:
-    username: Custom username (default ``"user"``).
-    hostname: Custom hostname (default ``"bashkit"``).
-    cwd: Initial working directory for the shell. Sets the starting
-        directory directly instead of running a leading ``cd``.
-    env: Initial environment variables applied before execution, so
-        scripts see them without an ``export`` prelude.
-    max_commands: Limit total commands executed.
-    max_loop_iterations: Limit iterations per loop.
-    max_memory: Memory limit in bytes for the VFS.
-    timeout_seconds: Abort execution after this duration.
-    python: Enable embedded Python (``python3`` builtin).
-    sqlite: Enable embedded SQLite (``sqlite``/``sqlite3`` builtin).
-        Defaults to ``False``. When ``True``, the Turso-backed engine
-        is registered and ``BASHKIT_ALLOW_INPROCESS_SQLITE=1`` is
-        injected automatically. Default ``SqliteLimits`` apply: 4 MiB
-        script cap, 256 MiB DB cap, 30 s wall-clock budget,
-        resource-affecting PRAGMAs (`cache_size`, `mmap_size`, …)
-        rejected, ``ATTACH``/``DETACH`` rejected.
-    external_functions: Function names callable from Python code.
-    external_handler: Async callback for external function calls.
-        The callback must not call back into the same ``Bash`` instance
-        via live methods like ``read_file()``, ``fs()``, or
-        ``execute()``; those re-entrant calls are rejected.
-    files: Dict mapping VFS paths to file contents or lazy callables.
-    mounts: List of real host directory mount configs.
-    allowed_mount_paths: Host path prefixes allowed for real filesystem
-        mounts. Required when mounting sensitive host locations such as
-        paths under a user home directory.
-    readonly_filesystem: Deny all filesystem mutations after configured
-        files and mounts are applied.
-    custom_builtins: Constructor-time Python callbacks exposed as
-        bash builtins. Each callback receives a ``BuiltinContext``
-        with raw ``argv`` tokens, optional pipeline ``stdin``, and a
-        live ``fs`` handle to the virtual filesystem, and must return a
-        stdout string, a ``BuiltinResult``, or await either. Async
-        callbacks run on the caller's active asyncio loop for
-        ``await execute()`` and on a private loop for
-        ``execute_sync()``.
-    network: Optional outbound HTTP / network configuration. Pass
-        ``{"allow": [...]}`` for an explicit allowlist or
-        ``{"allow_all": True}`` to allow every URL (mirrors
-        ``NetworkAllowlist::allow_all()`` in the Rust core). Set
-        ``"block_private_ips": False`` to relax the SSRF guard.
-        Add ``"credentials": [...]`` to inject headers transparently
-        for matching URLs and ``"credential_placeholders": [...]``
-        to expose opaque placeholder env vars that are replaced with
-        the real secret on the wire. When omitted, network access
-        is disabled (current default). Preserved across ``reset()``
-        and ``from_snapshot()`` — placeholder env vars are
-        regenerated on each rebuild.
+**Parameters:**
 
-Example::
+- **`username`** — Custom username (default ``"user"``).
+- **`hostname`** — Custom hostname (default ``"bashkit"``).
+- **`cwd`** — Initial working directory for the shell. Sets the starting directory directly instead of running a leading ``cd``.
+- **`env`** — Initial environment variables applied before execution, so scripts see them without an ``export`` prelude.
+- **`max_commands`** — Limit total commands executed.
+- **`max_loop_iterations`** — Limit iterations per loop.
+- **`max_memory`** — Memory limit in bytes for the VFS.
+- **`timeout_seconds`** — Abort execution after this duration.
+- **`python`** — Enable embedded Python (``python3`` builtin).
+- **`sqlite`** — Enable embedded SQLite (``sqlite``/``sqlite3`` builtin). Defaults to ``False``. When ``True``, the Turso-backed engine is registered and ``BASHKIT_ALLOW_INPROCESS_SQLITE=1`` is injected automatically. Default ``SqliteLimits`` apply: 4 MiB script cap, 256 MiB DB cap, 30 s wall-clock budget, resource-affecting PRAGMAs (`cache_size`, `mmap_size`, …) rejected, ``ATTACH``/``DETACH`` rejected.
+- **`external_functions`** — Function names callable from Python code.
+- **`external_handler`** — Async callback for external function calls. The callback must not call back into the same ``Bash`` instance via live methods like ``read_file()``, ``fs()``, or ``execute()``; those re-entrant calls are rejected.
+- **`files`** — Dict mapping VFS paths to file contents or lazy callables.
+- **`mounts`** — List of real host directory mount configs.
+- **`allowed_mount_paths`** — Host path prefixes allowed for real filesystem mounts. Required when mounting sensitive host locations such as paths under a user home directory.
+- **`readonly_filesystem`** — Deny all filesystem mutations after configured files and mounts are applied.
+- **`custom_builtins`** — Constructor-time Python callbacks exposed as bash builtins. Each callback receives a ``BuiltinContext`` with raw ``argv`` tokens, optional pipeline ``stdin``, and a live ``fs`` handle to the virtual filesystem, and must return a stdout string, a ``BuiltinResult``, or await either. Async callbacks run on the caller's active asyncio loop for ``await execute()`` and on a private loop for ``execute_sync()``.
+- **`network`** — Optional outbound HTTP / network configuration. Pass ``{"allow": [...]}`` for an explicit allowlist or ``{"allow_all": True}`` to allow every URL (mirrors ``NetworkAllowlist::allow_all()`` in the Rust core). Set ``"block_private_ips": False`` to relax the SSRF guard. Add ``"credentials": [...]`` to inject headers transparently for matching URLs and ``"credential_placeholders": [...]`` to expose opaque placeholder env vars that are replaced with the real secret on the wire. When omitted, network access is disabled (current default). Preserved across ``reset()`` and ``from_snapshot()`` — placeholder env vars are regenerated on each rebuild.
 
-    >>> bash = Bash(
-    ...     timeout_seconds=30,
-    ...     files={"/input.txt": "some data"},
-    ...     custom_builtins={"ping": lambda ctx: "pong\n"},
-    ...     network={
-    ...         "allow": ["https://api.github.com"],
-    ...         "credentials": [
-    ...             {
-    ...                 "pattern": "https://api.github.com",
-    ...                 "kind": "bearer",
-    ...                 "token": "ghp_xxx",
-    ...             }
-    ...         ],
-    ...     },
-    ... )
+Example:
+
+```python
+>>> bash = Bash(
+...     timeout_seconds=30,
+...     files={"/input.txt": "some data"},
+...     custom_builtins={"ping": lambda ctx: "pong\n"},
+...     network={
+...         "allow": ["https://api.github.com"],
+...         "credentials": [
+...             {
+...                 "pattern": "https://api.github.com",
+...                 "kind": "bearer",
+...                 "token": "ghp_xxx",
+...             }
+...         ],
+...     },
+... )
+```
 
 ### `execute`
 
@@ -113,24 +91,25 @@ Bash.execute(commands: str, on_output: OutputHandler | None = None) -> ExecResul
 
 Execute bash commands asynchronously.
 
-Args:
-    commands: Bash script to run (like ``bash -c "commands"``).
-    on_output: Optional callback receiving chunked ``(stdout, stderr)``
-        pairs during execution. Must be synchronous.
+**Parameters:**
+
+- **`commands`** — Bash script to run (like ``bash -c "commands"``).
+- **`on_output`** — Optional callback receiving chunked ``(stdout, stderr)`` pairs during execution. Must be synchronous.
 
 Async ``custom_builtins`` callbacks run on the caller's active asyncio
 loop.
 
-Returns:
-    ExecResult with stdout, stderr, exit_code.
+**Returns:** ExecResult with stdout, stderr, exit_code.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> result = await bash.execute("echo hello && echo world")
-    >>> print(result.stdout)
-    hello
-    world
+```python
+>>> bash = Bash()
+>>> result = await bash.execute("echo hello && echo world")
+>>> print(result.stdout)
+hello
+world
+```
 
 ### `execute_sync`
 
@@ -148,12 +127,14 @@ callbacks are dispatched to a background thread with their own loop so
 that asyncio's "cannot run while another loop is running" restriction
 is not triggered.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> result = bash.execute_sync("date +%Y")
-    >>> print(result.exit_code)
-    0
+```python
+>>> bash = Bash()
+>>> result = bash.execute_sync("date +%Y")
+>>> print(result.exit_code)
+0
+```
 
 ### `execute_or_throw`
 
@@ -165,15 +146,17 @@ Execute commands asynchronously; raise ``BashError`` on non-zero exit.
 
 ``on_output`` must be synchronous.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> result = await bash.execute_or_throw("echo ok")
-    >>> # Raises BashError if the command fails:
-    >>> await bash.execute_or_throw("false")  # doctest: +SKIP
-    Traceback (most recent call last):
-        ...
-    BashError: ...
+```python
+>>> bash = Bash()
+>>> result = await bash.execute_or_throw("echo ok")
+>>> # Raises BashError if the command fails:
+>>> await bash.execute_or_throw("false")  # doctest: +SKIP
+Traceback (most recent call last):
+    ...
+BashError: ...
+```
 
 ### `execute_sync_or_throw`
 
@@ -185,12 +168,14 @@ Execute commands synchronously; raise ``BashError`` on non-zero exit.
 
 ``on_output`` must be synchronous.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> result = bash.execute_sync_or_throw("echo ok")
-    >>> print(result.stdout.strip())
-    ok
+```python
+>>> bash = Bash()
+>>> result = bash.execute_sync_or_throw("echo ok")
+>>> print(result.stdout.strip())
+ok
+```
 
 ### `cancel`
 
@@ -203,12 +188,14 @@ Cancel the currently running execution.
 Safe to call from any thread. Execution aborts at the next
 command boundary.
 
-Example::
+Example:
 
-    >>> import threading
-    >>> bash = Bash()
-    >>> threading.Timer(1.0, bash.cancel).start()
-    >>> # Long-running command will be cancelled after 1 second
+```python
+>>> import threading
+>>> bash = Bash()
+>>> threading.Timer(1.0, bash.cancel).start()
+>>> # Long-running command will be cancelled after 1 second
+```
 
 ### `clear_cancel`
 
@@ -228,14 +215,16 @@ allow that execution to continue past the cancellation point.
 Wait for the cancelled execution to finish before clearing
 (await the async call or let ``execute_sync`` return).
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> bash.cancel()
-    >>> bash.clear_cancel()
-    >>> result = bash.execute_sync("echo ok")
-    >>> result.exit_code
-    0
+```python
+>>> bash = Bash()
+>>> bash.cancel()
+>>> bash.clear_cancel()
+>>> result = bash.execute_sync("echo ok")
+>>> result.exit_code
+0
+```
 
 ### `reset`
 
@@ -249,14 +238,16 @@ Clears all VFS contents, environment variables, and shell state.
 Re-applies the original ``files``, ``mounts``, and
 ``custom_builtins`` configuration.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> bash.execute_sync("echo hi > /tmp/file.txt")
-    >>> bash.reset()
-    >>> result = bash.execute_sync("cat /tmp/file.txt")
-    >>> result.exit_code  # file is gone after reset
-    1
+```python
+>>> bash = Bash()
+>>> bash.execute_sync("echo hi > /tmp/file.txt")
+>>> bash.reset()
+>>> result = bash.execute_sync("cat /tmp/file.txt")
+>>> result.exit_code  # file is gone after reset
+1
+```
 
 ### `snapshot`
 
@@ -429,13 +420,15 @@ Return a live filesystem handle.
 Each operation acquires the interpreter lock, so the handle always
 reflects the latest state (including after ``reset()``).
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> bash.execute_sync("echo hello > /greeting.txt")
-    >>> fs = bash.fs()
-    >>> fs.read_file("/greeting.txt")
-    b'hello\n'
+```python
+>>> bash = Bash()
+>>> bash.execute_sync("echo hello > /greeting.txt")
+>>> fs = bash.fs()
+>>> fs.read_file("/greeting.txt")
+b'hello\n'
+```
 
 ### `mount`
 
@@ -445,19 +438,22 @@ Bash.mount(vfs_path: str, fs: FileSystem) -> None
 
 Mount an external filesystem at the given VFS path.
 
-Args:
-    vfs_path: Mount point inside the VFS.
-    fs: FileSystem instance to mount.
+**Parameters:**
 
-Example::
+- **`vfs_path`** — Mount point inside the VFS.
+- **`fs`** — FileSystem instance to mount.
 
-    >>> bash = Bash()
-    >>> overlay = FileSystem()
-    >>> overlay.write_file("/data.csv", b"a,b,c")
-    >>> bash.mount("/mnt/data", overlay)
-    >>> result = bash.execute_sync("cat /mnt/data/data.csv")
-    >>> print(result.stdout)
-    a,b,c
+Example:
+
+```python
+>>> bash = Bash()
+>>> overlay = FileSystem()
+>>> overlay.write_file("/data.csv", b"a,b,c")
+>>> bash.mount("/mnt/data", overlay)
+>>> result = bash.execute_sync("cat /mnt/data/data.csv")
+>>> print(result.stdout)
+a,b,c
+```
 
 ### `unmount`
 
@@ -467,12 +463,14 @@ Bash.unmount(vfs_path: str) -> None
 
 Unmount a previously mounted filesystem.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> overlay = FileSystem()
-    >>> bash.mount("/mnt/ext", overlay)
-    >>> bash.unmount("/mnt/ext")
+```python
+>>> bash = Bash()
+>>> overlay = FileSystem()
+>>> bash.mount("/mnt/ext", overlay)
+>>> bash.unmount("/mnt/ext")
+```
 
 ## BashTool
 
@@ -484,12 +482,6 @@ sandbox - no access to the real filesystem.
 
 Adds LLM-facing contract metadata (``description``, ``system_prompt``,
 ``input_schema``, ``output_schema``) on top of the core interpreter.
-
-Example:
-    >>> tool = BashTool()
-    >>> result = await tool.execute("echo 'Hello!'")
-    >>> print(result.stdout)
-    Hello!
 
 ### Fields
 
@@ -505,44 +497,34 @@ BashTool(username: str | None = None, hostname: str | None = None, cwd: str | No
 
 Create a new BashTool.
 
-Args:
-    username: Custom username (default ``"user"``).
-    hostname: Custom hostname (default ``"bashkit"``).
-    cwd: Initial working directory for the shell. Sets the starting
-        directory directly instead of running a leading ``cd``.
-    env: Initial environment variables applied before execution, so
-        scripts see them without an ``export`` prelude.
-    max_commands: Limit total commands executed.
-    max_loop_iterations: Limit iterations per loop.
-    max_memory: Memory limit in bytes for the VFS.
-    timeout_seconds: Abort execution after this duration.
-    files: Dict mapping VFS paths to file contents or lazy callables.
-    mounts: List of real host directory mount configs.
-    allowed_mount_paths: Host path prefixes allowed for real filesystem
-        mounts. Required when mounting sensitive host locations such as
-        paths under a user home directory.
-    readonly_filesystem: Deny all filesystem mutations after configured
-        files and mounts are applied.
-    custom_builtins: Constructor-time Python callbacks exposed as
-        bash builtins. Each callback receives a ``BuiltinContext``
-        (including a live ``fs`` handle to the virtual filesystem) and
-        must return a stdout string, a ``BuiltinResult``, or await
-        either. Async callbacks run on the caller's active asyncio
-        loop for ``await execute()`` and on a private loop for
-        ``execute_sync()``.
-    network: Optional outbound HTTP / network configuration. See
-        ``Bash.__init__`` for accepted keys. Preserved across
-        ``reset()`` and ``from_snapshot()``.
+**Parameters:**
 
-Example::
+- **`username`** — Custom username (default ``"user"``).
+- **`hostname`** — Custom hostname (default ``"bashkit"``).
+- **`cwd`** — Initial working directory for the shell. Sets the starting directory directly instead of running a leading ``cd``.
+- **`env`** — Initial environment variables applied before execution, so scripts see them without an ``export`` prelude.
+- **`max_commands`** — Limit total commands executed.
+- **`max_loop_iterations`** — Limit iterations per loop.
+- **`max_memory`** — Memory limit in bytes for the VFS.
+- **`timeout_seconds`** — Abort execution after this duration.
+- **`files`** — Dict mapping VFS paths to file contents or lazy callables.
+- **`mounts`** — List of real host directory mount configs.
+- **`allowed_mount_paths`** — Host path prefixes allowed for real filesystem mounts. Required when mounting sensitive host locations such as paths under a user home directory.
+- **`readonly_filesystem`** — Deny all filesystem mutations after configured files and mounts are applied.
+- **`custom_builtins`** — Constructor-time Python callbacks exposed as bash builtins. Each callback receives a ``BuiltinContext`` (including a live ``fs`` handle to the virtual filesystem) and must return a stdout string, a ``BuiltinResult``, or await either. Async callbacks run on the caller's active asyncio loop for ``await execute()`` and on a private loop for ``execute_sync()``.
+- **`network`** — Optional outbound HTTP / network configuration. See ``Bash.__init__`` for accepted keys. Preserved across ``reset()`` and ``from_snapshot()``.
 
-    >>> tool = BashTool(
-    ...     timeout_seconds=30,
-    ...     custom_builtins={"ping": lambda ctx: "pong\n"},
-    ...     network={"allow_all": True},
-    ... )
-    >>> print(tool.name)
-    bash
+Example:
+
+```python
+>>> tool = BashTool(
+...     timeout_seconds=30,
+...     custom_builtins={"ping": lambda ctx: "pong\n"},
+...     network={"allow_all": True},
+... )
+>>> print(tool.name)
+bash
+```
 
 ### `execute`
 
@@ -557,12 +539,14 @@ loop.
 
 ``on_output`` must be synchronous.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> result = await tool.execute("ls /")
-    >>> result.success
-    True
+```python
+>>> tool = BashTool()
+>>> result = await tool.execute("ls /")
+>>> result.success
+True
+```
 
 ### `execute_sync`
 
@@ -580,12 +564,14 @@ is not triggered.
 
 ``on_output`` must be synchronous.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> result = tool.execute_sync("echo 42")
-    >>> result.stdout.strip()
-    '42'
+```python
+>>> tool = BashTool()
+>>> result = tool.execute_sync("echo 42")
+>>> result.stdout.strip()
+'42'
+```
 
 ### `execute_or_throw`
 
@@ -597,12 +583,14 @@ Execute commands asynchronously; raise ``BashError`` on non-zero exit.
 
 ``on_output`` must be synchronous.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> result = await tool.execute_or_throw("echo ok")
-    >>> result.success
-    True
+```python
+>>> tool = BashTool()
+>>> result = await tool.execute_or_throw("echo ok")
+>>> result.success
+True
+```
 
 ### `execute_sync_or_throw`
 
@@ -614,12 +602,14 @@ Execute commands synchronously; raise ``BashError`` on non-zero exit.
 
 ``on_output`` must be synchronous.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> result = tool.execute_sync_or_throw("echo ok")
-    >>> result.stdout.strip()
-    'ok'
+```python
+>>> tool = BashTool()
+>>> result = tool.execute_sync_or_throw("echo ok")
+>>> result.stdout.strip()
+'ok'
+```
 
 ### `cancel`
 
@@ -631,10 +621,12 @@ Cancel the currently running execution.
 
 Safe to call from any thread.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> tool.cancel()  # no-op if nothing is running
+```python
+>>> tool = BashTool()
+>>> tool.cancel()  # no-op if nothing is running
+```
 
 ### `clear_cancel`
 
@@ -654,14 +646,16 @@ allow that execution to continue past the cancellation point.
 Wait for the cancelled execution to finish before clearing
 (await the async call or let ``execute_sync`` return).
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> tool.cancel()
-    >>> tool.clear_cancel()
-    >>> result = tool.execute_sync("echo ok")
-    >>> result.exit_code
-    0
+```python
+>>> tool = BashTool()
+>>> tool.cancel()
+>>> tool.clear_cancel()
+>>> result = tool.execute_sync("echo ok")
+>>> result.exit_code
+0
+```
 
 ### `description`
 
@@ -671,12 +665,14 @@ BashTool.description() -> str
 
 Return the tool description for LLM consumption.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> desc = tool.description()
-    >>> "bash" in desc.lower()
-    True
+```python
+>>> tool = BashTool()
+>>> desc = tool.description()
+>>> "bash" in desc.lower()
+True
+```
 
 ### `help`
 
@@ -686,12 +682,14 @@ BashTool.help() -> str
 
 Return extended help text.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> help_text = tool.help()
-    >>> len(help_text) > 0
-    True
+```python
+>>> tool = BashTool()
+>>> help_text = tool.help()
+>>> len(help_text) > 0
+True
+```
 
 ### `system_prompt`
 
@@ -703,12 +701,14 @@ Return the system prompt for LLM agents.
 
 Includes tool description, usage guidelines, and capabilities.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> prompt = tool.system_prompt()
-    >>> "sandbox" in prompt.lower() or "bash" in prompt.lower()
-    True
+```python
+>>> tool = BashTool()
+>>> prompt = tool.system_prompt()
+>>> "sandbox" in prompt.lower() or "bash" in prompt.lower()
+True
+```
 
 ### `input_schema`
 
@@ -718,13 +718,15 @@ BashTool.input_schema() -> str
 
 Return the JSON Schema for tool input.
 
-Example::
+Example:
 
-    >>> import json
-    >>> tool = BashTool()
-    >>> schema = json.loads(tool.input_schema())
-    >>> "commands" in str(schema)
-    True
+```python
+>>> import json
+>>> tool = BashTool()
+>>> schema = json.loads(tool.input_schema())
+>>> "commands" in str(schema)
+True
+```
 
 ### `output_schema`
 
@@ -734,13 +736,15 @@ BashTool.output_schema() -> str
 
 Return the JSON Schema for tool output.
 
-Example::
+Example:
 
-    >>> import json
-    >>> tool = BashTool()
-    >>> schema = json.loads(tool.output_schema())
-    >>> isinstance(schema, dict)
-    True
+```python
+>>> import json
+>>> tool = BashTool()
+>>> schema = json.loads(tool.output_schema())
+>>> isinstance(schema, dict)
+True
+```
 
 ### `reset`
 
@@ -753,14 +757,16 @@ Reset the tool to initial state.
 Clears VFS, environment, and shell state while re-applying
 constructor-time ``custom_builtins``.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> tool.execute_sync("touch /tmp/file")
-    >>> tool.reset()
-    >>> result = tool.execute_sync("test -f /tmp/file")
-    >>> result.exit_code  # file is gone
-    1
+```python
+>>> tool = BashTool()
+>>> tool.execute_sync("touch /tmp/file")
+>>> tool.reset()
+>>> result = tool.execute_sync("test -f /tmp/file")
+>>> result.exit_code  # file is gone
+1
+```
 
 ### `snapshot`
 
@@ -933,13 +939,15 @@ Return a live filesystem handle.
 Each operation acquires the interpreter lock, so the handle always
 reflects the latest state (including after ``reset()``).
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> tool.execute_sync("echo data > /out.txt")
-    >>> fs = tool.fs()
-    >>> fs.read_file("/out.txt")
-    b'data\n'
+```python
+>>> tool = BashTool()
+>>> tool.execute_sync("echo data > /out.txt")
+>>> fs = tool.fs()
+>>> fs.read_file("/out.txt")
+b'data\n'
+```
 
 ### `mount`
 
@@ -949,15 +957,17 @@ BashTool.mount(vfs_path: str, fs: FileSystem) -> None
 
 Mount an external filesystem at the given VFS path.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> ext = FileSystem()
-    >>> ext.write_file("/info.txt", b"external")
-    >>> tool.mount("/mnt/ext", ext)
-    >>> result = tool.execute_sync("cat /mnt/ext/info.txt")
-    >>> result.stdout.strip()
-    'external'
+```python
+>>> tool = BashTool()
+>>> ext = FileSystem()
+>>> ext.write_file("/info.txt", b"external")
+>>> tool.mount("/mnt/ext", ext)
+>>> result = tool.execute_sync("cat /mnt/ext/info.txt")
+>>> result.stdout.strip()
+'external'
+```
 
 ### `unmount`
 
@@ -967,12 +977,14 @@ BashTool.unmount(vfs_path: str) -> None
 
 Unmount a previously mounted filesystem.
 
-Example::
+Example:
 
-    >>> tool = BashTool()
-    >>> ext = FileSystem()
-    >>> tool.mount("/mnt/ext", ext)
-    >>> tool.unmount("/mnt/ext")
+```python
+>>> tool = BashTool()
+>>> ext = FileSystem()
+>>> tool.mount("/mnt/ext", ext)
+>>> tool.unmount("/mnt/ext")
+```
 
 ## ScriptedTool
 
@@ -980,15 +992,6 @@ Compose Python callbacks as bash builtins for multi-tool orchestration.
 
 Each registered tool becomes a bash builtin command. An LLM (or user)
 writes a single bash script that pipes, loops, and branches across tools.
-
-Example:
-    >>> tool = ScriptedTool("api")
-    >>> tool.add_tool("greet", "Greet user",
-    ...     callback=lambda p, s=None: f"hello {p.get('name', 'world')}\n",
-    ...     schema={"type": "object", "properties": {"name": {"type": "string"}}})
-    >>> result = tool.execute_sync("greet --name Alice")
-    >>> print(result.stdout.strip())
-    hello Alice
 
 ### Fields
 
@@ -1004,17 +1007,20 @@ ScriptedTool(name: str, short_description: str | None = None, max_commands: int 
 
 Create a new ScriptedTool.
 
-Args:
-    name: Tool name (used as the LLM tool identifier).
-    short_description: One-line description of the tool.
-    max_commands: Limit total commands per execution.
-    max_loop_iterations: Limit iterations per loop.
+**Parameters:**
 
-Example::
+- **`name`** — Tool name (used as the LLM tool identifier).
+- **`short_description`** — One-line description of the tool.
+- **`max_commands`** — Limit total commands per execution.
+- **`max_loop_iterations`** — Limit iterations per loop.
 
-    >>> tool = ScriptedTool("data_pipeline", short_description="ETL tools")
-    >>> print(tool.name)
-    data_pipeline
+Example:
+
+```python
+>>> tool = ScriptedTool("data_pipeline", short_description="ETL tools")
+>>> print(tool.name)
+data_pipeline
+```
 
 ### `add_tool`
 
@@ -1024,29 +1030,29 @@ ScriptedTool.add_tool(name: str, description: str, callback: Callable[[dict[str,
 
 Register a Python callback as a bash builtin command.
 
-Args:
-    name: Command name (becomes a bash builtin).
-    description: Human-readable description of the sub-tool.
-    callback: ``(params_dict, stdin_or_none) -> output_string`` or
-        an async callback that resolves to one. Async callbacks run on
-        the caller's active asyncio loop for ``await execute()`` and on
-        a private loop for ``execute_sync()``.
-    schema: Optional JSON Schema for the tool's parameters.
+**Parameters:**
 
-Example::
+- **`name`** — Command name (becomes a bash builtin).
+- **`description`** — Human-readable description of the sub-tool.
+- **`callback`** — ``(params_dict, stdin_or_none) -> output_string`` or an async callback that resolves to one. Async callbacks run on the caller's active asyncio loop for ``await execute()`` and on a private loop for ``execute_sync()``.
+- **`schema`** — Optional JSON Schema for the tool's parameters.
 
-    >>> tool = ScriptedTool("math")
-    >>> tool.add_tool(
-    ...     "add", "Add two numbers",
-    ...     callback=lambda p, s=None: str(int(p["a"]) + int(p["b"])) + "\n",
-    ...     schema={
-    ...         "type": "object",
-    ...         "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
-    ...     },
-    ... )
-    >>> result = tool.execute_sync("add --a 2 --b 3")
-    >>> result.stdout.strip()
-    '5'
+Example:
+
+```python
+>>> tool = ScriptedTool("math")
+>>> tool.add_tool(
+...     "add", "Add two numbers",
+...     callback=lambda p, s=None: str(int(p["a"]) + int(p["b"])) + "\n",
+...     schema={
+...         "type": "object",
+...         "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+...     },
+... )
+>>> result = tool.execute_sync("add --a 2 --b 3")
+>>> result.stdout.strip()
+'5'
+```
 
 ### `env`
 
@@ -1056,13 +1062,15 @@ ScriptedTool.env(key: str, value: str) -> None
 
 Set an environment variable for subsequent executions.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("demo")
-    >>> tool.env("API_KEY", "secret-123")
-    >>> result = tool.execute_sync("echo $API_KEY")
-    >>> result.stdout.strip()
-    'secret-123'
+```python
+>>> tool = ScriptedTool("demo")
+>>> tool.env("API_KEY", "secret-123")
+>>> result = tool.execute_sync("echo $API_KEY")
+>>> result.stdout.strip()
+'secret-123'
+```
 
 ### `execute`
 
@@ -1074,13 +1082,15 @@ Execute commands asynchronously.
 
 Async callbacks run on the caller's active asyncio loop.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("demo")
-    >>> tool.add_tool("hi", "Say hi", callback=lambda p, s=None: "hi\n")
-    >>> result = await tool.execute("hi")
-    >>> result.stdout.strip()
-    'hi'
+```python
+>>> tool = ScriptedTool("demo")
+>>> tool.add_tool("hi", "Say hi", callback=lambda p, s=None: "hi\n")
+>>> result = await tool.execute("hi")
+>>> result.stdout.strip()
+'hi'
+```
 
 ### `execute_sync`
 
@@ -1092,13 +1102,15 @@ Execute commands synchronously (blocking).
 
 Async callbacks run on a private loop here.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("demo")
-    >>> tool.add_tool("ping", "Ping", callback=lambda p, s=None: "pong\n")
-    >>> result = tool.execute_sync("ping")
-    >>> result.stdout.strip()
-    'pong'
+```python
+>>> tool = ScriptedTool("demo")
+>>> tool.add_tool("ping", "Ping", callback=lambda p, s=None: "pong\n")
+>>> result = tool.execute_sync("ping")
+>>> result.stdout.strip()
+'pong'
+```
 
 ### `tool_count`
 
@@ -1108,14 +1120,16 @@ ScriptedTool.tool_count() -> int
 
 Return the number of registered sub-tools.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("demo")
-    >>> tool.tool_count()
-    0
-    >>> tool.add_tool("a", "A", callback=lambda p, s=None: "")
-    >>> tool.tool_count()
-    1
+```python
+>>> tool = ScriptedTool("demo")
+>>> tool.tool_count()
+0
+>>> tool.add_tool("a", "A", callback=lambda p, s=None: "")
+>>> tool.tool_count()
+1
+```
 
 ### `description`
 
@@ -1125,12 +1139,14 @@ ScriptedTool.description() -> str
 
 Return the tool description for LLM consumption.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("api", short_description="API tools")
-    >>> desc = tool.description()
-    >>> len(desc) > 0
-    True
+```python
+>>> tool = ScriptedTool("api", short_description="API tools")
+>>> desc = tool.description()
+>>> len(desc) > 0
+True
+```
 
 ### `help`
 
@@ -1140,12 +1156,14 @@ ScriptedTool.help() -> str
 
 Return extended help text listing all registered sub-tools.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("api")
-    >>> tool.add_tool("fetch", "Fetch URL", callback=lambda p, s=None: "")
-    >>> "fetch" in tool.help()
-    True
+```python
+>>> tool = ScriptedTool("api")
+>>> tool.add_tool("fetch", "Fetch URL", callback=lambda p, s=None: "")
+>>> "fetch" in tool.help()
+True
+```
 
 ### `system_prompt`
 
@@ -1157,13 +1175,15 @@ Return the system prompt for LLM agents.
 
 Includes descriptions of all registered sub-tools and usage examples.
 
-Example::
+Example:
 
-    >>> tool = ScriptedTool("api")
-    >>> tool.add_tool("fetch", "Fetch URL", callback=lambda p, s=None: "")
-    >>> prompt = tool.system_prompt()
-    >>> "fetch" in prompt.lower()
-    True
+```python
+>>> tool = ScriptedTool("api")
+>>> tool.add_tool("fetch", "Fetch URL", callback=lambda p, s=None: "")
+>>> prompt = tool.system_prompt()
+>>> "fetch" in prompt.lower()
+True
+```
 
 ### `input_schema`
 
@@ -1173,13 +1193,15 @@ ScriptedTool.input_schema() -> str
 
 Return the JSON Schema for tool input.
 
-Example::
+Example:
 
-    >>> import json
-    >>> tool = ScriptedTool("api")
-    >>> schema = json.loads(tool.input_schema())
-    >>> "commands" in str(schema)
-    True
+```python
+>>> import json
+>>> tool = ScriptedTool("api")
+>>> schema = json.loads(tool.input_schema())
+>>> "commands" in str(schema)
+True
+```
 
 ### `output_schema`
 
@@ -1189,13 +1211,15 @@ ScriptedTool.output_schema() -> str
 
 Return the JSON Schema for tool output.
 
-Example::
+Example:
 
-    >>> import json
-    >>> tool = ScriptedTool("api")
-    >>> schema = json.loads(tool.output_schema())
-    >>> isinstance(schema, dict)
-    True
+```python
+>>> import json
+>>> tool = ScriptedTool("api")
+>>> schema = json.loads(tool.output_schema())
+>>> isinstance(schema, dict)
+True
+```
 
 ## FileSystem
 
@@ -1203,18 +1227,23 @@ Direct access to Bashkit's virtual filesystem or a standalone mountable FS.
 
 Two ways to create:
 
-1. In-memory (default) — starts empty::
+1. In-memory (default) — starts empty:
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/hello.txt", b"hi")
-    >>> fs.read_file("/hello.txt")
-    b'hi'
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/hello.txt", b"hi")
+>>> fs.read_file("/hello.txt")
+b'hi'
+```
 
-2. Backed by a real host directory::
 
-    >>> fs = FileSystem.real("/tmp/data", writable=False)
-    >>> fs.exists("/some-host-file.txt")
-    True
+2. Backed by a real host directory:
+
+```python
+>>> fs = FileSystem.real("/tmp/data", writable=False)
+>>> fs.exists("/some-host-file.txt")
+True
+```
 
 ### Constructor
 
@@ -1224,11 +1253,13 @@ FileSystem() -> None
 
 Create a new empty in-memory filesystem.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.exists("/anything")
-    False
+```python
+>>> fs = FileSystem()
+>>> fs.exists("/anything")
+False
+```
 
 ### `real`
 
@@ -1238,14 +1269,17 @@ FileSystem.real(host_path: str, writable: bool = False) -> FileSystem
 
 Create a filesystem backed by a real host directory.
 
-Args:
-    host_path: Absolute path on the host to expose.
-    writable: Allow write operations (default read-only).
+**Parameters:**
 
-Example::
+- **`host_path`** — Absolute path on the host to expose.
+- **`writable`** — Allow write operations (default read-only).
 
-    >>> fs = FileSystem.real("/tmp/project", writable=True)
-    >>> fs.write_file("/tmp/project/out.txt", b"data")
+Example:
+
+```python
+>>> fs = FileSystem.real("/tmp/project", writable=True)
+>>> fs.write_file("/tmp/project/out.txt", b"data")
+```
 
 ### `from_capsule`
 
@@ -1273,18 +1307,20 @@ FileSystem.read_file(path: str) -> bytes
 
 Read the entire contents of a file.
 
-Args:
-    path: Absolute path in the filesystem.
+**Parameters:**
 
-Returns:
-    File contents as bytes.
+- **`path`** — Absolute path in the filesystem.
 
-Example::
+**Returns:** File contents as bytes.
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/demo.txt", b"hello")
-    >>> fs.read_file("/demo.txt")
-    b'hello'
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/demo.txt", b"hello")
+>>> fs.read_file("/demo.txt")
+b'hello'
+```
 
 ### `write_file`
 
@@ -1294,14 +1330,17 @@ FileSystem.write_file(path: str, content: bytes) -> None
 
 Write content to a file, creating or overwriting it.
 
-Args:
-    path: Absolute path in the filesystem.
-    content: Data to write.
+**Parameters:**
 
-Example::
+- **`path`** — Absolute path in the filesystem.
+- **`content`** — Data to write.
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/output.txt", b"result data")
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/output.txt", b"result data")
+```
 
 ### `append_file`
 
@@ -1311,17 +1350,20 @@ FileSystem.append_file(path: str, content: bytes) -> None
 
 Append content to an existing file.
 
-Args:
-    path: Absolute path in the filesystem.
-    content: Data to append.
+**Parameters:**
 
-Example::
+- **`path`** — Absolute path in the filesystem.
+- **`content`** — Data to append.
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/log.txt", b"line1\n")
-    >>> fs.append_file("/log.txt", b"line2\n")
-    >>> fs.read_file("/log.txt")
-    b'line1\nline2\n'
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/log.txt", b"line1\n")
+>>> fs.append_file("/log.txt", b"line2\n")
+>>> fs.read_file("/log.txt")
+b'line1\nline2\n'
+```
 
 ### `mkdir`
 
@@ -1331,16 +1373,19 @@ FileSystem.mkdir(path: str, recursive: bool = False) -> None
 
 Create a directory.
 
-Args:
-    path: Absolute path for the new directory.
-    recursive: Create parent directories as needed.
+**Parameters:**
 
-Example::
+- **`path`** — Absolute path for the new directory.
+- **`recursive`** — Create parent directories as needed.
 
-    >>> fs = FileSystem()
-    >>> fs.mkdir("/a/b/c", recursive=True)
-    >>> fs.exists("/a/b/c")
-    True
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.mkdir("/a/b/c", recursive=True)
+>>> fs.exists("/a/b/c")
+True
+```
 
 ### `remove`
 
@@ -1350,17 +1395,20 @@ FileSystem.remove(path: str, recursive: bool = False) -> None
 
 Remove a file or directory.
 
-Args:
-    path: Absolute path to remove.
-    recursive: Remove directory contents recursively.
+**Parameters:**
 
-Example::
+- **`path`** — Absolute path to remove.
+- **`recursive`** — Remove directory contents recursively.
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/tmp.txt", b"x")
-    >>> fs.remove("/tmp.txt")
-    >>> fs.exists("/tmp.txt")
-    False
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/tmp.txt", b"x")
+>>> fs.remove("/tmp.txt")
+>>> fs.exists("/tmp.txt")
+False
+```
 
 ### `stat`
 
@@ -1370,18 +1418,19 @@ FileSystem.stat(path: str) -> dict[str, Any]
 
 Get file metadata.
 
-Returns:
-    Dict with ``file_type``, ``size``, ``mode``, ``modified``, ``created``.
+**Returns:** Dict with ``file_type``, ``size``, ``mode``, ``modified``, ``created``.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/f.txt", b"data")
-    >>> info = fs.stat("/f.txt")
-    >>> info["file_type"]
-    'file'
-    >>> info["size"]
-    4
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/f.txt", b"data")
+>>> info = fs.stat("/f.txt")
+>>> info["file_type"]
+'file'
+>>> info["size"]
+4
+```
 
 ### `read_dir`
 
@@ -1391,16 +1440,17 @@ FileSystem.read_dir(path: str) -> list[dict[str, Any]]
 
 List directory entries.
 
-Returns:
-    List of dicts, each with ``name`` and ``metadata`` keys.
+**Returns:** List of dicts, each with ``name`` and ``metadata`` keys.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/dir/a.txt", b"a")
-    >>> entries = fs.read_dir("/dir")
-    >>> entries[0]["name"]
-    'a.txt'
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/dir/a.txt", b"a")
+>>> entries = fs.read_dir("/dir")
+>>> entries[0]["name"]
+'a.txt'
+```
 
 ### `exists`
 
@@ -1410,14 +1460,16 @@ FileSystem.exists(path: str) -> bool
 
 Check whether a path exists.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.exists("/nope")
-    False
-    >>> fs.write_file("/yes.txt", b"")
-    >>> fs.exists("/yes.txt")
-    True
+```python
+>>> fs = FileSystem()
+>>> fs.exists("/nope")
+False
+>>> fs.write_file("/yes.txt", b"")
+>>> fs.exists("/yes.txt")
+True
+```
 
 ### `rename`
 
@@ -1427,13 +1479,15 @@ FileSystem.rename(from_path: str, to_path: str) -> None
 
 Rename (move) a file or directory.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/old.txt", b"data")
-    >>> fs.rename("/old.txt", "/new.txt")
-    >>> fs.exists("/new.txt")
-    True
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/old.txt", b"data")
+>>> fs.rename("/old.txt", "/new.txt")
+>>> fs.exists("/new.txt")
+True
+```
 
 ### `copy`
 
@@ -1443,13 +1497,15 @@ FileSystem.copy(from_path: str, to_path: str) -> None
 
 Copy a file.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/src.txt", b"data")
-    >>> fs.copy("/src.txt", "/dst.txt")
-    >>> fs.read_file("/dst.txt")
-    b'data'
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/src.txt", b"data")
+>>> fs.copy("/src.txt", "/dst.txt")
+>>> fs.read_file("/dst.txt")
+b'data'
+```
 
 ### `symlink`
 
@@ -1459,17 +1515,20 @@ FileSystem.symlink(target: str, link: str) -> None
 
 Create a symbolic link.
 
-Args:
-    target: Path the symlink points to.
-    link: Path of the symlink itself.
+**Parameters:**
 
-Example::
+- **`target`** — Path the symlink points to.
+- **`link`** — Path of the symlink itself.
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/real.txt", b"data")
-    >>> fs.symlink("/real.txt", "/link.txt")
-    >>> fs.read_file("/link.txt")
-    b'data'
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/real.txt", b"data")
+>>> fs.symlink("/real.txt", "/link.txt")
+>>> fs.read_file("/link.txt")
+b'data'
+```
 
 ### `chmod`
 
@@ -1479,15 +1538,18 @@ FileSystem.chmod(path: str, mode: int) -> None
 
 Change file permissions.
 
-Args:
-    path: Absolute path.
-    mode: Octal permission bits (e.g. ``0o755``).
+**Parameters:**
 
-Example::
+- **`path`** — Absolute path.
+- **`mode`** — Octal permission bits (e.g. ``0o755``).
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/script.sh", b"#!/bin/bash")
-    >>> fs.chmod("/script.sh", 0o755)
+Example:
+
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/script.sh", b"#!/bin/bash")
+>>> fs.chmod("/script.sh", 0o755)
+```
 
 ### `read_link`
 
@@ -1497,28 +1559,32 @@ FileSystem.read_link(path: str) -> str
 
 Read the target of a symbolic link.
 
-Example::
+Example:
 
-    >>> fs = FileSystem()
-    >>> fs.write_file("/target.txt", b"data")
-    >>> fs.symlink("/target.txt", "/link.txt")
-    >>> fs.read_link("/link.txt")
-    '/target.txt'
+```python
+>>> fs = FileSystem()
+>>> fs.write_file("/target.txt", b"data")
+>>> fs.symlink("/target.txt", "/link.txt")
+>>> fs.read_link("/link.txt")
+'/target.txt'
+```
 
 ## ExecResult
 
 Result from executing bash commands.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> result = bash.execute_sync("echo hello")
-    >>> result.success
-    True
-    >>> result.stdout
-    'hello\n'
-    >>> result.exit_code
-    0
+```python
+>>> bash = Bash()
+>>> result = bash.execute_sync("echo hello")
+>>> result.success
+True
+>>> result.stdout
+'hello\n'
+>>> result.exit_code
+0
+```
 
 ### Fields
 
@@ -1536,19 +1602,19 @@ ExecResult.to_dict() -> dict[str, Any]
 
 Convert result to a plain dictionary.
 
-Returns:
-    Dict with ``stdout``, ``stderr``, ``exit_code``, ``error``,
-    ``stdout_truncated``, ``stderr_truncated``, ``final_env``.
+**Returns:** Dict with ``stdout``, ``stderr``, ``exit_code``, ``error``, ``stdout_truncated``, ``stderr_truncated``, ``final_env``.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> result = bash.execute_sync("echo hi")
-    >>> d = result.to_dict()
-    >>> d["stdout"]
-    'hi\n'
-    >>> d["exit_code"]
-    0
+```python
+>>> bash = Bash()
+>>> result = bash.execute_sync("echo hi")
+>>> d = result.to_dict()
+>>> d["stdout"]
+'hi\n'
+>>> d["exit_code"]
+0
+```
 
 ## ShellState
 
@@ -1578,22 +1644,6 @@ clears them before running a new command.
 
 Invocation context for a custom builtin callback.
 
-Attributes:
-    name: Builtin command name.
-    argv: Raw argv tokens after shell parsing, excluding the command name.
-    stdin: Pipeline input from the previous command, if any.
-    env: Environment variables visible to the builtin.
-    cwd: Current working directory at invocation time.
-    fs: Live handle to the interpreter's virtual filesystem. Reads see
-        files created by earlier commands and writes are visible to later
-        ones. Same API as ``Bash.fs()`` — e.g. ``ctx.fs.read_file(path)``
-        returns ``bytes``. Operates directly on the interpreter's VFS, so
-        it is safe to use from inside the callback. Ops are synchronous and,
-        while a runtime is active, may run off-thread (relatively expensive
-        per call), so batch filesystem work rather than looping over many
-        tiny ops. May be retained past the callback: a stashed handle keeps
-        the VFS (and its runtime) alive even after the ``Bash`` is dropped.
-
 ### Fields
 
 - **`name`** — `str`
@@ -1606,11 +1656,6 @@ Attributes:
 ## BuiltinResult
 
 Shell-facing result for a custom builtin callback.
-
-Attributes:
-    stdout: Text written to stdout.
-    stderr: Text written to stderr.
-    exit_code: Shell exit status.
 
 ### Fields
 
@@ -1628,14 +1673,16 @@ BuiltinResult(stdout: str = '', stderr: str = '', exit_code: int = 0) -> None
 
 Exception raised when a bash command exits with non-zero status.
 
-Example::
+Example:
 
-    >>> bash = Bash()
-    >>> try:
-    ...     bash.execute_sync_or_throw("exit 42")
-    ... except BashError as e:
-    ...     print(e.exit_code)
-    42
+```python
+>>> bash = Bash()
+>>> try:
+...     bash.execute_sync_or_throw("exit 42")
+... except BashError as e:
+...     print(e.exit_code)
+42
+```
 
 ### Fields
 
@@ -1651,14 +1698,15 @@ create_langchain_tool_spec() -> dict[str, Any]
 
 Create a LangChain-compatible tool specification.
 
-Returns:
-    Dict with name, description, and args_schema.
+**Returns:** Dict with name, description, and args_schema.
 
-Example::
+Example:
 
-    >>> spec = create_langchain_tool_spec()
-    >>> spec["name"]
-    'bash'
+```python
+>>> spec = create_langchain_tool_spec()
+>>> spec["name"]
+'bash'
+```
 
 ## get_version()
 
@@ -1668,11 +1716,13 @@ get_version() -> str
 
 Get the bashkit version string.
 
-Example::
+Example:
 
-    >>> version = get_version()
-    >>> isinstance(version, str)
-    True
+```python
+>>> version = get_version()
+>>> isinstance(version, str)
+True
+```
 
 ---
 
@@ -1702,35 +1752,24 @@ bashkit.langchain.create_bash_tool(username: str | None = None, hostname: str | 
 
 Create a LangChain-compatible Bashkit tool.
 
-Args:
-    username: Custom username for sandbox
-    hostname: Custom hostname for sandbox
-    max_commands: Max commands to execute
-    max_loop_iterations: Max loop iterations
-    timeout_seconds: Execution timeout in seconds. When set, commands
-        that exceed this duration are aborted with exit code 124.
-    files: Static VFS file mounts keyed by sandbox path.
-    mounts: Real host directory mounts exposed inside the sandbox.
-        Mounts are read-only by default; pass ``{"writable": True}``
-        on a mount config to allow writes.
-    allowed_mount_paths: Host path prefixes allowed for real filesystem
-        mounts. Required when mounting sensitive host locations such as
-        paths under a user home directory.
-    readonly_filesystem: Deny all filesystem mutations after configured
-        files and mounts are applied.
-    max_output_length: Maximum number of characters returned to the
-        LangChain agent from one bash tool call before truncation.
+**Parameters:**
 
-Returns:
-    BashkitTool instance for use with LangChain agents
+- **`username`** — Custom username for sandbox
+- **`hostname`** — Custom hostname for sandbox
+- **`max_commands`** — Max commands to execute
+- **`max_loop_iterations`** — Max loop iterations
+- **`timeout_seconds`** — Execution timeout in seconds. When set, commands that exceed this duration are aborted with exit code 124.
+- **`files`** — Static VFS file mounts keyed by sandbox path.
+- **`mounts`** — Real host directory mounts exposed inside the sandbox. Mounts are read-only by default; pass ``{"writable": True}`` on a mount config to allow writes.
+- **`allowed_mount_paths`** — Host path prefixes allowed for real filesystem mounts. Required when mounting sensitive host locations such as paths under a user home directory.
+- **`readonly_filesystem`** — Deny all filesystem mutations after configured files and mounts are applied.
+- **`max_output_length`** — Maximum number of characters returned to the LangChain agent from one bash tool call before truncation.
 
-Raises:
-    ImportError: If langchain-core is not installed
+**Returns:** BashkitTool instance for use with LangChain agents
 
-Example:
-    >>> from bashkit.langchain import create_bash_tool
-    >>> tool = create_bash_tool(timeout_seconds=30)
-    >>> result = tool.invoke({"commands": "ls -la"})
+**Raises:**
+
+- **`ImportError`** — If langchain-core is not installed
 
 ### `create_scripted_tool`
 
@@ -1740,23 +1779,15 @@ bashkit.langchain.create_scripted_tool(scripted_tool: NativeScriptedTool) -> Scr
 
 Create a LangChain-compatible tool from a configured ScriptedTool.
 
-Args:
-    scripted_tool: A ScriptedTool with registered tool callbacks
+**Parameters:**
 
-Returns:
-    ScriptedToolLangChain instance for use with LangChain agents
+- **`scripted_tool`** — A ScriptedTool with registered tool callbacks
 
-Raises:
-    ImportError: If langchain-core is not installed
+**Returns:** ScriptedToolLangChain instance for use with LangChain agents
 
-Example:
-    >>> from bashkit import ScriptedTool
-    >>> from bashkit.langchain import create_scripted_tool
-    >>>
-    >>> st = ScriptedTool("api")
-    >>> st.add_tool("get_data", "Fetch data", callback=my_fn)
-    >>> tool = create_scripted_tool(st)
-    >>> # Use with: create_react_agent(model, [tool])
+**Raises:**
+
+- **`ImportError`** — If langchain-core is not installed
 
 ## `bashkit.pydantic_ai`
 
@@ -1770,25 +1801,19 @@ bashkit.pydantic_ai.create_bash_tool(username: str | None = None, hostname: str 
 
 Create a PydanticAI Tool wrapping Bashkit.
 
-Args:
-    username: Custom username for sandbox
-    hostname: Custom hostname for sandbox
-    max_commands: Max commands to execute
-    max_loop_iterations: Max loop iterations
-    timeout_seconds: Execution timeout in seconds. When set, commands
-        that exceed this duration are aborted with exit code 124.
+**Parameters:**
 
-Returns:
-    Tool for use with ``Agent(tools=[...])``
+- **`username`** — Custom username for sandbox
+- **`hostname`** — Custom hostname for sandbox
+- **`max_commands`** — Max commands to execute
+- **`max_loop_iterations`** — Max loop iterations
+- **`timeout_seconds`** — Execution timeout in seconds. When set, commands that exceed this duration are aborted with exit code 124.
 
-Raises:
-    ImportError: If pydantic-ai is not installed
+**Returns:** Tool for use with ``Agent(tools=[...])``
 
-Example:
-    >>> from bashkit.pydantic_ai import create_bash_tool
-    >>> tool = create_bash_tool(timeout_seconds=30)
-    >>> from pydantic_ai import Agent
-    >>> agent = Agent('anthropic:claude-sonnet-4-20250514', tools=[tool])
+**Raises:**
+
+- **`ImportError`** — If pydantic-ai is not installed
 
 ## `bashkit.deepagents`
 

--- a/site/src/content/apidocs/python.md
+++ b/site/src/content/apidocs/python.md
@@ -25,7 +25,7 @@ Example (Python execution with external function handler):
     ...     external_functions=["api_request"],
     ...     external_handler=handler,
     ... )
-    >>> result = await bash.execute("python3 -c 'print(api_request(url="/data"))'")
+    >>> result = await bash.execute("python3 -c 'print(api_request())'")
 
 ### Constructor
 

--- a/site/src/content/apidocs/typescript.md
+++ b/site/src/content/apidocs/typescript.md
@@ -1027,74 +1027,100 @@ Options for creating a Bash or BashTool instance.
 
 ### Fields
 
-- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+- **`allowedMountPaths?`** — `string[]`
 
-Required for `mounts` and runtime `mount()` APIs. Mount targets must
-resolve under one of these prefixes; otherwise the call is rejected.
-- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+  Allowlist of host path prefixes permitted for real filesystem mounts.
 
-Each entry becomes a bash command that shares the instance's VFS — files
-created by the callback persist across `execute()` calls. Callbacks can be
-sync (`string` return) or async (`Promise<string>`); exceptions surface as
-stderr with exit code 1.
+  Required for `mounts` and runtime `mount()` APIs. Mount targets must
+  resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>`
 
-Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
-`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
-the option again after restoring.
+  Custom JS callbacks registered as bash builtins.
 
-Override precedence: shell function > POSIX special builtin > custom
-builtin > baked-in builtin > PATH.
-- **`cwd?`** — `string` Initial working directory for the shell.
+  Each entry becomes a bash command that shares the instance's VFS — files
+  created by the callback persist across `execute()` calls. Callbacks can be
+  sync (`string` return) or async (`Promise<string>`); exceptions surface as
+  stderr with exit code 1.
 
-Sets the starting `cwd` directly instead of running a leading
-`cd "${cwd}"` command, avoiding the parse/exec overhead.
-- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+  Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+  `reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+  the option again after restoring.
 
-Scripts see these immediately without an `export` prelude. Keys are
-variable names, values are their string values.
-- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+  Override precedence: shell function > POSIX special builtin > custom
+  builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string`
 
-These function names become available as Python builtins within
-the embedded interpreter. When called, they invoke the external handler.
-- **`files?`** — `Record<string, FileValue>` Files to mount in the virtual filesystem.
-Keys are absolute paths, values are content strings or lazy providers.
+  Initial working directory for the shell.
 
-String values are mounted immediately. Function values are called on
-first read and the result is cached.
+  Sets the starting `cwd` directly instead of running a leading
+  `cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>`
+
+  Initial environment variables, applied before execution.
+
+  Scripts see these immediately without an `export` prelude. Keys are
+  variable names, values are their string values.
+- **`externalFunctions?`** — `string[]`
+
+  Names of external functions callable from embedded Python code.
+
+  These function names become available as Python builtins within
+  the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, FileValue>`
+
+  Files to mount in the virtual filesystem.
+  Keys are absolute paths, values are content strings or lazy providers.
+
+  String values are mounted immediately. Function values are called on
+  first read and the result is cached.
 - **`hostname?`** — `string`
 - **`maxCommands?`** — `number`
-- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+- **`maxInputBytes?`** — `number`
 
-Async execute validates this before entering the per-instance queue so
-oversized calls cannot wait while retaining large command strings.
+  Maximum script input size in UTF-8 bytes.
+
+  Async execute validates this before entering the per-instance queue so
+  oversized calls cannot wait while retaining large command strings.
 - **`maxLoopIterations?`** — `number`
-- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+- **`maxMemory?`** — `number`
 
-Caps the total byte budget for variable storage and function bodies.
-Prevents OOM from untrusted input such as exponential string doubling.
+  Maximum interpreter memory in bytes (variables, arrays, functions).
+
+  Caps the total byte budget for variable storage and function bodies.
+  Prevents OOM from untrusted input such as exponential string doubling.
 - **`maxTotalLoopIterations?`** — `number`
-- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
-- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
-restricted to the configured allowlist, with optional transparent
-credential injection. Omitted = network disabled (no `curl`/`wget`).
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]`
 
-Must specify either `allow` (list of URL patterns) or `allowAll: true`,
-not both. `blockPrivateIps` defaults to `true`.
-- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+  Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions`
 
-When true, bash scripts can use `python -c '...'` or `python3 script.py`
-to run Python code within the sandbox.
-- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+  Outbound network configuration. When set, enables `curl`/`wget`
+  restricted to the configured allowlist, with optional transparent
+  credential injection. Omitted = network disabled (no `curl`/`wget`).
 
-Backed by Turso. When `true`, the binding both registers the builtin
-and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
-satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
-script cap, 256 MiB DB cap, 30 s wall-clock budget,
-resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
-- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+  Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+  not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean`
 
-When set, commands that exceed this duration are aborted with
-exit code 124 (matching the bash `timeout` convention).
+  Enable embedded Python execution (`python`/`python3` builtins).
+
+  When true, bash scripts can use `python -c '...'` or `python3 script.py`
+  to run Python code within the sandbox.
+- **`sqlite?`** — `boolean`
+
+  Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+  Backed by Turso. When `true`, the binding both registers the builtin
+  and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+  satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+  script cap, 256 MiB DB cap, 30 s wall-clock budget,
+  resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number`
+
+  Execution timeout in milliseconds.
+
+  When set, commands that exceed this duration are aborted with
+  exit code 124 (matching the bash `timeout` convention).
 - **`username?`** — `string`
 
 ## BuiltinContext
@@ -1108,15 +1134,27 @@ virtual filesystem.
 
 ### Fields
 
-- **`argv`** — `string[]` Arguments (not including the command name).
-- **`cwd`** — `string` Current working directory.
-- **`env`** — `Record<string, string>` Environment variables visible at the call site.
-- **`fs`** — `FileSystem` Live handle to the interpreter's virtual filesystem — the same VFS the
-executing script sees. Reads observe earlier script writes and writes
-are visible to subsequent commands. Inherits mounts and read-only
-configuration.
-- **`name`** — `string` The command name as invoked.
-- **`stdin`** — `null | string` Piped input, or `null` if there is no pipe.
+- **`argv`** — `string[]`
+
+  Arguments (not including the command name).
+- **`cwd`** — `string`
+
+  Current working directory.
+- **`env`** — `Record<string, string>`
+
+  Environment variables visible at the call site.
+- **`fs`** — `FileSystem`
+
+  Live handle to the interpreter's virtual filesystem — the same VFS the
+  executing script sees. Reads observe earlier script writes and writes
+  are visible to subsequent commands. Inherits mounts and read-only
+  configuration.
+- **`name`** — `string`
+
+  The command name as invoked.
+- **`stdin`** — `null | string`
+
+  Piped input, or `null` if there is no pipe.
 
 ## CredentialHeader
 
@@ -1140,18 +1178,22 @@ Result from executing bash commands.
 - **`stderrTruncated`** — `boolean`
 - **`stdout`** — `string`
 - **`stdoutTruncated`** — `boolean`
-- **`success`** — `boolean` True if exit_code is 0.
+- **`success`** — `boolean`
+
+  True if exit_code is 0.
 
 ## ExecuteOptions
 
 ### Fields
 
-- **`onOutput?`** — `OnOutput` Live chunk callback. Must be synchronous.
+- **`onOutput?`** — `OnOutput`
 
-Limitation: do not call back into the same `Bash` / `BashTool` instance
-from this handler (`execute*`, `readFile`, `fs()`, etc.). The current
-binding rejects same-instance re-entry to avoid deadlocks and runtime
-panics.
+  Live chunk callback. Must be synchronous.
+
+  Limitation: do not call back into the same `Bash` / `BashTool` instance
+  from this handler (`execute*`, `readFile`, `fs()`, etc.). The current
+  binding rejects same-instance re-entry to avoid deadlocks and runtime
+  panics.
 - **`signal?`** — `AbortSignal`
 
 ## FileSystemRealOptions
@@ -1173,12 +1215,24 @@ Scripts never see the secret — it is attached on the wire only.
 
 ### Fields
 
-- **`headers?`** — `CredentialHeader[]` Header list (for `kind: "headers"`).
-- **`kind`** — `string` One of `"bearer"`, `"header"`, `"headers"`.
-- **`name?`** — `string` Header name (for `kind: "header"`).
-- **`pattern`** — `string` URL pattern the credential applies to (e.g. `https://api.example.com/**`).
-- **`token?`** — `string` Bearer token (for `kind: "bearer"`).
-- **`value?`** — `string` Header value (for `kind: "header"`).
+- **`headers?`** — `CredentialHeader[]`
+
+  Header list (for `kind: "headers"`).
+- **`kind`** — `string`
+
+  One of `"bearer"`, `"header"`, `"headers"`.
+- **`name?`** — `string`
+
+  Header name (for `kind: "header"`).
+- **`pattern`** — `string`
+
+  URL pattern the credential applies to (e.g. `https://api.example.com/**`).
+- **`token?`** — `string`
+
+  Bearer token (for `kind: "bearer"`).
+- **`value?`** — `string`
+
+  Header value (for `kind: "header"`).
 
 ## NetworkCredentialPlaceholder
 
@@ -1188,13 +1242,27 @@ placeholder value visible to scripts; outbound requests matching
 
 ### Fields
 
-- **`env`** — `string` Environment variable that receives the placeholder value.
-- **`headers?`** — `CredentialHeader[]` Header list (for `kind: "headers"`).
-- **`kind`** — `string` One of `"bearer"`, `"header"`, `"headers"`.
-- **`name?`** — `string` Header name (for `kind: "header"`).
-- **`pattern`** — `string` URL pattern the credential applies to.
-- **`token?`** — `string` Bearer token (for `kind: "bearer"`).
-- **`value?`** — `string` Header value (for `kind: "header"`).
+- **`env`** — `string`
+
+  Environment variable that receives the placeholder value.
+- **`headers?`** — `CredentialHeader[]`
+
+  Header list (for `kind: "headers"`).
+- **`kind`** — `string`
+
+  One of `"bearer"`, `"header"`, `"headers"`.
+- **`name?`** — `string`
+
+  Header name (for `kind: "header"`).
+- **`pattern`** — `string`
+
+  URL pattern the credential applies to.
+- **`token?`** — `string`
+
+  Bearer token (for `kind: "bearer"`).
+- **`value?`** — `string`
+
+  Header value (for `kind: "header"`).
 
 ## NetworkOptions
 
@@ -1205,11 +1273,21 @@ not both. `blockPrivateIps` defaults to `true`.
 
 ### Fields
 
-- **`allow?`** — `string[]` URL patterns permitted for outbound requests.
-- **`allowAll?`** — `boolean` Allow all outbound requests (mutually exclusive with `allow`).
-- **`blockPrivateIps?`** — `boolean` Block requests resolving to private/loopback IPs (default: true).
-- **`credentialPlaceholders?`** — `NetworkCredentialPlaceholder[]` Placeholder-mode credential injection (see type docs).
-- **`credentials?`** — `NetworkCredential[]` Credentials injected transparently into matching requests.
+- **`allow?`** — `string[]`
+
+  URL patterns permitted for outbound requests.
+- **`allowAll?`** — `boolean`
+
+  Allow all outbound requests (mutually exclusive with `allow`).
+- **`blockPrivateIps?`** — `boolean`
+
+  Block requests resolving to private/loopback IPs (default: true).
+- **`credentialPlaceholders?`** — `NetworkCredentialPlaceholder[]`
+
+  Placeholder-mode credential injection (see type docs).
+- **`credentials?`** — `NetworkCredential[]`
+
+  Credentials injected transparently into matching requests.
 
 ## OutputChunk
 
@@ -1237,15 +1315,31 @@ definitions (use `snapshot()` for full state capture/restore).
 
 ### Fields
 
-- **`aliases`** — `Record<string, string>` Shell aliases.
-- **`arrays`** — `Record<string, Record<string, string>>` Indexed arrays: name → { index (as string) → value }. Sparse indices
-are preserved, hence a map rather than a dense JS array.
-- **`assocArrays`** — `Record<string, Record<string, string>>` Associative arrays: name → { key → value }.
-- **`cwd`** — `string` Current working directory.
-- **`env`** — `Record<string, string>` Environment variables.
-- **`lastExitCode`** — `number` Exit code of the last executed command.
-- **`traps`** — `Record<string, string>` Trap handlers keyed by signal/condition name.
-- **`variables`** — `Record<string, string>` Shell variables (non-exported).
+- **`aliases`** — `Record<string, string>`
+
+  Shell aliases.
+- **`arrays`** — `Record<string, Record<string, string>>`
+
+  Indexed arrays: name → { index (as string) → value }. Sparse indices
+  are preserved, hence a map rather than a dense JS array.
+- **`assocArrays`** — `Record<string, Record<string, string>>`
+
+  Associative arrays: name → { key → value }.
+- **`cwd`** — `string`
+
+  Current working directory.
+- **`env`** — `Record<string, string>`
+
+  Environment variables.
+- **`lastExitCode`** — `number`
+
+  Exit code of the last executed command.
+- **`traps`** — `Record<string, string>`
+
+  Trap handlers keyed by signal/condition name.
+- **`variables`** — `Record<string, string>`
+
+  Shell variables (non-exported).
 
 ## SnapshotOptions
 
@@ -1253,10 +1347,12 @@ are preserved, hence a map rather than a dense JS array.
 
 - **`excludeFilesystem?`** — `boolean`
 - **`excludeFunctions?`** — `boolean`
-- **`hmacKey?`** — `Uint8Array<ArrayBufferLike>` Secret key used to authenticate snapshot bytes with HMAC-SHA256.
-Required for BashTool snapshots because tool snapshots may cross tenant
-or network trust boundaries. Recommended for any snapshot accepted from
-users, shared storage, or remote callers.
+- **`hmacKey?`** — `Uint8Array<ArrayBufferLike>`
+
+  Secret key used to authenticate snapshot bytes with HMAC-SHA256.
+  Required for BashTool snapshots because tool snapshots may cross tenant
+  or network trust boundaries. Recommended for any snapshot accepted from
+  users, shared storage, or remote callers.
 
 ## BuiltinCallback
 
@@ -1422,18 +1518,26 @@ Return value of `bashTool()`.
 
 ### Fields
 
-- **`bash`** — `BashTool` The underlying BashTool instance for direct access.
-- **`handler`** — `(toolUse: ToolUseBlock, options: HandlerOptions) => Promise<ToolResult>` Handler that executes a tool_use block and returns a tool_result.
+- **`bash`** — `BashTool`
 
-Pass an AbortSignal via the options parameter to cancel execution
-when the framework aborts the tool call:
+  The underlying BashTool instance for direct access.
+- **`handler`** — `(toolUse: ToolUseBlock, options: HandlerOptions) => Promise<ToolResult>`
 
-```typescript
-const controller = new AbortController();
-const result = await bash.handler(block, { signal: controller.signal });
-```
-- **`system`** — `string` System prompt describing bash capabilities and constraints.
-- **`tools`** — `AnthropicTool[]` Tool definitions for Anthropic's messages.create() API.
+  Handler that executes a tool_use block and returns a tool_result.
+
+  Pass an AbortSignal via the options parameter to cancel execution
+  when the framework aborts the tool call:
+
+  ```typescript
+  const controller = new AbortController();
+  const result = await bash.handler(block, { signal: controller.signal });
+  ```
+- **`system`** — `string`
+
+  System prompt describing bash capabilities and constraints.
+- **`tools`** — `AnthropicTool[]`
+
+  Tool definitions for Anthropic's messages.create() API.
 
 ### BashToolOptions
 
@@ -1441,85 +1545,115 @@ Options for configuring the bash tool adapter.
 
 ### Fields
 
-- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+- **`allowedMountPaths?`** — `string[]`
 
-Required for `mounts` and runtime `mount()` APIs. Mount targets must
-resolve under one of these prefixes; otherwise the call is rejected.
-- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+  Allowlist of host path prefixes permitted for real filesystem mounts.
 
-Each entry becomes a bash command that shares the instance's VFS — files
-created by the callback persist across `execute()` calls. Callbacks can be
-sync (`string` return) or async (`Promise<string>`); exceptions surface as
-stderr with exit code 1.
+  Required for `mounts` and runtime `mount()` APIs. Mount targets must
+  resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>`
 
-Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
-`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
-the option again after restoring.
+  Custom JS callbacks registered as bash builtins.
 
-Override precedence: shell function > POSIX special builtin > custom
-builtin > baked-in builtin > PATH.
-- **`cwd?`** — `string` Initial working directory for the shell.
+  Each entry becomes a bash command that shares the instance's VFS — files
+  created by the callback persist across `execute()` calls. Callbacks can be
+  sync (`string` return) or async (`Promise<string>`); exceptions surface as
+  stderr with exit code 1.
 
-Sets the starting `cwd` directly instead of running a leading
-`cd "${cwd}"` command, avoiding the parse/exec overhead.
-- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+  Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+  `reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+  the option again after restoring.
 
-Scripts see these immediately without an `export` prelude. Keys are
-variable names, values are their string values.
-- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+  Override precedence: shell function > POSIX special builtin > custom
+  builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string`
 
-These function names become available as Python builtins within
-the embedded interpreter. When called, they invoke the external handler.
-- **`files?`** — `Record<string, string>` Pre-populate VFS files. Keys are absolute paths, values are file contents.
+  Initial working directory for the shell.
+
+  Sets the starting `cwd` directly instead of running a leading
+  `cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>`
+
+  Initial environment variables, applied before execution.
+
+  Scripts see these immediately without an `export` prelude. Keys are
+  variable names, values are their string values.
+- **`externalFunctions?`** — `string[]`
+
+  Names of external functions callable from embedded Python code.
+
+  These function names become available as Python builtins within
+  the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, string>`
+
+  Pre-populate VFS files. Keys are absolute paths, values are file contents.
 - **`hostname?`** — `string`
 - **`maxCommands?`** — `number`
-- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+- **`maxInputBytes?`** — `number`
 
-Async execute validates this before entering the per-instance queue so
-oversized calls cannot wait while retaining large command strings.
+  Maximum script input size in UTF-8 bytes.
+
+  Async execute validates this before entering the per-instance queue so
+  oversized calls cannot wait while retaining large command strings.
 - **`maxLoopIterations?`** — `number`
-- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+- **`maxMemory?`** — `number`
 
-Caps the total byte budget for variable storage and function bodies.
-Prevents OOM from untrusted input such as exponential string doubling.
-- **`maxOutputLength?`** — `number` Maximum output length in characters (default: 100000).
+  Maximum interpreter memory in bytes (variables, arrays, functions).
 
-Output exceeding this limit is truncated with a `[truncated]` marker.
-Prevents context window flooding when scripts produce large output.
+  Caps the total byte budget for variable storage and function bodies.
+  Prevents OOM from untrusted input such as exponential string doubling.
+- **`maxOutputLength?`** — `number`
+
+  Maximum output length in characters (default: 100000).
+
+  Output exceeding this limit is truncated with a `[truncated]` marker.
+  Prevents context window flooding when scripts produce large output.
 - **`maxTotalLoopIterations?`** — `number`
-- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
-- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
-restricted to the configured allowlist, with optional transparent
-credential injection. Omitted = network disabled (no `curl`/`wget`).
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]`
 
-Must specify either `allow` (list of URL patterns) or `allowAll: true`,
-not both. `blockPrivateIps` defaults to `true`.
-- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+  Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions`
 
-When true, bash scripts can use `python -c '...'` or `python3 script.py`
-to run Python code within the sandbox.
-- **`sanitizeOutput?`** — `boolean` Wrap tool output in XML boundary markers (default: false).
+  Outbound network configuration. When set, enables `curl`/`wget`
+  restricted to the configured allowlist, with optional transparent
+  credential injection. Omitted = network disabled (no `curl`/`wget`).
 
-When enabled, output is wrapped in `<tool_output>...</tool_output>` tags
-to help LLMs distinguish tool output data from instructions, reducing
-prompt injection risk via tool output.
+  Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+  not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean`
 
-**Security note:** This is a defense-in-depth measure. Tool output from
-untrusted sources (files, network) may contain text that attempts to
-manipulate LLM behavior. Boundary markers help but do not eliminate this risk.
-- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+  Enable embedded Python execution (`python`/`python3` builtins).
 
-Backed by Turso. When `true`, the binding both registers the builtin
-and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
-satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
-script cap, 256 MiB DB cap, 30 s wall-clock budget,
-resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
-- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+  When true, bash scripts can use `python -c '...'` or `python3 script.py`
+  to run Python code within the sandbox.
+- **`sanitizeOutput?`** — `boolean`
 
-When set, this is passed to the underlying BashTool as `timeoutMs`.
-Commands exceeding this duration are aborted with exit code 124.
-Framework-level timeouts can be propagated here to ensure bashkit
-stops execution when the framework cancels a tool call.
+  Wrap tool output in XML boundary markers (default: false).
+
+  When enabled, output is wrapped in `<tool_output>...</tool_output>` tags
+  to help LLMs distinguish tool output data from instructions, reducing
+  prompt injection risk via tool output.
+
+  **Security note:** This is a defense-in-depth measure. Tool output from
+  untrusted sources (files, network) may contain text that attempts to
+  manipulate LLM behavior. Boundary markers help but do not eliminate this risk.
+- **`sqlite?`** — `boolean`
+
+  Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+  Backed by Turso. When `true`, the binding both registers the builtin
+  and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+  satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+  script cap, 256 MiB DB cap, 30 s wall-clock budget,
+  resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number`
+
+  Execution timeout in milliseconds.
+
+  When set, this is passed to the underlying BashTool as `timeoutMs`.
+  Commands exceeding this duration are aborted with exit code 124.
+  Framework-level timeouts can be propagated here to ensure bashkit
+  stops execution when the framework cancels a tool call.
 - **`username?`** — `string`
 
 ### HandlerOptions
@@ -1528,7 +1662,9 @@ Options for handler invocation.
 
 ### Fields
 
-- **`signal?`** — `AbortSignal` AbortSignal to cancel execution when the framework aborts the tool call.
+- **`signal?`** — `AbortSignal`
+
+  AbortSignal to cancel execution when the framework aborts the tool call.
 
 ### ToolResult
 
@@ -1604,18 +1740,26 @@ Return value of `bashTool()`.
 
 ### Fields
 
-- **`bash`** — `BashTool` The underlying BashTool instance for direct access.
-- **`handler`** — `(toolCall: OpenAIToolCall, options: HandlerOptions) => Promise<ToolResult>` Handler that executes a tool_call and returns a tool message.
+- **`bash`** — `BashTool`
 
-Pass an AbortSignal via the options parameter to cancel execution
-when the framework aborts the tool call:
+  The underlying BashTool instance for direct access.
+- **`handler`** — `(toolCall: OpenAIToolCall, options: HandlerOptions) => Promise<ToolResult>`
 
-```typescript
-const controller = new AbortController();
-const result = await bash.handler(call, { signal: controller.signal });
-```
-- **`system`** — `string` System prompt describing bash capabilities and constraints.
-- **`tools`** — `OpenAITool[]` Tool definitions for OpenAI's chat.completions.create() API.
+  Handler that executes a tool_call and returns a tool message.
+
+  Pass an AbortSignal via the options parameter to cancel execution
+  when the framework aborts the tool call:
+
+  ```typescript
+  const controller = new AbortController();
+  const result = await bash.handler(call, { signal: controller.signal });
+  ```
+- **`system`** — `string`
+
+  System prompt describing bash capabilities and constraints.
+- **`tools`** — `OpenAITool[]`
+
+  Tool definitions for OpenAI's chat.completions.create() API.
 
 ### BashToolOptions
 
@@ -1623,81 +1767,111 @@ Options for configuring the bash tool adapter.
 
 ### Fields
 
-- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+- **`allowedMountPaths?`** — `string[]`
 
-Required for `mounts` and runtime `mount()` APIs. Mount targets must
-resolve under one of these prefixes; otherwise the call is rejected.
-- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+  Allowlist of host path prefixes permitted for real filesystem mounts.
 
-Each entry becomes a bash command that shares the instance's VFS — files
-created by the callback persist across `execute()` calls. Callbacks can be
-sync (`string` return) or async (`Promise<string>`); exceptions surface as
-stderr with exit code 1.
+  Required for `mounts` and runtime `mount()` APIs. Mount targets must
+  resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>`
 
-Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
-`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
-the option again after restoring.
+  Custom JS callbacks registered as bash builtins.
 
-Override precedence: shell function > POSIX special builtin > custom
-builtin > baked-in builtin > PATH.
-- **`cwd?`** — `string` Initial working directory for the shell.
+  Each entry becomes a bash command that shares the instance's VFS — files
+  created by the callback persist across `execute()` calls. Callbacks can be
+  sync (`string` return) or async (`Promise<string>`); exceptions surface as
+  stderr with exit code 1.
 
-Sets the starting `cwd` directly instead of running a leading
-`cd "${cwd}"` command, avoiding the parse/exec overhead.
-- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+  Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+  `reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+  the option again after restoring.
 
-Scripts see these immediately without an `export` prelude. Keys are
-variable names, values are their string values.
-- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+  Override precedence: shell function > POSIX special builtin > custom
+  builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string`
 
-These function names become available as Python builtins within
-the embedded interpreter. When called, they invoke the external handler.
-- **`files?`** — `Record<string, string>` Pre-populate VFS files. Keys are absolute paths, values are file contents.
+  Initial working directory for the shell.
+
+  Sets the starting `cwd` directly instead of running a leading
+  `cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>`
+
+  Initial environment variables, applied before execution.
+
+  Scripts see these immediately without an `export` prelude. Keys are
+  variable names, values are their string values.
+- **`externalFunctions?`** — `string[]`
+
+  Names of external functions callable from embedded Python code.
+
+  These function names become available as Python builtins within
+  the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, string>`
+
+  Pre-populate VFS files. Keys are absolute paths, values are file contents.
 - **`hostname?`** — `string`
 - **`maxCommands?`** — `number`
-- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+- **`maxInputBytes?`** — `number`
 
-Async execute validates this before entering the per-instance queue so
-oversized calls cannot wait while retaining large command strings.
+  Maximum script input size in UTF-8 bytes.
+
+  Async execute validates this before entering the per-instance queue so
+  oversized calls cannot wait while retaining large command strings.
 - **`maxLoopIterations?`** — `number`
-- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+- **`maxMemory?`** — `number`
 
-Caps the total byte budget for variable storage and function bodies.
-Prevents OOM from untrusted input such as exponential string doubling.
-- **`maxOutputLength?`** — `number` Maximum output length in characters (default: 100000).
+  Maximum interpreter memory in bytes (variables, arrays, functions).
 
-Output exceeding this limit is truncated with a `[truncated]` marker.
-Prevents context window flooding when scripts produce large output.
+  Caps the total byte budget for variable storage and function bodies.
+  Prevents OOM from untrusted input such as exponential string doubling.
+- **`maxOutputLength?`** — `number`
+
+  Maximum output length in characters (default: 100000).
+
+  Output exceeding this limit is truncated with a `[truncated]` marker.
+  Prevents context window flooding when scripts produce large output.
 - **`maxTotalLoopIterations?`** — `number`
-- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
-- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
-restricted to the configured allowlist, with optional transparent
-credential injection. Omitted = network disabled (no `curl`/`wget`).
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]`
 
-Must specify either `allow` (list of URL patterns) or `allowAll: true`,
-not both. `blockPrivateIps` defaults to `true`.
-- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+  Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions`
 
-When true, bash scripts can use `python -c '...'` or `python3 script.py`
-to run Python code within the sandbox.
-- **`sanitizeOutput?`** — `boolean` Wrap tool output in XML boundary markers (default: false).
+  Outbound network configuration. When set, enables `curl`/`wget`
+  restricted to the configured allowlist, with optional transparent
+  credential injection. Omitted = network disabled (no `curl`/`wget`).
 
-When enabled, output is wrapped in `<tool_output>...</tool_output>` tags
-to help LLMs distinguish tool output data from instructions, reducing
-prompt injection risk via tool output.
-- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+  Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+  not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean`
 
-Backed by Turso. When `true`, the binding both registers the builtin
-and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
-satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
-script cap, 256 MiB DB cap, 30 s wall-clock budget,
-resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
-- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+  Enable embedded Python execution (`python`/`python3` builtins).
 
-When set, this is passed to the underlying BashTool as `timeoutMs`.
-Commands exceeding this duration are aborted with exit code 124.
-Framework-level timeouts can be propagated here to ensure bashkit
-stops execution when the framework cancels a tool call.
+  When true, bash scripts can use `python -c '...'` or `python3 script.py`
+  to run Python code within the sandbox.
+- **`sanitizeOutput?`** — `boolean`
+
+  Wrap tool output in XML boundary markers (default: false).
+
+  When enabled, output is wrapped in `<tool_output>...</tool_output>` tags
+  to help LLMs distinguish tool output data from instructions, reducing
+  prompt injection risk via tool output.
+- **`sqlite?`** — `boolean`
+
+  Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+  Backed by Turso. When `true`, the binding both registers the builtin
+  and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+  satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+  script cap, 256 MiB DB cap, 30 s wall-clock budget,
+  resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number`
+
+  Execution timeout in milliseconds.
+
+  When set, this is passed to the underlying BashTool as `timeoutMs`.
+  Commands exceeding this duration are aborted with exit code 124.
+  Framework-level timeouts can be propagated here to ensure bashkit
+  stops execution when the framework cancels a tool call.
 - **`username?`** — `string`
 
 ### HandlerOptions
@@ -1706,7 +1880,9 @@ Options for handler invocation.
 
 ### Fields
 
-- **`signal?`** — `AbortSignal` AbortSignal to cancel execution when the framework aborts the tool call.
+- **`signal?`** — `AbortSignal`
+
+  AbortSignal to cancel execution when the framework aborts the tool call.
 
 ### ToolResult
 
@@ -1778,9 +1954,15 @@ Return value of `bashTool()`.
 
 ### Fields
 
-- **`bash`** — `BashTool` The underlying BashTool instance for direct access.
-- **`system`** — `string` System prompt describing bash capabilities and constraints.
-- **`tools`** — `Record<string, AiTool>` Tool definitions for Vercel AI SDK's generateText/streamText.
+- **`bash`** — `BashTool`
+
+  The underlying BashTool instance for direct access.
+- **`system`** — `string`
+
+  System prompt describing bash capabilities and constraints.
+- **`tools`** — `Record<string, AiTool>`
+
+  Tool definitions for Vercel AI SDK's generateText/streamText.
 
 ### BashToolOptions
 
@@ -1788,68 +1970,94 @@ Options for configuring the bash tool adapter.
 
 ### Fields
 
-- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+- **`allowedMountPaths?`** — `string[]`
 
-Required for `mounts` and runtime `mount()` APIs. Mount targets must
-resolve under one of these prefixes; otherwise the call is rejected.
-- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+  Allowlist of host path prefixes permitted for real filesystem mounts.
 
-Each entry becomes a bash command that shares the instance's VFS — files
-created by the callback persist across `execute()` calls. Callbacks can be
-sync (`string` return) or async (`Promise<string>`); exceptions surface as
-stderr with exit code 1.
+  Required for `mounts` and runtime `mount()` APIs. Mount targets must
+  resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>`
 
-Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
-`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
-the option again after restoring.
+  Custom JS callbacks registered as bash builtins.
 
-Override precedence: shell function > POSIX special builtin > custom
-builtin > baked-in builtin > PATH.
-- **`cwd?`** — `string` Initial working directory for the shell.
+  Each entry becomes a bash command that shares the instance's VFS — files
+  created by the callback persist across `execute()` calls. Callbacks can be
+  sync (`string` return) or async (`Promise<string>`); exceptions surface as
+  stderr with exit code 1.
 
-Sets the starting `cwd` directly instead of running a leading
-`cd "${cwd}"` command, avoiding the parse/exec overhead.
-- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+  Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+  `reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+  the option again after restoring.
 
-Scripts see these immediately without an `export` prelude. Keys are
-variable names, values are their string values.
-- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+  Override precedence: shell function > POSIX special builtin > custom
+  builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string`
 
-These function names become available as Python builtins within
-the embedded interpreter. When called, they invoke the external handler.
-- **`files?`** — `Record<string, string>` Pre-populate VFS files. Keys are absolute paths, values are file contents.
+  Initial working directory for the shell.
+
+  Sets the starting `cwd` directly instead of running a leading
+  `cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>`
+
+  Initial environment variables, applied before execution.
+
+  Scripts see these immediately without an `export` prelude. Keys are
+  variable names, values are their string values.
+- **`externalFunctions?`** — `string[]`
+
+  Names of external functions callable from embedded Python code.
+
+  These function names become available as Python builtins within
+  the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, string>`
+
+  Pre-populate VFS files. Keys are absolute paths, values are file contents.
 - **`hostname?`** — `string`
 - **`maxCommands?`** — `number`
-- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+- **`maxInputBytes?`** — `number`
 
-Async execute validates this before entering the per-instance queue so
-oversized calls cannot wait while retaining large command strings.
+  Maximum script input size in UTF-8 bytes.
+
+  Async execute validates this before entering the per-instance queue so
+  oversized calls cannot wait while retaining large command strings.
 - **`maxLoopIterations?`** — `number`
-- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+- **`maxMemory?`** — `number`
 
-Caps the total byte budget for variable storage and function bodies.
-Prevents OOM from untrusted input such as exponential string doubling.
+  Maximum interpreter memory in bytes (variables, arrays, functions).
+
+  Caps the total byte budget for variable storage and function bodies.
+  Prevents OOM from untrusted input such as exponential string doubling.
 - **`maxTotalLoopIterations?`** — `number`
-- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
-- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
-restricted to the configured allowlist, with optional transparent
-credential injection. Omitted = network disabled (no `curl`/`wget`).
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]`
 
-Must specify either `allow` (list of URL patterns) or `allowAll: true`,
-not both. `blockPrivateIps` defaults to `true`.
-- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+  Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions`
 
-When true, bash scripts can use `python -c '...'` or `python3 script.py`
-to run Python code within the sandbox.
-- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+  Outbound network configuration. When set, enables `curl`/`wget`
+  restricted to the configured allowlist, with optional transparent
+  credential injection. Omitted = network disabled (no `curl`/`wget`).
 
-Backed by Turso. When `true`, the binding both registers the builtin
-and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
-satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
-script cap, 256 MiB DB cap, 30 s wall-clock budget,
-resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
-- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+  Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+  not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean`
 
-When set, commands that exceed this duration are aborted with
-exit code 124 (matching the bash `timeout` convention).
+  Enable embedded Python execution (`python`/`python3` builtins).
+
+  When true, bash scripts can use `python -c '...'` or `python3 script.py`
+  to run Python code within the sandbox.
+- **`sqlite?`** — `boolean`
+
+  Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+  Backed by Turso. When `true`, the binding both registers the builtin
+  and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+  satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+  script cap, 256 MiB DB cap, 30 s wall-clock budget,
+  resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number`
+
+  Execution timeout in milliseconds.
+
+  When set, commands that exceed this duration are aborted with
+  exit code 124 (matching the bash `timeout` convention).
 - **`username?`** — `string`

--- a/site/src/content/apidocs/typescript.md
+++ b/site/src/content/apidocs/typescript.md
@@ -28,7 +28,7 @@ new Bash(options?: BashOptions): Bash
 ### `addBuiltin`
 
 ```typescript
-Bash.addBuiltin(name: string, callback: BuiltinCallback): void
+bash.addBuiltin(name: string, callback: BuiltinCallback): void
 ```
 
 Register a JS callback as a custom bash builtin.
@@ -44,7 +44,7 @@ Survives `reset()`.
 ### `appendFile`
 
 ```typescript
-Bash.appendFile(path: string, content: string): void
+bash.appendFile(path: string, content: string): void
 ```
 
 Append content to a file.
@@ -52,7 +52,7 @@ Append content to a file.
 ### `cancel`
 
 ```typescript
-Bash.cancel(): void
+bash.cancel(): void
 ```
 
 Cancel the currently running execution.
@@ -60,7 +60,7 @@ Cancel the currently running execution.
 ### `chmod`
 
 ```typescript
-Bash.chmod(path: string, mode: number): void
+bash.chmod(path: string, mode: number): void
 ```
 
 Change file permissions (octal mode, e.g. 0o755).
@@ -68,7 +68,7 @@ Change file permissions (octal mode, e.g. 0o755).
 ### `clearCancel`
 
 ```typescript
-Bash.clearCancel(): void
+bash.clearCancel(): void
 ```
 
 Clear the cancellation flag so subsequent executions proceed normally.
@@ -79,7 +79,7 @@ you want to reuse the same instance without discarding shell or VFS state.
 ### `execute`
 
 ```typescript
-Bash.execute(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+bash.execute(commands: string, options?: ExecuteOptions): Promise<ExecResult>
 ```
 
 Execute bash commands asynchronously, returning a Promise.
@@ -98,7 +98,7 @@ console.log(result.stdout); // hello\n
 ### `executeOrThrow`
 
 ```typescript
-Bash.executeOrThrow(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+bash.executeOrThrow(commands: string, options?: ExecuteOptions): Promise<ExecResult>
 ```
 
 Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
@@ -106,7 +106,7 @@ Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
 ### `executeSync`
 
 ```typescript
-Bash.executeSync(commands: string, options?: ExecuteOptions): ExecResult
+bash.executeSync(commands: string, options?: ExecuteOptions): ExecResult
 ```
 
 Execute bash commands synchronously and return the result.
@@ -120,7 +120,7 @@ same instance from `onOutput` via `execute*`, `readFile`, `fs()`, etc.
 ### `executeSyncOrThrow`
 
 ```typescript
-Bash.executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult
+bash.executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult
 ```
 
 Execute bash commands synchronously. Throws `BashError` on non-zero exit.
@@ -128,7 +128,7 @@ Execute bash commands synchronously. Throws `BashError` on non-zero exit.
 ### `exists`
 
 ```typescript
-Bash.exists(path: string): boolean
+bash.exists(path: string): boolean
 ```
 
 Check if a path exists in the virtual filesystem.
@@ -136,7 +136,7 @@ Check if a path exists in the virtual filesystem.
 ### `fs`
 
 ```typescript
-Bash.fs(): FileSystem
+bash.fs(): FileSystem
 ```
 
 Get a FileSystem handle for direct VFS operations.
@@ -144,7 +144,7 @@ Get a FileSystem handle for direct VFS operations.
 ### `glob`
 
 ```typescript
-Bash.glob(pattern: string): string[]
+bash.glob(pattern: string): string[]
 ```
 
 Find files matching a name pattern. Returns absolute paths.
@@ -152,7 +152,7 @@ Find files matching a name pattern. Returns absolute paths.
 ### `ls`
 
 ```typescript
-Bash.ls(path?: string): string[]
+bash.ls(path?: string): string[]
 ```
 
 List entry names in a directory. Returns empty array if directory does not exist.
@@ -160,7 +160,7 @@ List entry names in a directory. Returns empty array if directory does not exist
 ### `mkdir`
 
 ```typescript
-Bash.mkdir(path: string, recursive?: boolean): void
+bash.mkdir(path: string, recursive?: boolean): void
 ```
 
 Create a directory. If recursive is true, creates parents as needed.
@@ -168,7 +168,7 @@ Create a directory. If recursive is true, creates parents as needed.
 ### `mount`
 
 ```typescript
-Bash.mount(vfsPath: string, fs: FileSystem): void
+bash.mount(vfsPath: string, fs: FileSystem): void
 ```
 
 Mount either a host directory or a FileSystem into the VFS.
@@ -176,7 +176,7 @@ Mount either a host directory or a FileSystem into the VFS.
 ### `readDir`
 
 ```typescript
-Bash.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
+bash.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
 ```
 
 List directory entries with metadata.
@@ -184,7 +184,7 @@ List directory entries with metadata.
 ### `readFile`
 
 ```typescript
-Bash.readFile(path: string): string
+bash.readFile(path: string): string
 ```
 
 Read a file from the virtual filesystem as a UTF-8 string.
@@ -192,7 +192,7 @@ Read a file from the virtual filesystem as a UTF-8 string.
 ### `readLink`
 
 ```typescript
-Bash.readLink(path: string): string
+bash.readLink(path: string): string
 ```
 
 Read the target of a symbolic link.
@@ -200,7 +200,7 @@ Read the target of a symbolic link.
 ### `remove`
 
 ```typescript
-Bash.remove(path: string, recursive?: boolean): void
+bash.remove(path: string, recursive?: boolean): void
 ```
 
 Remove a file or directory. If recursive is true, removes contents.
@@ -208,7 +208,7 @@ Remove a file or directory. If recursive is true, removes contents.
 ### `removeBuiltin`
 
 ```typescript
-Bash.removeBuiltin(name: string): void
+bash.removeBuiltin(name: string): void
 ```
 
 Remove a previously registered custom builtin.
@@ -216,7 +216,7 @@ Remove a previously registered custom builtin.
 ### `reset`
 
 ```typescript
-Bash.reset(): void
+bash.reset(): void
 ```
 
 Reset interpreter to fresh state, preserving configuration.
@@ -224,7 +224,7 @@ Reset interpreter to fresh state, preserving configuration.
 ### `restoreSnapshot`
 
 ```typescript
-Bash.restoreSnapshot(data: Uint8Array, options?: SnapshotOptions): void
+bash.restoreSnapshot(data: Uint8Array, options?: SnapshotOptions): void
 ```
 
 Restore interpreter state from a previously captured snapshot.
@@ -234,7 +234,7 @@ shell state and VFS contents.
 ### `restoreSnapshotKeyed`
 
 ```typescript
-Bash.restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void
+bash.restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void
 ```
 
 Restore interpreter state from a HMAC-protected snapshot.
@@ -242,7 +242,7 @@ Restore interpreter state from a HMAC-protected snapshot.
 ### `shellState`
 
 ```typescript
-Bash.shellState(): ShellState
+bash.shellState(): ShellState
 ```
 
 Capture a lightweight snapshot of shell state (variables, env, cwd,
@@ -253,7 +253,7 @@ state capture/restore.
 ### `snapshot`
 
 ```typescript
-Bash.snapshot(options?: SnapshotOptions): Uint8Array
+bash.snapshot(options?: SnapshotOptions): Uint8Array
 ```
 
 Serialize interpreter state (variables, VFS, counters) to a Uint8Array.
@@ -274,7 +274,7 @@ const r = await bash2.execute("echo $x"); // "42\n"
 ### `snapshotKeyed`
 
 ```typescript
-Bash.snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array
+bash.snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array
 ```
 
 Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
@@ -283,7 +283,7 @@ Use for snapshots crossing trust boundaries.
 ### `stat`
 
 ```typescript
-Bash.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
+bash.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
 ```
 
 Get metadata for a path (fileType, size, mode, timestamps).
@@ -291,7 +291,7 @@ Get metadata for a path (fileType, size, mode, timestamps).
 ### `symlink`
 
 ```typescript
-Bash.symlink(target: string, link: string): void
+bash.symlink(target: string, link: string): void
 ```
 
 Create a symbolic link pointing to target.
@@ -299,7 +299,7 @@ Create a symbolic link pointing to target.
 ### `unmount`
 
 ```typescript
-Bash.unmount(vfsPath: string): void
+bash.unmount(vfsPath: string): void
 ```
 
 Unmount a previously mounted filesystem.
@@ -307,7 +307,7 @@ Unmount a previously mounted filesystem.
 ### `writeFile`
 
 ```typescript
-Bash.writeFile(path: string, content: string): void
+bash.writeFile(path: string, content: string): void
 ```
 
 Write a string to a file in the virtual filesystem.
@@ -402,7 +402,7 @@ Tool version.
 ### `addBuiltin`
 
 ```typescript
-BashTool.addBuiltin(name: string, callback: BuiltinCallback): void
+bashTool.addBuiltin(name: string, callback: BuiltinCallback): void
 ```
 
 Register a JS callback as a custom builtin. See `Bash.addBuiltin`.
@@ -410,7 +410,7 @@ Register a JS callback as a custom builtin. See `Bash.addBuiltin`.
 ### `appendFile`
 
 ```typescript
-BashTool.appendFile(path: string, content: string): void
+bashTool.appendFile(path: string, content: string): void
 ```
 
 Append content to a file.
@@ -418,7 +418,7 @@ Append content to a file.
 ### `cancel`
 
 ```typescript
-BashTool.cancel(): void
+bashTool.cancel(): void
 ```
 
 Cancel the currently running execution.
@@ -426,7 +426,7 @@ Cancel the currently running execution.
 ### `chmod`
 
 ```typescript
-BashTool.chmod(path: string, mode: number): void
+bashTool.chmod(path: string, mode: number): void
 ```
 
 Change file permissions (octal mode, e.g. 0o755).
@@ -434,7 +434,7 @@ Change file permissions (octal mode, e.g. 0o755).
 ### `clearCancel`
 
 ```typescript
-BashTool.clearCancel(): void
+bashTool.clearCancel(): void
 ```
 
 Clear the cancellation flag so subsequent executions proceed normally.
@@ -445,7 +445,7 @@ you want to reuse the same instance without discarding shell or VFS state.
 ### `description`
 
 ```typescript
-BashTool.description(): string
+bashTool.description(): string
 ```
 
 Token-efficient tool description.
@@ -453,7 +453,7 @@ Token-efficient tool description.
 ### `execute`
 
 ```typescript
-BashTool.execute(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+bashTool.execute(commands: string, options?: ExecuteOptions): Promise<ExecResult>
 ```
 
 Execute bash commands asynchronously, returning a Promise.
@@ -465,7 +465,7 @@ via `execute*`, `readFile`, `fs()`, etc.
 ### `executeOrThrow`
 
 ```typescript
-BashTool.executeOrThrow(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+bashTool.executeOrThrow(commands: string, options?: ExecuteOptions): Promise<ExecResult>
 ```
 
 Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
@@ -473,7 +473,7 @@ Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
 ### `executeSync`
 
 ```typescript
-BashTool.executeSync(commands: string, options?: ExecuteOptions): ExecResult
+bashTool.executeSync(commands: string, options?: ExecuteOptions): ExecResult
 ```
 
 Execute bash commands synchronously and return the result.
@@ -485,7 +485,7 @@ via `execute*`, `readFile`, `fs()`, etc.
 ### `executeSyncOrThrow`
 
 ```typescript
-BashTool.executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult
+bashTool.executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult
 ```
 
 Execute bash commands synchronously. Throws `BashError` on non-zero exit.
@@ -493,7 +493,7 @@ Execute bash commands synchronously. Throws `BashError` on non-zero exit.
 ### `exists`
 
 ```typescript
-BashTool.exists(path: string): boolean
+bashTool.exists(path: string): boolean
 ```
 
 Check whether a path exists in the virtual filesystem.
@@ -501,7 +501,7 @@ Check whether a path exists in the virtual filesystem.
 ### `fs`
 
 ```typescript
-BashTool.fs(): FileSystem
+bashTool.fs(): FileSystem
 ```
 
 Get a FileSystem handle for direct VFS operations.
@@ -509,7 +509,7 @@ Get a FileSystem handle for direct VFS operations.
 ### `glob`
 
 ```typescript
-BashTool.glob(pattern: string): string[]
+bashTool.glob(pattern: string): string[]
 ```
 
 Find files matching a name pattern. Returns absolute paths.
@@ -517,7 +517,7 @@ Find files matching a name pattern. Returns absolute paths.
 ### `help`
 
 ```typescript
-BashTool.help(): string
+bashTool.help(): string
 ```
 
 Markdown help document.
@@ -525,7 +525,7 @@ Markdown help document.
 ### `inputSchema`
 
 ```typescript
-BashTool.inputSchema(): string
+bashTool.inputSchema(): string
 ```
 
 JSON input schema as string.
@@ -533,7 +533,7 @@ JSON input schema as string.
 ### `ls`
 
 ```typescript
-BashTool.ls(path?: string): string[]
+bashTool.ls(path?: string): string[]
 ```
 
 List entry names in a directory. Returns empty array if directory does not exist.
@@ -541,7 +541,7 @@ List entry names in a directory. Returns empty array if directory does not exist
 ### `mkdir`
 
 ```typescript
-BashTool.mkdir(path: string, recursive?: boolean): void
+bashTool.mkdir(path: string, recursive?: boolean): void
 ```
 
 Create a directory. If recursive is true, creates parents as needed.
@@ -549,7 +549,7 @@ Create a directory. If recursive is true, creates parents as needed.
 ### `mount`
 
 ```typescript
-BashTool.mount(vfsPath: string, fs: FileSystem): void
+bashTool.mount(vfsPath: string, fs: FileSystem): void
 ```
 
 Mount either a host directory or a FileSystem into the VFS.
@@ -557,7 +557,7 @@ Mount either a host directory or a FileSystem into the VFS.
 ### `outputSchema`
 
 ```typescript
-BashTool.outputSchema(): string
+bashTool.outputSchema(): string
 ```
 
 JSON output schema as string.
@@ -565,7 +565,7 @@ JSON output schema as string.
 ### `readDir`
 
 ```typescript
-BashTool.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
+bashTool.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
 ```
 
 List directory entries with metadata.
@@ -573,7 +573,7 @@ List directory entries with metadata.
 ### `readFile`
 
 ```typescript
-BashTool.readFile(path: string): string
+bashTool.readFile(path: string): string
 ```
 
 Read file contents from the virtual filesystem.
@@ -582,7 +582,7 @@ Throws `BashError` if the file does not exist.
 ### `readLink`
 
 ```typescript
-BashTool.readLink(path: string): string
+bashTool.readLink(path: string): string
 ```
 
 Read the target of a symbolic link.
@@ -590,7 +590,7 @@ Read the target of a symbolic link.
 ### `remove`
 
 ```typescript
-BashTool.remove(path: string, recursive?: boolean): void
+bashTool.remove(path: string, recursive?: boolean): void
 ```
 
 Remove a file or directory. If recursive is true, removes contents.
@@ -598,7 +598,7 @@ Remove a file or directory. If recursive is true, removes contents.
 ### `removeBuiltin`
 
 ```typescript
-BashTool.removeBuiltin(name: string): void
+bashTool.removeBuiltin(name: string): void
 ```
 
 Remove a previously registered custom builtin.
@@ -606,7 +606,7 @@ Remove a previously registered custom builtin.
 ### `reset`
 
 ```typescript
-BashTool.reset(): void
+bashTool.reset(): void
 ```
 
 Reset interpreter to fresh state, preserving configuration.
@@ -614,7 +614,7 @@ Reset interpreter to fresh state, preserving configuration.
 ### `restoreSnapshot`
 
 ```typescript
-BashTool.restoreSnapshot(data: Uint8Array, options: SnapshotOptions & { hmacKey: Uint8Array }): void
+bashTool.restoreSnapshot(data: Uint8Array, options: SnapshotOptions & { hmacKey: Uint8Array }): void
 ```
 
 Restore interpreter state from an HMAC-authenticated snapshot.
@@ -624,7 +624,7 @@ shell state and VFS contents.
 ### `restoreSnapshotKeyed`
 
 ```typescript
-BashTool.restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void
+bashTool.restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void
 ```
 
 Restore interpreter state from a HMAC-protected snapshot.
@@ -632,7 +632,7 @@ Restore interpreter state from a HMAC-protected snapshot.
 ### `shellState`
 
 ```typescript
-BashTool.shellState(): ShellState
+bashTool.shellState(): ShellState
 ```
 
 Capture a lightweight snapshot of shell state (variables, env, cwd,
@@ -643,7 +643,7 @@ state capture/restore.
 ### `snapshot`
 
 ```typescript
-BashTool.snapshot(options: SnapshotOptions & { hmacKey: Uint8Array }): Uint8Array
+bashTool.snapshot(options: SnapshotOptions & { hmacKey: Uint8Array }): Uint8Array
 ```
 
 Serialize interpreter state (variables, VFS, counters) to an
@@ -653,7 +653,7 @@ they include tenant-controlled shell state, VFS contents, and counters.
 ### `snapshotKeyed`
 
 ```typescript
-BashTool.snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array
+bashTool.snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array
 ```
 
 Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
@@ -661,7 +661,7 @@ Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
 ### `stat`
 
 ```typescript
-BashTool.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
+bashTool.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
 ```
 
 Get metadata for a path (fileType, size, mode, timestamps).
@@ -669,7 +669,7 @@ Get metadata for a path (fileType, size, mode, timestamps).
 ### `symlink`
 
 ```typescript
-BashTool.symlink(target: string, link: string): void
+bashTool.symlink(target: string, link: string): void
 ```
 
 Create a symbolic link pointing to target.
@@ -677,7 +677,7 @@ Create a symbolic link pointing to target.
 ### `systemPrompt`
 
 ```typescript
-BashTool.systemPrompt(): string
+bashTool.systemPrompt(): string
 ```
 
 Compact system prompt for orchestration.
@@ -685,7 +685,7 @@ Compact system prompt for orchestration.
 ### `unmount`
 
 ```typescript
-BashTool.unmount(vfsPath: string): void
+bashTool.unmount(vfsPath: string): void
 ```
 
 Unmount a previously mounted filesystem.
@@ -693,7 +693,7 @@ Unmount a previously mounted filesystem.
 ### `writeFile`
 
 ```typescript
-BashTool.writeFile(path: string, content: string): void
+bashTool.writeFile(path: string, content: string): void
 ```
 
 Write content to a file in the virtual filesystem.
@@ -777,7 +777,7 @@ Tool version.
 ### `addTool`
 
 ```typescript
-ScriptedTool.addTool(name: string, description: string, callback: ToolCallback, schema?: Record<string, unknown>): void
+scriptedTool.addTool(name: string, description: string, callback: ToolCallback, schema?: Record<string, unknown>): void
 ```
 
 Register a tool command.
@@ -785,7 +785,7 @@ Register a tool command.
 ### `description`
 
 ```typescript
-ScriptedTool.description(): string
+scriptedTool.description(): string
 ```
 
 Token-efficient tool description.
@@ -793,7 +793,7 @@ Token-efficient tool description.
 ### `env`
 
 ```typescript
-ScriptedTool.env(key: string, value: string): void
+scriptedTool.env(key: string, value: string): void
 ```
 
 Add an environment variable visible inside scripts.
@@ -801,7 +801,7 @@ Add an environment variable visible inside scripts.
 ### `execute`
 
 ```typescript
-ScriptedTool.execute(commands: string): Promise<ExecResult>
+scriptedTool.execute(commands: string): Promise<ExecResult>
 ```
 
 Execute a bash script asynchronously, returning a Promise.
@@ -812,7 +812,7 @@ tool callbacks require the Node.js event loop to be running.
 ### `executeOrThrow`
 
 ```typescript
-ScriptedTool.executeOrThrow(commands: string): Promise<ExecResult>
+scriptedTool.executeOrThrow(commands: string): Promise<ExecResult>
 ```
 
 Execute asynchronously. Throws `BashError` on non-zero exit.
@@ -820,7 +820,7 @@ Execute asynchronously. Throws `BashError` on non-zero exit.
 ### `executeSync`
 
 ```typescript
-ScriptedTool.executeSync(commands: string): ExecResult
+scriptedTool.executeSync(commands: string): ExecResult
 ```
 
 Execute a bash script synchronously.
@@ -834,7 +834,7 @@ that don't invoke any registered tools (e.g., pure bash).
 ### `executeSyncOrThrow`
 
 ```typescript
-ScriptedTool.executeSyncOrThrow(commands: string): ExecResult
+scriptedTool.executeSyncOrThrow(commands: string): ExecResult
 ```
 
 Execute synchronously. Throws `BashError` on non-zero exit.
@@ -845,7 +845,7 @@ require the blocked Node event loop. Use `executeOrThrow()` instead.
 ### `help`
 
 ```typescript
-ScriptedTool.help(): string
+scriptedTool.help(): string
 ```
 
 Markdown help document.
@@ -853,7 +853,7 @@ Markdown help document.
 ### `inputSchema`
 
 ```typescript
-ScriptedTool.inputSchema(): string
+scriptedTool.inputSchema(): string
 ```
 
 JSON input schema as string.
@@ -861,7 +861,7 @@ JSON input schema as string.
 ### `outputSchema`
 
 ```typescript
-ScriptedTool.outputSchema(): string
+scriptedTool.outputSchema(): string
 ```
 
 JSON output schema as string.
@@ -869,7 +869,7 @@ JSON output schema as string.
 ### `systemPrompt`
 
 ```typescript
-ScriptedTool.systemPrompt(): string
+scriptedTool.systemPrompt(): string
 ```
 
 Compact system prompt for orchestration.
@@ -877,7 +877,7 @@ Compact system prompt for orchestration.
 ### `toolCount`
 
 ```typescript
-ScriptedTool.toolCount(): number
+scriptedTool.toolCount(): number
 ```
 
 Number of registered tools.
@@ -893,85 +893,85 @@ new FileSystem(): FileSystem
 ### `appendFile`
 
 ```typescript
-FileSystem.appendFile(path: string, content: string): void
+fileSystem.appendFile(path: string, content: string): void
 ```
 
 ### `chmod`
 
 ```typescript
-FileSystem.chmod(path: string, mode: number): void
+fileSystem.chmod(path: string, mode: number): void
 ```
 
 ### `copy`
 
 ```typescript
-FileSystem.copy(fromPath: string, toPath: string): void
+fileSystem.copy(fromPath: string, toPath: string): void
 ```
 
 ### `exists`
 
 ```typescript
-FileSystem.exists(path: string): boolean
+fileSystem.exists(path: string): boolean
 ```
 
 ### `mkdir`
 
 ```typescript
-FileSystem.mkdir(path: string, recursive?: boolean): void
+fileSystem.mkdir(path: string, recursive?: boolean): void
 ```
 
 ### `readDir`
 
 ```typescript
-FileSystem.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
+fileSystem.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
 ```
 
 ### `readFile`
 
 ```typescript
-FileSystem.readFile(path: string): string
+fileSystem.readFile(path: string): string
 ```
 
 ### `readLink`
 
 ```typescript
-FileSystem.readLink(path: string): string
+fileSystem.readLink(path: string): string
 ```
 
 ### `remove`
 
 ```typescript
-FileSystem.remove(path: string, recursive?: boolean): void
+fileSystem.remove(path: string, recursive?: boolean): void
 ```
 
 ### `rename`
 
 ```typescript
-FileSystem.rename(fromPath: string, toPath: string): void
+fileSystem.rename(fromPath: string, toPath: string): void
 ```
 
 ### `stat`
 
 ```typescript
-FileSystem.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
+fileSystem.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
 ```
 
 ### `symlink`
 
 ```typescript
-FileSystem.symlink(target: string, link: string): void
+fileSystem.symlink(target: string, link: string): void
 ```
 
 ### `toExternal`
 
 ```typescript
-FileSystem.toExternal(): unknown
+fileSystem.toExternal(): unknown
 ```
 
 ### `writeFile`
 
 ```typescript
-FileSystem.writeFile(path: string, content: string): void
+fileSystem.writeFile(path: string, content: string): void
 ```
 
 ### `fromExternal`
@@ -1010,7 +1010,7 @@ new BashError(result: ExecResult): BashError
 ### `display`
 
 ```typescript
-BashError.display(): string
+bashError.display(): string
 ```
 
 ## getVersion()

--- a/site/src/content/apidocs/typescript.md
+++ b/site/src/content/apidocs/typescript.md
@@ -1,0 +1,1855 @@
+# TypeScript API reference
+
+Auto-generated reference for the [`@everruns/bashkit`](https://www.npmjs.com/package/@everruns/bashkit) npm package. Reflects the latest published release.
+
+> Install with `npm install @everruns/bashkit`. See the [Embedding guide](/docs/embedding/) and [LLM tools guide](/docs/llm-tools/) for task-oriented walkthroughs.
+
+## Bash
+
+Core bash interpreter with virtual filesystem.
+
+State persists between calls — files created in one `execute()` are
+available in subsequent calls.
+
+```typescript
+import { Bash } from '@everruns/bashkit';
+
+const bash = new Bash();
+const result = bash.executeSync('echo "Hello, World!"');
+console.log(result.stdout); // Hello, World!\n
+```
+
+### Constructor
+
+```typescript
+new Bash(options?: BashOptions): Bash
+```
+
+### `addBuiltin`
+
+```typescript
+Bash.addBuiltin(name: string, callback: BuiltinCallback): void
+```
+
+Register a JS callback as a custom bash builtin.
+
+The callback receives a `BuiltinContext` and returns the stdout to
+emit. Sync (`string`) and async (`Promise<string>`) returns are both
+supported. Exceptions become stderr + exit code 1.
+
+Safe to call at any time — the new builtin is visible to the next
+`execute*()` invocation with no interpreter rebuild or VFS disturbance.
+Survives `reset()`.
+
+### `appendFile`
+
+```typescript
+Bash.appendFile(path: string, content: string): void
+```
+
+Append content to a file.
+
+### `cancel`
+
+```typescript
+Bash.cancel(): void
+```
+
+Cancel the currently running execution.
+
+### `chmod`
+
+```typescript
+Bash.chmod(path: string, mode: number): void
+```
+
+Change file permissions (octal mode, e.g. 0o755).
+
+### `clearCancel`
+
+```typescript
+Bash.clearCancel(): void
+```
+
+Clear the cancellation flag so subsequent executions proceed normally.
+
+Call this after `cancel()` once the in-flight execution has finished and
+you want to reuse the same instance without discarding shell or VFS state.
+
+### `execute`
+
+```typescript
+Bash.execute(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+```
+
+Execute bash commands asynchronously, returning a Promise.
+
+Non-blocking for the Node.js event loop.
+If `onOutput` is provided, it receives chunk objects with `{ stdout, stderr }`
+during execution. Chunks are not line-aligned. The callback must be
+synchronous; Promise-returning handlers are rejected. Do not re-enter the
+same instance from `onOutput` via `execute*`, `readFile`, `fs()`, etc.
+
+```typescript
+const result = await bash.execute('echo hello');
+console.log(result.stdout); // hello\n
+```
+
+### `executeOrThrow`
+
+```typescript
+Bash.executeOrThrow(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+```
+
+Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
+
+### `executeSync`
+
+```typescript
+Bash.executeSync(commands: string, options?: ExecuteOptions): ExecResult
+```
+
+Execute bash commands synchronously and return the result.
+
+If `signal` is provided, the execution will be cancelled when the signal
+is aborted. If `onOutput` is provided, it receives chunk objects with
+`{ stdout, stderr }` during execution. Chunks are not line-aligned. The callback must be
+synchronous; Promise-returning handlers are rejected. Do not re-enter the
+same instance from `onOutput` via `execute*`, `readFile`, `fs()`, etc.
+
+### `executeSyncOrThrow`
+
+```typescript
+Bash.executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult
+```
+
+Execute bash commands synchronously. Throws `BashError` on non-zero exit.
+
+### `exists`
+
+```typescript
+Bash.exists(path: string): boolean
+```
+
+Check if a path exists in the virtual filesystem.
+
+### `fs`
+
+```typescript
+Bash.fs(): FileSystem
+```
+
+Get a FileSystem handle for direct VFS operations.
+
+### `glob`
+
+```typescript
+Bash.glob(pattern: string): string[]
+```
+
+Find files matching a name pattern. Returns absolute paths.
+
+### `ls`
+
+```typescript
+Bash.ls(path?: string): string[]
+```
+
+List entry names in a directory. Returns empty array if directory does not exist.
+
+### `mkdir`
+
+```typescript
+Bash.mkdir(path: string, recursive?: boolean): void
+```
+
+Create a directory. If recursive is true, creates parents as needed.
+
+### `mount`
+
+```typescript
+Bash.mount(vfsPath: string, fs: FileSystem): void
+```
+
+Mount either a host directory or a FileSystem into the VFS.
+
+### `readDir`
+
+```typescript
+Bash.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
+```
+
+List directory entries with metadata.
+
+### `readFile`
+
+```typescript
+Bash.readFile(path: string): string
+```
+
+Read a file from the virtual filesystem as a UTF-8 string.
+
+### `readLink`
+
+```typescript
+Bash.readLink(path: string): string
+```
+
+Read the target of a symbolic link.
+
+### `remove`
+
+```typescript
+Bash.remove(path: string, recursive?: boolean): void
+```
+
+Remove a file or directory. If recursive is true, removes contents.
+
+### `removeBuiltin`
+
+```typescript
+Bash.removeBuiltin(name: string): void
+```
+
+Remove a previously registered custom builtin.
+
+### `reset`
+
+```typescript
+Bash.reset(): void
+```
+
+Reset interpreter to fresh state, preserving configuration.
+
+### `restoreSnapshot`
+
+```typescript
+Bash.restoreSnapshot(data: Uint8Array, options?: SnapshotOptions): void
+```
+
+Restore interpreter state from a previously captured snapshot.
+Preserves current configuration (limits, builtins) but replaces
+shell state and VFS contents.
+
+### `restoreSnapshotKeyed`
+
+```typescript
+Bash.restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void
+```
+
+Restore interpreter state from a HMAC-protected snapshot.
+
+### `shellState`
+
+```typescript
+Bash.shellState(): ShellState
+```
+
+Capture a lightweight snapshot of shell state (variables, env, cwd,
+arrays, aliases, traps) for inspection — e.g. prompt rendering or
+debugging. Function definitions are omitted; use `snapshot()` for full
+state capture/restore.
+
+### `snapshot`
+
+```typescript
+Bash.snapshot(options?: SnapshotOptions): Uint8Array
+```
+
+Serialize interpreter state (variables, VFS, counters) to a Uint8Array.
+
+Use `hmacKey` when snapshots are stored outside the current trust boundary
+(network, user uploads, shared storage). Without `hmacKey`, the snapshot
+digest only detects accidental corruption and is forgeable.
+
+```typescript
+const bash = new Bash();
+await bash.execute("x=42");
+const snapshot = bash.snapshot();
+// persist snapshot...
+const bash2 = Bash.fromSnapshot(snapshot);
+const r = await bash2.execute("echo $x"); // "42\n"
+```
+
+### `snapshotKeyed`
+
+```typescript
+Bash.snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array
+```
+
+Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
+Use for snapshots crossing trust boundaries.
+
+### `stat`
+
+```typescript
+Bash.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
+```
+
+Get metadata for a path (fileType, size, mode, timestamps).
+
+### `symlink`
+
+```typescript
+Bash.symlink(target: string, link: string): void
+```
+
+Create a symbolic link pointing to target.
+
+### `unmount`
+
+```typescript
+Bash.unmount(vfsPath: string): void
+```
+
+Unmount a previously mounted filesystem.
+
+### `writeFile`
+
+```typescript
+Bash.writeFile(path: string, content: string): void
+```
+
+Write a string to a file in the virtual filesystem.
+
+### `create`
+
+```typescript
+Bash.create(options?: BashOptions): Promise<Bash>
+```
+
+Create a Bash instance with support for async file providers.
+
+Use this instead of `new Bash()` when file values are async functions.
+
+```typescript
+const bash = await Bash.create({
+  files: {
+    "/data/remote.json": async () => await fetchData(),
+  }
+});
+```
+
+### `fromSnapshot`
+
+```typescript
+Bash.fromSnapshot(data: Uint8Array, options?: SnapshotOptions): Bash
+```
+
+Create a new Bash instance from a snapshot.
+
+```typescript
+const snapshot = existingBash.snapshot();
+const restored = Bash.fromSnapshot(snapshot);
+```
+
+### `fromSnapshotKeyed`
+
+```typescript
+Bash.fromSnapshotKeyed(data: Uint8Array, key: Uint8Array): Bash
+```
+
+Create a new Bash instance from a HMAC-protected snapshot.
+
+## BashTool
+
+Bash interpreter with tool-contract metadata.
+
+Use this when integrating with AI frameworks that need tool definitions.
+
+```typescript
+import { BashTool } from '@everruns/bashkit';
+
+const tool = new BashTool();
+console.log(tool.name);           // "bashkit"
+console.log(tool.inputSchema());  // JSON schema string
+console.log(tool.help());         // Markdown help document
+
+const result = tool.executeSync('echo hello');
+console.log(result.stdout);       // hello\n
+```
+
+### Constructor
+
+```typescript
+new BashTool(options?: BashOptions): BashTool
+```
+
+### `name`
+
+```typescript
+name: string
+```
+
+Tool name.
+
+### `shortDescription`
+
+```typescript
+shortDescription: string
+```
+
+Short description.
+
+### `version`
+
+```typescript
+version: string
+```
+
+Tool version.
+
+### `addBuiltin`
+
+```typescript
+BashTool.addBuiltin(name: string, callback: BuiltinCallback): void
+```
+
+Register a JS callback as a custom builtin. See `Bash.addBuiltin`.
+
+### `appendFile`
+
+```typescript
+BashTool.appendFile(path: string, content: string): void
+```
+
+Append content to a file.
+
+### `cancel`
+
+```typescript
+BashTool.cancel(): void
+```
+
+Cancel the currently running execution.
+
+### `chmod`
+
+```typescript
+BashTool.chmod(path: string, mode: number): void
+```
+
+Change file permissions (octal mode, e.g. 0o755).
+
+### `clearCancel`
+
+```typescript
+BashTool.clearCancel(): void
+```
+
+Clear the cancellation flag so subsequent executions proceed normally.
+
+Call this after `cancel()` once the in-flight execution has finished and
+you want to reuse the same instance without discarding shell or VFS state.
+
+### `description`
+
+```typescript
+BashTool.description(): string
+```
+
+Token-efficient tool description.
+
+### `execute`
+
+```typescript
+BashTool.execute(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+```
+
+Execute bash commands asynchronously, returning a Promise.
+
+If `onOutput` is provided, it must be synchronous; Promise-returning
+handlers are rejected. Do not re-enter the same instance from `onOutput`
+via `execute*`, `readFile`, `fs()`, etc.
+
+### `executeOrThrow`
+
+```typescript
+BashTool.executeOrThrow(commands: string, options?: ExecuteOptions): Promise<ExecResult>
+```
+
+Execute bash commands asynchronously. Throws `BashError` on non-zero exit.
+
+### `executeSync`
+
+```typescript
+BashTool.executeSync(commands: string, options?: ExecuteOptions): ExecResult
+```
+
+Execute bash commands synchronously and return the result.
+
+If `onOutput` is provided, it must be synchronous; Promise-returning
+handlers are rejected. Do not re-enter the same instance from `onOutput`
+via `execute*`, `readFile`, `fs()`, etc.
+
+### `executeSyncOrThrow`
+
+```typescript
+BashTool.executeSyncOrThrow(commands: string, options?: ExecuteOptions): ExecResult
+```
+
+Execute bash commands synchronously. Throws `BashError` on non-zero exit.
+
+### `exists`
+
+```typescript
+BashTool.exists(path: string): boolean
+```
+
+Check whether a path exists in the virtual filesystem.
+
+### `fs`
+
+```typescript
+BashTool.fs(): FileSystem
+```
+
+Get a FileSystem handle for direct VFS operations.
+
+### `glob`
+
+```typescript
+BashTool.glob(pattern: string): string[]
+```
+
+Find files matching a name pattern. Returns absolute paths.
+
+### `help`
+
+```typescript
+BashTool.help(): string
+```
+
+Markdown help document.
+
+### `inputSchema`
+
+```typescript
+BashTool.inputSchema(): string
+```
+
+JSON input schema as string.
+
+### `ls`
+
+```typescript
+BashTool.ls(path?: string): string[]
+```
+
+List entry names in a directory. Returns empty array if directory does not exist.
+
+### `mkdir`
+
+```typescript
+BashTool.mkdir(path: string, recursive?: boolean): void
+```
+
+Create a directory. If recursive is true, creates parents as needed.
+
+### `mount`
+
+```typescript
+BashTool.mount(vfsPath: string, fs: FileSystem): void
+```
+
+Mount either a host directory or a FileSystem into the VFS.
+
+### `outputSchema`
+
+```typescript
+BashTool.outputSchema(): string
+```
+
+JSON output schema as string.
+
+### `readDir`
+
+```typescript
+BashTool.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
+```
+
+List directory entries with metadata.
+
+### `readFile`
+
+```typescript
+BashTool.readFile(path: string): string
+```
+
+Read file contents from the virtual filesystem.
+Throws `BashError` if the file does not exist.
+
+### `readLink`
+
+```typescript
+BashTool.readLink(path: string): string
+```
+
+Read the target of a symbolic link.
+
+### `remove`
+
+```typescript
+BashTool.remove(path: string, recursive?: boolean): void
+```
+
+Remove a file or directory. If recursive is true, removes contents.
+
+### `removeBuiltin`
+
+```typescript
+BashTool.removeBuiltin(name: string): void
+```
+
+Remove a previously registered custom builtin.
+
+### `reset`
+
+```typescript
+BashTool.reset(): void
+```
+
+Reset interpreter to fresh state, preserving configuration.
+
+### `restoreSnapshot`
+
+```typescript
+BashTool.restoreSnapshot(data: Uint8Array, options: SnapshotOptions & { hmacKey: Uint8Array }): void
+```
+
+Restore interpreter state from an HMAC-authenticated snapshot.
+Preserves current configuration (limits, identity) but replaces
+shell state and VFS contents.
+
+### `restoreSnapshotKeyed`
+
+```typescript
+BashTool.restoreSnapshotKeyed(data: Uint8Array, key: Uint8Array): void
+```
+
+Restore interpreter state from a HMAC-protected snapshot.
+
+### `shellState`
+
+```typescript
+BashTool.shellState(): ShellState
+```
+
+Capture a lightweight snapshot of shell state (variables, env, cwd,
+arrays, aliases, traps) for inspection — e.g. prompt rendering or
+debugging. Function definitions are omitted; use `snapshot()` for full
+state capture/restore.
+
+### `snapshot`
+
+```typescript
+BashTool.snapshot(options: SnapshotOptions & { hmacKey: Uint8Array }): Uint8Array
+```
+
+Serialize interpreter state (variables, VFS, counters) to an
+HMAC-authenticated Uint8Array. BashTool snapshots require `hmacKey` because
+they include tenant-controlled shell state, VFS contents, and counters.
+
+### `snapshotKeyed`
+
+```typescript
+BashTool.snapshotKeyed(key: Uint8Array, options?: SnapshotOptions): Uint8Array
+```
+
+Serialize interpreter state with HMAC-SHA256 using a caller-provided key.
+
+### `stat`
+
+```typescript
+BashTool.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
+```
+
+Get metadata for a path (fileType, size, mode, timestamps).
+
+### `symlink`
+
+```typescript
+BashTool.symlink(target: string, link: string): void
+```
+
+Create a symbolic link pointing to target.
+
+### `systemPrompt`
+
+```typescript
+BashTool.systemPrompt(): string
+```
+
+Compact system prompt for orchestration.
+
+### `unmount`
+
+```typescript
+BashTool.unmount(vfsPath: string): void
+```
+
+Unmount a previously mounted filesystem.
+
+### `writeFile`
+
+```typescript
+BashTool.writeFile(path: string, content: string): void
+```
+
+Write content to a file in the virtual filesystem.
+Creates parent directories as needed.
+
+### `create`
+
+```typescript
+BashTool.create(options?: BashOptions): Promise<BashTool>
+```
+
+Create a BashTool instance with support for async file providers.
+
+### `fromSnapshot`
+
+```typescript
+BashTool.fromSnapshot(data: Uint8Array, options: undefined | BashOptions, snapshotOptions: SnapshotOptions & { hmacKey: Uint8Array }): BashTool
+```
+
+Create a new BashTool instance from an HMAC-authenticated snapshot.
+
+Any provided Bash options are applied before restoring the snapshot so
+limits and identity settings survive round-trips.
+
+### `fromSnapshotKeyed`
+
+```typescript
+BashTool.fromSnapshotKeyed(data: Uint8Array, key: Uint8Array, options?: BashOptions): BashTool
+```
+
+Create a new BashTool instance from a HMAC-protected snapshot.
+
+## ScriptedTool
+
+Compose JS callbacks as bash builtins for multi-tool orchestration.
+
+Each registered tool becomes a bash builtin command. An LLM (or user) writes
+a single bash script that pipes, loops, and branches across all tools.
+
+```typescript
+import { ScriptedTool } from '@everruns/bashkit';
+
+const tool = new ScriptedTool({ name: "api" });
+tool.addTool("greet", "Greet user",
+  (params) => `hello ${params.name ?? "world"}\n`
+);
+const result = tool.executeSync("greet --name Alice");
+console.log(result.stdout); // hello Alice\n
+```
+
+### Constructor
+
+```typescript
+new ScriptedTool(options: ScriptedToolOptions): ScriptedTool
+```
+
+### `name`
+
+```typescript
+name: string
+```
+
+Tool name.
+
+### `shortDescription`
+
+```typescript
+shortDescription: string
+```
+
+Short description.
+
+### `version`
+
+```typescript
+version: string
+```
+
+Tool version.
+
+### `addTool`
+
+```typescript
+ScriptedTool.addTool(name: string, description: string, callback: ToolCallback, schema?: Record<string, unknown>): void
+```
+
+Register a tool command.
+
+### `description`
+
+```typescript
+ScriptedTool.description(): string
+```
+
+Token-efficient tool description.
+
+### `env`
+
+```typescript
+ScriptedTool.env(key: string, value: string): void
+```
+
+Add an environment variable visible inside scripts.
+
+### `execute`
+
+```typescript
+ScriptedTool.execute(commands: string): Promise<ExecResult>
+```
+
+Execute a bash script asynchronously, returning a Promise.
+
+This is the recommended execution method for ScriptedTool since
+tool callbacks require the Node.js event loop to be running.
+
+### `executeOrThrow`
+
+```typescript
+ScriptedTool.executeOrThrow(commands: string): Promise<ExecResult>
+```
+
+Execute asynchronously. Throws `BashError` on non-zero exit.
+
+### `executeSync`
+
+```typescript
+ScriptedTool.executeSync(commands: string): ExecResult
+```
+
+Execute a bash script synchronously.
+
+Note: ScriptedTool callbacks run asynchronously via Node's event loop.
+If a registered tool is invoked, this method returns a non-zero result
+instead of queueing a callback that would deadlock. Use `execute()`
+(async) for scripts that call registered tools. Only use this for scripts
+that don't invoke any registered tools (e.g., pure bash).
+
+### `executeSyncOrThrow`
+
+```typescript
+ScriptedTool.executeSyncOrThrow(commands: string): ExecResult
+```
+
+Execute synchronously. Throws `BashError` on non-zero exit.
+
+Same caveats as `executeSync()` — throws when a registered tool would
+require the blocked Node event loop. Use `executeOrThrow()` instead.
+
+### `help`
+
+```typescript
+ScriptedTool.help(): string
+```
+
+Markdown help document.
+
+### `inputSchema`
+
+```typescript
+ScriptedTool.inputSchema(): string
+```
+
+JSON input schema as string.
+
+### `outputSchema`
+
+```typescript
+ScriptedTool.outputSchema(): string
+```
+
+JSON output schema as string.
+
+### `systemPrompt`
+
+```typescript
+ScriptedTool.systemPrompt(): string
+```
+
+Compact system prompt for orchestration.
+
+### `toolCount`
+
+```typescript
+ScriptedTool.toolCount(): number
+```
+
+Number of registered tools.
+
+## FileSystem
+
+### Constructor
+
+```typescript
+new FileSystem(): FileSystem
+```
+
+### `appendFile`
+
+```typescript
+FileSystem.appendFile(path: string, content: string): void
+```
+
+### `chmod`
+
+```typescript
+FileSystem.chmod(path: string, mode: number): void
+```
+
+### `copy`
+
+```typescript
+FileSystem.copy(fromPath: string, toPath: string): void
+```
+
+### `exists`
+
+```typescript
+FileSystem.exists(path: string): boolean
+```
+
+### `mkdir`
+
+```typescript
+FileSystem.mkdir(path: string, recursive?: boolean): void
+```
+
+### `readDir`
+
+```typescript
+FileSystem.readDir(path: string): ({ metadata: { created: number; fileType: string; mode: number; modified: number; size: number }; name: string })[]
+```
+
+### `readFile`
+
+```typescript
+FileSystem.readFile(path: string): string
+```
+
+### `readLink`
+
+```typescript
+FileSystem.readLink(path: string): string
+```
+
+### `remove`
+
+```typescript
+FileSystem.remove(path: string, recursive?: boolean): void
+```
+
+### `rename`
+
+```typescript
+FileSystem.rename(fromPath: string, toPath: string): void
+```
+
+### `stat`
+
+```typescript
+FileSystem.stat(path: string): { created: number; fileType: string; mode: number; modified: number; size: number }
+```
+
+### `symlink`
+
+```typescript
+FileSystem.symlink(target: string, link: string): void
+```
+
+### `toExternal`
+
+```typescript
+FileSystem.toExternal(): unknown
+```
+
+### `writeFile`
+
+```typescript
+FileSystem.writeFile(path: string, content: string): void
+```
+
+### `fromExternal`
+
+```typescript
+FileSystem.fromExternal(external: unknown): FileSystem
+```
+
+### `fromNative`
+
+```typescript
+FileSystem.fromNative(nativeFs: any): FileSystem
+```
+
+### `real`
+
+```typescript
+FileSystem.real(hostPath: string, options: FileSystemRealOptions): FileSystem
+```
+
+## BashError
+
+Error thrown when a bash command execution fails.
+
+### Properties
+
+- **`exitCode`** — `number`
+- **`stderr`** — `string`
+
+### Constructor
+
+```typescript
+new BashError(result: ExecResult): BashError
+```
+
+### `display`
+
+```typescript
+BashError.display(): string
+```
+
+## getVersion()
+
+```typescript
+getVersion(): string
+```
+
+Get the bashkit version string.
+
+## BashOptions
+
+Options for creating a Bash or BashTool instance.
+
+### Fields
+
+- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+
+Required for `mounts` and runtime `mount()` APIs. Mount targets must
+resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+
+Each entry becomes a bash command that shares the instance's VFS — files
+created by the callback persist across `execute()` calls. Callbacks can be
+sync (`string` return) or async (`Promise<string>`); exceptions surface as
+stderr with exit code 1.
+
+Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+the option again after restoring.
+
+Override precedence: shell function > POSIX special builtin > custom
+builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string` Initial working directory for the shell.
+
+Sets the starting `cwd` directly instead of running a leading
+`cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+
+Scripts see these immediately without an `export` prelude. Keys are
+variable names, values are their string values.
+- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+
+These function names become available as Python builtins within
+the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, FileValue>` Files to mount in the virtual filesystem.
+Keys are absolute paths, values are content strings or lazy providers.
+
+String values are mounted immediately. Function values are called on
+first read and the result is cached.
+- **`hostname?`** — `string`
+- **`maxCommands?`** — `number`
+- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+
+Async execute validates this before entering the per-instance queue so
+oversized calls cannot wait while retaining large command strings.
+- **`maxLoopIterations?`** — `number`
+- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+
+Caps the total byte budget for variable storage and function bodies.
+Prevents OOM from untrusted input such as exponential string doubling.
+- **`maxTotalLoopIterations?`** — `number`
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
+restricted to the configured allowlist, with optional transparent
+credential injection. Omitted = network disabled (no `curl`/`wget`).
+
+Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+
+When true, bash scripts can use `python -c '...'` or `python3 script.py`
+to run Python code within the sandbox.
+- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+Backed by Turso. When `true`, the binding both registers the builtin
+and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+script cap, 256 MiB DB cap, 30 s wall-clock budget,
+resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+
+When set, commands that exceed this duration are aborted with
+exit code 124 (matching the bash `timeout` convention).
+- **`username?`** — `string`
+
+## BuiltinContext
+
+Execution context passed to a custom builtin registered via
+`customBuiltins` or `addBuiltin`.
+
+`name`, `argv`, `stdin`, `env`, and `cwd` are snapshots of the shell
+state at invocation time; `fs` is a live handle to the interpreter's
+virtual filesystem.
+
+### Fields
+
+- **`argv`** — `string[]` Arguments (not including the command name).
+- **`cwd`** — `string` Current working directory.
+- **`env`** — `Record<string, string>` Environment variables visible at the call site.
+- **`fs`** — `FileSystem` Live handle to the interpreter's virtual filesystem — the same VFS the
+executing script sees. Reads observe earlier script writes and writes
+are visible to subsequent commands. Inherits mounts and read-only
+configuration.
+- **`name`** — `string` The command name as invoked.
+- **`stdin`** — `null | string` Piped input, or `null` if there is no pipe.
+
+## CredentialHeader
+
+A single HTTP header (name/value pair) for credential injection.
+
+### Fields
+
+- **`name`** — `string`
+- **`value`** — `string`
+
+## ExecResult
+
+Result from executing bash commands.
+
+### Fields
+
+- **`error?`** — `string`
+- **`exitCode`** — `number`
+- **`finalEnv?`** — `Record<string, string>`
+- **`stderr`** — `string`
+- **`stderrTruncated`** — `boolean`
+- **`stdout`** — `string`
+- **`stdoutTruncated`** — `boolean`
+- **`success`** — `boolean` True if exit_code is 0.
+
+## ExecuteOptions
+
+### Fields
+
+- **`onOutput?`** — `OnOutput` Live chunk callback. Must be synchronous.
+
+Limitation: do not call back into the same `Bash` / `BashTool` instance
+from this handler (`execute*`, `readFile`, `fs()`, etc.). The current
+binding rejects same-instance re-entry to avoid deadlocks and runtime
+panics.
+- **`signal?`** — `AbortSignal`
+
+## FileSystemRealOptions
+
+Standalone filesystem handle for direct VFS operations and native addon interop.
+
+### Fields
+
+- **`allowedMountPaths`** — `string[]`
+- **`writable?`** — `boolean`
+
+## NetworkCredential
+
+Credential injected into outbound HTTP requests matching `pattern`.
+
+`kind` selects the shape: `"bearer"` (requires `token`), `"header"`
+(requires `name` + `value`), or `"headers"` (requires `headers`).
+Scripts never see the secret — it is attached on the wire only.
+
+### Fields
+
+- **`headers?`** — `CredentialHeader[]` Header list (for `kind: "headers"`).
+- **`kind`** — `string` One of `"bearer"`, `"header"`, `"headers"`.
+- **`name?`** — `string` Header name (for `kind: "header"`).
+- **`pattern`** — `string` URL pattern the credential applies to (e.g. `https://api.example.com/**`).
+- **`token?`** — `string` Bearer token (for `kind: "bearer"`).
+- **`value?`** — `string` Header value (for `kind: "header"`).
+
+## NetworkCredentialPlaceholder
+
+Placeholder-mode credential injection: `env` is set to an opaque
+placeholder value visible to scripts; outbound requests matching
+`pattern` have the placeholder replaced with the real credential.
+
+### Fields
+
+- **`env`** — `string` Environment variable that receives the placeholder value.
+- **`headers?`** — `CredentialHeader[]` Header list (for `kind: "headers"`).
+- **`kind`** — `string` One of `"bearer"`, `"header"`, `"headers"`.
+- **`name?`** — `string` Header name (for `kind: "header"`).
+- **`pattern`** — `string` URL pattern the credential applies to.
+- **`token?`** — `string` Bearer token (for `kind: "bearer"`).
+- **`value?`** — `string` Header value (for `kind: "header"`).
+
+## NetworkOptions
+
+Outbound network configuration (enables `curl`/`wget`).
+
+Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+not both. `blockPrivateIps` defaults to `true`.
+
+### Fields
+
+- **`allow?`** — `string[]` URL patterns permitted for outbound requests.
+- **`allowAll?`** — `boolean` Allow all outbound requests (mutually exclusive with `allow`).
+- **`blockPrivateIps?`** — `boolean` Block requests resolving to private/loopback IPs (default: true).
+- **`credentialPlaceholders?`** — `NetworkCredentialPlaceholder[]` Placeholder-mode credential injection (see type docs).
+- **`credentials?`** — `NetworkCredential[]` Credentials injected transparently into matching requests.
+
+## OutputChunk
+
+### Fields
+
+- **`stderr`** — `string`
+- **`stdout`** — `string`
+
+## ScriptedToolOptions
+
+Options for creating a ScriptedTool instance.
+
+### Fields
+
+- **`maxCommands?`** — `number`
+- **`maxLoopIterations?`** — `number`
+- **`name`** — `string`
+- **`shortDescription?`** — `string`
+
+## ShellState
+
+Lightweight snapshot of shell state for inspection (prompt rendering,
+debugging). Mirrors the Python binding's `ShellState`; omits function
+definitions (use `snapshot()` for full state capture/restore).
+
+### Fields
+
+- **`aliases`** — `Record<string, string>` Shell aliases.
+- **`arrays`** — `Record<string, Record<string, string>>` Indexed arrays: name → { index (as string) → value }. Sparse indices
+are preserved, hence a map rather than a dense JS array.
+- **`assocArrays`** — `Record<string, Record<string, string>>` Associative arrays: name → { key → value }.
+- **`cwd`** — `string` Current working directory.
+- **`env`** — `Record<string, string>` Environment variables.
+- **`lastExitCode`** — `number` Exit code of the last executed command.
+- **`traps`** — `Record<string, string>` Trap handlers keyed by signal/condition name.
+- **`variables`** — `Record<string, string>` Shell variables (non-exported).
+
+## SnapshotOptions
+
+### Fields
+
+- **`excludeFilesystem?`** — `boolean`
+- **`excludeFunctions?`** — `boolean`
+- **`hmacKey?`** — `Uint8Array<ArrayBufferLike>` Secret key used to authenticate snapshot bytes with HMAC-SHA256.
+Required for BashTool snapshots because tool snapshots may cross tenant
+or network trust boundaries. Recommended for any snapshot accepted from
+users, shared storage, or remote callers.
+
+## BuiltinCallback
+
+Callback signature for custom builtins. Return the stdout to emit.
+Both sync (`string`) and async (`Promise<string>`) returns are supported.
+Exceptions / rejections surface as stderr with exit code 1.
+
+```typescript
+type BuiltinCallback = (ctx: BuiltinContext) => string | Promise<string>
+```
+
+## FileValue
+
+A file value: either a string, a sync function returning a string,
+or an async function returning a Promise<string>.
+
+Function values are resolved lazily on first read and cached.
+
+```typescript
+type FileValue = string | () => string | () => Promise<string>
+```
+
+## OnOutput
+
+```typescript
+type OnOutput = (chunk: OutputChunk) => void
+```
+
+## ToolCallback
+
+Callback type for ScriptedTool tool commands.
+
+Receives parsed `--key value` flags as `params` and optional piped input as `stdin`.
+Must return a string.
+
+```typescript
+type ToolCallback = (params: Record<string, unknown>, stdin: string | null) => string
+```
+
+---
+
+# Framework integrations
+
+## `@everruns/bashkit/langchain`
+
+LangChain.js integration for Bashkit.
+
+Provides LangChain-compatible tools wrapping BashTool and ScriptedTool
+for use with LangChain agents and chains.
+
+```typescript
+import { createBashTool, createScriptedTool } from '@everruns/bashkit/langchain';
+
+// Basic bash tool
+const tool = createBashTool();
+const result = await tool.invoke({ commands: "echo hello" });
+
+// Scripted tool
+import { ScriptedTool } from '@everruns/bashkit';
+const st = new ScriptedTool({ name: "api" });
+st.addTool("greet", "Greet user", (p) => `hello ${p.name}\n`);
+const langchainTool = createScriptedTool(st);
+```
+
+### createBashTool()
+
+```typescript
+createBashTool(options?: Omit<BashOptions, "files">): DynamicStructuredTool
+```
+
+Create a LangChain-compatible Bashkit tool.
+
+Returns a `DynamicStructuredTool` that can be passed directly to
+LangChain agents like `createReactAgent`.
+
+```typescript
+import { createBashTool } from '@everruns/bashkit/langchain';
+import { createReactAgent } from '@langchain/langgraph/prebuilt';
+
+const tool = createBashTool({ username: "agent" });
+const agent = createReactAgent({ llm: model, tools: [tool] });
+```
+
+### createScriptedTool()
+
+```typescript
+createScriptedTool(scriptedTool: ScriptedTool): DynamicStructuredTool
+```
+
+Create a LangChain-compatible tool from a configured ScriptedTool.
+
+The ScriptedTool should already have tools registered via `addTool()`.
+
+```typescript
+import { ScriptedTool } from '@everruns/bashkit';
+import { createScriptedTool } from '@everruns/bashkit/langchain';
+
+const st = new ScriptedTool({ name: "api" });
+st.addTool("get_data", "Fetch data", (p) => JSON.stringify({ id: p.id }));
+const tool = createScriptedTool(st);
+```
+
+## `@everruns/bashkit/anthropic`
+
+Anthropic SDK adapter for Bashkit.
+
+Returns a ready-to-use `{ system, tools, handler }` object for Claude's
+`messages.create()` API, eliminating boilerplate for tool integration.
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import { bashTool } from "@everruns/bashkit/anthropic";
+
+const client = new Anthropic();
+const bash = bashTool();
+
+const response = await client.messages.create({
+  model: "claude-haiku-4-5-20251001",
+  max_tokens: 1024,
+  system: bash.system,
+  tools: bash.tools,
+  messages: [{ role: "user", content: "List files in /home" }],
+});
+
+for (const block of response.content) {
+  if (block.type === "tool_use") {
+    const result = await bash.handler(block);
+    // send result back as tool_result
+  }
+}
+```
+
+### bashTool()
+
+```typescript
+bashTool(options?: BashToolOptions): BashToolAdapter
+```
+
+Create a bash tool adapter for the Anthropic SDK.
+
+Returns `{ system, tools, handler }` that plugs directly into
+`client.messages.create()`.
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import { bashTool } from "@everruns/bashkit/anthropic";
+
+const client = new Anthropic();
+const bash = bashTool({ files: { "/data.txt": "hello" } });
+
+const response = await client.messages.create({
+  model: "claude-haiku-4-5-20251001",
+  max_tokens: 256,
+  system: bash.system,
+  tools: bash.tools,
+  messages: [{ role: "user", content: "Read /data.txt" }],
+});
+```
+
+### BashToolAdapter
+
+Return value of `bashTool()`.
+
+### Fields
+
+- **`bash`** — `BashTool` The underlying BashTool instance for direct access.
+- **`handler`** — `(toolUse: ToolUseBlock, options: HandlerOptions) => Promise<ToolResult>` Handler that executes a tool_use block and returns a tool_result.
+
+Pass an AbortSignal via the options parameter to cancel execution
+when the framework aborts the tool call:
+
+```typescript
+const controller = new AbortController();
+const result = await bash.handler(block, { signal: controller.signal });
+```
+- **`system`** — `string` System prompt describing bash capabilities and constraints.
+- **`tools`** — `AnthropicTool[]` Tool definitions for Anthropic's messages.create() API.
+
+### BashToolOptions
+
+Options for configuring the bash tool adapter.
+
+### Fields
+
+- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+
+Required for `mounts` and runtime `mount()` APIs. Mount targets must
+resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+
+Each entry becomes a bash command that shares the instance's VFS — files
+created by the callback persist across `execute()` calls. Callbacks can be
+sync (`string` return) or async (`Promise<string>`); exceptions surface as
+stderr with exit code 1.
+
+Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+the option again after restoring.
+
+Override precedence: shell function > POSIX special builtin > custom
+builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string` Initial working directory for the shell.
+
+Sets the starting `cwd` directly instead of running a leading
+`cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+
+Scripts see these immediately without an `export` prelude. Keys are
+variable names, values are their string values.
+- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+
+These function names become available as Python builtins within
+the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, string>` Pre-populate VFS files. Keys are absolute paths, values are file contents.
+- **`hostname?`** — `string`
+- **`maxCommands?`** — `number`
+- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+
+Async execute validates this before entering the per-instance queue so
+oversized calls cannot wait while retaining large command strings.
+- **`maxLoopIterations?`** — `number`
+- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+
+Caps the total byte budget for variable storage and function bodies.
+Prevents OOM from untrusted input such as exponential string doubling.
+- **`maxOutputLength?`** — `number` Maximum output length in characters (default: 100000).
+
+Output exceeding this limit is truncated with a `[truncated]` marker.
+Prevents context window flooding when scripts produce large output.
+- **`maxTotalLoopIterations?`** — `number`
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
+restricted to the configured allowlist, with optional transparent
+credential injection. Omitted = network disabled (no `curl`/`wget`).
+
+Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+
+When true, bash scripts can use `python -c '...'` or `python3 script.py`
+to run Python code within the sandbox.
+- **`sanitizeOutput?`** — `boolean` Wrap tool output in XML boundary markers (default: false).
+
+When enabled, output is wrapped in `<tool_output>...</tool_output>` tags
+to help LLMs distinguish tool output data from instructions, reducing
+prompt injection risk via tool output.
+
+**Security note:** This is a defense-in-depth measure. Tool output from
+untrusted sources (files, network) may contain text that attempts to
+manipulate LLM behavior. Boundary markers help but do not eliminate this risk.
+- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+Backed by Turso. When `true`, the binding both registers the builtin
+and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+script cap, 256 MiB DB cap, 30 s wall-clock budget,
+resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+
+When set, this is passed to the underlying BashTool as `timeoutMs`.
+Commands exceeding this duration are aborted with exit code 124.
+Framework-level timeouts can be propagated here to ensure bashkit
+stops execution when the framework cancels a tool call.
+- **`username?`** — `string`
+
+### HandlerOptions
+
+Options for handler invocation.
+
+### Fields
+
+- **`signal?`** — `AbortSignal` AbortSignal to cancel execution when the framework aborts the tool call.
+
+### ToolResult
+
+Result from handling a tool call, ready to send back as tool_result.
+
+### Fields
+
+- **`content`** — `string`
+- **`is_error?`** — `boolean`
+- **`tool_use_id`** — `string`
+- **`type`** — `"tool_result"`
+
+## `@everruns/bashkit/openai`
+
+OpenAI SDK adapter for Bashkit.
+
+Returns a ready-to-use `{ system, tools, handler }` object for OpenAI's
+`chat.completions.create()` API.
+
+```typescript
+import OpenAI from "openai";
+import { bashTool } from "@everruns/bashkit/openai";
+
+const client = new OpenAI();
+const bash = bashTool();
+
+const response = await client.chat.completions.create({
+  model: "gpt-4.1-mini",
+  tools: bash.tools,
+  messages: [
+    { role: "system", content: bash.system },
+    { role: "user", content: "Create a file with today's date" },
+  ],
+});
+
+for (const call of response.choices[0].message.tool_calls ?? []) {
+  const result = await bash.handler(call);
+  // send result back as tool message
+}
+```
+
+### bashTool()
+
+```typescript
+bashTool(options?: BashToolOptions): BashToolAdapter
+```
+
+Create a bash tool adapter for the OpenAI SDK.
+
+Returns `{ system, tools, handler }` that plugs directly into
+`client.chat.completions.create()`.
+
+```typescript
+import OpenAI from "openai";
+import { bashTool } from "@everruns/bashkit/openai";
+
+const client = new OpenAI();
+const bash = bashTool({ files: { "/data.txt": "42" } });
+
+const response = await client.chat.completions.create({
+  model: "gpt-4.1-nano",
+  tools: bash.tools,
+  messages: [
+    { role: "system", content: bash.system },
+    { role: "user", content: "What's in /data.txt?" },
+  ],
+});
+```
+
+### BashToolAdapter
+
+Return value of `bashTool()`.
+
+### Fields
+
+- **`bash`** — `BashTool` The underlying BashTool instance for direct access.
+- **`handler`** — `(toolCall: OpenAIToolCall, options: HandlerOptions) => Promise<ToolResult>` Handler that executes a tool_call and returns a tool message.
+
+Pass an AbortSignal via the options parameter to cancel execution
+when the framework aborts the tool call:
+
+```typescript
+const controller = new AbortController();
+const result = await bash.handler(call, { signal: controller.signal });
+```
+- **`system`** — `string` System prompt describing bash capabilities and constraints.
+- **`tools`** — `OpenAITool[]` Tool definitions for OpenAI's chat.completions.create() API.
+
+### BashToolOptions
+
+Options for configuring the bash tool adapter.
+
+### Fields
+
+- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+
+Required for `mounts` and runtime `mount()` APIs. Mount targets must
+resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+
+Each entry becomes a bash command that shares the instance's VFS — files
+created by the callback persist across `execute()` calls. Callbacks can be
+sync (`string` return) or async (`Promise<string>`); exceptions surface as
+stderr with exit code 1.
+
+Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+the option again after restoring.
+
+Override precedence: shell function > POSIX special builtin > custom
+builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string` Initial working directory for the shell.
+
+Sets the starting `cwd` directly instead of running a leading
+`cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+
+Scripts see these immediately without an `export` prelude. Keys are
+variable names, values are their string values.
+- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+
+These function names become available as Python builtins within
+the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, string>` Pre-populate VFS files. Keys are absolute paths, values are file contents.
+- **`hostname?`** — `string`
+- **`maxCommands?`** — `number`
+- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+
+Async execute validates this before entering the per-instance queue so
+oversized calls cannot wait while retaining large command strings.
+- **`maxLoopIterations?`** — `number`
+- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+
+Caps the total byte budget for variable storage and function bodies.
+Prevents OOM from untrusted input such as exponential string doubling.
+- **`maxOutputLength?`** — `number` Maximum output length in characters (default: 100000).
+
+Output exceeding this limit is truncated with a `[truncated]` marker.
+Prevents context window flooding when scripts produce large output.
+- **`maxTotalLoopIterations?`** — `number`
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
+restricted to the configured allowlist, with optional transparent
+credential injection. Omitted = network disabled (no `curl`/`wget`).
+
+Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+
+When true, bash scripts can use `python -c '...'` or `python3 script.py`
+to run Python code within the sandbox.
+- **`sanitizeOutput?`** — `boolean` Wrap tool output in XML boundary markers (default: false).
+
+When enabled, output is wrapped in `<tool_output>...</tool_output>` tags
+to help LLMs distinguish tool output data from instructions, reducing
+prompt injection risk via tool output.
+- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+Backed by Turso. When `true`, the binding both registers the builtin
+and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+script cap, 256 MiB DB cap, 30 s wall-clock budget,
+resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+
+When set, this is passed to the underlying BashTool as `timeoutMs`.
+Commands exceeding this duration are aborted with exit code 124.
+Framework-level timeouts can be propagated here to ensure bashkit
+stops execution when the framework cancels a tool call.
+- **`username?`** — `string`
+
+### HandlerOptions
+
+Options for handler invocation.
+
+### Fields
+
+- **`signal?`** — `AbortSignal` AbortSignal to cancel execution when the framework aborts the tool call.
+
+### ToolResult
+
+Result from handling a tool call, ready to send as a tool message.
+
+### Fields
+
+- **`content`** — `string`
+- **`role`** — `"tool"`
+- **`tool_call_id`** — `string`
+
+## `@everruns/bashkit/ai`
+
+Vercel AI SDK adapter for Bashkit.
+
+Returns `{ system, tools }` that plugs directly into `generateText()` /
+`streamText()` with zero boilerplate. Tools include built-in `execute`
+functions, so the AI SDK auto-executes tool calls in its `maxSteps` loop.
+
+```typescript
+import { generateText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { bashTool } from "@everruns/bashkit/ai";
+
+const bash = bashTool({
+  files: { "/home/user/data.csv": "name,age\nAlice,30\nBob,25" },
+});
+
+const { text } = await generateText({
+  model: anthropic("claude-haiku-4-5-20251001"),
+  system: bash.system,
+  tools: bash.tools,
+  maxSteps: 5,
+  prompt: "Analyze the CSV file and tell me the average age",
+});
+```
+
+### bashTool()
+
+```typescript
+bashTool(options?: BashToolOptions): BashToolAdapter
+```
+
+Create a bash tool adapter for the Vercel AI SDK.
+
+Returns `{ system, tools }` that plugs directly into `generateText()` or
+`streamText()`. The tool includes a built-in `execute` function, so tool
+calls are auto-executed when using `maxSteps`.
+
+```typescript
+import { generateText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { bashTool } from "@everruns/bashkit/ai";
+
+const bash = bashTool({ files: { "/test.txt": "hello world" } });
+
+const { text } = await generateText({
+  model: anthropic("claude-haiku-4-5-20251001"),
+  system: bash.system,
+  tools: bash.tools,
+  maxSteps: 3,
+  prompt: "Read /test.txt and tell me what it says",
+});
+```
+
+### BashToolAdapter
+
+Return value of `bashTool()`.
+
+### Fields
+
+- **`bash`** — `BashTool` The underlying BashTool instance for direct access.
+- **`system`** — `string` System prompt describing bash capabilities and constraints.
+- **`tools`** — `Record<string, AiTool>` Tool definitions for Vercel AI SDK's generateText/streamText.
+
+### BashToolOptions
+
+Options for configuring the bash tool adapter.
+
+### Fields
+
+- **`allowedMountPaths?`** — `string[]` Allowlist of host path prefixes permitted for real filesystem mounts.
+
+Required for `mounts` and runtime `mount()` APIs. Mount targets must
+resolve under one of these prefixes; otherwise the call is rejected.
+- **`customBuiltins?`** — `Record<string, BuiltinCallback>` Custom JS callbacks registered as bash builtins.
+
+Each entry becomes a bash command that shares the instance's VFS — files
+created by the callback persist across `execute()` calls. Callbacks can be
+sync (`string` return) or async (`Promise<string>`); exceptions surface as
+stderr with exit code 1.
+
+Equivalent to calling `addBuiltin(name, cb)` for each entry. Survives
+`reset()`; not preserved through `snapshot()`/`restoreSnapshot()` — pass
+the option again after restoring.
+
+Override precedence: shell function > POSIX special builtin > custom
+builtin > baked-in builtin > PATH.
+- **`cwd?`** — `string` Initial working directory for the shell.
+
+Sets the starting `cwd` directly instead of running a leading
+`cd "${cwd}"` command, avoiding the parse/exec overhead.
+- **`env?`** — `Record<string, string>` Initial environment variables, applied before execution.
+
+Scripts see these immediately without an `export` prelude. Keys are
+variable names, values are their string values.
+- **`externalFunctions?`** — `string[]` Names of external functions callable from embedded Python code.
+
+These function names become available as Python builtins within
+the embedded interpreter. When called, they invoke the external handler.
+- **`files?`** — `Record<string, string>` Pre-populate VFS files. Keys are absolute paths, values are file contents.
+- **`hostname?`** — `string`
+- **`maxCommands?`** — `number`
+- **`maxInputBytes?`** — `number` Maximum script input size in UTF-8 bytes.
+
+Async execute validates this before entering the per-instance queue so
+oversized calls cannot wait while retaining large command strings.
+- **`maxLoopIterations?`** — `number`
+- **`maxMemory?`** — `number` Maximum interpreter memory in bytes (variables, arrays, functions).
+
+Caps the total byte budget for variable storage and function bodies.
+Prevents OOM from untrusted input such as exponential string doubling.
+- **`maxTotalLoopIterations?`** — `number`
+- **`mounts?`** — `({ path: string; root: string; writable?: boolean })[]` Real filesystem mounts. Each mount maps a host directory into the VFS.
+- **`network?`** — `NetworkOptions` Outbound network configuration. When set, enables `curl`/`wget`
+restricted to the configured allowlist, with optional transparent
+credential injection. Omitted = network disabled (no `curl`/`wget`).
+
+Must specify either `allow` (list of URL patterns) or `allowAll: true`,
+not both. `blockPrivateIps` defaults to `true`.
+- **`python?`** — `boolean` Enable embedded Python execution (`python`/`python3` builtins).
+
+When true, bash scripts can use `python -c '...'` or `python3 script.py`
+to run Python code within the sandbox.
+- **`sqlite?`** — `boolean` Enable the embedded SQLite builtin (`sqlite`/`sqlite3`).
+
+Backed by Turso. When `true`, the binding both registers the builtin
+and injects `BASHKIT_ALLOW_INPROCESS_SQLITE=1` so the runtime gate is
+satisfied. Defaults to `false`. Default `SqliteLimits` apply: 4 MiB
+script cap, 256 MiB DB cap, 30 s wall-clock budget,
+resource-affecting PRAGMAs and `ATTACH`/`DETACH` rejected.
+- **`timeoutMs?`** — `number` Execution timeout in milliseconds.
+
+When set, commands that exceed this duration are aborted with
+exit code 124 (matching the bash `timeout` convention).
+- **`username?`** — `string`

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -2,21 +2,52 @@
 import BaseLayout from "./BaseLayout.astro";
 import { DOC_META, DOC_META_BY_SLUG } from "../pages/docs/_meta";
 
+type NavLink = { href: string; title: string };
+
 interface Props {
   slug: string;
   title: string;
   description?: string;
+  // Optional overrides so non-/docs sections (e.g. /api) can reuse this
+  // layout — and its branding — without being listed in DOC_META.
+  breadcrumb?: { href: string; label: string };
+  editUrl?: string | null;
+  prevLink?: NavLink | null;
+  nextLink?: NavLink | null;
 }
 
-const { slug, title, description } = Astro.props;
+const { slug, title, description, breadcrumb, editUrl: editUrlProp, prevLink, nextLink } =
+  Astro.props;
 
 const meta = DOC_META_BY_SLUG[slug];
 const index = DOC_META.findIndex((doc) => doc.slug === slug);
-const prev = index > 0 ? DOC_META[index - 1] : null;
-const next = index >= 0 && index < DOC_META.length - 1 ? DOC_META[index + 1] : null;
+const metaPrev = index > 0 ? DOC_META[index - 1] : null;
+const metaNext = index >= 0 && index < DOC_META.length - 1 ? DOC_META[index + 1] : null;
 
-const editPath = meta?.editPath ?? `docs/${slug}.md`;
-const editUrl = `https://github.com/everruns/bashkit/blob/main/${editPath}`;
+const prev: NavLink | null =
+  prevLink !== undefined
+    ? prevLink
+    : metaPrev
+      ? { href: `/docs/${metaPrev.slug}`, title: metaPrev.title }
+      : null;
+const next: NavLink | null =
+  nextLink !== undefined
+    ? nextLink
+    : metaNext
+      ? { href: `/docs/${metaNext.slug}`, title: metaNext.title }
+      : null;
+
+const breadcrumbHref = breadcrumb?.href ?? "/docs";
+const breadcrumbRoot = breadcrumb ? null : "Docs";
+const breadcrumbLabel = breadcrumb?.label ?? meta?.section ?? title;
+
+// editUrl: explicit null hides the link (generated pages have no editable
+// markdown source); undefined falls back to the GitHub source path.
+const editUrl =
+  editUrlProp === null
+    ? null
+    : (editUrlProp ??
+      `https://github.com/everruns/bashkit/blob/main/${meta?.editPath ?? `docs/${slug}.md`}`);
 ---
 
 <BaseLayout
@@ -26,9 +57,15 @@ const editUrl = `https://github.com/everruns/bashkit/blob/main/${editPath}`;
   <article class="doc section">
     <div class="container doc__container">
       <nav class="doc__breadcrumb" aria-label="Breadcrumb">
-        <a href="/docs">Docs</a>
-        <span aria-hidden="true">/</span>
-        <span>{meta?.section ?? title}</span>
+        {breadcrumbRoot ? (
+          <>
+            <a href={breadcrumbHref}>{breadcrumbRoot}</a>
+            <span aria-hidden="true">/</span>
+            <span>{breadcrumbLabel}</span>
+          </>
+        ) : (
+          <a href={breadcrumbHref}>{breadcrumbLabel}</a>
+        )}
       </nav>
 
       <div class="doc__body">
@@ -36,18 +73,20 @@ const editUrl = `https://github.com/everruns/bashkit/blob/main/${editPath}`;
       </div>
 
       <footer class="doc__foot">
-        <a class="doc__edit" href={editUrl} target="_blank" rel="noopener noreferrer">
-          Edit this page on GitHub
-        </a>
+        {editUrl ? (
+          <a class="doc__edit" href={editUrl} target="_blank" rel="noopener noreferrer">
+            Edit this page on GitHub
+          </a>
+        ) : <span />}
         <div class="doc__nav">
           {prev ? (
-            <a class="doc__nav-link doc__nav-link--prev" href={`/docs/${prev.slug}`}>
+            <a class="doc__nav-link doc__nav-link--prev" href={prev.href}>
               <span class="doc__nav-eyebrow">Previous</span>
               <span class="doc__nav-title">{prev.title}</span>
             </a>
           ) : <span />}
           {next ? (
-            <a class="doc__nav-link doc__nav-link--next" href={`/docs/${next.slug}`}>
+            <a class="doc__nav-link doc__nav-link--next" href={next.href}>
               <span class="doc__nav-eyebrow">Next</span>
               <span class="doc__nav-title">{next.title}</span>
             </a>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -3,6 +3,7 @@ import BaseLayout from "./BaseLayout.astro";
 import { DOC_META, DOC_META_BY_SLUG } from "../pages/docs/_meta";
 
 type NavLink = { href: string; title: string };
+type Heading = { depth: number; slug: string; text: string };
 
 interface Props {
   slug: string;
@@ -14,10 +15,20 @@ interface Props {
   editUrl?: string | null;
   prevLink?: NavLink | null;
   nextLink?: NavLink | null;
+  // Reference pages (e.g. /api) opt into a wider column, word-wrapped code
+  // (long signatures don't clip), and a sticky "On this page" TOC built from
+  // the rendered headings.
+  wide?: boolean;
+  headings?: Heading[];
 }
 
-const { slug, title, description, breadcrumb, editUrl: editUrlProp, prevLink, nextLink } =
+const { slug, title, description, breadcrumb, editUrl: editUrlProp, prevLink, nextLink, wide, headings } =
   Astro.props;
+
+// H2-level TOC: the classes/types/modules. Method-level (H3) headings would
+// run to ~150 entries on the reference pages, so keep the nav scannable.
+const toc: Heading[] = wide ? (headings ?? []).filter((h) => h.depth === 2) : [];
+const showToc = toc.length > 0;
 
 const meta = DOC_META_BY_SLUG[slug];
 const index = DOC_META.findIndex((doc) => doc.slug === slug);
@@ -54,8 +65,8 @@ const editUrl =
   title={title}
   description={description ?? meta?.summary}
 >
-  <article class="doc section">
-    <div class="container doc__container">
+  <article class:list={["doc", "section", wide && "doc--wide"]}>
+    <div class:list={["container", "doc__container", wide && "doc__container--wide"]}>
       <nav class="doc__breadcrumb" aria-label="Breadcrumb">
         {breadcrumbRoot ? (
           <>
@@ -68,8 +79,25 @@ const editUrl =
         )}
       </nav>
 
-      <div class="doc__body">
-        <slot />
+      <div class="doc__layout">
+        <div class="doc__body">
+          <slot />
+        </div>
+
+        {showToc && (
+          <aside class="doc__toc" aria-label="On this page">
+            <p class="doc__toc-title">On this page</p>
+            <nav>
+              <ul>
+                {toc.map((h) => (
+                  <li>
+                    <a href={`#${h.slug}`}>{h.text}</a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </aside>
+        )}
       </div>
 
       <footer class="doc__foot">
@@ -104,6 +132,66 @@ const editUrl =
   .doc__container {
     max-width: 44rem;
   }
+  .doc__container--wide {
+    max-width: 76rem;
+  }
+  /* Reference pages: content + sticky "On this page" rail. */
+  .doc--wide .doc__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 15rem;
+    gap: var(--space-xl);
+    align-items: start;
+  }
+  .doc__toc {
+    position: sticky;
+    top: calc(var(--header-height) + var(--space-md));
+    max-height: calc(100vh - var(--header-height) - var(--space-lg));
+    overflow-y: auto;
+    padding-left: 0.25rem;
+  }
+  .doc__toc-title {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--color-slate);
+    margin-bottom: 0.6rem;
+  }
+  .doc__toc ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+  }
+  .doc__toc li {
+    margin-bottom: 0.1rem;
+  }
+  .doc__toc a {
+    display: block;
+    font-size: 0.85rem;
+    line-height: 1.35;
+    color: var(--color-slate);
+    text-decoration: none;
+    padding: 0.2rem 0 0.2rem 0.7rem;
+    border-left: 2px solid rgb(10 22 54 / 0.1);
+  }
+  .doc__toc a:hover {
+    color: var(--color-obsidian);
+    border-left-color: var(--color-gold);
+  }
+  /* Long signatures wrap instead of clipping/scrolling on reference pages. */
+  .doc--wide .doc__body :global(pre),
+  .doc--wide .doc__body :global(pre) :global(code) {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+  }
+  @media (max-width: 1024px) {
+    .doc--wide .doc__layout {
+      grid-template-columns: 1fr;
+    }
+    .doc__toc {
+      display: none;
+    }
+  }
   .doc__breadcrumb {
     display: flex;
     gap: 0.5rem;
@@ -135,12 +223,14 @@ const editUrl =
     margin-bottom: var(--space-sm);
     letter-spacing: -0.01em;
     color: var(--color-obsidian);
+    scroll-margin-top: calc(var(--header-height) + 1rem);
   }
   .doc__body :global(h3) {
     font-size: 1.15rem;
     margin-top: var(--space-lg);
     margin-bottom: var(--space-sm);
     color: var(--color-obsidian);
+    scroll-margin-top: calc(var(--header-height) + 1rem);
   }
   .doc__body :global(p),
   .doc__body :global(ul),

--- a/site/src/pages/api/[slug].astro
+++ b/site/src/pages/api/[slug].astro
@@ -1,0 +1,45 @@
+---
+import { getCollection, render } from "astro:content";
+import DocsLayout from "../../layouts/DocsLayout.astro";
+import { API_REFS, API_REFS_BY_SLUG } from "./_meta";
+
+export async function getStaticPaths() {
+  const apidocs = await getCollection("apidocs");
+  const ids = new Set(apidocs.map((entry) => entry.id));
+
+  // Only emit routes for languages that actually have generated markdown, so
+  // the index never links to a missing page (TypeScript appears once its
+  // markdown is generated and committed).
+  return API_REFS.filter((ref) => ids.has(ref.slug)).map((ref) => {
+    const entry = apidocs.find((doc) => doc.id === ref.slug)!;
+    return { params: { slug: ref.slug }, props: { entry, ref } };
+  });
+}
+
+const { entry, ref } = Astro.props;
+const { Content, headings } = await render(entry);
+
+const h1 = headings.find((heading) => heading.depth === 1);
+const title = h1?.text ?? ref.title;
+const seoTitle = ref.seoTitle ?? `${title} — Bashkit`;
+
+// Prev/next across the available API references for consistent doc-style nav.
+const available = API_REFS.filter(
+  (r) => r.slug === ref.slug || API_REFS_BY_SLUG[r.slug],
+);
+const idx = available.findIndex((r) => r.slug === ref.slug);
+const prevRef = idx > 0 ? available[idx - 1] : null;
+const nextRef = idx >= 0 && idx < available.length - 1 ? available[idx + 1] : null;
+---
+
+<DocsLayout
+  slug={ref.slug}
+  title={seoTitle}
+  description={ref.seoDescription}
+  breadcrumb={{ href: "/api", label: "API reference" }}
+  editUrl={null}
+  prevLink={prevRef ? { href: `/api/${prevRef.slug}`, title: prevRef.title } : null}
+  nextLink={nextRef ? { href: `/api/${nextRef.slug}`, title: nextRef.title } : null}
+>
+  <Content />
+</DocsLayout>

--- a/site/src/pages/api/[slug].astro
+++ b/site/src/pages/api/[slug].astro
@@ -41,6 +41,8 @@ const nextRef = idx >= 0 && idx < available.length - 1 ? available[idx + 1] : nu
   editUrl={null}
   prevLink={prevRef ? { href: `/api/${prevRef.slug}`, title: prevRef.title } : null}
   nextLink={nextRef ? { href: `/api/${nextRef.slug}`, title: nextRef.title } : null}
+  wide
+  headings={headings}
 >
   <Content />
 </DocsLayout>

--- a/site/src/pages/api/[slug].astro
+++ b/site/src/pages/api/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
 import DocsLayout from "../../layouts/DocsLayout.astro";
-import { API_REFS, API_REFS_BY_SLUG } from "./_meta";
+import { API_REFS } from "./_meta";
 
 export async function getStaticPaths() {
   const apidocs = await getCollection("apidocs");
@@ -23,10 +23,11 @@ const h1 = headings.find((heading) => heading.depth === 1);
 const title = h1?.text ?? ref.title;
 const seoTitle = ref.seoTitle ?? `${title} — Bashkit`;
 
-// Prev/next across the available API references for consistent doc-style nav.
-const available = API_REFS.filter(
-  (r) => r.slug === ref.slug || API_REFS_BY_SLUG[r.slug],
-);
+// Prev/next across the API references that actually have generated markdown,
+// so nav never points at a missing page (mirrors the getStaticPaths filter).
+const apidocs = await getCollection("apidocs");
+const ids = new Set(apidocs.map((entry) => entry.id));
+const available = API_REFS.filter((r) => ids.has(r.slug));
 const idx = available.findIndex((r) => r.slug === ref.slug);
 const prevRef = idx > 0 ? available[idx - 1] : null;
 const nextRef = idx >= 0 && idx < available.length - 1 ? available[idx + 1] : null;

--- a/site/src/pages/api/_meta.ts
+++ b/site/src/pages/api/_meta.ts
@@ -1,0 +1,73 @@
+// Registry for the self-hosted package API references — the docs.rs analog for
+// the PyPI and npm packages. Rust keeps using docs.rs (external); Python and
+// TypeScript render generated markdown from the `apidocs` content collection
+// through the same branded DocsLayout. See specs/documentation.md.
+
+export type ApiRef = {
+  // Matches the `apidocs` collection entry id and the /api/<slug> route.
+  slug: string;
+  title: string;
+  language: string;
+  summary: string;
+  packageName: string;
+  packageUrl: string;
+  registry: string;
+  // Script that regenerates the markdown (provenance). Optional until a
+  // language's generator lands.
+  generator?: string;
+  seoTitle: string;
+  seoDescription: string;
+};
+
+// External reference (Rust → docs.rs). Listed on the index, no local page.
+export type ExternalApiRef = {
+  language: string;
+  title: string;
+  summary: string;
+  packageName: string;
+  registry: string;
+  href: string;
+};
+
+export const EXTERNAL_API_REFS: ExternalApiRef[] = [
+  {
+    language: "Rust",
+    title: "Rust API",
+    summary: "Full rustdoc for the bashkit crate, hosted on docs.rs.",
+    packageName: "bashkit",
+    registry: "crates.io",
+    href: "https://docs.rs/bashkit",
+  },
+];
+
+export const API_REFS: ApiRef[] = [
+  {
+    slug: "python",
+    title: "Python API reference",
+    language: "Python",
+    summary: "Classes and functions exported from the bashkit PyPI package.",
+    packageName: "bashkit",
+    packageUrl: "https://pypi.org/project/bashkit/",
+    registry: "PyPI",
+    generator: "scripts/gen_python_apidocs.py",
+    seoTitle: "Bashkit Python API reference",
+    seoDescription:
+      "API reference for the bashkit PyPI package: Bash, BashTool, ScriptedTool, FileSystem, ExecResult, and framework integrations.",
+  },
+  {
+    slug: "typescript",
+    title: "TypeScript API reference",
+    language: "TypeScript",
+    summary: "Types and functions exported from the @everruns/bashkit npm package.",
+    packageName: "@everruns/bashkit",
+    packageUrl: "https://www.npmjs.com/package/@everruns/bashkit",
+    registry: "npm",
+    seoTitle: "Bashkit TypeScript API reference",
+    seoDescription:
+      "API reference for the @everruns/bashkit npm package: Bash, BashTool, ScriptedTool, FileSystem, and framework integrations.",
+  },
+];
+
+export const API_REFS_BY_SLUG: Record<string, ApiRef> = Object.fromEntries(
+  API_REFS.map((ref) => [ref.slug, ref]),
+);

--- a/site/src/pages/api/index.astro
+++ b/site/src/pages/api/index.astro
@@ -1,0 +1,157 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
+import { API_REFS, EXTERNAL_API_REFS } from "./_meta";
+
+const apidocs = await getCollection("apidocs");
+const generatedIds = new Set(apidocs.map((entry) => entry.id));
+
+const refs = API_REFS.map((ref) => ({
+  ...ref,
+  available: generatedIds.has(ref.slug),
+}));
+---
+
+<BaseLayout
+  title="Bashkit API reference — Rust, Python, and TypeScript"
+  description="Hosted API references for every bashkit package: rustdoc on docs.rs, plus self-hosted Python and TypeScript references."
+>
+  <section class="docs-hero section">
+    <div class="container">
+      <span class="docs-eyebrow">API reference</span>
+      <h1>One reference per language.</h1>
+      <p class="docs-lede">
+        Generated from each package's own source — Rust on docs.rs, Python and
+        TypeScript self-hosted here in the same look as the rest of the docs.
+      </p>
+    </div>
+  </section>
+
+  <section class="docs-index section section-alt">
+    <div class="container docs-index__sections">
+      <div class="docs-section">
+        <h2 class="docs-section__title">Languages</h2>
+        <ul class="docs-cards">
+          {EXTERNAL_API_REFS.map((ref) => (
+            <li>
+              <a class="docs-card" href={ref.href} target="_blank" rel="noopener noreferrer">
+                <span class="docs-card__title">{ref.language}</span>
+                <span class="docs-card__summary">{ref.summary}</span>
+                <span class="docs-card__meta">{ref.packageName} · {ref.registry} ↗</span>
+              </a>
+            </li>
+          ))}
+          {refs.map((ref) =>
+            ref.available ? (
+              <li>
+                <a class="docs-card" href={`/api/${ref.slug}`}>
+                  <span class="docs-card__title">{ref.language}</span>
+                  <span class="docs-card__summary">{ref.summary}</span>
+                  <span class="docs-card__meta">{ref.packageName} · {ref.registry}</span>
+                </a>
+              </li>
+            ) : (
+              <li>
+                <div class="docs-card docs-card--soon" aria-disabled="true">
+                  <span class="docs-card__title">{ref.language}</span>
+                  <span class="docs-card__summary">{ref.summary}</span>
+                  <span class="docs-card__meta">Coming soon</span>
+                </div>
+              </li>
+            ),
+          )}
+        </ul>
+      </div>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .docs-hero {
+    padding-top: var(--space-xl);
+    padding-bottom: var(--space-lg);
+  }
+  .docs-eyebrow {
+    display: inline-flex;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-navy);
+    margin-bottom: var(--space-sm);
+  }
+  .docs-hero h1 {
+    font-size: clamp(2.2rem, 5vw, 3.6rem);
+    letter-spacing: -0.03em;
+    line-height: 1.02;
+    margin-bottom: var(--space-md);
+  }
+  .docs-lede {
+    max-width: 40rem;
+    font-size: 1.1rem;
+    color: var(--color-slate);
+  }
+
+  .docs-index__sections {
+    display: grid;
+    gap: var(--space-lg);
+  }
+  .docs-section {
+    display: grid;
+    gap: var(--space-md);
+  }
+  .docs-section__title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-navy);
+  }
+  .docs-cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+    gap: var(--space-md);
+  }
+  .docs-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1.1rem 1.2rem;
+    border: 1px solid rgb(10 22 54 / 0.12);
+    background: var(--color-white);
+    color: var(--color-obsidian);
+    text-decoration: none;
+    transition:
+      border-color 0.15s,
+      box-shadow 0.15s,
+      transform 0.1s;
+  }
+  a.docs-card:hover {
+    border-color: rgb(10 22 54 / 0.35);
+    box-shadow: 0 6px 20px rgb(10 22 54 / 0.06);
+    text-decoration: none;
+    transform: translateY(-1px);
+  }
+  .docs-card--soon {
+    opacity: 0.6;
+    cursor: default;
+  }
+  .docs-card__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+  .docs-card__summary {
+    color: var(--color-slate);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .docs-card__meta {
+    color: var(--color-navy);
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+</style>

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -89,6 +89,11 @@ through the existing Astro `DocsLayout`, so API pages inherit site branding
 (colors, typography, Shiki theme) instead of shipping a foreign pdoc/TypeDoc
 theme. This reuses the same single-source pipeline as the rustdoc guides.
 
+Reference pages opt into `DocsLayout`'s `wide` mode (a 76rem column, a sticky
+"On this page" rail built from the H2 headings — classes/types/modules; H3
+method headings would run to ~150 entries — and word-wrapped code so long
+signatures don't clip). Prose guides keep their 44rem reading width.
+
 **Latest-only** (no per-version archive): the page reflects the newest
 published release. **Generate-and-commit**: output lives in the `apidocs`
 content collection (`site/src/content/apidocs/*.md`) and is committed, so the

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -111,6 +111,16 @@ build-generated, gitignored `index.d.ts`), so it cannot run in the node-only
 output. A language's `/api/<slug>` route only appears once its markdown exists,
 so the `/api` index degrades gracefully if a page is missing.
 
+### Drift
+
+`apidocs-drift.yml` regenerates each reference and fails if the committed
+markdown is stale, same as `builtins-drift.yml`. It never auto-commits (a CI
+bot commit would violate the AGENTS.md commit-attribution rule) — a human runs
+`just apidocs` and commits. The Python check is cheap (static `griffe` parse,
+pinned) so it runs on every PR touching the Python surface; the TypeScript
+check needs a Rust `napi build`, so it runs only on the weekly schedule and on
+demand. Regenerate-and-commit is a release step (see `specs/release-process.md`).
+
 ### Constraints
 
 - Generated markdown must not contain local `*.md` links (`verify-public-links`

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -100,14 +100,16 @@ as `site/src/data/performance-timeline.json`).
 | Language | Source of truth | Tool | Command |
 |----------|-----------------|------|---------|
 | Python | `crates/bashkit-python/bashkit/*.pyi` + integration modules | `griffe` (static, `allow_inspection=False`) | `just apidocs-python` |
-| TypeScript | `crates/bashkit-js/*.ts` + napi-generated `index.d.ts` | `typedoc` (planned) | _follow-up_ |
+| TypeScript | `crates/bashkit-js/*.ts` + napi-generated `index.d.ts` | `typedoc` (JSON) + custom renderer | `just apidocs-ts` |
 
-Python is fully wired (`scripts/gen_python_apidocs.py`). TypeScript is
-infrastructure-ready: the `/api` index shows it as "coming soon" and the route
-appears automatically once `site/src/content/apidocs/typescript.md` is
-committed. Its generation must run `napi build` first (the `.ts` wrappers import
-types from the build-generated, gitignored `index.d.ts`), so it cannot run in
-the node-only `site.yml` — it belongs in a Rust-capable release job.
+Both languages are wired (`scripts/gen_python_apidocs.py`,
+`scripts/gen_ts_apidocs.mjs`; `just apidocs` runs both). The Python generator
+parses type stubs statically — no build needed. The TypeScript generator must
+run `napi build` first (the `.ts` wrappers import types from the
+build-generated, gitignored `index.d.ts`), so it cannot run in the node-only
+`site.yml` — regenerate it in a Rust-capable release job, then commit the
+output. A language's `/api/<slug>` route only appears once its markdown exists,
+so the `/api` index degrades gracefully if a page is missing.
 
 ### Constraints
 

--- a/specs/documentation.md
+++ b/specs/documentation.md
@@ -67,3 +67,51 @@ the canonical docs/content:
   (`site/public/_headers`), `robots.txt`, and a footer link.
 - All site verify scripts run in the `postbuild` chain (CI **Site Build** job),
   so these guarantees hold on every build.
+
+## API reference hosting
+
+### Problem
+
+Rust gets a hosted, versioned API reference for free via **docs.rs** on every
+crates.io release. The PyPI package (`bashkit`) and the npm package
+(`@everruns/bashkit`) have no equivalent — only a README and type definitions.
+
+### Decision
+
+Self-host per-language API references on **bashkit.sh** under `/api/`:
+
+- `/api` — index linking all three languages (Rust → docs.rs externally;
+  Python and TypeScript served locally).
+- `/api/python`, `/api/typescript` — generated reference pages.
+
+Generate **markdown** from each package's own source of truth and render it
+through the existing Astro `DocsLayout`, so API pages inherit site branding
+(colors, typography, Shiki theme) instead of shipping a foreign pdoc/TypeDoc
+theme. This reuses the same single-source pipeline as the rustdoc guides.
+
+**Latest-only** (no per-version archive): the page reflects the newest
+published release. **Generate-and-commit**: output lives in the `apidocs`
+content collection (`site/src/content/apidocs/*.md`) and is committed, so the
+node-only `site.yml` build just renders it. Regenerate on release (same pattern
+as `site/src/data/performance-timeline.json`).
+
+### Generators
+
+| Language | Source of truth | Tool | Command |
+|----------|-----------------|------|---------|
+| Python | `crates/bashkit-python/bashkit/*.pyi` + integration modules | `griffe` (static, `allow_inspection=False`) | `just apidocs-python` |
+| TypeScript | `crates/bashkit-js/*.ts` + napi-generated `index.d.ts` | `typedoc` (planned) | _follow-up_ |
+
+Python is fully wired (`scripts/gen_python_apidocs.py`). TypeScript is
+infrastructure-ready: the `/api` index shows it as "coming soon" and the route
+appears automatically once `site/src/content/apidocs/typescript.md` is
+committed. Its generation must run `napi build` first (the `.ts` wrappers import
+types from the build-generated, gitignored `index.d.ts`), so it cannot run in
+the node-only `site.yml` — it belongs in a Rust-capable release job.
+
+### Constraints
+
+- Generated markdown must not contain local `*.md` links (`verify-public-links`
+  fails on them) — use in-page anchors and absolute site/external links.
+- New `apidocs` pages are registered in `site/src/pages/api/_meta.ts`, not the
+  `/docs` `_meta.ts`, so `verify-doc-routes` does not require them.

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -41,6 +41,10 @@ silently failed.
    workspace `Cargo.toml`, `crates/bashkit-cli/Cargo.toml` path-dep pin on
    `bashkit`, `crates/bashkit-js/package.json`, and `Cargo.lock`
    (`cargo update -p bashkit -p bashkit-cli ...`).
+   - Refresh the self-hosted API references: `just apidocs` and commit any
+     changes. The `apidocs-drift` workflow only checks TypeScript weekly (its
+     regen needs a Rust build), so a release is the reliable point to catch TS
+     drift. See `specs/documentation.md` ("API reference hosting").
 4. **Run local verification** — `cargo fmt --check`, `cargo clippy
    --all-targets --all-features -- -D warnings`, `cargo test`.
 5. **Verify publish-readiness** (catches what local tests don't — the


### PR DESCRIPTION
## What

Self-host per-language API references on bashkit.sh under `/api/`, the docs.rs
analog for the PyPI (`bashkit`) and npm (`@everruns/bashkit`) packages — which
otherwise only ship a README and type definitions.

- **`/api`** — index linking all three languages (Rust → docs.rs externally;
  Python and TypeScript served locally). No more "coming soon".
- **`/api/python`** — generated from the PEP 561 type stubs via `griffe`
  (static parse, no build/compiled extension needed).
- **`/api/typescript`** — generated from the `.ts` wrappers + napi-generated
  `index.d.ts` via `typedoc` (JSON) → a custom markdown renderer.

Both render **markdown** that flows through the existing Astro `DocsLayout`, so
the API pages inherit site branding (colors, typography, Shiki theme) instead
of shipping a foreign pdoc/TypeDoc theme — same single-source pipeline as the
rustdoc guides. Output is generate-and-committed so the node-only `site.yml`
build just renders it.

## How it stays fresh

`apidocs-drift.yml` regenerates each reference and **fails on stale committed
markdown** (same pattern as `builtins-drift.yml`). It never auto-commits — a CI
bot commit would violate the AGENTS.md commit-attribution rule — so a human runs
`just apidocs` and commits. The Python check is cheap (static `griffe` parse,
pinned) and runs on every PR touching the Python surface; the TypeScript check
needs a Rust `napi build`, so it runs only weekly + on demand. Regeneration is
also a documented release step.

## Commands

- `just apidocs-python` / `just apidocs-ts` / `just apidocs` (both)

## Notes

- Generators emit no local `*.md` links (in-page anchors + absolute links only),
  so `verify-public-links` passes.
- Includes a rendering fix so multi-paragraph TypeScript field docs stay inside
  their list item (previously each field fragmented into its own `<ul>` with
  orphaned paragraphs).

## Verification

- `pnpm run build` + all 9 postbuild verifiers pass.
- `/api/typescript` and `/api/python` render branded; `/api` index links both.
- Drift checks are byte-idempotent against the committed output.

Specs updated: `specs/documentation.md` (generators, drift, constraints) and
`specs/release-process.md` (regen step).