### PR TITLE
fix(ci): add `with: tool: cargo-tarpaulin` to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Install cargo-tarpaulin
-        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # cargo-tarpaulin
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
+        with:
+          tool: cargo-tarpaulin
 
       # `rg` differential tests compare against real ripgrep. Pin the
       # binary so coverage does not depend on the runner image package set.


### PR DESCRIPTION
### Motivation
- The coverage job used the generic `taiki-e/install-action` without the `with: tool` input, so `cargo tarpaulin` was not installed while later steps invoke `cargo tarpaulin`.

### Description
- Update `.github/workflows/coverage.yml` to pass `with:
  tool: cargo-tarpaulin` to the `Install cargo-tarpaulin` step so the expected cargo subcommand is installed.

### Testing
- Rebased on `origin/main`, committed the change, and validated the workflow by running `ruby -ryaml -e 'wf=YAML.load_file(".github/workflows/coverage.yml"); step=wf.fetch("jobs").fetch("coverage").fetch("steps").find{|s| s["name"]=="Install cargo-tarpaulin"}; abort "missing tool" unless step.dig("with","tool")=="cargo-tarpaulin"; puts step.inspect'` and `rg -n "Install cargo-tarpaulin|cargo tarpaulin|tool: cargo-tarpaulin" .github/workflows/coverage.yml`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a569f128314832bb0b887d043e71f53)