### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,87 @@
 
 ## [Unreleased]
 
-### Breaking
+## [0.12.0] - 2026-06-23
+
+### Highlights
+
+- **`ExecOptions` request struct + `exec_with_options` entry point** — a single,
+  extensible request object for configuring a run, replacing ad-hoc parameter
+  threading at the library boundary
+  ([#2093](https://github.com/everruns/bashkit/pull/2093)).
+- **`BashToolBuilder::configure` for full `BashBuilder` access** — LLM-tool
+  callers can now reach the complete builder surface when wiring up a tool
+  ([#2104](https://github.com/everruns/bashkit/pull/2104)).
+- **Self-hosted Python + TypeScript API references at `/api`** — the binding API
+  docs are now built and hosted from the repo, with new public guides and a
+  reorganized docs navigation
+  ([#2109](https://github.com/everruns/bashkit/pull/2109),
+  [#2111](https://github.com/everruns/bashkit/pull/2111)).
+- **`agents`-friendly site surfaces** — `llms.txt` agent entry points, linked
+  skill sources, and cross-linked Markdown surfaces make the site easier for
+  agents to consume ([#2099](https://github.com/everruns/bashkit/pull/2099),
+  [#2106](https://github.com/everruns/bashkit/pull/2106)).
+- **Interpreter correctness & security sweep** — typed-state refactors of the
+  directory stack, `$!`, and `getopts` cursors, plus a batch of parser/expansion
+  fixes and several dependency security-advisory patches.
+
+### Breaking Changes
 
 - **`PythonLimits` / `TypeScriptLimits` fields moved under a shared `common: RuntimeLimits`.**
   The two embedded-VM limit types now share a `RuntimeLimits` core (duration,
-  memory, allocations, call depth). The fluent builder API is unchanged
-  (`.max_duration()`, `.max_memory()`, `.max_recursion()` / `.max_stack_depth()`,
-  `default()`), but code that read the `pub max_*` fields directly must now go
-  through `.common` (e.g. `limits.common.max_memory`). SQLite is unaffected.
+  memory, allocations, call depth)
+  ([#2095](https://github.com/everruns/bashkit/pull/2095)). The fluent builder
+  API is unchanged, but code that read the `pub max_*` fields directly must now
+  go through `.common`. SQLite is unaffected.
+  - Before: `let mem = limits.max_memory;`
+  - After: `let mem = limits.common.max_memory;`
+
+### What's Changed
+
+* test(parallel): verify 1000-session fan-out and extend scaling bench ([#2120](https://github.com/everruns/bashkit/pull/2120)) by @chaliy
+* chore(site): upgrade to Astro 7 ([#2119](https://github.com/everruns/bashkit/pull/2119)) by @chaliy
+* chore(ci): bump the github-actions group with 5 updates ([#2118](https://github.com/everruns/bashkit/pull/2118)) by @dependabot
+* chore(deps): bump the rust-dependencies group with 4 updates ([#2117](https://github.com/everruns/bashkit/pull/2117)) by @dependabot
+* fix(read): preserve implicit REPLY whitespace ([#2116](https://github.com/everruns/bashkit/pull/2116)) by @chaliy
+* fix(interpreter): reset getopts cursor across shell boundaries ([#2115](https://github.com/everruns/bashkit/pull/2115)) by @chaliy
+* fix(snapshot): validate restored last background pid ([#2114](https://github.com/everruns/bashkit/pull/2114)) by @chaliy
+* fix(snapshot): validate restored directory stack ([#2113](https://github.com/everruns/bashkit/pull/2113)) by @chaliy
+* fix(deps): bump langsmith 0.8.5 -> 0.8.18 (GHSA-f4xh-w4cj-qxq8) ([#2112](https://github.com/everruns/bashkit/pull/2112)) by @chaliy
+* docs(site): add six public guides and reorganize docs nav ([#2111](https://github.com/everruns/bashkit/pull/2111)) by @chaliy
+* fix(site): expand too-short meta descriptions on docs and builtins pages ([#2110](https://github.com/everruns/bashkit/pull/2110)) by @chaliy
+* feat(site): self-host Python + TypeScript API references at /api ([#2109](https://github.com/everruns/bashkit/pull/2109)) by @chaliy
+* fix(builtins): include special builtins in inventory ([#2108](https://github.com/everruns/bashkit/pull/2108)) by @chaliy
+* fix(expansion): fail closed on quote marker collision ([#2107](https://github.com/everruns/bashkit/pull/2107)) by @chaliy
+* feat(site): link skill source and enrich llms.txt for agents ([#2106](https://github.com/everruns/bashkit/pull/2106)) by @chaliy
+* docs(site): cross-link Markdown surfaces to llms.txt + document contract ([#2105](https://github.com/everruns/bashkit/pull/2105)) by @chaliy
+* feat(tool): add BashToolBuilder::configure for full BashBuilder access ([#2104](https://github.com/everruns/bashkit/pull/2104)) by @chaliy
+* refactor(dirstack): move directory stack to typed interpreter state ([#2103](https://github.com/everruns/bashkit/pull/2103)) by @chaliy
+* docs(skills): list http_client, ssh, jq, bot-auth in rust install features ([#2102](https://github.com/everruns/bashkit/pull/2102)) by @chaliy
+* docs(site): add LLM tools guide ([#2101](https://github.com/everruns/bashkit/pull/2101)) by @chaliy
+* docs(site): add Embedding getting-started guide ([#2100](https://github.com/everruns/bashkit/pull/2100)) by @chaliy
+* feat(site): add llms.txt agent entry points ([#2099](https://github.com/everruns/bashkit/pull/2099)) by @chaliy
+* docs(python): fix BashKit → Bashkit in FileSystem docstring ([#2098](https://github.com/everruns/bashkit/pull/2098)) by @chaliy
+* refactor(interpreter): move $! to typed state, drop dead _BG_EXIT_CODE ([#2097](https://github.com/everruns/bashkit/pull/2097)) by @chaliy
+* refactor(interpreter): move getopts cluster cursor to typed state ([#2096](https://github.com/everruns/bashkit/pull/2096)) by @chaliy
+* refactor(builtins): share RuntimeLimits core across Python/TypeScript VMs ([#2095](https://github.com/everruns/bashkit/pull/2095)) by @chaliy
+* refactor(interpreter): decompose monolith + group scoped shell state ([#2094](https://github.com/everruns/bashkit/pull/2094)) by @chaliy
+* feat(lib): add ExecOptions request struct + exec_with_options entry point ([#2093](https://github.com/everruns/bashkit/pull/2093)) by @chaliy
+* refactor(interpreter): remove _EVAL_CMD magic-variable channel ([#2092](https://github.com/everruns/bashkit/pull/2092)) by @chaliy
+* feat(tool): gate BashTool wrapper behind default `bash_tool` feature ([#2091](https://github.com/everruns/bashkit/pull/2091)) by @chaliy
+* fix(deps): patch newly-disclosed dependency security advisories ([#2090](https://github.com/everruns/bashkit/pull/2090)) by @chaliy
+* fix(eval): require balanced CSV quote matches ([#2089](https://github.com/everruns/bashkit/pull/2089)) by @chaliy
+* fix(rg): skip option values in delimiter scan ([#2088](https://github.com/everruns/bashkit/pull/2088)) by @chaliy
+* fix(read): trim trailing IFS whitespace when assigning final variable ([#2087](https://github.com/everruns/bashkit/pull/2087)) by @chaliy
+* fix(parser): keep literal case patterns unexpanded ([#2086](https://github.com/everruns/bashkit/pull/2086)) by @chaliy
+* fix(interpreter): suppress ERR trap in conditions ([#2085](https://github.com/everruns/bashkit/pull/2085)) by @chaliy
+* fix(strings): preserve double-dash delimiter ([#2084](https://github.com/everruns/bashkit/pull/2084)) by @chaliy
+* fix(interpreter): preserve mixed word IFS boundaries ([#2083](https://github.com/everruns/bashkit/pull/2083)) by @chaliy
+* fix(deps): patch npm security advisories in lockfiles ([#2082](https://github.com/everruns/bashkit/pull/2082)) by @chaliy
+* fix(parser): preserve expanded backslashes in glob dirs ([#2081](https://github.com/everruns/bashkit/pull/2081)) by @chaliy
+* fix(expansion): preserve quoted operands when markers collide ([#2076](https://github.com/everruns/bashkit/pull/2076)) by @chaliy
+* fix(fs): avoid duplicate lower hide accounting ([#2074](https://github.com/everruns/bashkit/pull/2074)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.11.0...v0.12.0
 
 ## [0.11.0] - 2026-06-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,20 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "serde",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,36 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attribute-derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
-dependencies = [
- "attribute-derive-macro",
- "derive-where",
- "manyhow",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "attribute-derive-macro"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
-dependencies = [
- "collection_literals",
- "interpolator",
- "manyhow",
- "proc-macro-utils",
- "proc-macro2",
- "quote",
- "quote-use",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,7 +303,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -359,7 +315,7 @@ dependencies = [
  "criterion",
  "ed25519-dalek 2.2.0",
  "fail",
- "fancy-regex 0.18.0",
+ "fancy-regex",
  "flate2",
  "futures-core",
  "futures-util",
@@ -370,7 +326,6 @@ dependencies = [
  "jaq-json",
  "jaq-std",
  "md-5",
- "monty",
  "num-traits",
  "os_display",
  "pretty_assertions",
@@ -400,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -415,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -429,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -443,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -460,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -472,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -726,7 +681,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -852,12 +806,6 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
 ]
-
-[[package]]
-name = "collection_literals"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
 
 [[package]]
 name = "colorchoice"
@@ -1015,7 +963,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.13.0",
+ "itertools",
  "num-traits",
  "oorandom",
  "page_size",
@@ -1036,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools",
 ]
 
 [[package]]
@@ -1248,17 +1196,6 @@ dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1499,17 +1436,6 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
@@ -1585,12 +1511,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1738,40 +1658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "get-size-derive2"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f8ab1b98a1284961d722ce994d9a0f3018ab1917618d4113824a72b9f71bc9"
-dependencies = [
- "attribute-derive",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "get-size2"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0cd0777a1057362cab35a779e0d79dacecb8d73e2c733eaafeb7ea917b08f03"
-dependencies = [
- "compact_str",
- "get-size-derive2",
- "hashbrown 0.17.1",
- "ordermap",
- "smallvec",
- "thin-vec",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width 0.2.2",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,8 +1751,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2238,12 +2122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
-
-[[package]]
 name = "intrusive-collections"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,18 +2137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-macro"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,15 +2147,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2319,7 +2176,7 @@ checksum = "d4ec9aaad7340e6990c6c1878ef3b46dbec624e535d7f786cc9ddcf94f773d33"
 dependencies = [
  "bstr",
  "bytes",
- "foldhash 0.1.5",
+ "foldhash",
  "hifijson",
  "indexmap",
  "jaq-core",
@@ -2386,21 +2243,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
 dependencies = [
  "jiff-tzdb",
-]
-
-[[package]]
-name = "jiter"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7866f284df68dbc242796251ed9768bde2b58ebc4d7d32cc07cc7fd993e3ed6c"
-dependencies = [
- "ahash",
- "bitvec",
- "lexical-parse-float",
- "num-bigint",
- "num-traits",
- "pyo3",
- "smallvec",
 ]
 
 [[package]]
@@ -2500,31 +2342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lexical-parse-float"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
-dependencies = [
- "lexical-util",
-]
-
-[[package]]
-name = "lexical-util"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,29 +2431,6 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "manyhow"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
-dependencies = [
- "manyhow-macros",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -2748,45 +2542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "monty"
-version = "0.0.18"
-source = "git+https://github.com/pydantic/monty?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663"
-dependencies = [
- "ahash",
- "chrono",
- "fancy-regex 0.17.0",
- "hashbrown 0.16.1",
- "indexmap",
- "itertools 0.14.0",
- "jiter",
- "libm",
- "monty-macros",
- "num-bigint",
- "num-integer",
- "num-traits",
- "postcard",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_python_stdlib",
- "ruff_text_size",
- "serde",
- "serde_json",
- "smallvec",
- "speedate",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "monty-macros"
-version = "0.0.18"
-source = "git+https://github.com/pydantic/monty?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "napi"
 version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,7 +2649,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -2944,15 +2698,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "ordermap"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
-dependencies = [
- "indexmap",
-]
 
 [[package]]
 name = "os_display"
@@ -3036,7 +2781,7 @@ version = "0.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e65a38ae589e284dd45a85008024f04aa680e9ddf1321c163cf7f187c805e91"
 dependencies = [
- "phf 0.13.1",
+ "phf",
  "proc-macro2",
  "quote",
  "syn",
@@ -3125,7 +2870,7 @@ dependencies = [
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
- "phf 0.13.1",
+ "phf",
  "rustc-hash",
  "unicode-id-start",
 ]
@@ -3171,7 +2916,7 @@ dependencies = [
  "oxc_estree",
  "oxc_index",
  "oxc_span",
- "phf 0.13.1",
+ "phf",
  "unicode-id-start",
 ]
 
@@ -3341,42 +3086,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared 0.13.1",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -3386,7 +3102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3395,20 +3111,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3662,17 +3369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-utils"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
-dependencies = [
- "proc-macro2",
- "quote",
- "smallvec",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,8 +3403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
- "num-bigint",
- "num-traits",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
@@ -3797,28 +3491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "quote-use"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
-dependencies = [
- "quote",
- "quote-use-macros",
-]
-
-[[package]]
-name = "quote-use-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4106,83 +3778,6 @@ dependencies = [
  "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
-]
-
-[[package]]
-name = "ruff_python_ast"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
-dependencies = [
- "aho-corasick",
- "bitflags",
- "compact_str",
- "get-size2",
- "is-macro",
- "memchr",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
- "rustc-hash",
- "thin-vec",
- "thiserror",
-]
-
-[[package]]
-name = "ruff_python_parser"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
-dependencies = [
- "bitflags",
- "bstr",
- "compact_str",
- "get-size2",
- "memchr",
- "ruff_python_ast",
- "ruff_python_trivia",
- "ruff_text_size",
- "rustc-hash",
- "static_assertions",
- "thin-vec",
- "unicode-ident",
- "unicode-normalization",
- "unicode_names2",
-]
-
-[[package]]
-name = "ruff_python_stdlib"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
-dependencies = [
- "bitflags",
- "unicode-ident",
-]
-
-[[package]]
-name = "ruff_python_trivia"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
-dependencies = [
- "itertools 0.14.0",
- "ruff_source_file",
- "ruff_text_size",
- "unicode-ident",
-]
-
-[[package]]
-name = "ruff_source_file"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
-dependencies = [
- "memchr",
- "ruff_text_size",
-]
-
-[[package]]
-name = "ruff_text_size"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
-dependencies = [
- "get-size2",
 ]
 
 [[package]]
@@ -4809,9 +4404,6 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smawk"
@@ -4834,17 +4426,6 @@ name = "softaes"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
-
-[[package]]
-name = "speedate"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba069c070b5e213f2a094deb7e5ed50ecb092be36102a4f4042e8d2056d060e"
-dependencies = [
- "lexical-parse-float",
- "strum 0.27.2",
- "strum_macros 0.27.2",
-]
 
 [[package]]
 name = "spin"
@@ -4960,16 +4541,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4982,18 +4554,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
  "syn",
 ]
 
@@ -5114,12 +4674,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thin-vec"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5167,21 +4721,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5455,8 +4994,8 @@ dependencies = [
  "shuttle",
  "simsimd",
  "smallvec",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
+ "strum_macros",
  "tempfile",
  "thiserror",
  "tracing",
@@ -5501,8 +5040,8 @@ dependencies = [
  "bitflags",
  "memchr",
  "miette",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum",
+ "strum_macros",
  "thiserror",
  "turso_macros",
 ]
@@ -5562,15 +5101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5587,28 +5117,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode_names2"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
-dependencies = [
- "phf 0.11.3",
- "unicode_names2_generator",
-]
-
-[[package]]
-name = "unicode_names2_generator"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
-dependencies = [
- "getopts",
- "log",
- "phf_codegen",
- "rand 0.8.6",
-]
 
 [[package]]
 name = "unit-prefix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.11.0", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.12.0", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",


### PR DESCRIPTION
## Release v0.12.0

Prepares the v0.12.0 release. On merge to `main`, `release.yml` creates the GitHub Release + tag and dispatches the publish workflows (crates.io, PyPI, npm, Homebrew).

### Why minor, not patch

`main` contains a **breaking API change** (#2095 — `PythonLimits`/`TypeScriptLimits` fields moved under a shared `common: RuntimeLimits`) plus several new `feat` commits. Per SemVer and `specs/release-process.md`, a breaking change pre-1.0 requires a **MINOR** bump, so this is **v0.12.0**, not v0.11.1.

### Changelog excerpt

**Highlights**
- `ExecOptions` request struct + `exec_with_options` entry point (#2093)
- `BashToolBuilder::configure` for full `BashBuilder` access (#2104)
- Self-hosted Python + TypeScript API references at `/api` (#2109, #2111)
- `llms.txt` agent entry points and linked skill sources (#2099, #2106)
- Interpreter correctness & security sweep (typed-state refactors, parser/expansion fixes, dependency advisory patches)

**Breaking Changes**
- **`PythonLimits` / `TypeScriptLimits` fields moved under a shared `common: RuntimeLimits`** (#2095). Fluent builder API unchanged; direct field reads must now go through `.common`.
  - Before: `limits.max_memory`
  - After: `limits.common.max_memory`

Full diff for 0.12.0: https://github.com/everruns/bashkit/compare/v0.11.0...v0.12.0

### Publish-readiness report

- `cargo fmt --check` — ✅ clean
- `cargo clippy --all-targets --features http_client,ssh,sqlite -- -D warnings` — ✅ clean
- `cargo publish --dry-run -p bashkit` (with CI's git-only-dep strip applied) — ✅ packages `bashkit v0.12.0`
- `cargo publish -p bashkit-cli` — deferred to CI: dry-run fails locally only because `bashkit 0.12.0` is not yet on crates.io (ordered publish: bashkit → bashkit-cli). CLI packaging structure unchanged from v0.11.0 and compiles cleanly.
- Version sync — workspace `Cargo.toml`, CLI path-dep pin, `Cargo.lock`, and `@everruns/bashkit` `package.json` all read `0.12.0`; greater than latest published (`v0.11.0`).
- API references — Python apidocs regenerated (no drift); no public TS binding API changes this cycle (only `pnpm-lock.yaml` moved), so no TS apidoc drift.

### What's Changed

42 PRs since v0.11.0 — see `CHANGELOG.md` for the full list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1RHW3ado49F49nYKub2a5)_