### PR TITLE
chore(release): prepare v0.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
+      - name: Install binaryen (wasm-opt)
+        run: sudo apt-get update && sudo apt-get install -y binaryen
+
       - name: Build web bundle
         run: bash crates/bashkit-wasm/scripts/build.sh release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.14.1] - 2026-07-17
+
+### Fixed
+
+- **Browser package publishing** — enable the stable WebAssembly bulk-memory
+  and nontrapping float-to-int features during Binaryen optimization, and run
+  that optimized path in pull-request CI. This fixes publication of the new
+  `@everruns/bashkit-web` package after the v0.14.0 release build failed.
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.14.0...v0.14.1
+
 ## [0.14.0] - 2026-07-17
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bashkit",
  "napi",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.14.0", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.14.1", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/__test__/ai-adapters.spec.ts
+++ b/crates/bashkit-js/__test__/ai-adapters.spec.ts
@@ -241,7 +241,9 @@ test("openai: handler respects pre-aborted signal", async (t) => {
 test("openai: aborted handler leaves adapter bash reusable", async (t) => {
   const adapter = openAiBashTool();
   const controller = new AbortController();
-  setTimeout(() => controller.abort(), 10);
+  // Abort after handler setup yields to its execution promise. A timer races
+  // the finite script on fast release runners and can fire after completion.
+  queueMicrotask(() => controller.abort());
 
   const cancelled = await adapter.handler(
     {

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-web",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/crates/bashkit-wasm/scripts/build.sh
+++ b/crates/bashkit-wasm/scripts/build.sh
@@ -42,7 +42,6 @@ if command -v wasm-opt >/dev/null 2>&1; then
   echo "==> wasm-opt -Oz (Rust WebAssembly features enabled)"
   wasm-opt -Oz \
     --enable-bulk-memory \
-    --enable-bulk-memory-opt \
     --enable-nontrapping-float-to-int \
     "$OUT_DIR/bashkit_wasm_bg.wasm" -o "$OUT_DIR/bashkit_wasm_bg.wasm"
 else

--- a/crates/bashkit-wasm/scripts/build.sh
+++ b/crates/bashkit-wasm/scripts/build.sh
@@ -37,12 +37,13 @@ wasm-bindgen "$WASM_IN" \
   --omit-default-module-path
 
 if command -v wasm-opt >/dev/null 2>&1; then
-  # Rust emits memory.copy and saturating float conversions; explicitly enable
-  # those stable WebAssembly features without accepting unrelated proposals.
+  # Rust emits memory.copy, saturating float conversions, and sign extension;
+  # enable those stable features without accepting unrelated proposals.
   echo "==> wasm-opt -Oz (Rust WebAssembly features enabled)"
   wasm-opt -Oz \
     --enable-bulk-memory \
     --enable-nontrapping-float-to-int \
+    --enable-sign-ext \
     "$OUT_DIR/bashkit_wasm_bg.wasm" -o "$OUT_DIR/bashkit_wasm_bg.wasm"
 else
   echo "==> wasm-opt not found; skipping size optimization"

--- a/crates/bashkit-wasm/scripts/build.sh
+++ b/crates/bashkit-wasm/scripts/build.sh
@@ -37,8 +37,14 @@ wasm-bindgen "$WASM_IN" \
   --omit-default-module-path
 
 if command -v wasm-opt >/dev/null 2>&1; then
-  echo "==> wasm-opt -Oz"
-  wasm-opt -Oz "$OUT_DIR/bashkit_wasm_bg.wasm" -o "$OUT_DIR/bashkit_wasm_bg.wasm"
+  # Rust emits memory.copy and saturating float conversions; explicitly enable
+  # those stable WebAssembly features without accepting unrelated proposals.
+  echo "==> wasm-opt -Oz (Rust WebAssembly features enabled)"
+  wasm-opt -Oz \
+    --enable-bulk-memory \
+    --enable-bulk-memory-opt \
+    --enable-nontrapping-float-to-int \
+    "$OUT_DIR/bashkit_wasm_bg.wasm" -o "$OUT_DIR/bashkit_wasm_bg.wasm"
 else
   echo "==> wasm-opt not found; skipping size optimization"
 fi

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -43,7 +43,13 @@ class ReleaseWorkflowTests(unittest.TestCase):
         build_script = (ROOT / "crates/bashkit-wasm/scripts/build.sh").read_text()
         ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text()
 
-        self.assertIn("--enable-bulk-memory", build_script)
+        for stable_feature in (
+            "--enable-bulk-memory",
+            "--enable-nontrapping-float-to-int",
+            "--enable-sign-ext",
+        ):
+            self.assertIn(stable_feature, build_script)
+        self.assertNotIn("--all-features", build_script)
         self.assertIn("apt-get install -y binaryen", ci_workflow)
 
 

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -39,6 +39,13 @@ class ReleaseWorkflowTests(unittest.TestCase):
             with self.subTest(package_manifest=package_manifest):
                 self.assertIn(f'"version": "{workspace_version}"', manifest)
 
+    def test_web_ci_exercises_release_wasm_optimization(self) -> None:
+        build_script = (ROOT / "crates/bashkit-wasm/scripts/build.sh").read_text()
+        ci_workflow = (ROOT / ".github/workflows/ci.yml").read_text()
+
+        self.assertIn("--enable-bulk-memory", build_script)
+        self.assertIn("apt-get install -y binaryen", ci_workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
Publishes the 0.14.1 patch release and repairs the optimized browser-package build. Binaryen now receives the stable Wasm features emitted by Rust, and PR CI exercises the same optimized build path used for npm publishing.

## Why
The v0.14.0 @everruns/bashkit-web publisher failed during wasm-opt validation because bulk-memory and saturating float conversions were disabled. The unoptimized PR build did not expose that release-only failure.

## Before / After
Before: Publish Web run 29630799319 failed validation; npm publication was skipped.

After: the local release build completes with Binaryen 130 and all 22 headless browser integration tests pass.

## Risk
- Low
- The optimizer feature list must continue matching stable Wasm features emitted by the pinned Rust toolchain. CI now guards this path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered