### PR TITLE
feat(xargs): support -P/--max-procs and --process-slot-var

### DIFF
--- a/crates/bashkit/src/builtins/arg_parser.rs
+++ b/crates/bashkit/src/builtins/arg_parser.rs
@@ -150,6 +150,46 @@ impl<'a> ArgParser<'a> {
         Ok(None)
     }
 
+    /// Try to consume a long option with a value, handling both
+    /// `--name=value` and `--name value` forms.
+    ///
+    /// Unlike [`flag_value`](Self::flag_value), the attached form requires an
+    /// explicit `=` separator (GNU long-option convention), so `--max-procs4`
+    /// is not mistaken for `--max-procs=4`. Returns `Ok(Some(value))` if
+    /// matched, `Err` if matched but no value follows, `Ok(None)` otherwise.
+    pub fn long_value(
+        &mut self,
+        name: &str,
+        cmd: &str,
+    ) -> std::result::Result<Option<&'a str>, String> {
+        let arg = match self.args.get(self.pos) {
+            Some(a) => a.as_str(),
+            None => return Ok(None),
+        };
+
+        if arg == name {
+            // Separate form: --name value
+            self.pos += 1;
+            return match self.args.get(self.pos) {
+                Some(val) => {
+                    self.pos += 1;
+                    Ok(Some(val.as_str()))
+                }
+                None => Err(format!("{cmd}: {name} requires an argument")),
+            };
+        }
+
+        // Attached form: --name=value
+        if let Some(rest) = arg.strip_prefix(name)
+            && let Some(val) = rest.strip_prefix('=')
+        {
+            self.pos += 1;
+            return Ok(Some(val));
+        }
+
+        Ok(None)
+    }
+
     /// Try to consume a flag with a value, silently returning None if
     /// the flag matches but no value is available (for lenient parsers).
     pub fn flag_value_opt(&mut self, name: &str) -> Option<&'a str> {
@@ -322,6 +362,48 @@ mod tests {
         let a = args(&["--output"]);
         let mut p = ArgParser::new(&a);
         assert!(p.flag_value_any(&["-o", "--output"], "cmd").is_err());
+    }
+
+    #[test]
+    fn test_long_value_attached() {
+        let a = args(&["--max-procs=4", "cmd"]);
+        let mut p = ArgParser::new(&a);
+        assert_eq!(p.long_value("--max-procs", "xargs").unwrap(), Some("4"));
+        assert_eq!(p.current(), Some("cmd"));
+    }
+
+    #[test]
+    fn test_long_value_separate() {
+        let a = args(&["--process-slot-var", "SLOT", "cmd"]);
+        let mut p = ArgParser::new(&a);
+        assert_eq!(
+            p.long_value("--process-slot-var", "xargs").unwrap(),
+            Some("SLOT")
+        );
+        assert_eq!(p.current(), Some("cmd"));
+    }
+
+    #[test]
+    fn test_long_value_no_match() {
+        let a = args(&["-P", "4"]);
+        let mut p = ArgParser::new(&a);
+        assert_eq!(p.long_value("--max-procs", "xargs").unwrap(), None);
+        assert_eq!(p.current(), Some("-P"));
+    }
+
+    #[test]
+    fn test_long_value_missing() {
+        let a = args(&["--max-procs"]);
+        let mut p = ArgParser::new(&a);
+        assert!(p.long_value("--max-procs", "xargs").is_err());
+    }
+
+    #[test]
+    fn test_long_value_attached_empty() {
+        // `--max-procs=` yields an empty value, not None.
+        let a = args(&["--max-procs="]);
+        let mut p = ArgParser::new(&a);
+        assert_eq!(p.long_value("--max-procs", "xargs").unwrap(), Some(""));
     }
 
     #[test]

--- a/crates/bashkit/src/builtins/ls/find.rs
+++ b/crates/bashkit/src/builtins/ls/find.rs
@@ -326,6 +326,7 @@ pub(super) fn build_find_exec_commands(
             name: cmd_args[0].clone(),
             args: cmd_args[1..].to_vec(),
             stdin: None,
+            assignments: Vec::new(),
         }]
     } else {
         // Per-file mode: -exec cmd {} \;
@@ -341,6 +342,7 @@ pub(super) fn build_find_exec_commands(
                     name: cmd_args[0].clone(),
                     args: cmd_args[1..].to_vec(),
                     stdin: None,
+                    assignments: Vec::new(),
                 }
             })
             .collect()

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -486,6 +486,10 @@ pub struct SubCommand {
     pub args: Vec<String>,
     /// Optional stdin to pipe into the command.
     pub stdin: Option<String>,
+    /// Command-scoped environment assignments (`VAR=value cmd ...`), applied
+    /// only to this command's environment. Used by `xargs --process-slot-var`
+    /// to expose a per-invocation parallel-slot index.
+    pub assignments: Vec<(String, String)>,
 }
 
 /// Execution plan returned by builtins that need to run sub-commands.

--- a/crates/bashkit/src/builtins/pipeline.rs
+++ b/crates/bashkit/src/builtins/pipeline.rs
@@ -8,13 +8,27 @@ use crate::interpreter::ExecResult;
 
 /// The xargs builtin - build and execute command lines from stdin.
 ///
-/// Usage: xargs [-I REPLACE] [-n MAX-ARGS] [-d DELIM] [COMMAND [ARGS...]]
+/// Usage: xargs [-I REPLACE] [-n MAX-ARGS] [-d DELIM] [-P N]
+///              [--process-slot-var=VAR] [COMMAND [ARGS...]]
 ///
 /// Options:
-///   -I REPLACE   Replace REPLACE with input (implies -n 1)
-///   -n MAX-ARGS  Use at most MAX-ARGS arguments per command
-///   -d DELIM     Use DELIM as delimiter instead of whitespace
-///   -0           Use NUL as delimiter (same as -d '\0')
+///   -I REPLACE              Replace REPLACE with input (implies -n 1)
+///   -n MAX-ARGS             Use at most MAX-ARGS arguments per command
+///   -d DELIM                Use DELIM as delimiter instead of whitespace
+///   -0                      Use NUL as delimiter (same as -d '\0')
+///   -P N, --max-procs=N     Allocate N parallel slots (see decision below)
+///   --process-slot-var=VAR  Set VAR to this invocation's slot index (0..N-1)
+///
+/// Important decision (parallelism): bashkit runs a single `Bash` interpreter
+/// sequentially — even background `&` jobs execute synchronously for
+/// deterministic output (see `specs/parallel-execution.md` and
+/// `interpreter/jobs.rs`). So `-P N` does NOT spawn N OS processes for
+/// wall-clock speedup; instead it allocates N round-robin *slots*, and the
+/// commands still run in order. The slot index is exposed via
+/// `--process-slot-var`, which is the behaviour real sharding logic depends
+/// on (`worker $SLOT of $N`). GNU's own `--process-slot-var` ranges 0..N-1
+/// and is 0 when N is 1, so this matches GNU exactly for the deterministic
+/// case while staying faithful to bashkit's no-hidden-concurrency model.
 pub struct Xargs;
 
 /// Parsed xargs options.
@@ -22,6 +36,11 @@ struct XargsOptions {
     replace_str: Option<String>,
     max_args: Option<usize>,
     delimiter: Option<char>,
+    /// `-P N` / `--max-procs=N`: number of parallel slots. `Some(0)` means
+    /// "as many as possible" (one slot per command). `None` means 1 slot.
+    max_procs: Option<usize>,
+    /// `--process-slot-var=VAR`: env var to expose the per-command slot index.
+    process_slot_var: Option<String>,
     command: Vec<String>,
 }
 
@@ -31,6 +50,8 @@ fn parse_xargs_args(args: &[String]) -> std::result::Result<XargsOptions, ExecRe
     let mut replace_str: Option<String> = None;
     let mut max_args: Option<usize> = None;
     let mut delimiter: Option<char> = None;
+    let mut max_procs: Option<usize> = None;
+    let mut process_slot_var: Option<String> = None;
     let mut command: Vec<String> = Vec::new();
     let mut p = super::arg_parser::ArgParser::new(args);
 
@@ -61,6 +82,34 @@ fn parse_xargs_args(args: &[String]) -> std::result::Result<XargsOptions, ExecRe
             delimiter = val.chars().next();
         } else if p.flag("-0") {
             delimiter = Some('\0');
+        } else if let Some(val) = p
+            .flag_value("-P", "xargs")
+            .map_err(|e| ExecResult::err(format!("{e}\n"), 1))?
+            .or(p
+                .long_value("--max-procs", "xargs")
+                .map_err(|e| ExecResult::err(format!("{e}\n"), 1))?)
+        {
+            // -P 0 / --max-procs=0 means "as many as possible" (GNU).
+            match val.parse::<usize>() {
+                Ok(n) => max_procs = Some(n),
+                _ => {
+                    return Err(ExecResult::err(
+                        format!("xargs: invalid number for -P option: '{}'\n", val),
+                        1,
+                    ));
+                }
+            }
+        } else if let Some(val) = p
+            .long_value("--process-slot-var", "xargs")
+            .map_err(|e| ExecResult::err(format!("{e}\n"), 1))?
+        {
+            if val.is_empty() {
+                return Err(ExecResult::err(
+                    "xargs: --process-slot-var requires a variable name\n".to_string(),
+                    1,
+                ));
+            }
+            process_slot_var = Some(val.to_string());
         } else if p.is_flag() && p.current() != Some("-") {
             let Some(s) = p.current() else {
                 p.advance();
@@ -84,6 +133,8 @@ fn parse_xargs_args(args: &[String]) -> std::result::Result<XargsOptions, ExecRe
         replace_str,
         max_args,
         delimiter,
+        max_procs,
+        process_slot_var,
         command,
     })
 }
@@ -107,9 +158,19 @@ fn build_xargs_commands(opts: &XargsOptions, input: &str) -> Vec<SubCommand> {
     let chunk_size = opts.max_args.unwrap_or(items.len());
     let chunks: Vec<Vec<&str>> = items.chunks(chunk_size).map(|c| c.to_vec()).collect();
 
+    // Number of parallel slots for --process-slot-var assignment. `-P 0`
+    // ("as many as possible") gives every command a distinct slot; absent
+    // `-P`, GNU uses a single slot so the index is always 0.
+    let slot_count = match opts.max_procs {
+        Some(0) => chunks.len().max(1),
+        Some(n) => n,
+        None => 1,
+    };
+
     chunks
         .into_iter()
-        .map(|chunk| {
+        .enumerate()
+        .map(|(idx, chunk)| {
             let cmd_args: Vec<String> = if let Some(ref repl) = opts.replace_str {
                 let item = chunk.first().unwrap_or(&"");
                 opts.command
@@ -122,12 +183,18 @@ fn build_xargs_commands(opts: &XargsOptions, input: &str) -> Vec<SubCommand> {
                 full
             };
 
+            let assignments = match opts.process_slot_var {
+                Some(ref var) => vec![(var.clone(), (idx % slot_count).to_string())],
+                None => Vec::new(),
+            };
+
             let name = cmd_args[0].clone();
             let args = cmd_args[1..].to_vec();
             SubCommand {
                 name,
                 args,
                 stdin: None,
+                assignments,
             }
         })
         .collect()
@@ -138,7 +205,7 @@ impl Builtin for Xargs {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
         if let Some(r) = super::check_help_version(
             ctx.args,
-            "Usage: xargs [OPTION]... [COMMAND [ARGS]...]\nBuild and execute command lines from standard input.\n\n  -I REPLACE\treplace REPLACE with input (implies -n 1)\n  -n MAX-ARGS\tuse at most MAX-ARGS arguments per command\n  -d DELIM\tuse DELIM as delimiter instead of whitespace\n  -0\tuse NUL as delimiter\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            "Usage: xargs [OPTION]... [COMMAND [ARGS]...]\nBuild and execute command lines from standard input.\n\n  -I REPLACE\treplace REPLACE with input (implies -n 1)\n  -n MAX-ARGS\tuse at most MAX-ARGS arguments per command\n  -d DELIM\tuse DELIM as delimiter instead of whitespace\n  -0\tuse NUL as delimiter\n  -P, --max-procs=N\tallocate N parallel slots (runs sequentially)\n  --process-slot-var=VAR\tset VAR to the slot index (0..N-1)\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
             Some("xargs (bashkit) 0.1"),
         ) {
             return Ok(r);
@@ -160,9 +227,17 @@ impl Builtin for Xargs {
             return Ok(ExecResult::ok(String::new()));
         }
 
-        // Fallback: output what would be run (for standalone builtin context)
+        // Fallback: output what would be run (for standalone builtin context).
+        // Command-scoped assignments (e.g. the --process-slot-var index) are
+        // rendered as a `VAR=value` prefix so the slot is visible here too.
         let mut output = String::new();
         for cmd in &commands {
+            for (var, val) in &cmd.assignments {
+                output.push_str(var);
+                output.push('=');
+                output.push_str(val);
+                output.push(' ');
+            }
             output.push_str(&cmd.name);
             for arg in &cmd.args {
                 output.push(' ');
@@ -632,6 +707,230 @@ mod tests {
             }
             _ => panic!("expected Batch plan"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_xargs_p_option_accepted() {
+        // -P must no longer be rejected as an invalid option.
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec!["-P".to_string(), "4".to_string(), "echo".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: Some("a b c"),
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Xargs.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("echo a b c"));
+    }
+
+    #[tokio::test]
+    async fn test_xargs_p_invalid_number() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec!["-P".to_string(), "abc".to_string(), "echo".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: Some("a"),
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Xargs.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid number for -P"));
+    }
+
+    #[tokio::test]
+    async fn test_xargs_process_slot_var_round_robin() {
+        // -P N with --process-slot-var assigns slots 0..N-1 round-robin.
+        // The fallback rendering shows them as a `VAR=value` prefix.
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec![
+            "-P".to_string(),
+            "2".to_string(),
+            "--process-slot-var=SLOT".to_string(),
+            "-n".to_string(),
+            "1".to_string(),
+            "echo".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: Some("a b c d"),
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Xargs.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<_> = result.stdout.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "SLOT=0 echo a",
+                "SLOT=1 echo b",
+                "SLOT=0 echo c",
+                "SLOT=1 echo d",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_xargs_process_slot_var_single_slot_is_zero() {
+        // Without -P there is one slot, so the index is always 0 (GNU parity).
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec![
+            "--process-slot-var".to_string(),
+            "S".to_string(),
+            "-n".to_string(),
+            "1".to_string(),
+            "echo".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: Some("a b"),
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Xargs.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<_> = result.stdout.lines().collect();
+        assert_eq!(lines, vec!["S=0 echo a", "S=0 echo b"]);
+    }
+
+    #[tokio::test]
+    async fn test_xargs_plan_carries_slot_assignment() {
+        // The execution plan must carry the per-command slot assignment so the
+        // interpreter runs each command with `VAR=slot cmd ...`.
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec![
+            "-P".to_string(),
+            "2".to_string(),
+            "--process-slot-var=SLOT".to_string(),
+            "-n".to_string(),
+            "1".to_string(),
+            "echo".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: Some("a b c"),
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let plan = Xargs.execution_plan(&ctx).await.unwrap();
+        match plan {
+            Some(ExecutionPlan::Batch { commands }) => {
+                assert_eq!(commands.len(), 3);
+                assert_eq!(
+                    commands[0].assignments,
+                    vec![("SLOT".to_string(), "0".to_string())]
+                );
+                assert_eq!(
+                    commands[1].assignments,
+                    vec![("SLOT".to_string(), "1".to_string())]
+                );
+                assert_eq!(
+                    commands[2].assignments,
+                    vec![("SLOT".to_string(), "0".to_string())]
+                );
+            }
+            _ => panic!("expected Batch plan"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_xargs_max_procs_long_form() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+
+        let args = vec![
+            "--max-procs=3".to_string(),
+            "--process-slot-var=S".to_string(),
+            "-n".to_string(),
+            "1".to_string(),
+            "echo".to_string(),
+        ];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: Some("a b c d"),
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Xargs.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 0);
+        let lines: Vec<_> = result.stdout.lines().collect();
+        assert_eq!(
+            lines,
+            vec!["S=0 echo a", "S=1 echo b", "S=2 echo c", "S=0 echo d",]
+        );
     }
 
     // ==================== tee tests ====================

--- a/crates/bashkit/src/builtins/timeout.rs
+++ b/crates/bashkit/src/builtins/timeout.rs
@@ -185,6 +185,7 @@ impl Builtin for Timeout {
                         name: cmd_name,
                         args: cmd_args,
                         stdin: ctx.stdin.map(|s| s.to_string()),
+                        assignments: Vec::new(),
                     },
                 }))
             }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -252,6 +252,21 @@ use fail::fail_point;
 /// This is handled at the interpreter level to prevent custom filesystems from bypassing it.
 const DEV_NULL: &str = "/dev/null";
 
+/// Convert a [`SubCommand`](crate::builtins::SubCommand)'s command-scoped
+/// `(VAR, value)` pairs into AST [`Assignment`]s, so a plan's inner command
+/// runs with `VAR=value cmd ...` semantics (used by `xargs --process-slot-var`).
+fn subcommand_env_assignments(pairs: &[(String, String)]) -> Vec<Assignment> {
+    pairs
+        .iter()
+        .map(|(name, value)| Assignment {
+            name: name.clone(),
+            index: None,
+            value: AssignmentValue::Scalar(Word::quoted_literal(value.clone())),
+            append: false,
+        })
+        .collect()
+}
+
 /// Check if a name is a shell keyword (for `command -v`/`command -V`).
 fn is_keyword(name: &str) -> bool {
     matches!(
@@ -7976,7 +7991,7 @@ impl Interpreter {
                         .map(|s| Word::quoted_literal(s.clone()))
                         .collect(),
                     redirects: inner_redirects,
-                    assignments: Vec::new(),
+                    assignments: subcommand_env_assignments(&command.assignments),
                     span: Span::new(),
                 });
 
@@ -8030,7 +8045,7 @@ impl Interpreter {
                             .map(|s| Word::quoted_literal(s.clone()))
                             .collect(),
                         redirects: cmd_redirects,
-                        assignments: Vec::new(),
+                        assignments: subcommand_env_assignments(&cmd.assignments),
                         span: Span::new(),
                     });
 
@@ -8077,7 +8092,7 @@ impl Interpreter {
                             .map(|s| Word::quoted_literal(s.clone()))
                             .collect(),
                         redirects: cmd_redirects,
-                        assignments: Vec::new(),
+                        assignments: subcommand_env_assignments(&cmd.assignments),
                         span: Span::new(),
                     });
 

--- a/crates/bashkit/tests/spec_cases/bash/xargs.test.sh
+++ b/crates/bashkit/tests/spec_cases/bash/xargs.test.sh
@@ -50,3 +50,32 @@ echo -n "" | xargs
 ### expect
 
 ### end
+
+### xargs_max_procs_accepted
+# -P is accepted (no longer an "invalid option" error); a single batched
+# invocation is order-deterministic and matches real bash.
+printf "a\nb\nc\n" | xargs -P 4 echo
+### expect
+a b c
+### end
+
+### xargs_process_slot_var
+### bash_diff: real xargs -P runs children in parallel (non-deterministic slot/order); bashkit runs deterministically in order with round-robin slot assignment
+# --process-slot-var exposes a distinct slot index (0..N-1) per invocation,
+# so sharding logic like `worker $SLOT` works instead of always reading 0.
+printf "0\n1\n2\n3\n" | xargs -P 2 --process-slot-var=SLOT -I{} sh -c 'echo {} slot=$SLOT'
+### expect
+0 slot=0
+1 slot=1
+2 slot=0
+3 slot=1
+### end
+
+### xargs_process_slot_var_single_slot
+### bash_diff: real xargs parallel scheduling is non-deterministic; bashkit is deterministic
+# Without -P, there is a single slot, so the index is always 0 (matches GNU).
+printf "x\ny\n" | xargs --process-slot-var=SLOT -I{} sh -c 'echo {} slot=$SLOT'
+### expect
+x slot=0
+y slot=0
+### end

--- a/specs/builtins.md
+++ b/specs/builtins.md
@@ -162,7 +162,24 @@ plan instead of using the `execute()` result.
 Variants: `Timeout { duration, preserve_status, command }`,
 `Batch { commands }` (`builtins/mod.rs`).
 
+Each `SubCommand` carries optional command-scoped `assignments`
+(`VAR=value cmd ...`), which the interpreter applies as the inner command's
+environment. `xargs --process-slot-var=VAR` uses this to expose a
+per-invocation parallel-slot index.
+
 **Current users:** `timeout` → Timeout, `xargs` → Batch, `find -exec` → Batch.
+
+#### `xargs -P` / `--process-slot-var` (parallelism)
+
+bashkit runs a single `Bash` interpreter sequentially — even background `&`
+jobs run synchronously for deterministic output (see
+`specs/parallel-execution.md`). So `xargs -P N` / `--max-procs=N` does **not**
+spawn N OS processes for wall-clock speedup. Instead it allocates N
+round-robin *slots* and the commands still run in order, with the slot index
+(0..N-1, `idx % N`) surfaced via `--process-slot-var`. This is the behaviour
+sharding logic depends on (`worker $SLOT of $N`) and matches GNU's
+`--process-slot-var` for the deterministic case (single slot ⇒ index always
+0). `-P 0` means "as many as possible" (one slot per command).
 
 **Adding new execution plans:** Add a variant to `ExecutionPlan` and handle it
 in the interpreter's plan fulfillment code (`interpreter/mod.rs`).


### PR DESCRIPTION
## What

Adds `xargs -P N` / `--max-procs=N` and `--process-slot-var=VAR` support.

- **Before:** `xargs -P 4` failed with `xargs: invalid option -- 'P'`.
- **After:** `-P`/`--max-procs` are accepted, and `--process-slot-var=VAR` exposes a **distinct** slot index (`0..N-1`, round-robin) to each invocation instead of always reading `0`.

## Why

Came out of a compatibility audit against the [bashbox in-process shell sandbox blog post](https://loomcycle.dev/blog/bashbox-in-process-shell-sandbox). Of the issues that post raised about a *different* sandbox (gbash), bashkit already handled 4/5 (find relative symlinks, grep `--include`/`--exclude`, sandbox boundaries, zero-stdout chains). The one genuine gap was `xargs -P`: bashkit rejected it outright, and there was no `--process-slot-var`, which breaks agent sharding logic (`worker $SLOT of $N`).

## How

**Design decision (parallelism):** bashkit runs a single `Bash` interpreter sequentially — even background `&` jobs run synchronously for deterministic output (see `specs/parallel-execution.md`, `interpreter/jobs.rs`). So `-P N` does **not** spawn N OS processes for wall-clock speedup. Instead it allocates N round-robin *slots* and commands still run in order, with the slot index surfaced via `--process-slot-var`. This matches GNU's `--process-slot-var` for the deterministic case (single slot ⇒ index `0`) and stays faithful to bashkit's no-hidden-concurrency model — no silent "looks parallel but isn't". `-P 0` = one slot per command.

Mechanism:
- New command-scoped `assignments: Vec<(String, String)>` field on `SubCommand`, so an `ExecutionPlan`'s inner command runs with `VAR=value cmd ...`. The interpreter applies these across all plan variants (`Timeout`, `Batch`, `BatchWithStatus`) via a small `subcommand_env_assignments` helper. The slot value is a pure integer and the var name bypasses parsing (built directly as an `Assignment` AST node), so there's no shell-injection vector.
- New `ArgParser::long_value` helper handles `--name=value` / `--name value`.

## Tests

- `ArgParser::long_value` unit tests (attached, separate, missing, empty, no-match).
- xargs unit tests: `-P` accepted, invalid `-P` number, slot round-robin, single-slot ⇒ 0, `--max-procs=` long form, plan carries slot assignment.
- 3 new bash spec cases (`xargs_max_procs_accepted`, `xargs_process_slot_var`, `xargs_process_slot_var_single_slot`) exercising the full interpreter path; the slot-var cases are marked `### bash_diff` because real `xargs -P` schedules children non-deterministically.
- Existing find/timeout/xargs suites unaffected. `cargo fmt`, `clippy`, and the feature-sliced test slices pass locally; full suite runs in CI.

## Specs

`specs/builtins.md` updated: documents `SubCommand` command-scoped assignments and the `xargs -P` / `--process-slot-var` slot-allocation semantics.

https://claude.ai/code/session_01Jut4fwqMEBtvaUxTaTT7QX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jut4fwqMEBtvaUxTaTT7QX)_