### PR TITLE
fix(glob): linear-time * matching to stop exponential blowup (TM-DOS-031)

### DIFF
--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -189,10 +189,35 @@ impl Interpreter {
         let mut value_chars = value.chars().peekable();
         let mut pattern_chars = pattern.chars().peekable();
 
+        // THREAT[TM-DOS-031]: `*` matching uses a single backtracking restore
+        // point (the classic linear wildcard algorithm) instead of recursing
+        // over every value position. A run of `*` — consecutive (`****`) or
+        // separated (`*a*b*c`) — no longer causes exponential blowup: each new
+        // `*` simply overwrites the restore point (an earlier `*` is provably
+        // never needed again), keeping the worst case O(value.len * pattern.len).
+        let mut star_pat: Option<std::iter::Peekable<std::str::Chars>> = None;
+        let mut star_val: Option<std::iter::Peekable<std::str::Chars>> = None;
+
+        // On a content mismatch, resume from the most recent `*`, letting it
+        // consume one more value char. With no active `*`, the match fails.
+        macro_rules! backtrack {
+            () => {{
+                if let (Some(sp), Some(sv)) = (&star_pat, star_val.as_mut()) {
+                    if sv.peek().is_some() {
+                        sv.next();
+                        pattern_chars = sp.clone();
+                        value_chars = sv.clone();
+                        continue;
+                    }
+                }
+                return false;
+            }};
+        }
+
         loop {
             match (pattern_chars.peek().copied(), value_chars.peek().copied()) {
                 (None, None) => return true,
-                (None, Some(_)) => return false,
+                (None, Some(_)) => backtrack!(),
                 (Some('\\'), Some(v)) => {
                     pattern_chars.next();
                     let literal = pattern_chars.next().unwrap_or('\\');
@@ -204,10 +229,10 @@ impl Interpreter {
                     if matches {
                         value_chars.next();
                     } else {
-                        return false;
+                        backtrack!();
                     }
                 }
-                (Some('\\'), None) => return false,
+                (Some('\\'), None) => backtrack!(),
                 (Some('*'), _) => {
                     // Check for extglob *(...)
                     let mut pc_clone = pattern_chars.clone();
@@ -216,22 +241,6 @@ impl Interpreter {
                         // Extglob *(pattern-list) — collect remaining pattern
                         let remaining_pattern: String = pattern_chars.collect();
                         let remaining_value: String = value_chars.collect();
-                        return self.glob_match_impl(
-                            &remaining_value,
-                            &remaining_pattern,
-                            nocase,
-                            depth + 1,
-                        );
-                    }
-                    pattern_chars.next();
-                    // * matches zero or more characters
-                    if pattern_chars.peek().is_none() {
-                        return true; // * at end matches everything
-                    }
-                    // Try matching from each position
-                    while value_chars.peek().is_some() {
-                        let remaining_value: String = value_chars.clone().collect();
-                        let remaining_pattern: String = pattern_chars.clone().collect();
                         if self.glob_match_impl(
                             &remaining_value,
                             &remaining_pattern,
@@ -240,11 +249,19 @@ impl Interpreter {
                         ) {
                             return true;
                         }
-                        value_chars.next();
+                        backtrack!();
                     }
-                    // Also try with empty match
-                    let remaining_pattern: String = pattern_chars.collect();
-                    return self.glob_match_impl("", &remaining_pattern, nocase, depth + 1);
+                    pattern_chars.next();
+                    // * matches zero or more characters
+                    if pattern_chars.peek().is_none() {
+                        return true; // * at end matches everything
+                    }
+                    // Record a restore point: the pattern after this `*` is
+                    // matched greedily against the current value position. On a
+                    // later mismatch, `backtrack!` lets the `*` consume one more
+                    // value char and retries. Overwrites any earlier `*`.
+                    star_pat = Some(pattern_chars.clone());
+                    star_val = Some(value_chars.clone());
                 }
                 (Some('?'), _) => {
                     // Check for extglob ?(...)
@@ -253,18 +270,21 @@ impl Interpreter {
                     if extglob && pc_clone.peek() == Some(&'(') {
                         let remaining_pattern: String = pattern_chars.collect();
                         let remaining_value: String = value_chars.collect();
-                        return self.glob_match_impl(
+                        if self.glob_match_impl(
                             &remaining_value,
                             &remaining_pattern,
                             nocase,
                             depth + 1,
-                        );
+                        ) {
+                            return true;
+                        }
+                        backtrack!();
                     }
                     if value_chars.peek().is_some() {
                         pattern_chars.next();
                         value_chars.next();
                     } else {
-                        return false;
+                        backtrack!();
                     }
                 }
                 (Some('['), Some(v)) => {
@@ -274,7 +294,7 @@ impl Interpreter {
                         if v == '[' {
                             value_chars.next();
                         } else {
-                            return false;
+                            backtrack!();
                         }
                         continue;
                     }
@@ -290,7 +310,7 @@ impl Interpreter {
                         if matched {
                             value_chars.next();
                         } else {
-                            return false;
+                            backtrack!();
                         }
                     } else {
                         // Invalid bracket expression — treat '[' as literal
@@ -305,11 +325,11 @@ impl Interpreter {
                         if match_ok {
                             value_chars.next();
                         } else {
-                            return false;
+                            backtrack!();
                         }
                     }
                 }
-                (Some('['), None) => return false,
+                (Some('['), None) => backtrack!(),
                 (Some(p), Some(v)) => {
                     // Check for extglob operators: @(, +(, !(
                     if extglob && matches!(p, '@' | '+' | '!') {
@@ -318,12 +338,15 @@ impl Interpreter {
                         if pc_clone.peek() == Some(&'(') {
                             let remaining_pattern: String = pattern_chars.collect();
                             let remaining_value: String = value_chars.collect();
-                            return self.glob_match_impl(
+                            if self.glob_match_impl(
                                 &remaining_value,
                                 &remaining_pattern,
                                 nocase,
                                 depth + 1,
-                            );
+                            ) {
+                                return true;
+                            }
+                            backtrack!();
                         }
                     }
                     let matches = if nocase {
@@ -335,10 +358,10 @@ impl Interpreter {
                         pattern_chars.next();
                         value_chars.next();
                     } else {
-                        return false;
+                        backtrack!();
                     }
                 }
-                (Some(_), None) => return false,
+                (Some(_), None) => backtrack!(),
             }
         }
     }
@@ -957,5 +980,46 @@ mod tests {
         assert!(interp.pattern_matches("[]", "[]"));
         assert!(interp.pattern_matches("[", "["));
         assert!(interp.pattern_matches("a", "[a]"));
+    }
+
+    // THREAT[TM-DOS-031]: a run of `*` must not cause exponential backtracking.
+    // Before the linear restore-point rewrite, patterns like `****…%=` (found
+    // by `glob_fuzz`) or `*a*a*…b` blew up to a libFuzzer timeout. These cases
+    // finish instantly now; if the exponential path returns, the test hangs.
+    #[test]
+    fn many_stars_do_not_blow_up() {
+        let interp = interp();
+
+        // The reproducer minimized by `glob_fuzz`: a leading byte, a long run
+        // of `*`, then a suffix the value never ends with → must fail fast.
+        let pathological = format!("\u{1}{}%=", "*".repeat(1000));
+        assert!(!interp.pattern_matches("hello.world", &pathological));
+        assert!(!interp.pattern_matches("test.txt", &pathological));
+
+        // Consecutive `*` collapse to a single wildcard (matches anything).
+        assert!(interp.pattern_matches("anything at all", &"*".repeat(1000)));
+        assert!(interp.pattern_matches("test.txt", &format!("{}txt", "*".repeat(500))));
+
+        // Separated stars are the other classic exponential shape.
+        let separated = format!("{}b", "a*".repeat(500));
+        assert!(!interp.pattern_matches(&"a".repeat(2000), &separated));
+        assert!(interp.pattern_matches(&format!("{}b", "a".repeat(2000)), &separated));
+    }
+
+    // Ordinary `*` / `?` / literal semantics are unchanged by the rewrite.
+    #[test]
+    fn star_matching_semantics_preserved() {
+        let interp = interp();
+
+        assert!(interp.pattern_matches("test.txt", "*.txt"));
+        assert!(!interp.pattern_matches("test.md", "*.txt"));
+        assert!(interp.pattern_matches("axxbyyc", "a*b*c"));
+        assert!(!interp.pattern_matches("axxbyy", "a*b*c"));
+        assert!(interp.pattern_matches("abcabc", "*abc"));
+        assert!(interp.pattern_matches("abc", "a?c"));
+        assert!(!interp.pattern_matches("ac", "a?c"));
+        assert!(interp.pattern_matches("hello", "he*"));
+        assert!(interp.pattern_matches("hello", "*llo"));
+        assert!(interp.pattern_matches("hello", "*"));
     }
 }

--- a/specs/threat-model.md
+++ b/specs/threat-model.md
@@ -242,7 +242,7 @@ runaway scripts without permanently breaking the session.
 | TM-DOS-028 | Diff algorithm DoS | `diff` on two large unrelated files | LCS matrix capped at 10M cells; falls back to simple line-by-line output | **MITIGATED** |
 | TM-DOS-029 | Arithmetic overflow/panic | `$(( 2 ** -1 ))`, `$(( 1 << 64 ))`, `i64::MIN / -1` | `wrapping_*` / saturating ops; `wrapping_neg` for `i64::MIN / -1` and unary negate; `<<`/`>>` clamp shift amount | **MITIGATED** |
 | TM-DOS-030 | Parser limit bypass via eval/source/trap | `eval`, `source`, trap handlers now use `Parser::with_limits()` | — | **FIXED** (2026-03 audit verified) |
-| TM-DOS-031 | ExtGlob exponential blowup | `+(a\|aa)` against long string causes O(n!) recursion in `glob_match_impl` | `glob_match_impl` carries a recursion-depth cap and bails on excessive depth (`interpreter/glob.rs:162,324`); aliases that expand to huge brace ranges go through the same parser-budget check (`interpreter/mod.rs:4216`) | **MITIGATED** |
+| TM-DOS-031 | Glob/ExtGlob exponential blowup | `+(a\|aa)` against long string causes O(n!) recursion in `glob_match_impl`; a run of plain `*` (consecutive `****…` or separated `*a*b*…`) previously recursed per value position and blew up (a 33-`*` pattern timed out `glob_fuzz`) | Plain `*` now matches via a single backtracking restore point (the classic linear wildcard algorithm) — worst case O(value·pattern), no per-position recursion; `glob_match_impl` still carries a recursion-depth cap for extglob nesting and bails on excessive depth; aliases that expand to huge brace ranges go through the same parser-budget check (`interpreter/mod.rs:4216`) | **MITIGATED** |
 | TM-DOS-035 | DEBUG trap recursive amplification | `trap 'a=1;b=2;...' DEBUG` amplifies N commands to N*M | Suppress DEBUG trap inside trap handlers (`in_trap` guard) | **FIXED** |
 | TM-DOS-032 | Tokio runtime exhaustion (Python) | Rapid `execute_sync()` calls each create new tokio runtime, exhausting OS threads | `PyBash` and `BashTool` create one `Arc<Runtime>` per instance in `__new__` via `make_runtime()` and reuse it for every `execute_sync` call; no per-call runtime construction | **MITIGATED** |
 | TM-DOS-033 | AWK unbounded loops | `BEGIN { while(1){} }` has no iteration limit in AWK interpreter | Timeout (30s) backstop | **PARTIAL** |
@@ -281,7 +281,7 @@ panicked. Resolved with `wrapping_*` ops, masked shift amounts, clamped exponent
 `execute_script_body(.., run_exit_trap=false)` (like `source`) so they do not fire the EXIT trap
 — previously `trap 'eval :' EXIT` could recurse one command per level until the budget aborted.
 
-**TM-DOS-031** (mitigated): see table — recursion-depth cap in `glob_match_impl`
+**TM-DOS-031** (mitigated): see table — linear backtracking for plain `*`, plus a recursion-depth cap for extglob nesting in `glob_match_impl`
 (`interpreter/glob.rs`).
 
 **Implementation**: `timeout` 30s + `parser_timeout` 5s + `max_parser_operations` 100K in `limits.rs` (TM-DOS-023/024); `MAX_AWK_PARSER_DEPTH` 100 (`builtins/awk.rs`) and `MAX_JQ_JSON_DEPTH` 100 (`builtins/jq/`) for TM-DOS-027; `MAX_LCS_CELLS` 10M (`builtins/diff.rs`) for TM-DOS-028.


### PR DESCRIPTION
## Problem

The nightly **Fuzz Testing** workflow has been failing on `main` (`glob_fuzz`): libFuzzer reported a **timeout** on a pattern with ~33 consecutive `*` (reproducer minimized to a leading byte + a long run of `*` + a `%=` suffix).

Root cause: the `*` arm of `glob_match_impl` recursed over *every* value position for each `*`. A run of `*` — consecutive (`****…`) or separated (`*a*b*…`) — therefore matched in roughly `O(value_len ^ stars)`. The existing recursion-depth cap did not help: the branching factor exploded well before the cap, so a short pattern pinned a CPU for minutes. This is an algorithmic-complexity DoS (TM-DOS-031).

## Fix

Replace the per-position recursion with the classic **single restore-point backtracking** algorithm (linear wildcard matching):

- On a plain `*`, record one restore point: the pattern position after the `*` and the current value position.
- On any later content mismatch, resume from that restore point, letting the `*` consume one more value char, and retry.
- Each new `*` overwrites the restore point — an earlier `*` is provably never needed again — so the worst case is `O(value_len × pattern_len)`.

Match **semantics are unchanged** (both the old and new matchers are correct globbers; only the running time differs). The extglob recursion-depth cap stays in place for nested `@(…)`/`+(…)` operators.

## Verification

- New regression tests in `interpreter::glob::tests`:
  - `many_stars_do_not_blow_up` — the exact `glob_fuzz` reproducer (leading byte + 1000 `*` + `%=`), plus consecutive and separated star runs; all resolve instantly (a return of the exponential path would hang the test).
  - `star_matching_semantics_preserved` — ordinary `*` / `?` / literal behavior.
- `cargo test -p bashkit --lib` — 2504 passed.
- `cargo test -p bashkit --test integration --features http_client,ssh,sqlite` — 1097 passed.
- `cargo fmt --check` and `cargo clippy -p bashkit --lib -- -D warnings` clean.

## Spec

Updated the TM-DOS-031 entry in `specs/threat-model.md` to describe the linear-`*` mitigation (the depth cap alone did not cover the plain-`*` blowup that fuzzing found).

https://claude.ai/code/session_01UT88iM52kJ3L5TriEeU7aN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT88iM52kJ3L5TriEeU7aN)_