### PR TITLE
fix(deps): bump langgraph-checkpoint to 4.1.1 (GHSA-fjqc-hq36-qh5p)

### DIFF
--- a/examples/docs-grep-agent/uv.lock
+++ b/examples/docs-grep-agent/uv.lock
@@ -413,15 +413,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

Resolves the open Dependabot security alert (#74) for the `docs-grep-agent` example.

`langgraph-checkpoint < 4.1.1` is vulnerable to **unsafe JSON deserialization in checkpoint loading** — GHSA-fjqc-hq36-qh5p / CVE-2026-48775 (medium). It is pulled in transitively via `langgraph` in `examples/docs-grep-agent/uv.lock`.

## Changes

- `examples/docs-grep-agent/uv.lock`: `langgraph-checkpoint` 4.1.0 → 4.1.1, via `uv lock --upgrade-package langgraph-checkpoint`. No other packages changed; `langgraph` already permits 4.1.1.

## Testing

- `uv lock` resolved cleanly (45 packages); diff is limited to the single `langgraph-checkpoint` stanza.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDLavdiVC5NASL5Tf5bAt5)_