### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
           gh workflow run publish.yml --ref "$TAG"
           gh workflow run publish-python.yml --ref "$TAG"
           gh workflow run publish-js.yml --ref "$TAG"
+          gh workflow run publish-web.yml --ref "$TAG"
 
       - name: Trigger CLI binary builds for release tag
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [0.14.0] - 2026-07-17
+
+### Highlights
+
+- **Browser-native `@everruns/bashkit-web` package** — a slim,
+  single-threaded WebAssembly build runs Bashkit directly in browsers without
+  `SharedArrayBuffer` or COOP/COEP headers, with async custom builtins and live
+  VFS access ([#2175](https://github.com/everruns/bashkit/pull/2175)).
+- **Generic filesystem namespaces** — mount independent filesystems under
+  virtual path prefixes, with longest-prefix routing, rebasing, and sandboxed
+  namespace examples ([#2174](https://github.com/everruns/bashkit/pull/2174)).
+- **VFS and glob hardening** — directory limits now apply to `add_dir`, and
+  glob backtracking correctly restores bracket-match cache state
+  ([#2168](https://github.com/everruns/bashkit/pull/2168),
+  [#2167](https://github.com/everruns/bashkit/pull/2167)).
+
+### What's Changed
+
+* feat(wasm): slim single-threaded browser package (@everruns/bashkit-web) ([#2175](https://github.com/everruns/bashkit/pull/2175)) by @chaliy
+* feat(fs): add generic filesystem namespaces ([#2174](https://github.com/everruns/bashkit/pull/2174)) by @chaliy
+* feat(site): add Google Analytics tag ([#2173](https://github.com/everruns/bashkit/pull/2173)) by @chaliy
+* fix(ci): install prebuilt cargo-audit to unblock Audit job ([#2171](https://github.com/everruns/bashkit/pull/2171)) by @chaliy
+* test(fuzzer): avoid host env dependent assertion ([#2170](https://github.com/everruns/bashkit/pull/2170)) by @chaliy
+* fix(ci): add cargo-tarpaulin tool input to coverage workflow ([#2169](https://github.com/everruns/bashkit/pull/2169)) by @chaliy
+* fix(vfs): enforce add_dir directory limits ([#2168](https://github.com/everruns/bashkit/pull/2168)) by @chaliy
+* fix(glob): restore bracket cache on '*' backtrack ([#2167](https://github.com/everruns/bashkit/pull/2167)) by @chaliy
+* chore(deps): bump turso_core from 0.6.1 to 0.7.0 ([#2166](https://github.com/everruns/bashkit/pull/2166)) by @dependabot
+* chore(ci): bump the github-actions group with 3 updates ([#2165](https://github.com/everruns/bashkit/pull/2165)) by @dependabot
+* chore(deps): bump rustls from 0.23.41 to 0.23.42 ([#2164](https://github.com/everruns/bashkit/pull/2164)) by @dependabot
+* ci(apidocs-drift): build index.cjs so typedoc can resolve wrapper imports ([#2163](https://github.com/everruns/bashkit/pull/2163)) by @chaliy
+* chore(deps): bump the rust-dependencies group with 5 updates ([#2162](https://github.com/everruns/bashkit/pull/2162)) by @dependabot
+* chore: sync uutils/coreutils argument surfaces and integrate new i18n-decimal gate ([#2161](https://github.com/everruns/bashkit/pull/2161)) by @chaliy
+* chore(ci): bump the github-actions group with 3 updates ([#2160](https://github.com/everruns/bashkit/pull/2160)) by @dependabot
+* ci: repair scheduled drift guards ([#2159](https://github.com/everruns/bashkit/pull/2159)) by @chaliy
+* docs(threat-model): sync public doc with spec ledger and drift guard ([#2158](https://github.com/everruns/bashkit/pull/2158)) by @chaliy
+* chore: pre-release maintenance pass ([#2156](https://github.com/everruns/bashkit/pull/2156)) by @chaliy
+* chore(js): upgrade bashkit-js to TypeScript 7 ([#2154](https://github.com/everruns/bashkit/pull/2154)) by @chaliy
+* chore: standardize PR descriptions on functional change and before/after proof ([#2153](https://github.com/everruns/bashkit/pull/2153)) by @chaliy
+* fix(site): lengthen crawler meta descriptions ([#2152](https://github.com/everruns/bashkit/pull/2152)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.13.0...v0.14.0
+
 ## [0.13.0] - 2026-07-07
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.13.0", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.14.0", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-web",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/justfile
+++ b/justfile
@@ -37,6 +37,7 @@ check:
     cargo fmt --check
     cargo clippy --all-targets -- -D warnings
     cargo test
+    python3 -m unittest discover -s scripts/tests -p 'test_*.py'
 
 # Lint and format-check Python bindings
 python-lint:
@@ -87,6 +88,7 @@ apidocs-python:
 # Needs network for `npx typedoc`. See specs/documentation.md.
 apidocs-ts:
     cd crates/bashkit-js && pnpm exec napi build --platform
+    cd crates/bashkit-js && pnpm run build:cjs
     node scripts/gen_ts_apidocs.mjs
 
 # Regenerate all self-hosted package API references.

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -1,0 +1,44 @@
+"""Release orchestration must publish every public package."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    def test_release_dispatches_every_publish_workflow(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+        for publish_workflow in (
+            "publish.yml",
+            "publish-python.yml",
+            "publish-js.yml",
+            "publish-web.yml",
+        ):
+            with self.subTest(publish_workflow=publish_workflow):
+                self.assertIn(
+                    f'gh workflow run {publish_workflow} --ref "$TAG"', workflow
+                )
+
+    def test_public_package_versions_match_workspace(self) -> None:
+        cargo_manifest = (ROOT / "Cargo.toml").read_text()
+        match = re.search(r'^version = "([^"]+)"$', cargo_manifest, re.MULTILINE)
+        self.assertIsNotNone(match)
+        workspace_version = match.group(1)
+
+        for package_manifest in (
+            "crates/bashkit-js/package.json",
+            "crates/bashkit-wasm/package.json",
+        ):
+            manifest = (ROOT / package_manifest).read_text()
+            with self.subTest(package_manifest=package_manifest):
+                self.assertIn(f'"version": "{workspace_version}"', manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -39,7 +39,8 @@ silently failed.
 2. **Update CHANGELOG.md** (format below).
 3. **Update version across all manifests** (must match the workspace version):
    workspace `Cargo.toml`, `crates/bashkit-cli/Cargo.toml` path-dep pin on
-   `bashkit`, `crates/bashkit-js/package.json`, and `Cargo.lock`
+   `bashkit`, `crates/bashkit-js/package.json`,
+   `crates/bashkit-wasm/package.json`, and `Cargo.lock`
    (`cargo update -p bashkit -p bashkit-cli ...`).
    - Refresh the self-hosted API references: `just apidocs` and commit any
      changes. The `apidocs-drift` workflow only checks TypeScript weekly (its
@@ -49,38 +50,49 @@ silently failed.
    --all-targets --all-features -- -D warnings`, `cargo test`.
 5. **Verify publish-readiness** (catches what local tests don't — the
    `cargo publish` packaging step, missing files, version drift):
-   - `cargo publish --dry-run -p bashkit` and `-p bashkit-cli` must succeed.
-     This caught the v0.4.0 → v0.4.1 incident: the rustdoc guide lived
-     outside the crate dir, so `cargo publish` couldn't find it; local
-     `cargo build` did not catch it.
+   - `cargo publish --dry-run -p bashkit` must succeed in a disposable copy
+     after applying the same git-only Monty/Python manifest transform as
+     `publish.yml`. Package `bashkit-cli` there against the latest published
+     core version as a structural proxy; Cargo cannot resolve the CLI's new
+     registry dependency until the core crate is live. Normal workspace checks
+     still compile the CLI against the new local core, and `publish.yml` waits
+     for the core registry version before publishing the CLI. Packaging caught
+     the v0.4.0 → v0.4.1 incident: the rustdoc guide lived outside the crate
+     dir, so `cargo publish` couldn't find it; local `cargo build` did not catch
+     it.
    - PyPI / npm: confirm the feeding pipelines still build (`maturin build
-     --release`, `napi build` smokes) when changes touch packaging.
+     --release`, `napi build`, browser WASM build smokes) when changes touch
+     packaging.
    - Version sync: all manifests read the same `X.Y.Z`, and it is greater
      than the latest published version on every registry (`cargo search
      bashkit`, `pip index versions bashkit`, `npm view @everruns/bashkit
-     version`).
+     version`, `npm view @everruns/bashkit-web version`). A missing registry
+     entry is valid only for a package's first release.
    - On any failure, fix root cause and re-run before opening the PR — do
      **not** merge a release PR with a known-broken publish path.
 6. **Commit and push** — `chore(release): prepare vX.Y.Z` on a feature branch.
 7. **Create PR** — same title, changelog excerpt + publish-readiness report in description.
 8. **Monitor post-merge publishing** — watch `release.yml` create the
-   Release + tag, watch `publish.yml`, `publish-python.yml`,
-   `publish-js.yml`, `cli-binaries.yml` to completion, run the post-release
-   verification commands, and only declare "shipped" when **all four**
-   targets (crates.io, PyPI, npm, Homebrew) report the new version. If one
+   Release + tag, watch `publish.yml`, `publish-python.yml`, `publish-js.yml`,
+   `publish-web.yml`, and `cli-binaries.yml` to completion, run the
+   post-release verification commands, and only declare "shipped" when all
+   six published artifacts (`bashkit` + `bashkit-cli` on crates.io, `bashkit`
+   on PyPI, both npm packages, and Homebrew) report the new version. If one
    fails, open a hotfix PR rather than leaving the release half-shipped.
 
 ### CI Automation
 
 - On merge to main, `release.yml` detects the `chore(release): prepare vX.Y.Z` commit, extracts notes from CHANGELOG.md, creates the GitHub Release + tag.
-- On Release published, `publish.yml` / `publish-js.yml` / `publish-python.yml` publish to crates.io, npm, PyPI; each includes a published-version verification step.
+- On Release published, `publish.yml` / `publish-js.yml` /
+  `publish-web.yml` / `publish-python.yml` publish to crates.io, npm, PyPI;
+  each includes a published-version verification step.
 
 ## Pre-Release Checklist
 
 `AGENTS.md` Pre-PR Checklist applies, plus: CI green on main, CHANGELOG.md
 has entries since last release, version consistent across all manifests
-(step 3), both `cargo publish --dry-run`s succeed, and new version > latest
-published on each registry.
+(step 3), the core publish dry-run and CLI package check succeed, and new
+version > latest published on each registry.
 
 ## Post-Merge Monitoring
 
@@ -89,7 +101,10 @@ Confirm each target (workflow → check):
 - GitHub Release (`release.yml`): `gh release view vX.Y.Z`
 - crates.io (`publish.yml`): `cargo search bashkit` / `cargo search bashkit-cli`
 - PyPI (`publish-python.yml`): `pip index versions bashkit`
-- npm (`publish-js.yml`): `npm view @everruns/bashkit version`; `npm dist-tags ls @everruns/bashkit` ("latest" points at it)
+- npm Node (`publish-js.yml`): `npm view @everruns/bashkit version`;
+  `npm dist-tags ls @everruns/bashkit` ("latest" points at it)
+- npm browser (`publish-web.yml`): `npm view @everruns/bashkit-web version`;
+  `npm dist-tags ls @everruns/bashkit-web` ("latest" points at it)
 - Homebrew (`cli-binaries.yml`): `everruns/homebrew-tap` formula bumped
 
 If a workflow fails: `gh run view <run-id> --log-failed`, identify root
@@ -112,13 +127,14 @@ Use the latest entries in `CHANGELOG.md` as the template. Rules:
 - `bashkit-cli` on crates.io (CLI tool)
 - `bashkit` on PyPI (pre-built wheels)
 - `@everruns/bashkit` on npm (native NAPI-RS bindings)
+- `@everruns/bashkit-web` on npm (single-threaded browser WebAssembly)
 
 ## Publishing Order
 
 Crates publish in dependency order: `bashkit` (no internal deps) then
 `bashkit-cli` (depends on bashkit). Python wheels (native matrix + the
 reduced-feature Pyodide/Emscripten wheel — see `specs/emscripten-wheels.md`)
-and npm packages publish independently (no crates.io dependency). CI
+and both npm packages publish independently (no crates.io dependency). CI
 workflows handle ordering automatically on GitHub Release.
 
 ## Workflows
@@ -163,6 +179,14 @@ wasm32-wasip1-threads), tests on Node 20/22/24, publishes to npm. Secret:
 `--provenance`, same pattern as everruns/sdk. JS package version is synced
 from the workspace `Cargo.toml` by `build.rs` updating `package.json`.
 
+### publish-web.yml
+
+Dispatched by `release.yml` from the verified release tag. Builds the
+single-threaded `wasm32-unknown-unknown` browser bundle, runs the headless Node
+integration suite, and publishes `@everruns/bashkit-web` to npm with
+provenance. Uses the same `NPM_TOKEN` as `publish-js.yml`; the package version
+is synced manually from the workspace version during release preparation.
+
 ## Authentication
 
 - `CARGO_REGISTRY_TOKEN` (crates.io token, publish scopes) in GitHub Actions secrets.
@@ -174,6 +198,7 @@ from the workspace `Cargo.toml` by `build.rs` updating `package.json`.
 ```bash
 cargo search bashkit; cargo search bashkit-cli
 npm view @everruns/bashkit version; npm dist-tags ls @everruns/bashkit
+npm view @everruns/bashkit-web version; npm dist-tags ls @everruns/bashkit-web
 pip index versions bashkit
 gh release view --repo everruns/bashkit
 ```
@@ -193,4 +218,4 @@ selected for new projects.
 ## Release Artifacts
 
 GitHub Release (tag, notes, source archives, prebuilt CLI binaries),
-crates.io crates, PyPI wheels, npm bindings, Homebrew formula.
+crates.io crates, PyPI wheels, Node and browser npm bindings, Homebrew formula.


### PR DESCRIPTION
## What changed
Prepare Bashkit v0.14.0 across Rust, Node, Python, and browser WASM artifacts.

Highlights:
- Publish the new single-threaded `@everruns/bashkit-web` browser package.
- Add generic filesystem namespaces.
- Harden VFS directory-limit enforcement and glob backtracking.
- Dispatch and monitor the browser npm publish alongside every existing release artifact.

## Why
Changes since v0.13.0 include two user-facing features, requiring a minor release. The browser package had a publish workflow but the release orchestrator did not dispatch it; without this change, the first npm publication would be silently skipped.

## Before / After
Before:
- Workspace/package versions: `0.13.0`
- `release.yml` dispatched crates.io, PyPI, and Node npm publishing, but not `publish-web.yml`
- `npm view @everruns/bashkit-web version` returned 404 (package not yet published)

After:
- Workspace and both npm manifests: `0.14.0`
- `release.yml` explicitly dispatches `publish-web.yml` from the verified release tag
- A regression test asserts every public publish workflow is dispatched and npm manifest versions match the workspace

## Publish readiness
- Full history verified: local and GitHub compare both report 21 commits since v0.13.0
- Latest main CI, JS, Python, Coverage, CodeQL, Nightly, and Fuzz runs are green
- `just pre-pr` passed (fmt, Clippy with warnings denied, full tests, script tests, cargo vet)
- `cargo publish --dry-run -p bashkit` passed after the production Monty/Python manifest transform
- `bashkit-cli` package boundary verified against the latest published core; workspace checks compile it against local v0.14.0
- Python v0.14.0 release wheel built successfully with maturin
- Native npm bindings built; Python and TypeScript API references regenerated without drift
- Browser WASM v0.14.0 release bundle built; 22/22 integration tests passed
- Registry baseline: crates.io, PyPI, and `@everruns/bashkit` are at v0.13.0; `@everruns/bashkit-web` is a first publication

## Risk
- Medium
- Release orchestration now adds one parallel npm publication. A regression test protects dispatch coverage; post-merge monitoring will verify all six artifacts before declaring the release shipped.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
