### PR TITLE
fix(site): lengthen crawler meta descriptions

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,7 @@
     "data:performance": "node scripts/build-performance-data.mjs",
     "prebuild": "node scripts/build-performance-data.mjs",
     "build": "astro build",
-    "postbuild": "node scripts/normalize-generated-html.mjs && node scripts/verify-doc-routes.mjs && node scripts/verify-doc-markdown-routes.mjs && node scripts/verify-public-links.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs && node scripts/verify-llms.mjs",
+    "postbuild": "node scripts/normalize-generated-html.mjs && node scripts/verify-doc-routes.mjs && node scripts/verify-doc-markdown-routes.mjs && node scripts/verify-public-links.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs && node scripts/verify-meta-descriptions.mjs && node scripts/verify-llms.mjs",
     "preview": "wrangler dev",
     "deploy": "pnpm run build && wrangler deploy",
     "check": "astro check",

--- a/site/scripts/verify-meta-descriptions.mjs
+++ b/site/scripts/verify-meta-descriptions.mjs
@@ -1,0 +1,48 @@
+// Decision: verify the crawler-reported public pages from generated HTML,
+// because Astro props and generated inventories can change the final text.
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MIN_DESCRIPTION_LENGTH = 160;
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(scriptDir, "..");
+const distRoot = path.join(siteRoot, "dist");
+
+const checkedPages = [
+  { route: "/benches/", file: "benches/index.html" },
+  { route: "/builtins/", file: "builtins/index.html" },
+];
+
+const failures = [];
+
+for (const page of checkedPages) {
+  const filePath = path.join(distRoot, page.file);
+
+  if (!existsSync(filePath)) {
+    failures.push(`${page.route}: missing generated HTML at ${page.file}`);
+    continue;
+  }
+
+  const html = readFileSync(filePath, "utf8");
+  const description = html.match(
+    /<meta\s+name="description"\s+content="([^"]*)"\s*\/?>/,
+  )?.[1];
+
+  if (!description) {
+    failures.push(`${page.route}: missing meta description`);
+    continue;
+  }
+
+  if (description.length < MIN_DESCRIPTION_LENGTH) {
+    failures.push(
+      `${page.route}: meta description is ${description.length} chars; expected at least ${MIN_DESCRIPTION_LENGTH}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Meta description verification failed:\n${failures.join("\n")}`);
+}
+
+console.log("Verified crawler-reported meta descriptions.");

--- a/site/src/pages/benches.astro
+++ b/site/src/pages/benches.astro
@@ -84,7 +84,7 @@ const evalResultsUrl =
   "https://github.com/everruns/bashkit/tree/main/crates/bashkit-eval/results";
 
 const pageDescription =
-  "Latest Bashkit benchmark, criterion bench, and LLM eval snapshot.";
+  "Explore Bashkit benchmark, Criterion bench, and LLM eval results with latest runtime snapshots, category scores, raw reports, and historical artifact links over time.";
 ---
 
 <BaseLayout title="Bashkit Benches" description={pageDescription}>

--- a/site/src/pages/builtins.astro
+++ b/site/src/pages/builtins.astro
@@ -66,7 +66,7 @@ const builtinsJsonHref =
 
 <BaseLayout
   title={`Bashkit builtins — ${builtins.length} commands in the virtual runtime`}
-  description={`Browse the ${builtins.length} builtins Bashkit exposes in its in-process virtual shell runtime: text, files, archives, network, plus optional Python, TypeScript, and SQLite.`}
+  description="Browse Bashkit builtins for the in-process virtual shell runtime: text, files, archives, networking, shell control, and optional Python, TypeScript, and SQLite commands."
 >
   <section class="builtins-hero section">
     <div class="container builtins-hero__grid">


### PR DESCRIPTION
## What
- Lengthen the `/benches/` and `/builtins/` meta descriptions reported as too short by crawler tooling.
- Add a generated-HTML verifier for those crawler-reported routes so future builds catch regressions.

## Why
Bing reported the pages as having meta descriptions that were too short, which can hurt search result snippets and page understanding.

## How
The site build now verifies the final generated `<meta name="description">` content for both routes is at least 160 characters.

## Risk
Low. Static metadata-only change plus build-time verification.

## Security
No security-relevant code changes. Reviewed: verifier reads local generated HTML only.

## Tests
- `npx --yes pnpm@10.11.1 run build`
- `npx --yes pnpm@10.11.1 run check`
- `just pre-pr`
