### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.13.0] - 2026-07-07
 
 ### Highlights
 
@@ -13,7 +13,18 @@
   addresses, and the response size cap, and returns typed errors
   (`Denied`/`Timeout`/`TooLarge`/`Transport`) that map onto curl exit codes
   (7/28/63/1). Mirrors fetchkit's transport injection so one host egress
-  implementation can back both libraries. See `specs/http-transport.md`.
+  implementation can back both libraries. See `specs/http-transport.md`
+  ([#2147](https://github.com/everruns/bashkit/pull/2147)).
+- **`xargs -P` parallel execution** — `-P/--max-procs` runs command batches
+  concurrently, with `--process-slot-var` exposing the slot index to each child
+  ([#2126](https://github.com/everruns/bashkit/pull/2126)).
+- **`ls -d/--directory`** — list directories themselves instead of their
+  contents ([#2134](https://github.com/everruns/bashkit/pull/2134)).
+- **`bashkit-eval` reimplemented on the mira framework** — the LLM eval harness
+  now runs on mira ([#2129](https://github.com/everruns/bashkit/pull/2129)).
+- **Linear-time glob `*` matching (TM-DOS-031)** — replaces the pathological
+  backtracking that allowed exponential blowup on adversarial patterns
+  ([#2142](https://github.com/everruns/bashkit/pull/2142)).
 
 ### Breaking Changes
 
@@ -25,6 +36,32 @@
   and return `HttpTransportError` variants instead of `String`.
   - Before: `.http_handler(Box::new(MyHandler))`
   - After: `.http_transport(Arc::new(MyTransport))`
+
+### What's Changed
+
+* fix(test): exclude host-dependent vars from differential fuzzer ([#2150](https://github.com/everruns/bashkit/pull/2150)) by @chaliy
+* fix(eval): bound transcript VFS snapshots ([#2149](https://github.com/everruns/bashkit/pull/2149)) by @chaliy
+* feat(network): pluggable HttpTransport for host-routed HTTP egress ([#2147](https://github.com/everruns/bashkit/pull/2147)) by @chaliy
+* chore(ci): bump the github-actions group with 3 updates ([#2146](https://github.com/everruns/bashkit/pull/2146)) by @dependabot
+* chore(deps): bump the rust-dependencies group with 5 updates ([#2145](https://github.com/everruns/bashkit/pull/2145)) by @dependabot
+* fix(ls): render actual UTC calendar dates in long format ([#2144](https://github.com/everruns/bashkit/pull/2144)) by @a0preetham
+* fix(security): update fuzz cmov lockfile ([#2143](https://github.com/everruns/bashkit/pull/2143)) by @chaliy
+* fix(glob): linear-time * matching to stop exponential blowup (TM-DOS-031) ([#2142](https://github.com/everruns/bashkit/pull/2142)) by @chaliy
+* fix(wasm): route clock reads through web-time so bashkit runs on wasm32-unknown-unknown ([#2140](https://github.com/everruns/bashkit/pull/2140)) by @a0preetham
+* chore(deps): bump the rust-dependencies group with 6 updates ([#2138](https://github.com/everruns/bashkit/pull/2138)) by @dependabot
+* chore(ci): bump the github-actions group with 4 updates ([#2137](https://github.com/everruns/bashkit/pull/2137)) by @dependabot
+* fix(deps): bump langgraph-checkpoint to 4.1.1 (GHSA-fjqc-hq36-qh5p) ([#2136](https://github.com/everruns/bashkit/pull/2136)) by @chaliy
+* fix(vfs): provision user home directory so $HOME is writable ([#2135](https://github.com/everruns/bashkit/pull/2135)) by @chaliy
+* feat(ls): support -d/--directory to list directories themselves ([#2134](https://github.com/everruns/bashkit/pull/2134)) by @chaliy
+* chore(security): drop stale pyo3 ignore from audit.toml + bump site ws/yaml ([#2131](https://github.com/everruns/bashkit/pull/2131)) by @chaliy
+* fix(deps): remove stale pyo3 advisory ignores ([#2130](https://github.com/everruns/bashkit/pull/2130)) by @chaliy
+* feat(eval): reimplement bashkit-eval on the mira framework ([#2129](https://github.com/everruns/bashkit/pull/2129)) by @chaliy
+* feat(xargs): support -P/--max-procs and --process-slot-var ([#2126](https://github.com/everruns/bashkit/pull/2126)) by @chaliy
+* fix(js): bump js-yaml to >=4.2.0 (GHSA-h67p-54hq-rp68) ([#2124](https://github.com/everruns/bashkit/pull/2124)) by @chaliy
+* fix(parser): treat do/done as words inside for/select in-list ([#2123](https://github.com/everruns/bashkit/pull/2123)) by @chaliy
+* fix(deps): bump pyo3 to 0.29 to resolve two security advisories ([#2122](https://github.com/everruns/bashkit/pull/2122)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.12.0...v0.13.0
 
 ## [0.12.0] - 2026-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bashkit",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.12.0", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.13.0", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",


### PR DESCRIPTION
## Release v0.13.0

Bumps the workspace from `0.12.0` → `0.13.0`. On merge, `release.yml` will cut the GitHub Release + tag and dispatch the crates.io / PyPI / npm / Homebrew publish workflows.

### Why minor (not patch)

The unreleased diff contains a **breaking API removal** (`HttpHandler` → `HttpTransport`) plus several new features, so per the repo's semver policy (`specs/release-process.md`: MINOR = new features/builtins) this is a minor bump, not a patch.

### Highlights

- **Pluggable `HttpTransport` for curl/wget** — hosts can route all sandbox HTTP through their own egress boundary while bashkit keeps enforcing policy ([#2147](https://github.com/everruns/bashkit/pull/2147)). **Breaking:** `HttpHandler` / `http_handler` removed; migrate to `HttpTransport` / `http_transport`.
- **`xargs -P` parallel execution** with `--process-slot-var` ([#2126](https://github.com/everruns/bashkit/pull/2126)).
- **`ls -d/--directory`** ([#2134](https://github.com/everruns/bashkit/pull/2134)).
- **`bashkit-eval` reimplemented on the mira framework** ([#2129](https://github.com/everruns/bashkit/pull/2129)).
- **Linear-time glob `*` matching (TM-DOS-031)** — kills exponential backtracking ([#2142](https://github.com/everruns/bashkit/pull/2142)).

Full notes in `CHANGELOG.md`.

### Publish-readiness report

- **Version sync** — `Cargo.toml`, `bashkit-cli` path-dep pin, `bashkit-js/package.json`, and all 7 workspace crates in `Cargo.lock` read `0.13.0`; greater than the latest published `0.12.0`.
- **`cargo publish --dry-run -p bashkit`** — ✅ passes (with the CI git-only-dep strip applied, matching `publish.yml`).
- **`cargo publish -p bashkit-cli`** — packages cleanly; dry-run version resolution is blocked only because `bashkit 0.13.0` isn't on crates.io yet (expected — CI publishes `bashkit` first, then `bashkit-cli`).
- **API references** — `just apidocs` (Python + TypeScript) regenerated; **no drift**.
- **`cargo fmt --check`** — ✅ clean.
- Full test matrix left to CI (diff is version strings + changelog + lockfile only, no code changes).

### Post-merge monitoring

Watch `release.yml`, `publish.yml`, `publish-python.yml`, `publish-js.yml`, `cli-binaries.yml` to completion and confirm crates.io, PyPI, npm, and Homebrew all report `0.13.0` before declaring shipped.