### PR TITLE
fix(parser): treat do/done as words inside for/select in-list

### DIFF
--- a/crates/bashkit/src/parser/mod.rs
+++ b/crates/bashkit/src/parser/mod.rs
@@ -826,11 +826,14 @@ impl<'a> Parser<'a> {
         let words = if self.is_keyword("in") {
             self.advance(); // consume 'in'
 
-            // Parse word list until do/newline/;
+            // Parse word list until a list terminator (newline/;)
             let mut words = Vec::new();
             loop {
                 match &self.current_token {
-                    Some(tokens::Token::Word(w)) if w == "do" => break,
+                    // `do`/`done` are reserved words only in command position.
+                    // Inside the `in` list they are ordinary words until a list
+                    // terminator (`;`/newline), matching bash: `for a in do; do
+                    // echo $a; done` iterates over the single word `do`.
                     Some(tokens::Token::Word(w))
                     | Some(tokens::Token::QuotedWord(w))
                     | Some(tokens::Token::QuotedGlobWord(w)) => {
@@ -929,11 +932,13 @@ impl<'a> Parser<'a> {
         }
         self.advance(); // consume 'in'
 
-        // Parse word list until do/newline/;
+        // Parse word list until a list terminator (newline/;)
         let mut words = Vec::new();
         loop {
             match &self.current_token {
-                Some(tokens::Token::Word(w)) if w == "do" => break,
+                // `do`/`done` are reserved words only in command position.
+                // Inside the `in` list they are ordinary words until a list
+                // terminator (`;`/newline), matching bash.
                 Some(tokens::Token::Word(w))
                 | Some(tokens::Token::QuotedWord(w))
                 | Some(tokens::Token::QuotedGlobWord(w)) => {

--- a/crates/bashkit/tests/integration/for_in_reserved_word_tests.rs
+++ b/crates/bashkit/tests/integration/for_in_reserved_word_tests.rs
@@ -1,0 +1,39 @@
+//! Regression: reserved words (`do`, `done`, `in`, `then`, ...) are ordinary
+//! words inside a `for`/`select` `in` list until a list terminator (`;` or
+//! newline). They only become keywords in command position.
+//!
+//! Found by the nightly differential proptest:
+//! `for a in do; do echo $a; done` must print `do`, not nothing.
+
+use bashkit::Bash;
+
+#[tokio::test]
+async fn for_in_do_word_iterates() {
+    let mut bash = Bash::new();
+    let result = bash.exec("for a in do; do echo $a; done").await.unwrap();
+    assert_eq!(result.stdout, "do\n");
+}
+
+#[tokio::test]
+async fn for_in_multiple_reserved_words() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("for a in do done then in; do echo $a; done")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "do\ndone\nthen\nin\n");
+}
+
+#[tokio::test]
+async fn for_in_reserved_word_newline_terminator() {
+    let mut bash = Bash::new();
+    let result = bash.exec("for a in done\ndo echo $a; done").await.unwrap();
+    assert_eq!(result.stdout, "done\n");
+}
+
+#[tokio::test]
+async fn for_in_normal_words_still_work() {
+    let mut bash = Bash::new();
+    let result = bash.exec("for a in 1 2 3; do echo $a; done").await.unwrap();
+    assert_eq!(result.stdout, "1\n2\n3\n");
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -39,6 +39,7 @@ pub mod dev_null_tests;
 pub mod exec_options_tests;
 pub mod final_env_tests;
 pub mod find_multi_path_tests;
+pub mod for_in_reserved_word_tests;
 pub mod git_advanced_tests;
 pub mod git_inspection_tests;
 pub mod git_integration_tests;


### PR DESCRIPTION
## Problem

The nightly differential proptest (`multi_statement_matches_bash`) went red on 2026-06-24 (run [28076841758](https://github.com/everruns/bashkit/actions/runs/28076841758)) with the minimal failing input:

```
for a in do; do echo $a; done
Bashkit: ""   Bash: "do\n"
```

## Root cause

Reserved words (`do`, `done`, `in`, …) are keywords **only in command position**. Inside a `for`/`select` `in` list they are ordinary words until a list terminator (`;` or newline). The word-list parser broke the loop on the first `Word("do")`, so the list parsed as empty and the loop produced no output.

## Fix

Remove the special-case `do` break in both the `for` and `select` word-list loops (`crates/bashkit/src/parser/mod.rs`). The list now ends only at `;`/newline/non-word, matching bash. This also makes `for a in done; …`, multi reserved-word lists, etc. parse correctly.

## Tests

Added `for_in_reserved_word_tests.rs` covering the reproducer plus bash-parity cases. Verified output matches real bash exactly:

| script | bash & bashkit |
|---|---|
| `for a in do; do echo $a; done` | `do` |
| `for a in do done then in; do echo $a; done` | `do/done/then/in` |
| `for a in done\ndo echo $a; done` | `done` |
| `for a in 1 2 3; do echo $a; done` | `1/2/3` |

Note: full `cargo test` could not run in the authoring sandbox (egress policy blocks the `jiter` git dep pinned via `[patch.crates-io]`); the change was verified through a standalone harness against the real `bashkit` crate and against real bash. CI provides the authoritative check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY5HEmvr7NNXBWVczQkMc3)_