### PR TITLE
ci(apidocs-drift): build index.cjs so typedoc can resolve wrapper imports

### DIFF
--- a/.github/workflows/apidocs-drift.yml
+++ b/.github/workflows/apidocs-drift.yml
@@ -100,8 +100,16 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: crates/bashkit-js
 
-      - name: Build napi addon (generates index.d.ts)
-        run: pnpm exec napi build --platform
+      - name: Build napi addon (generates index.cjs + type declarations)
+        # wrapper.ts imports from ./index.cjs, but napi emits index.js /
+        # index.d.ts. The build:cjs script renames them to index.cjs /
+        # index.d.cts (same as the published `build`). Without it typedoc
+        # cannot resolve ./index.cjs (TS2307) and every type that flows from
+        # the native module collapses to `any`, producing spurious implicit-
+        # any errors so the drift check never runs.
+        run: |
+          pnpm exec napi build --platform
+          pnpm run build:cjs
         working-directory: crates/bashkit-js
 
       - name: Regenerate TypeScript API reference


### PR DESCRIPTION
## What changed
The `typescript` job of the **API Reference Drift** guard now runs `pnpm run build:cjs` after `napi build`, so `index.cjs` / `index.d.cts` exist before typedoc runs.

## Why
After #2159 unblocked pnpm setup, the re-dispatched run exposed the real failure: the job ran only `napi build --platform` (which emits `index.js` / `index.d.ts`), but `wrapper.ts` imports from `./index.cjs`. typedoc therefore failed with:

```
wrapper.ts:15:8 - error TS2307: Cannot find module './index.cjs' or its corresponding type declarations.
wrapper.ts:1236:13 - error TS7006: Parameter 's' implicitly has an 'any' type.
... (4 implicit-any errors)
[error] Found 5 errors and 0 warnings
```

The 4 implicit-any errors are a **cascade** from the single unresolved-module error — with `./index.cjs` unresolved, every type flowing from the native module (e.g. `result.stdout`) collapses to `any`. The published `build` script already handles this via `build:cjs` (rename `index.js`→`index.cjs`, copy `index.d.ts`→`index.d.cts`); the drift job just never ran it.

## Before / After
Reproduced locally (napi build + `build:cjs` + `node scripts/gen_ts_apidocs.mjs`):

- **Before:** `[error] Found 5 errors and 0 warnings`; typedoc exits non-zero, drift check never runs.
- **After:**
  ```
  [info] json generated at /tmp/.../api.json
  [warning] Found 0 errors and 5 warnings
  wrote site/src/content/apidocs/typescript.md (52849 bytes)
  ```
  0 errors, and the committed `typescript.md` is unchanged — **no content drift**, so this is purely a workflow fix.

## Risk
- Low
- CI-only YAML change; reuses the existing `build:cjs` script.

## Checklist
- [x] Tests added or updated — N/A (CI workflow config only)
- [x] Backward compatibility considered — N/A (internal automation)