### PR TITLE
fix(snapshot): validate restored directory stack

### DIFF
--- a/crates/bashkit/src/builtins/limits.rs
+++ b/crates/bashkit/src/builtins/limits.rs
@@ -48,6 +48,8 @@ pub(crate) const EXPAND_MAX_OUTPUT_BYTES: usize = 1_048_576;
 
 /// dirs/pushd/popd: max entries on the directory stack.
 pub(crate) const DIRSTACK_MAX_SIZE: usize = 4096;
+/// dirs/pushd/popd: max UTF-8 bytes per restored directory-stack entry.
+pub(crate) const DIRSTACK_MAX_ENTRY_BYTES: usize = 4096;
 
 /// find: total stdout cap for default and `-printf` output.
 pub(crate) const FIND_MAX_OUTPUT_BYTES: usize = 1_048_576;

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -2264,6 +2264,32 @@ impl Interpreter {
     ///
     /// Used by snapshot restore paths before applying untrusted state.
     pub(crate) fn validate_shell_state_restore_limits(&self, state: &ShellState) -> Result<()> {
+        // THREAT[TM-DOS-061]: typed snapshot state must obey the same dirstack
+        // DoS bounds as pushd; otherwise forged snapshots bypass runtime growth
+        // limits before dirs/format_stack allocate output.
+        if state.dir_stack.len() > crate::builtins::limits::DIRSTACK_MAX_SIZE {
+            return Err(crate::limits::LimitExceeded::Memory(format!(
+                "directory stack entry limit ({}) exceeded",
+                crate::builtins::limits::DIRSTACK_MAX_SIZE
+            ))
+            .into());
+        }
+        for dir in &state.dir_stack {
+            if dir.len() > crate::builtins::limits::DIRSTACK_MAX_ENTRY_BYTES {
+                return Err(crate::limits::LimitExceeded::Memory(format!(
+                    "directory stack entry byte limit ({}) exceeded",
+                    crate::builtins::limits::DIRSTACK_MAX_ENTRY_BYTES
+                ))
+                .into());
+            }
+            if dir.contains('\0') {
+                return Err(crate::limits::LimitExceeded::Memory(
+                    "directory stack entry contains NUL".to_string(),
+                )
+                .into());
+            }
+        }
+
         let budget = crate::limits::MemoryBudget::recompute_from_state(
             &state.variables,
             &state.arrays,
@@ -12088,6 +12114,33 @@ cat /tmp/test_fd_exec_public.txt"#,
             .await
             .unwrap();
         assert!(out.stdout.contains("/tmp"));
+    }
+
+    #[test]
+    fn test_restore_validation_rejects_oversized_dir_stack() {
+        let mut state = Interpreter::new(Arc::new(InMemoryFs::new())).shell_state();
+        state.dir_stack = vec!["/tmp".to_string(); crate::builtins::limits::DIRSTACK_MAX_SIZE + 1];
+
+        let interp = Interpreter::new(Arc::new(InMemoryFs::new()));
+        assert!(
+            interp.validate_shell_state_restore_limits(&state).is_err(),
+            "restore must reject a dir_stack larger than pushd can create"
+        );
+    }
+
+    #[test]
+    fn test_restore_validation_rejects_oversized_dir_stack_entry() {
+        let mut state = Interpreter::new(Arc::new(InMemoryFs::new())).shell_state();
+        state.dir_stack = vec![format!(
+            "/{}",
+            "a".repeat(crate::builtins::limits::DIRSTACK_MAX_ENTRY_BYTES)
+        )];
+
+        let interp = Interpreter::new(Arc::new(InMemoryFs::new()));
+        assert!(
+            interp.validate_shell_state_restore_limits(&state).is_err(),
+            "restore must reject a dir_stack entry larger than path limits"
+        );
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/integration/snapshot_tests.rs
+++ b/crates/bashkit/tests/integration/snapshot_tests.rs
@@ -692,6 +692,29 @@ async fn snapshot_restore_rejects_tampered_shell_state_that_exceeds_memory_limit
     );
 }
 
+#[tokio::test]
+async fn snapshot_restore_rejects_tampered_dir_stack_above_pushd_limit() {
+    let src = Bash::new();
+    let bytes = src.snapshot().unwrap();
+
+    let mut tampered_json: serde_json::Value = serde_json::from_slice(&bytes[32..]).unwrap();
+    tampered_json["shell"]["dir_stack"] = serde_json::Value::Array(
+        (0..4097)
+            .map(|n| serde_json::Value::String(format!("/tmp/{n}")))
+            .collect(),
+    );
+
+    let tampered_snapshot: Snapshot = serde_json::from_value(tampered_json).unwrap();
+    let tampered_bytes = tampered_snapshot.to_bytes().unwrap();
+
+    let mut restored = Bash::new();
+    let result = restored.restore_snapshot(&tampered_bytes);
+    assert!(
+        result.is_err(),
+        "restore must reject dir_stack states pushd could not create"
+    );
+}
+
 // ==================== Atomic restore (Issue #1576) ====================
 
 /// A malformed VFS snapshot (path validation failure) must cause


### PR DESCRIPTION
### Motivation
- Restored `ShellState::dir_stack` was deserialized without size/byte/path checks, allowing forged snapshots to bypass `pushd` caps and cause resource exhaustion. 
- Remedy must reject oversized or invalid entries during snapshot validation before mutating interpreter state.

### Description
- Add a per-entry byte cap and NUL check and enforce the existing entry-count cap during snapshot validation in `Interpreter::validate_shell_state_restore_limits` (`crates/bashkit/src/interpreter/mod.rs`).
- Introduce `DIRSTACK_MAX_ENTRY_BYTES` constant next to `DIRSTACK_MAX_SIZE` (`crates/bashkit/src/builtins/limits.rs`).
- Reject restores where `state.dir_stack.len()` exceeds `DIRSTACK_MAX_SIZE`, any entry byte length exceeds `DIRSTACK_MAX_ENTRY_BYTES`, or any entry contains NUL before applying state.
- Add unit tests for oversized stacks and oversized entries and an integration test that tampers a snapshot with 4097 entries to verify restore rejection (`crates/bashkit/src/interpreter/mod.rs`, `crates/bashkit/tests/integration/snapshot_tests.rs`).

### Testing
- Ran formatting check with `cargo fmt --check`, which passed.
- Ran targeted unit tests with `cargo test -p bashkit test_restore_validation_rejects_oversized_dir_stack --lib`, which passed.
- Ran the new integration test with `cargo test -p bashkit --test integration snapshot_restore_rejects_tampered_dir_stack_above_pushd_limit`, which passed.
- Ran lints with `cargo clippy -p bashkit --lib --tests -- -D warnings`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a362cb2ef48832ba3f97a9105a10029)