### PR TITLE
feat(site): add Google Analytics tag

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -22,6 +22,18 @@ const pageUrl = Astro.site
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      is:inline
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-GSSMG0YBEX"
+    ></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-GSSMG0YBEX');
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />


### PR DESCRIPTION
## What changed
Adds Google tag `G-GSSMG0YBEX` to the shared site layout, enabling analytics on every generated HTML page.

## Why
Enable Google Analytics measurement across bashkit.sh.

## Before / After
Before: generated pages did not load a Google tag.

After: all 31 generated HTML pages load and configure `G-GSSMG0YBEX`. Non-HTML endpoints remain unchanged.

## Risk
- Low
- A third-party analytics script now loads on HTML pages; page rendering remains asynchronous.

## Checklist
- [x] Tests added or updated (existing site build verifies every generated page; no new logic)
- [x] Backward compatibility considered

## Verification
- `just test`
- `just pre-pr`
- `pnpm run check` in `site/`
- `pnpm run build` in `site/`
- Confirmed tag in all 31 generated HTML pages