### PR TITLE
fix(ci): install prebuilt cargo-audit to unblock Audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
-      - name: Security audit (cargo-audit)
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      # Install the prebuilt cargo-audit binary rather than letting
+      # rustsec/audit-check compile it from source. The source build resolves
+      # cargo-audit's own dependencies unlocked, and a newer `kstring` bumped
+      # its MSRV past our pinned toolchain (rust-toolchain.toml forces the
+      # override even for `cargo install`), which broke this job. A prebuilt
+      # binary is immune to future tool-dependency MSRV bumps.
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2023-0071
+          tool: cargo-audit
+
+      - name: Security audit (cargo-audit)
+        run: cargo audit --ignore RUSTSEC-2023-0071
 
       - name: License check (cargo-deny)
         # Held at v2.0.20: v2.1.0 (6f99e34) bundles cargo-deny 0.20.2, whose


### PR DESCRIPTION
## What changed
The `Audit` CI job now installs a **prebuilt** `cargo-audit` binary via `taiki-e/install-action` and runs `cargo audit` directly, instead of letting `rustsec/audit-check` compile `cargo-audit` from source. The `RUSTSEC-2023-0071` ignore is preserved (both on the CLI and via the existing `.cargo/audit.toml`).

## Why
The `Audit` job compiled `cargo-audit` from source. That build resolves `cargo-audit`'s own dependencies **unlocked**, and a newly published `kstring 2.0.3` bumped its MSRV to rustc **1.96.0**. Our `rust-toolchain.toml` pins **1.95.0**, and that override applies even to `cargo install`, so the build failed with:

```
error: failed to compile `cargo-audit v0.22.2`
Caused by:
  rustc 1.95.0 is not supported by the following package:
    kstring@2.0.3 requires rustc 1.96.0
```

This failed the `Audit` job — and therefore the required `Check` aggregator — on **every** open PR, and would fail `main` on any re-run. It was blocking all in-flight PRs.

## Before / After
- **Before:** `Audit` job red on every PR (`cargo install cargo-audit` fails at the `kstring` MSRV wall). `Check` gate red as a result.
- **After:** `cargo-audit` is downloaded as a prebuilt release binary (no source compile, no MSRV coupling) and `cargo audit --ignore RUSTSEC-2023-0071` runs against `Cargo.lock`. Immune to future tool-dependency MSRV bumps. Same pattern already used in this job for `cargo-vet`.

## Risk
- Low
- Only touches the `Audit` job wiring. Loses the inline GitHub annotations that `rustsec/audit-check` posted, but the pass/fail gate is unchanged and matches how `cargo-deny`/`cargo-vet` steps already run in the same job.

## Checklist
- [x] Tests added or updated (CI workflow change; verified `cargo audit` locally)
- [x] Backward compatibility considered (no runtime/library change)
