### PR TITLE
fix(deps): remove stale pyo3 advisory ignores

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,15 +38,6 @@ ignore = [
     # Unmaintained build-time proc-macro in the bench harness only (not shipped
     # library code); no upgrade available (tabled 0.21 is latest)
     "RUSTSEC-2026-0173",
-    # pyo3: OOB read in PyList/PyTuple nth/nth_back (RUSTSEC-2026-0176)
-    # Patched in pyo3 >=0.29, but pyo3-async-runtimes has no 0.29 release yet
-    # (still pins pyo3 0.28), so we can't upgrade. Host-side Python bindings
-    # only — not reachable from sandboxed scripts. Remove on pyo3 0.29 bump.
-    "RUSTSEC-2026-0176",
-    # pyo3: missing Sync bound on PyCFunction::new_closure (RUSTSEC-2026-0177)
-    # Same 0.29 blocker; `new_closure` is not called anywhere in this
-    # workspace, so the unsound API is unreachable. Remove on pyo3 0.29 bump.
-    "RUSTSEC-2026-0177",
 ]
 
 [bans]


### PR DESCRIPTION
### Motivation
- Remove stale cargo-deny ignores for PyO3 advisories `RUSTSEC-2026-0176` and `RUSTSEC-2026-0177` now that the workspace upgrades `pyo3` and `pyo3-async-runtimes` to `0.29` so future reintroductions are not silently suppressed.

### Description
- Deleted the two PyO3 advisory IDs from `deny.toml`'s `[advisories].ignore` array to restore normal advisory reporting.

### Testing
- Ran a small assertion script (`python3 - <<'PY' ...`) that confirmed both advisory IDs are absent from `deny.toml` (passed).
- Attempted `cargo deny check advisories` but it could not be executed in this environment because `cargo-deny` is not installed (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b5ad85924832b84c3ada3665a4e66)