### PR TITLE
chore(security): drop stale pyo3 ignore from audit.toml + bump site ws/yaml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,18 +7,4 @@ ignore = [
     # Transitive via russh-keys -> ssh-key -> rsa
     # Only used for RSA key parsing in SSH; no direct exposure
     "RUSTSEC-2023-0071",
-    # pyo3: OOB read in PyList/PyTuple nth/nth_back (RUSTSEC-2026-0176)
-    # Patched in pyo3 >=0.29. Blocked from upgrading: pyo3-async-runtimes
-    # (the asyncio bridge in bashkit-python) has no 0.29 release yet and its
-    # main branch still pins pyo3 0.28. pyo3 here powers the host-side Python
-    # bindings only, not the sandboxed-script path, so sandboxed bash cannot
-    # reach the vulnerable iterators. Remove once pyo3-async-runtimes ships
-    # a 0.29-compatible release and we bump pyo3.
-    "RUSTSEC-2026-0176",
-    # pyo3: missing Sync bound on PyCFunction::new_closure (RUSTSEC-2026-0177)
-    # Patched in pyo3 >=0.29; same pyo3-async-runtimes blocker as above.
-    # Stronger justification: `PyCFunction::new_closure` is not called
-    # anywhere in this workspace, so the unsound API is unreachable.
-    # Remove on the same pyo3 0.29 bump.
-    "RUSTSEC-2026-0177",
 ]

--- a/site/package.json
+++ b/site/package.json
@@ -33,7 +33,9 @@
   "pnpm": {
     "overrides": {
       "esbuild": ">=0.28.1",
-      "undici": "^7.28.0"
+      "undici": "^7.28.0",
+      "ws": ">=8.21.0",
+      "yaml": ">=2.8.3"
     },
     "onlyBuiltDependencies": [
       "esbuild",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   esbuild: '>=0.28.1'
   undici: ^7.28.0
+  ws: '>=8.21.0'
+  yaml: '>=2.8.3'
 
 importers:
 
@@ -1998,7 +2000,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -2151,8 +2153,8 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2172,11 +2174,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.9.0:
@@ -3853,7 +3850,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.28.0
       workerd: 1.20260521.1
-      ws: 8.20.1
+      ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -4523,7 +4520,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  ws@8.20.1: {}
+  ws@8.21.0: {}
 
   xxhash-wasm@1.1.0: {}
 
@@ -4541,9 +4538,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
Security dependency hygiene. Rebased on latest `main`; scope narrowed after #2130 landed.

> **Note:** #2130 already removed the stale pyo3 ignores from `deny.toml`. That overlap dropped out cleanly on rebase — but #2130 **missed `.cargo/audit.toml`**, which carried the same now-stale entries. This PR finishes that cleanup and adds an unrelated npm fix.

## 1. Drop stale pyo3 advisory ignores from `.cargo/audit.toml` (cargo)

`pyo3`/`pyo3-async-runtimes` are at **0.29.0** in `Cargo.lock`, so these are "patched in >= 0.29" and no longer match any crate — dead suppressions:

- `RUSTSEC-2026-0176` — OOB read in `PyList`/`PyTuple` `nth`/`nth_back`
- `RUSTSEC-2026-0177` — missing `Sync` bound on `PyCFunction::new_closure`

`.cargo/audit.toml` is the file CI's `cargo-audit` (`rustsec/audit-check`) actually reads, so leaving these here keeps a live suppression that would re-mask the advisory if pyo3 were downgraded. The matching `deny.toml` entries were already removed by #2130.

Remaining ignore kept (still present, no fixed release): `RUSTSEC-2023-0071` (`rsa` Marvin, via `russh`).

## 2. Bump site ws/yaml to patched versions (npm)

Two GitHub Dependabot alerts on the `site/` Astro project, both deep transitive **dev** deps (build/deploy tooling, not shipped in the bundle):

- `ws` (GHSA-96hv-2xvq-fx4p, **high**): memory-exhaustion DoS; affects `>=8.0.0 <8.21.0`; via `wrangler > miniflare > ws`. Pinned `>=8.21.0`.
- `yaml` (GHSA-48c2-rrv3-qjmp, **moderate**): stack overflow via deeply nested collections; affects `>=2.0.0 <2.8.3`; via `@astrojs/check > … > yaml`. Pinned `>=2.8.3` (resolves 2.9.0).

Added as pnpm `overrides` alongside the existing esbuild/undici security pins. `pnpm audit` now reports **no known vulnerabilities** for `site/`.

## Verification

- `pyo3 = 0.29.0` / `pyo3-async-runtimes = 0.29.0` in `Cargo.lock`.
- `pnpm audit` clean for `site/`; Site Build + Cloudflare deploy green on the PR.
- RustSec DB is egress-blocked in the dev sandbox; CI's `cargo-audit` validates the cargo side on networked runners.

https://claude.ai/code/session_01CCnF1i7QRggAj9as2RWs8g