### PR TITLE
test(fuzzer): avoid host env dependent assertion

### DIFF
--- a/crates/bashkit/tests/integration/proptest_differential.rs
+++ b/crates/bashkit/tests/integration/proptest_differential.rs
@@ -643,11 +643,14 @@ fn host_dependent_vars_are_excluded() {
             "{name} must be treated as host-dependent and excluded from the fuzzer"
         );
     }
-    // Ordinary user variable names, not present in the environment, are allowed.
-    for name in ["XZQV", "MYVAR", "FOOBAR", "ABCDEFGH"] {
-        assert!(
-            !is_host_dependent_var(name),
-            "{name} is a safe user variable and must remain generatable"
-        );
-    }
+    // Ordinary user variable names are allowed only when absent from the host
+    // environment; the helper intentionally rejects any inherited variable.
+    let ordinary_name = (0..1000)
+        .map(|i| format!("BASHKIT_FUZZ_SAFE_{}_{}", std::process::id(), i))
+        .find(|name| std::env::var_os(name).is_none())
+        .expect("fresh process-scoped variable name should be absent");
+    assert!(
+        !is_host_dependent_var(&ordinary_name),
+        "{ordinary_name} is absent from the host environment and must remain generatable"
+    );
 }


### PR DESCRIPTION
### Motivation
- The regression test assumed specific ordinary variable names (e.g. `MYVAR`, `FOOBAR`) were absent from the host environment, making it flaky when CI or a developer had one set.
- The `is_host_dependent_var` helper intentionally treats any inherited environment variable as host-dependent, so the test needed to stop relying on hard-coded names.

### Description
- Replace the brittle hard-coded-name loop with a search for a fresh process-scoped variable name (`BASHKIT_FUZZ_SAFE_<pid>_<i>`) that is guaranteed absent in the current process environment.
- Assert `!is_host_dependent_var(&ordinary_name)` for that generated absent name, preserving the helper semantics that inherited env vars remain excluded.
- Change is limited to `crates/bashkit/tests/integration/proptest_differential.rs` and does not alter runtime logic.

### Testing
- Ran `cargo fmt --check --all` which succeeded.
- Ran `MYVAR=attacker cargo test -p bashkit --test integration proptest_differential::host_dependent_vars_are_excluded -- --nocapture` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d716b7390832b88bd10ea7da2ac92)