### PR TITLE
fix(deps): bump langsmith 0.8.5 -> 0.8.18 (GHSA-f4xh-w4cj-qxq8)

### DIFF
--- a/examples/docs-grep-agent/uv.lock
+++ b/examples/docs-grep-agent/uv.lock
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.8.5"
+version = "0.8.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -465,12 +465,13 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
+    { name = "websockets" },
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/eb/8883d1158c743d0aac350f09df7880714d27283497e8c80bb9fe3480f165/langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c", size = 4462348, upload-time = "2026-05-15T21:31:41.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d9/a6681aa9847bbbc5ec21abe20a5e233b94e5edcfe39624db607ac7e8ccb4/langsmith-0.8.18.tar.gz", hash = "sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd", size = 4526988, upload-time = "2026-06-19T13:12:17.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/85/968c88a63e32a59b3e5c68afd2fe114ce0708a125db0be1a85efc25fb2ea/langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae", size = 399564, upload-time = "2026-05-15T21:31:39.046Z" },
+    { url = "https://files.pythonhosted.org/packages/03/70/0e0cc80a3b064c8d6c8d697c3125ed86e39d5a7393ec6dc8b07cb1cf13c4/langsmith-0.8.18-py3-none-any.whl", hash = "sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282", size = 508108, upload-time = "2026-06-19T13:12:15.348Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves Dependabot alert **#73 (HIGH)** — *LangSmith SDK TracingMiddleware: Arbitrary server-side file read* (GHSA-f4xh-w4cj-qxq8).

`langsmith` is a transitive dependency in the `docs-grep-agent` example. Bumped `0.8.5 → 0.8.18` (first patched version) via `uv lock --upgrade-package langsmith`.

## Changes
- `examples/docs-grep-agent/uv.lock`: langsmith `0.8.5` → `0.8.18`

## Verification
- `uv lock --check` passes (lock consistent, 45 packages resolved).
- Only the langsmith entry changed; `websockets` (already present) added to its dependency list by the new release.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vDoom7wtujjiPtSuh96kr)_