### PR TITLE
fix(read): preserve implicit REPLY whitespace

### DIFF
--- a/crates/bashkit/src/builtins/read.rs
+++ b/crates/bashkit/src/builtins/read.rs
@@ -279,12 +279,16 @@ impl Builtin for Read {
             return Ok(result);
         }
 
-        // If no variable names given, use REPLY
-        let var_names: Vec<&str> = if var_args.is_empty() {
-            vec!["REPLY"]
-        } else {
-            var_args
-        };
+        if var_args.is_empty() {
+            let mut result = ExecResult::ok(String::new());
+            result.side_effects.push(BuiltinSideEffect::SetVariable {
+                name: "REPLY".to_string(),
+                value: line,
+            });
+            return Ok(result);
+        }
+
+        let var_names = var_args;
 
         // Assign words to variables via side effects (respects local scoping)
         let mut result = ExecResult::ok(String::new());
@@ -380,6 +384,25 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         let vars = extract_vars(&result);
         assert_eq!(vars.get("REPLY").unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn read_into_reply_preserves_trailing_ifs_whitespace() {
+        let (fs, mut cwd, mut variables) = setup().await;
+        let env = HashMap::new();
+        let args: Vec<String> = vec![];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            Some("secret  "),
+        );
+        let result = Read.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let vars = extract_vars(&result);
+        assert_eq!(vars.get("REPLY").unwrap(), "secret  ");
     }
 
     // ==================== read into named variable ====================

--- a/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh
@@ -163,3 +163,10 @@ IFS=",:"; read -r a b <<< "1,2:3  "; printf 'a=<%s> b=<%s> len=%d\n' "$a" "$b" "
 ### expect
 a=<1> b=<2:3  > len=5
 ### end
+
+### read_reply_preserves_trailing_ifs_whitespace
+# read without names assigns the raw line to REPLY, not an IFS-trimmed field
+read -r <<< "secret  "; printf 'reply=<%s> len=%d\n' "$REPLY" "${#REPLY}"
+### expect
+reply=<secret  > len=8
+### end


### PR DESCRIPTION
### Motivation
- A recent change applied final-variable IFS trimming to the implicit `REPLY` path, causing `read` with no variable names to lose trailing IFS-space and diverge from GNU Bash semantics.
- The goal is to preserve the raw input for implicit `REPLY` while keeping the existing final-variable trimming behavior for named variables.

### Description
- When `read` is invoked with no variable names, return early and set `REPLY` to the parsed `line` unchanged so trailing IFS whitespace is preserved (`crates/bashkit/src/builtins/read.rs`).
- Keep named-variable logic unchanged so the last named variable still receives the unsplit tail with its existing `trim_end_matches` behavior.
- Add a unit test `read_into_reply_preserves_trailing_ifs_whitespace` to assert implicit `REPLY` preserves trailing spaces (`crates/bashkit/src/builtins/read.rs`).
- Add a bash spec case `read_reply_preserves_trailing_ifs_whitespace` to `crates/bashkit/tests/spec_cases/bash/read-builtin.test.sh` to validate runtime behavior against expected Bash output.

### Testing
- Ran `cargo test -p bashkit read_into_reply_preserves_trailing_ifs_whitespace --lib` and the new unit test passed.
- Ran `cargo test -p bashkit read_last_var --lib` and the existing final-field tests passed, confirming named-variable trimming unchanged.
- Ran integration spec runner `cargo test -p bashkit --test integration bash_spec_tests` and the bash spec cases passed.
- Ran `cargo fmt --check` and `cargo clippy -p bashkit --lib -- -D warnings` and both completed with no issues; note that `git fetch origin main && git rebase origin/main` was attempted but this checkout has no `origin` remote configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a363046515c832b99f2a7342d518ecb)