### PR TITLE
fix(deps): bump pyo3 to 0.29 to resolve two security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,9 +3398,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -3412,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3426,19 +3426,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "python3-dll-a",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3446,9 +3445,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3458,24 +3457,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,8 +110,8 @@ turso_core = "0.6"
 serial_test = "3"
 
 # Python bindings
-pyo3 = { version = "0.28.3", features = ["extension-module", "generate-import-lib"] }
-pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+pyo3 = { version = "0.29", features = ["extension-module", "generate-import-lib"] }
+pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 
 # JavaScript/Node.js bindings (NAPI-RS)
 napi = { version = "3.8.6", default-features = false, features = ["napi6", "compat-mode", "tokio_rt"] }
@@ -147,3 +147,21 @@ strip = "symbols"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
+
+# Important decision (security): pin `jiter` to upstream main so the whole
+# workspace can run pyo3 0.29, which fixes GHSA-36hh-v3qg-5jq4 (high, OOB read
+# in PyList/PyTuple iterators) and GHSA-chgr-c6px-7xpp (missing `Sync` bound)
+# in the bashkit-python extension.
+#
+# Blocker: `monty` -> `jiter 0.15.0` declares an optional `pyo3 = "^0.28.2"`.
+# Although jiter's `python` feature is never activated here (monty only enables
+# `num-bigint`), the weak `pyo3?/num-bigint` reference plus pyo3-ffi's
+# `links = "python"` global uniqueness force the resolver to honour jiter's
+# 0.28 constraint, pinning the whole graph below pyo3 0.29.
+#
+# jiter `main` is still version 0.15.0 (semver-compatible with monty's
+# `^0.15.0`) but already bumped its pyo3 dependency to 0.29, so this patch
+# unblocks the upgrade without a fork. Drop it once monty ships a release that
+# tracks a published jiter with pyo3 0.29.
+[patch.crates-io]
+jiter = { git = "https://github.com/pydantic/jiter", rev = "6d57715e01ec78859c62fc5447073c0b5902de39" }

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -1777,7 +1777,7 @@ impl PyFileSystem {
     fn to_capsule<'py>(&self, py: Python<'py>) -> PyResult<Py<PyCapsule>> {
         let fs = self.export_fs(py)?;
         let exported = export_filesystem(fs).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        let capsule = PyCapsule::new(py, exported, Some(FILESYSTEM_CAPSULE_NAME.to_owned()))?;
+        let capsule = PyCapsule::new_with_value(py, exported, FILESYSTEM_CAPSULE_NAME)?;
         Ok(capsule.unbind())
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -60,8 +60,12 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 
-# Allow git sources for Monty (not yet on crates.io) and its ruff deps
+# Allow git sources for Monty (not yet on crates.io) and its ruff deps.
+# jiter is pinned to upstream main via [patch.crates-io] in the root
+# Cargo.toml so the workspace can run pyo3 0.29 (security fix); see the
+# patch comment there.
 allow-git = [
     "https://github.com/pydantic/monty",
     "https://github.com/samuelcolvin/ruff",
+    "https://github.com/pydantic/jiter",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1408,31 +1408,27 @@ version = "1.11.0"
 criteria = "safe-to-run"
 
 [[exemptions.pyo3]]
-version = "0.28.3"
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pyo3-async-runtimes]]
-version = "0.28.0"
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pyo3-build-config]]
-version = "0.28.3"
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pyo3-ffi]]
-version = "0.28.3"
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pyo3-macros]]
-version = "0.28.3"
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pyo3-macros-backend]]
-version = "0.28.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.python3-dll-a]]
-version = "0.2.15"
+version = "0.29.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-error]]


### PR DESCRIPTION
## What

Bumps `pyo3` and `pyo3-async-runtimes` from 0.28 to 0.29, resolving two open Dependabot security advisories affecting the `bashkit-python` extension:

- **GHSA-36hh-v3qg-5jq4** (high) — out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators
- **GHSA-chgr-c6px-7xpp** (medium) — missing `Sync` bound on `PyCFunction::new_closure` closures

## Why it needed a jiter patch

The upgrade was blocked by `monty` → `jiter 0.15.0`, whose optional `pyo3 = "^0.28.2"` pins the whole workspace below 0.29 through pyo3-ffi's `links = "python"` global uniqueness. monty enables jiter's `num-bigint` feature, whose weak `pyo3?/num-bigint` reference forces the resolver to honour that 0.28 bound even though jiter's `python` feature is never activated here.

jiter `main` is still version `0.15.0` (semver-compatible with monty's `^0.15.0`) but already tracks pyo3 0.29, so it is pinned via `[patch.crates-io]` to upstream main — unblocking the bump without a fork. The patch can be dropped once monty ships a release tracking a published jiter with pyo3 0.29.

## Changes

- `Cargo.toml`: pyo3/pyo3-async-runtimes → 0.29; `[patch.crates-io]` jiter → upstream main (with rationale comment)
- `Cargo.lock`: pyo3 stack → 0.29.0 (kept git-dep-free, matching the repo convention)
- `crates/bashkit-python/src/lib.rs`: `PyCapsule::new` → `PyCapsule::new_with_value` (0.29 API)
- `deny.toml`: allow the `pydantic/jiter` git source
- `supply-chain/config.toml`: refresh cargo-vet exemptions to pyo3 0.29.0

## Verification

- `cargo check` / `cargo clippy -- -D warnings` (bashkit-python) ✅
- `cargo vet --locked` (full graph) ✅
- `cargo fmt --check` ✅
- Built the extension via `maturin develop` and the random-fs fixture; runtime smoke (exec + VFS) and the `test_filesystem_interop.py` capsule export/import tests (the changed code path) all pass under pyo3 0.29 ✅