### PR TITLE
fix(js): bump js-yaml to >=4.2.0 (GHSA-h67p-54hq-rp68)

### DIFF
--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -118,11 +118,15 @@
   },
   "pnpm": {
     "overrides": {
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "js-yaml": ">=4.2.0"
     },
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "patchedDependencies": {
+      "supertap@3.0.1": "patches/supertap@3.0.1.patch"
+    }
   },
   "ava": {
     "files": [

--- a/crates/bashkit-js/patches/supertap@3.0.1.patch
+++ b/crates/bashkit-js/patches/supertap@3.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.js b/dist/index.js
+index ab236cc5173801c1efc330642ec112339786b779..aaa1355319147bba2f33049185c41967b074fa9e 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -43,7 +43,7 @@ export const test = (title, options) => {
+     ];
+     if (error) {
+         const object = error instanceof Error ? serializeErrorForTap(error) : error;
+-        output.push(['  ---', indentString(yaml.safeDump(object).trim(), 4), '  ...'].join('\n'));
++        output.push(['  ---', indentString(yaml.dump(object).trim(), 4), '  ...'].join('\n'));
+     }
+     return output.filter(Boolean).join('\n');
+ };

--- a/crates/bashkit-js/pnpm-lock.yaml
+++ b/crates/bashkit-js/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 overrides:
   esbuild: '>=0.28.1'
+  js-yaml: '>=4.2.0'
+
+patchedDependencies:
+  supertap@3.0.1:
+    hash: fb62acff1ae3d1587268fef569b79684229eeb16c6a833a14b115a253cc00112
+    path: patches/supertap@3.0.1.patch
 
 importers:
 
@@ -897,9 +903,6 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1098,11 +1101,6 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -1254,10 +1252,6 @@ packages:
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -1486,9 +1480,6 @@ packages:
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -2305,10 +2296,6 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   array-find-index@1.0.2: {}
@@ -2357,7 +2344,7 @@ snapshots:
       resolve-cwd: 3.0.0
       stack-utils: 2.0.6
       strip-ansi: 7.2.0
-      supertap: 3.0.1
+      supertap: 3.0.1(patch_hash=fb62acff1ae3d1587268fef569b79684229eeb16c6a833a14b115a253cc00112)
       temp-dir: 3.0.0
       write-file-atomic: 6.0.0
       yargs: 17.7.2
@@ -2521,8 +2508,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  esprima@4.0.1: {}
-
   estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
@@ -2655,11 +2640,6 @@ snapshots:
   js-tiktoken@1.0.21:
     dependencies:
       base64-js: 1.5.1
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -2823,8 +2803,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
-  sprintf-js@1.0.3: {}
-
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -2855,10 +2833,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  supertap@3.0.1:
+  supertap@3.0.1(patch_hash=fb62acff1ae3d1587268fef569b79684229eeb16c6a833a14b115a253cc00112):
     dependencies:
       indent-string: 5.0.0
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       serialize-error: 7.0.1
       strip-ansi: 7.2.0
 


### PR DESCRIPTION
## Security: Dependabot alert #53

[GHSA-h67p-54hq-rp68](https://github.com/everruns/bashkit/security/dependabot/53) (medium) — js-yaml ≤ 4.1.1 has a quadratic-complexity DoS in YAML merge-key handling via repeated aliases. Fixed in 4.2.0.

The only vulnerable copy in `crates/bashkit-js` was `js-yaml@3.14.2`, pulled transitively by `supertap@3.0.1` (via the `ava` test runner). It is dev/test tooling and only *dumps* YAML (never parses untrusted input), so it isn't exploitable here — but the alert flags by version range, so this clears it with a real upgrade rather than a dismissal.

## Change

- pnpm override `js-yaml: >=4.2.0` — collapses the tree to a single `js-yaml@4.2.0`.
- `supertap@3.0.1` still calls `yaml.safeDump`, which was **removed in js-yaml 4**. Patched via `pnpm.patchedDependencies` to use `yaml.dump` (safe by default in v4, identical signature for this call). Patch file: `patches/supertap@3.0.1.patch`.

## Verification

- `pnpm install --frozen-lockfile` is consistent (the gate JS CI uses).
- Confirmed `js-yaml@3.14.2` is gone; only `4.2.0` remains; all `supertap` dependents resolve to the patched variant.
- Smoke-tested supertap's TAP error-diagnostic path under js-yaml 4.2.0 — it emits a valid `--- … ...` YAML block and `finish()` works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HY5HEmvr7NNXBWVczQkMc3)_