### PR TITLE
fix(security): update fuzz cmov lockfile

### DIFF
--- a/crates/bashkit/fuzz/Cargo.lock
+++ b/crates/bashkit/fuzz/Cargo.lock
@@ -113,12 +113,13 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bashkit"
-version = "0.6.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bigdecimal",
+ "bitflags",
  "chrono",
  "clap",
  "fancy-regex",
@@ -140,6 +141,7 @@ dependencies = [
  "tower",
  "unit-prefix",
  "url",
+ "web-time",
 ]
 
 [[package]]
@@ -279,9 +281,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -1259,6 +1261,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Updates the fuzz Cargo.lock so the fuzz dependency graph resolves cmov 0.5.4, the patched release for GHSA-3rjw-m598-pq24 / CVE-2026-50185.

## Why
Dependabot alert 75 reports cmov < 0.5.4 in crates/bashkit/fuzz/Cargo.lock.

## How
Regenerated the fuzz lockfile for the targeted dependency update and kept Cargo path-package metadata current.

## Risk
Low. Lockfile-only update for the fuzz workspace.

## Security
Addresses the reported vulnerable cmov version in the fuzz lockfile. No runtime code changed.

## Verification
- cargo tree -i cmov --manifest-path crates/bashkit/fuzz/Cargo.toml --locked
- cargo check --manifest-path crates/bashkit/fuzz/Cargo.toml --locked
- just test
- just pre-pr