### PR TITLE
fix(glob): restore bracket cache on '*' backtrack

### DIFF
--- a/crates/bashkit/src/interpreter/glob.rs
+++ b/crates/bashkit/src/interpreter/glob.rs
@@ -197,6 +197,7 @@ impl Interpreter {
         // never needed again), keeping the worst case O(value.len * pattern.len).
         let mut star_pat: Option<std::iter::Peekable<std::str::Chars>> = None;
         let mut star_val: Option<std::iter::Peekable<std::str::Chars>> = None;
+        let mut star_no_more_bracket_closes = false;
 
         // On a content mismatch, resume from the most recent `*`, letting it
         // consume one more value char. With no active `*`, the match fails.
@@ -207,6 +208,7 @@ impl Interpreter {
                         sv.next();
                         pattern_chars = sp.clone();
                         value_chars = sv.clone();
+                        no_more_bracket_closes = star_no_more_bracket_closes;
                         continue;
                     }
                 }
@@ -262,6 +264,7 @@ impl Interpreter {
                     // value char and retries. Overwrites any earlier `*`.
                     star_pat = Some(pattern_chars.clone());
                     star_val = Some(value_chars.clone());
+                    star_no_more_bracket_closes = no_more_bracket_closes;
                 }
                 (Some('?'), _) => {
                     // Check for extglob ?(...)
@@ -980,6 +983,13 @@ mod tests {
         assert!(interp.pattern_matches("[]", "[]"));
         assert!(interp.pattern_matches("[", "["));
         assert!(interp.pattern_matches("a", "[a]"));
+    }
+
+    #[test]
+    fn star_backtracking_restores_bracket_cache_state() {
+        let interp = interp();
+
+        assert!(!interp.pattern_matches("azX[a]z[", "*[a]z["));
     }
 
     // THREAT[TM-DOS-031]: a run of `*` must not cause exponential backtracking.


### PR DESCRIPTION
### Motivation
- Fix a regressed glob semantics bug where backtracking from `*` left `no_more_bracket_closes` stale, causing valid bracket expressions to be treated as literals and producing false-positive matches.

### Description
- Add `star_no_more_bracket_closes` to record bracket-cache state when a `*` restore point is created.
- Restore `no_more_bracket_closes` from `star_no_more_bracket_closes` inside `backtrack!()` so bracket parsing state is correct after retries.
- Add regression test `star_backtracking_restores_bracket_cache_state` asserting `interp.pattern_matches("azX[a]z[", "*[a]z[")` is false.

### Testing
- Ran `cargo test -p bashkit interpreter::glob::tests --lib` and the glob tests (5) passed.
- Ran `cargo test -p bashkit interpreter::glob::tests::star_backtracking_restores_bracket_cache_state --lib` which passed (it failed prior to the fix).
- Ran `cargo fmt --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7a56cbb8832bbd709f6f93b23158)