### PR TITLE
chore(deps): drop stale pyo3 advisory ignores resolved by 0.29

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,15 +38,9 @@ ignore = [
     # Unmaintained build-time proc-macro in the bench harness only (not shipped
     # library code); no upgrade available (tabled 0.21 is latest)
     "RUSTSEC-2026-0173",
-    # pyo3: OOB read in PyList/PyTuple nth/nth_back (RUSTSEC-2026-0176)
-    # Patched in pyo3 >=0.29, but pyo3-async-runtimes has no 0.29 release yet
-    # (still pins pyo3 0.28), so we can't upgrade. Host-side Python bindings
-    # only — not reachable from sandboxed scripts. Remove on pyo3 0.29 bump.
-    "RUSTSEC-2026-0176",
-    # pyo3: missing Sync bound on PyCFunction::new_closure (RUSTSEC-2026-0177)
-    # Same 0.29 blocker; `new_closure` is not called anywhere in this
-    # workspace, so the unsound API is unreachable. Remove on pyo3 0.29 bump.
-    "RUSTSEC-2026-0177",
+    # NOTE: RUSTSEC-2026-0176 and RUSTSEC-2026-0177 (pyo3 OOB read / missing
+    # Sync bound) were resolved by the pyo3 0.29 bump (#2122); both ignores
+    # have been removed now that the workspace resolves pyo3 >=0.29.
 ]
 
 [bans]


### PR DESCRIPTION
## What

Remove two now-stale advisory ignores from `deny.toml`:

- `RUSTSEC-2026-0176` — pyo3 OOB read in `PyList`/`PyTuple` `nth`/`nth_back`
- `RUSTSEC-2026-0177` — pyo3 missing `Sync` bound on `PyCFunction::new_closure`

## Why

Both advisories were patched in **pyo3 >= 0.29**. The workspace now resolves
`pyo3 0.29.0` and `pyo3-async-runtimes 0.29.0` (after #2122), so these ignores
no longer match any advisory in the graph. Their own comments flagged them for
removal *"on the pyo3 0.29 bump"* — this is that follow-up.

The remaining ignores (`RUSTSEC-2023-0089` atomic-polyfill, `RUSTSEC-2026-0173`
proc-macro-error2) are unmaintained-transitive notices we can't control and are
kept.

## How / Safety

- `deny.toml` `[advisories].ignore` is consulted only by the manual
  `cargo deny check advisories` (per AGENTS.md). CI's cargo-deny step runs
  `check licenses sources` and cargo-audit carries its own ignore list, so this
  change does not alter any CI gate — it removes config that no longer applies.
- Verified `deny.toml` remains valid TOML and pyo3 resolves to 0.29.0 in
  `Cargo.lock`.

No code paths changed; config/hygiene only.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gBMutby3mfrF2WPMMEsDh)_