### PR TITLE
fix(wasm): make bashkit run on single-threaded browser wasm (subshells, timers, jobs, awk)

### DIFF
--- a/crates/bashkit-wasm/__test__/bashkit-web.test.mjs
+++ b/crates/bashkit-wasm/__test__/bashkit-web.test.mjs
@@ -61,6 +61,44 @@ test("sync: stderr is captured", () => {
   assert.equal(r.stderr, "oops\n");
 });
 
+// --- Child shell (bash / sh builtin) ---------------------------------------
+// Regression: the bash/sh builtin re-parses its child script. On
+// wasm32-unknown-unknown that parse must run inline — the native path wraps it
+// in tokio::time::timeout + spawn_blocking, whose timer calls std::time, which
+// panics ("time not implemented") and poisons the entire wasm module. A single
+// `echo hi` at the top level takes a different path, so this only surfaces when
+// a subshell is spawned. See execute_shell in the interpreter.
+
+test("child shell: bash -c runs without panicking", async () => {
+  const bash = new Bash();
+  const r = await bash.execute("bash -c 'echo from-child'");
+  assert.equal(r.stdout, "from-child\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("child shell: sh -c with a pipe", async () => {
+  const bash = new Bash();
+  const r = await bash.execute("sh -c 'echo hi | tr a-z A-Z'");
+  assert.equal(r.stdout, "HI\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("child shell: running a script file", async () => {
+  const bash = new Bash({
+    files: { "/demo.sh": 'for i in 1 2 3; do echo "iter $i"; done\necho done' },
+  });
+  const r = await bash.execute("bash /demo.sh");
+  assert.equal(r.stdout, "iter 1\niter 2\niter 3\ndone\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("child shell: piping a script into bash", async () => {
+  const bash = new Bash();
+  const r = await bash.execute("echo 'echo piped' | bash");
+  assert.equal(r.stdout, "piped\n");
+  assert.equal(r.exitCode, 0);
+});
+
 // --- Options ---------------------------------------------------------------
 
 test("options: env and cwd", () => {

--- a/crates/bashkit-wasm/__test__/bashkit-web.test.mjs
+++ b/crates/bashkit-wasm/__test__/bashkit-web.test.mjs
@@ -99,6 +99,51 @@ test("child shell: piping a script into bash", async () => {
   assert.equal(r.exitCode, 0);
 });
 
+// --- Timers, jobs, awk file I/O --------------------------------------------
+// Each of these used to panic and poison the whole module on wasm32: they
+// reached for a tokio timer (sleep/timeout), tokio::spawn (background jobs), or
+// std::thread::spawn (awk file redirects). On single-threaded wasm they must
+// run inline instead. See specs/browser-package.md.
+
+test("sleep returns immediately (no timer driver on wasm)", async () => {
+  const bash = new Bash();
+  const r = await bash.execute("sleep 2; echo slept");
+  assert.equal(r.stdout, "slept\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("timeout runs the command (no wall-clock enforcement on wasm)", async () => {
+  const bash = new Bash();
+  const r = await bash.execute("timeout 5 echo hi");
+  assert.equal(r.stdout, "hi\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("background job runs and wait collects it", async () => {
+  const bash = new Bash();
+  const r = await bash.execute("echo bg & wait");
+  assert.equal(r.stdout, "bg\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("awk redirects a write into the VFS", async () => {
+  const bash = new Bash();
+  const r = await bash.execute(
+    'awk \'BEGIN{print "line" > "/out.txt"}\'; cat /out.txt',
+  );
+  assert.equal(r.stdout, "line\n");
+  assert.equal(r.exitCode, 0);
+});
+
+test("awk getline reads from the VFS", async () => {
+  const bash = new Bash({ files: { "/in.txt": "alpha\nbeta\n" } });
+  const r = await bash.execute(
+    'awk \'BEGIN{while((getline l < "/in.txt") > 0) print "got:" l}\'',
+  );
+  assert.equal(r.stdout, "got:alpha\ngot:beta\n");
+  assert.equal(r.exitCode, 0);
+});
+
 // --- Options ---------------------------------------------------------------
 
 test("options: env and cwd", () => {

--- a/crates/bashkit/src/builtins/awk/interpreter.rs
+++ b/crates/bashkit/src/builtins/awk/interpreter.rs
@@ -16,6 +16,10 @@ use crate::builtins::limits::{
 use crate::builtins::search_common::build_regex;
 use crate::fs::{FileSystem, normalize_path};
 use crate::limits::ExecutionLimits;
+// On wasm32 there is no OS thread to bridge the sync AWK evaluator to the async
+// VFS, so redirected reads/writes drive the VFS future inline with now_or_never.
+#[cfg(target_family = "wasm")]
+use futures_util::FutureExt;
 
 /// Flow control signal from action execution
 #[derive(Debug, PartialEq)]
@@ -36,6 +40,7 @@ pub(super) enum AwkFlow {
 // - AWK_MAX_GETLINE_FILE_BYTES / AWK_MAX_GETLINE_CACHE_BYTES (retained input bytes).
 
 /// One redirected VFS write, dispatched to the [`VfsWriter`] thread.
+#[cfg(not(target_family = "wasm"))]
 struct WriteJob {
     path: PathBuf,
     bytes: Vec<u8>,
@@ -52,11 +57,13 @@ struct WriteJob {
 /// `print > file` loop create thousands of threads/runtimes (DoS). Reusing one
 /// writer for the whole run keeps writes incremental (so VFS quotas are still
 /// enforced as they happen) at O(1) threads.
+#[cfg(not(target_family = "wasm"))]
 struct VfsWriter {
     tx: Option<std::sync::mpsc::Sender<WriteJob>>,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl VfsWriter {
     fn new(fs: Arc<dyn FileSystem>) -> Self {
         let (tx, rx) = std::sync::mpsc::channel::<WriteJob>();
@@ -102,6 +109,7 @@ impl VfsWriter {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl Drop for VfsWriter {
     fn drop(&mut self) {
         // Drop the sender first so the writer loop's `rx.recv()` returns Err and
@@ -110,6 +118,42 @@ impl Drop for VfsWriter {
         if let Some(handle) = self.handle.take() {
             let _ = handle.join();
         }
+    }
+}
+
+/// wasm32 has no OS threads (`std::thread::spawn` returns `Unsupported`), so the
+/// thread-hop writer above can't exist. The browser build only ever runs over
+/// the in-memory VFS, whose writes resolve in a single poll, so we drive the
+/// async VFS future to completion inline with `now_or_never` — same VFS, same
+/// quota accounting, no thread.
+#[cfg(target_family = "wasm")]
+struct VfsWriter {
+    fs: Arc<dyn FileSystem>,
+}
+
+#[cfg(target_family = "wasm")]
+impl VfsWriter {
+    fn new(fs: Arc<dyn FileSystem>) -> Self {
+        Self { fs }
+    }
+
+    /// Perform one write by polling the VFS future once. Returns the VFS result,
+    /// or `Err(())` if the write would suspend (an async-backed mount, which the
+    /// browser build does not use).
+    fn write(
+        &self,
+        path: PathBuf,
+        bytes: Vec<u8>,
+        append: bool,
+    ) -> Result<crate::error::Result<()>, ()> {
+        let fut = async {
+            if append {
+                self.fs.append_file(&path, &bytes).await
+            } else {
+                self.fs.write_file(&path, &bytes).await
+            }
+        };
+        fut.now_or_never().ok_or(())
     }
 }
 
@@ -199,7 +243,10 @@ impl AwkInterpreter {
         };
         let fs = fs.clone();
         let p = PathBuf::from(resolved);
-        // Spawn a thread with its own runtime to avoid blocking the current async runtime.
+
+        // Native: spawn a thread with its own runtime to bridge the sync AWK
+        // evaluator to the async VFS without blocking the outer runtime.
+        #[cfg(not(target_family = "wasm"))]
         let result = std::thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -212,6 +259,24 @@ impl AwkInterpreter {
             runtime.block_on(fs.read_file(&p))
         })
         .join();
+
+        // wasm32: no threads. Drive the in-memory VFS reads inline (they resolve
+        // in one poll). The outer Ok mirrors a thread that didn't panic.
+        #[cfg(target_family = "wasm")]
+        let result: std::result::Result<crate::error::Result<Vec<u8>>, ()> = Ok((|| {
+            let meta = match fs.stat(&p).now_or_never() {
+                Some(m) => m?,
+                None => return Err(std::io::Error::other("awk getline: vfs read suspended").into()),
+            };
+            if meta.size > MAX_GETLINE_FILE_BYTES as u64 {
+                return Err(std::io::Error::other("awk getline input too large").into());
+            }
+            match fs.read_file(&p).now_or_never() {
+                Some(bytes) => bytes,
+                None => Err(std::io::Error::other("awk getline: vfs read suspended").into()),
+            }
+        })());
+
         match result {
             Ok(Ok(bytes)) => {
                 if bytes.len() > MAX_GETLINE_FILE_BYTES {

--- a/crates/bashkit/src/builtins/sleep.rs
+++ b/crates/bashkit/src/builtins/sleep.rs
@@ -1,6 +1,7 @@
 //! Sleep builtin - pause execution for specified duration
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
 use super::limits::SLEEP_MAX_SECONDS as MAX_SLEEP_SECONDS;
@@ -51,6 +52,11 @@ impl Builtin for Sleep {
         };
 
         if seconds > 0.0 {
+            // wasm32-unknown-unknown has no timer driver, so tokio::time::sleep
+            // panics ("time not implemented"). The single-threaded sandbox has
+            // no wall-clock semantics anyway (see specs/browser-package.md), so
+            // on wasm the sleep elapses instantly.
+            #[cfg(not(target_family = "wasm"))]
             tokio::time::sleep(Duration::from_secs_f64(seconds)).await;
         }
 

--- a/crates/bashkit/src/interpreter/jobs.rs
+++ b/crates/bashkit/src/interpreter/jobs.rs
@@ -8,14 +8,20 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tokio::task::JoinHandle;
 
 use crate::interpreter::ExecResult;
 
-/// Job table for tracking background jobs
+/// Job table for tracking background jobs.
+///
+/// Background commands run synchronously (for deterministic output ordering),
+/// so by the time a job is registered its result is already fully computed. We
+/// therefore store the finished [`ExecResult`] directly rather than a
+/// `tokio::task::JoinHandle` — there is nothing left to await. This also keeps
+/// the interpreter usable on `wasm32-unknown-unknown`, where `tokio::spawn`
+/// panics (no reactor running).
 pub struct JobTable {
     /// Active jobs indexed by ID
-    jobs: BTreeMap<usize, JoinHandle<ExecResult>>,
+    jobs: BTreeMap<usize, ExecResult>,
     /// Next job ID to assign
     next_id: usize,
     /// Last spawned job ID (for $!)
@@ -38,13 +44,13 @@ impl JobTable {
         }
     }
 
-    /// Spawn a new background job
+    /// Register a finished background job.
     ///
-    /// Returns the job ID that can be used with wait
-    pub fn spawn(&mut self, handle: JoinHandle<ExecResult>) -> usize {
+    /// Returns the job ID that can be used with wait.
+    pub fn spawn(&mut self, result: ExecResult) -> usize {
         let id = self.next_id;
         self.next_id += 1;
-        self.jobs.insert(id, handle);
+        self.jobs.insert(id, result);
         self.last_job_id = Some(id);
         id
     }
@@ -56,14 +62,7 @@ impl JobTable {
 
     /// Wait for a specific job to complete
     pub async fn wait_for(&mut self, job_id: usize) -> Option<ExecResult> {
-        if let Some(handle) = self.jobs.remove(&job_id) {
-            match handle.await {
-                Ok(result) => Some(result),
-                Err(_) => Some(ExecResult::err("job panicked".to_string(), 1)),
-            }
-        } else {
-            None
-        }
+        self.jobs.remove(&job_id)
     }
 
     /// Wait for all jobs to complete
@@ -80,15 +79,7 @@ impl JobTable {
 
     /// Wait for all jobs and return their results (preserving output).
     pub async fn wait_all_results(&mut self) -> Vec<ExecResult> {
-        let jobs: Vec<_> = std::mem::take(&mut self.jobs).into_iter().collect();
-        let mut results = Vec::new();
-        for (_, handle) in jobs {
-            match handle.await {
-                Ok(result) => results.push(result),
-                Err(_) => results.push(ExecResult::err("job panicked".to_string(), 1)),
-            }
-        }
-        results
+        std::mem::take(&mut self.jobs).into_values().collect()
     }
 
     /// Check if there are any active jobs
@@ -120,10 +111,8 @@ mod tests {
     async fn test_spawn_and_wait() {
         let mut table = JobTable::new();
 
-        // Spawn a simple job
-        let handle = tokio::spawn(async { ExecResult::ok("hello".to_string()) });
-
-        let job_id = table.spawn(handle);
+        // Register a finished job
+        let job_id = table.spawn(ExecResult::ok("hello".to_string()));
         assert_eq!(job_id, 1);
         assert_eq!(table.last_job_id(), Some(1));
 
@@ -137,10 +126,9 @@ mod tests {
     async fn test_wait_all() {
         let mut table = JobTable::new();
 
-        // Spawn multiple jobs
+        // Register multiple finished jobs
         for i in 0..3 {
-            let handle = tokio::spawn(async move { ExecResult::ok(format!("job {}", i)) });
-            table.spawn(handle);
+            table.spawn(ExecResult::ok(format!("job {}", i)));
         }
 
         assert_eq!(table.job_count(), 3);

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4849,11 +4849,13 @@ impl Interpreter {
         parent_stdout.push_str(&result.stdout);
         parent_stderr.push_str(&result.stderr);
 
-        // Store only the exit code in the job table (output already emitted)
+        // Store only the exit code in the job table (output already emitted).
+        // The command already ran to completion synchronously, so the result is
+        // final — register it directly rather than round-tripping through
+        // tokio::spawn (which also panics on wasm, where no reactor runs).
         let exit_code = result.exit_code;
         let job_result = ExecResult::with_code(String::new(), exit_code);
-        let handle = tokio::spawn(async move { job_result });
-        let job_id = self.jobs.lock().await.spawn(handle);
+        let job_id = self.jobs.lock().await.spawn(job_result);
         self.last_bg_pid = Some(job_id.to_string());
 
         // Background commands always return exit code 0 to the parent.
@@ -8035,35 +8037,51 @@ impl Interpreter {
                 preserve_status,
                 command,
             } => {
-                use tokio::time::timeout;
-
                 // Build inner command with optional stdin via here-string
                 let inner_cmd = subcommand_to_command(&command);
 
-                let baseline_call_stack_len = self.call_stack.len();
-                let baseline_bash_source_len = self.bash_source_stack.len();
-                let baseline_function_depth = self.counters.function_depth;
-                let baseline_pipeline_stdin = self.pipeline_stdin.clone();
-                let exec_future = self.execute_command(&inner_cmd);
-                match timeout(duration, exec_future).await {
-                    Ok(Ok(result)) => result,
-                    Ok(Err(e)) => return Err(e),
-                    Err(_) => {
-                        self.reconcile_cancelled_execution_state(
-                            baseline_call_stack_len,
-                            baseline_bash_source_len,
-                            baseline_function_depth,
-                            baseline_pipeline_stdin,
-                        );
-                        // Timeout expired.
-                        // --preserve-status: in real bash, returns the signal+128 status
-                        // of the killed child.  We can't capture that from tokio::timeout,
-                        // so we always use 124 (the standard timeout exit code).
-                        // TODO: propagate child exit status when preserve_status is true
-                        let exit_code = if preserve_status { 137 } else { 124 };
-                        ExecResult::err(String::new(), exit_code)
+                // wasm32-unknown-unknown has no timer driver, so tokio::time::timeout
+                // panics ("time not implemented"). Run the command without wall-clock
+                // enforcement — the parser fuel budget, maxCommands and
+                // maxLoopIterations still bound runaway work. This matches the
+                // "no preemptive timeout" stance in specs/browser-package.md.
+                #[cfg(target_family = "wasm")]
+                let outcome = {
+                    let _ = (duration, preserve_status);
+                    self.execute_command(&inner_cmd).await?
+                };
+
+                #[cfg(not(target_family = "wasm"))]
+                let outcome = {
+                    use tokio::time::timeout;
+
+                    let baseline_call_stack_len = self.call_stack.len();
+                    let baseline_bash_source_len = self.bash_source_stack.len();
+                    let baseline_function_depth = self.counters.function_depth;
+                    let baseline_pipeline_stdin = self.pipeline_stdin.clone();
+                    let exec_future = self.execute_command(&inner_cmd);
+                    match timeout(duration, exec_future).await {
+                        Ok(Ok(result)) => result,
+                        Ok(Err(e)) => return Err(e),
+                        Err(_) => {
+                            self.reconcile_cancelled_execution_state(
+                                baseline_call_stack_len,
+                                baseline_bash_source_len,
+                                baseline_function_depth,
+                                baseline_pipeline_stdin,
+                            );
+                            // Timeout expired.
+                            // --preserve-status: in real bash, returns the signal+128 status
+                            // of the killed child.  We can't capture that from tokio::timeout,
+                            // so we always use 124 (the standard timeout exit code).
+                            // TODO: propagate child exit status when preserve_status is true
+                            let exit_code = if preserve_status { 137 } else { 124 };
+                            ExecResult::err(String::new(), exit_code)
+                        }
                     }
-                }
+                };
+
+                outcome
             }
             builtins::ExecutionPlan::Batch { commands } => {
                 let mut combined_stdout = String::new();
@@ -8125,6 +8143,11 @@ impl Interpreter {
     }
 
     /// Restore interpreter stacks/counters after an in-flight command future is cancelled.
+    ///
+    /// Only the native timeout/cancellation paths can cancel a command mid-flight;
+    /// wasm32 has no timer driver, so it is gated out there to keep the wasm build
+    /// warning-clean (CI checks wasm with `-D warnings`).
+    #[cfg(not(target_family = "wasm"))]
     fn reconcile_cancelled_execution_state(
         &mut self,
         baseline_call_stack_len: usize,

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -4348,41 +4348,75 @@ impl Interpreter {
         }
 
         // THREAT[TM-DOS-021]: Propagate interpreter's parser limits to child shell
-        let script_owned = script_content.clone();
         let max_ast_depth = self.limits.max_ast_depth;
         let max_parser_operations = self.limits.max_parser_operations;
-        let parse_result = tokio::time::timeout(self.limits.parser_timeout, async move {
-            tokio::task::spawn_blocking(move || {
-                let parser =
-                    Parser::with_limits(&script_owned, max_ast_depth, max_parser_operations);
-                parser.parse()
+        let parser_timeout = self.limits.parser_timeout;
+
+        // On wasm32-unknown-unknown there is no blocking thread pool and no
+        // reliable timer driver, so tokio::time::timeout + spawn_blocking call
+        // std::time and panic ("time not implemented"), poisoning the whole
+        // module. Parse inline instead: the parser enforces the timeout itself
+        // through time_compat and still bounds runaway input via
+        // max_parser_operations. Mirrors the top-level parse path in lib.rs.
+        // A top-level command never reaches this branch — only a spawned
+        // bash/sh child does — which is why the panic hid until a subshell ran.
+        #[cfg(target_family = "wasm")]
+        let script = {
+            let parser = Parser::with_limits_and_timeout(
+                &script_content,
+                max_ast_depth,
+                max_parser_operations,
+                Some(parser_timeout),
+            );
+            match parser.parse() {
+                Ok(s) => s,
+                Err(e) => {
+                    return Ok(ExecResult::err(
+                        format!("{}: syntax error: {}\n", shell_name, e),
+                        2,
+                    ));
+                }
+            }
+        };
+
+        // On native targets keep the spawn_blocking + timeout path so the async
+        // runtime can pre-empt a runaway parser off the executor thread.
+        #[cfg(not(target_family = "wasm"))]
+        let script = {
+            let script_owned = script_content.clone();
+            let parse_result = tokio::time::timeout(parser_timeout, async move {
+                tokio::task::spawn_blocking(move || {
+                    let parser =
+                        Parser::with_limits(&script_owned, max_ast_depth, max_parser_operations);
+                    parser.parse()
+                })
+                .await
             })
-            .await
-        })
-        .await;
-        let script = match parse_result {
-            Ok(Ok(Ok(s))) => s,
-            Ok(Ok(Err(e))) => {
-                return Ok(ExecResult::err(
-                    format!("{}: syntax error: {}\n", shell_name, e),
-                    2,
-                ));
-            }
-            Ok(Err(e)) => {
-                return Ok(ExecResult::err(
-                    format!("{}: parser task failed: {}\n", shell_name, e),
-                    2,
-                ));
-            }
-            Err(_) => {
-                return Ok(ExecResult::err(
-                    format!(
-                        "{}: parser timeout after {}ms\n",
-                        shell_name,
-                        self.limits.parser_timeout.as_millis()
-                    ),
-                    2,
-                ));
+            .await;
+            match parse_result {
+                Ok(Ok(Ok(s))) => s,
+                Ok(Ok(Err(e))) => {
+                    return Ok(ExecResult::err(
+                        format!("{}: syntax error: {}\n", shell_name, e),
+                        2,
+                    ));
+                }
+                Ok(Err(e)) => {
+                    return Ok(ExecResult::err(
+                        format!("{}: parser task failed: {}\n", shell_name, e),
+                        2,
+                    ));
+                }
+                Err(_) => {
+                    return Ok(ExecResult::err(
+                        format!(
+                            "{}: parser timeout after {}ms\n",
+                            shell_name,
+                            parser_timeout.as_millis()
+                        ),
+                        2,
+                    ));
+                }
             }
         };
 

--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -4,13 +4,19 @@ use super::{ScriptedExecutionTrace, ScriptedTool, ToolDefExtension, extension::I
 use crate::Bash;
 use crate::tool::{
     Tool, ToolError, ToolExecution, ToolOutputChunk, ToolRequest, ToolResponse, ToolStatus,
-    VERSION, localized, timeout_response, tool_output_from_response, tool_request_from_value,
-    tool_request_schema, tool_response_schema,
+    VERSION, localized, tool_output_from_response, tool_request_from_value, tool_request_schema,
+    tool_response_schema,
 };
+// timeout_response + Duration are only used on the native timeout path; wasm32
+// runs without wall-clock enforcement (no timer driver), so they are gated out
+// there to keep the wasm build warning-clean (CI checks wasm with `-D warnings`).
+#[cfg(not(target_family = "wasm"))]
+use crate::tool::timeout_response;
 use crate::tool_def::usage_from_schema;
 use async_trait::async_trait;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+#[cfg(not(target_family = "wasm"))]
 use std::time::Duration;
 
 // ============================================================================
@@ -155,6 +161,10 @@ impl ScriptedTool {
 
         // Keep ScriptedTool on the shared ToolRequest contract: per-call
         // timeouts must abort the whole orchestration, including callbacks.
+        // wasm32 has no timer driver (tokio::time::timeout panics), so there the
+        // orchestration runs without wall-clock enforcement; the timer path
+        // stays on native.
+        #[cfg(not(target_family = "wasm"))]
         let response = if let Some(ms) = timeout_ms {
             let duration = Duration::from_millis(ms);
             match tokio::time::timeout(duration, fut).await {
@@ -162,6 +172,11 @@ impl ScriptedTool {
                 Err(_) => timeout_response(duration),
             }
         } else {
+            fut.await
+        };
+        #[cfg(target_family = "wasm")]
+        let response = {
+            let _ = timeout_ms;
             fut.await
         };
 

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -960,7 +960,11 @@ impl BashTool {
             }
         };
 
-        if let Some(ms) = req.timeout_ms {
+        // wasm32-unknown-unknown has no timer driver, so tokio::time::timeout
+        // panics. Run without wall-clock enforcement there (fuel / maxCommands
+        // still bound the work); the timer path stays on native.
+        #[cfg(not(target_family = "wasm"))]
+        let out = if let Some(ms) = req.timeout_ms {
             let duration = Duration::from_millis(ms);
             match tokio::time::timeout(duration, fut).await {
                 Ok(response) => response,
@@ -968,7 +972,13 @@ impl BashTool {
             }
         } else {
             fut.await
-        }
+        };
+        #[cfg(target_family = "wasm")]
+        let out = {
+            let _ = req.timeout_ms;
+            fut.await
+        };
+        out
     }
 }
 
@@ -1057,7 +1067,9 @@ impl Tool for BashTool {
             }
         };
 
-        if let Some(ms) = req.timeout_ms {
+        // wasm32 has no timer driver; run without wall-clock enforcement there.
+        #[cfg(not(target_family = "wasm"))]
+        let out = if let Some(ms) = req.timeout_ms {
             let dur = Duration::from_millis(ms);
             match tokio::time::timeout(dur, fut).await {
                 Ok(resp) => resp,
@@ -1065,7 +1077,13 @@ impl Tool for BashTool {
             }
         } else {
             fut.await
-        }
+        };
+        #[cfg(target_family = "wasm")]
+        let out = {
+            let _ = req.timeout_ms;
+            fut.await
+        };
+        out
     }
 
     async fn execute_with_status(
@@ -1127,7 +1145,9 @@ impl Tool for BashTool {
             response
         };
 
-        if let Some(ms) = timeout_ms {
+        // wasm32 has no timer driver; run without wall-clock enforcement there.
+        #[cfg(not(target_family = "wasm"))]
+        let out = if let Some(ms) = timeout_ms {
             let dur = Duration::from_millis(ms);
             match tokio::time::timeout(dur, fut).await {
                 Ok(resp) => resp,
@@ -1135,7 +1155,13 @@ impl Tool for BashTool {
             }
         } else {
             fut.await
-        }
+        };
+        #[cfg(target_family = "wasm")]
+        let out = {
+            let _ = timeout_ms;
+            fut.await
+        };
+        out
     }
 }
 
@@ -1155,6 +1181,11 @@ fn error_kind(e: &Error) -> String {
 }
 
 /// Build a ToolResponse for a timed-out execution (exit code 124, like bash `timeout`).
+///
+/// Only the native timeout paths use this; wasm32 has no timer driver and runs
+/// without wall-clock enforcement, so it is gated out there to keep the wasm
+/// build warning-clean (CI checks wasm with `-D warnings`).
+#[cfg(not(target_family = "wasm"))]
 pub(crate) fn timeout_response(dur: Duration) -> ToolResponse {
     ToolResponse {
         stdout: String::new(),

--- a/specs/browser-package.md
+++ b/specs/browser-package.md
@@ -47,11 +47,12 @@ the app's own `fetch` instead.
 browser's one event loop. Two entry points:
 
 - **`executeSync(cmd)`** drives `Bash::exec` with `now_or_never` — a single
-  poll. Correct for scripts that never suspend (plain bash + `jq`). If a script
-  suspends (async builtin, `sleep`, background job) it throws, directing the
-  caller to `execute()`. While a sync call is in flight an `AtomicBool` is set so
-  async custom builtins fail fast with a clear message instead of returning
-  `Pending` forever.
+  poll. Correct for scripts that never suspend (plain bash + `jq`; `sleep` and
+  background jobs do not suspend on wasm — see Limitations). If a script does
+  suspend (e.g. an async JS custom builtin) it throws, directing the caller to
+  `execute()`. While a sync call is in flight an `AtomicBool` is set so async
+  custom builtins fail fast with a clear message instead of returning `Pending`
+  forever.
 - **`execute(cmd)`** returns a `Promise<ExecResult>` via
   `wasm-bindgen-futures::future_to_promise`. This is the path that can `await`
   async JS custom builtins (e.g. a GraphQL binary issuing a `fetch`/Relay
@@ -107,9 +108,21 @@ pattern as `publish-js.yml`.
 
 ## Limitations (see `specs/limitations.md`)
 
-- No preemptive timeout: `wasm32-unknown-unknown` has no reliable timer driver,
-  so `timeoutMs` is not enforced. The parser fuel budget and `maxCommands` /
-  `maxLoopIterations` still bound runaway scripts.
+- No wall-clock time on `wasm32-unknown-unknown` (no timer driver). This is a
+  hard platform constraint, so time-based behaviour degrades rather than
+  enforces, and never blocks:
+  - `sleep N` elapses **instantly** (it cannot suspend for real time).
+  - the `timeout N cmd` builtin and the tool-level `timeoutMs` run the command
+    **without** wall-clock enforcement.
+  - Runaway work is still bounded by the parser fuel budget and `maxCommands` /
+    `maxLoopIterations`, which do not depend on a clock.
+- Single-threaded: no OS threads (`std::thread::spawn` is unsupported) and no
+  `tokio::spawn` reactor. Paths that hop to a thread or a background task on
+  native run **inline** on wasm instead — background jobs (`cmd &`) execute
+  synchronously (they already did for output ordering), and `awk` file
+  redirects (`print > f`, `getline < f`) drive the VFS future to completion with
+  `now_or_never` rather than a writer thread. Correct because the browser build
+  only ever runs over the in-memory VFS, which never suspends.
 - `executeSync` cannot await JS callbacks; use `execute()` for async builtins.
 - Custom-builtin `ctx` exposes `{ name, argv, stdin, env, cwd, fs }`, where `fs`
   is a live handle to the same VFS the script sees (mirrors the napi bindings).

--- a/specs/limitations.md
+++ b/specs/limitations.md
@@ -40,8 +40,9 @@ execution model. Evidence is a threat-model ID, a test, or `stance`
 | L-NET-001 | No raw network sockets; HTTP only via `curl`/`wget`/`http` builtins | Allowlist-mediated egress is the only network surface | `l_net_001_no_raw_sockets` |
 | L-NET-002 | No DNS resolution; hosts must appear in the allowlist | Resolution would bypass allowlist intent | `l_net_002_default_deny_no_resolution` |
 | L-SIG-001 | `trap` stores INT/TERM handlers but no signal delivery in virtual mode (EXIT, ERR fire) | No host signals exist inside the sandbox | `l_sig_001_signal_traps_not_delivered` |
-| L-WASM-001 | Browser build (`@everruns/bashkit-web`, `wasm32-unknown-unknown`) does not enforce `timeoutMs` | No reliable timer driver on the target; parser fuel + `maxCommands`/`maxLoopIterations` still bound runaway scripts | `specs/browser-package.md`, stance |
+| L-WASM-001 | Browser build (`@everruns/bashkit-web`, `wasm32-unknown-unknown`) has no wall-clock time: `sleep N` elapses instantly, and neither the `timeout N` builtin nor `timeoutMs` is enforced | No reliable timer driver on the target; parser fuel + `maxCommands`/`maxLoopIterations` still bound runaway scripts | `specs/browser-package.md`, stance |
 | L-WASM-002 | Browser build: `executeSync()` cannot run async custom builtins (fails with a clear message); use `execute()` | Single-threaded event loop can't settle a JS `Promise` without yielding | `crates/bashkit-wasm/__test__/bashkit-web.test.mjs` |
+| L-WASM-003 | Browser build: background jobs (`cmd &`) run synchronously and `awk` file redirects drive the VFS inline; no work runs on a separate thread | `wasm32-unknown-unknown` is single-threaded — `std::thread::spawn`/`tokio::spawn` are unavailable; safe because the in-memory VFS never suspends | `crates/bashkit-wasm/__test__/bashkit-web.test.mjs` |
 
 ### Design Rationale
 


### PR DESCRIPTION
## What changed

A range of common commands hard-panicked on `wasm32-unknown-unknown` (the `@everruns/bashkit-web` browser build), and a wasm panic poisons the whole module — every later call in the page fails too. They all shared a root cause: paths that assume a multi-threaded tokio runtime **with a timer driver**, which the single-threaded browser build doesn't have. A plain top-level command took a different path, so the panics stayed hidden until a subshell / timer / job / awk-file-redirect ran.

Commands fixed (each verified panic → works):

- `bash -c` / `sh -c` / `bash script.sh` / pipe-into-`bash` — child-shell parse was wrapped in `tokio::time::timeout` + `spawn_blocking`.
- `sleep N` — `tokio::time::sleep`.
- `timeout N cmd` — `tokio::time::timeout`.
- background jobs `cmd &` / `wait` — `tokio::spawn` (no reactor).
- `awk '…print > "f"'` / `awk '…getline < "f"'` — `std::thread::spawn` + a nested tokio runtime.
- `ScriptedTool` / `BashTool` `timeout_ms` — `tokio::time::timeout`.

The wasm paths now run **inline**: parse inline (parser enforces its own fuel/timeout via `time_compat`), timers elapse instantly / run without wall-clock enforcement, and awk file I/O drives the in-memory VFS future to completion with `now_or_never` instead of hopping to a thread. Background jobs already ran synchronously for output ordering, so the job table now stores the finished `ExecResult` directly rather than round-tripping through `tokio::spawn` — that also drops an unnecessary abstraction on **all** targets.

Native behavior is unchanged: every timer/thread path stays under `cfg(not(target_family = "wasm"))`.

## Why

The browser package is unusable for anything beyond a single plain command — typing `sleep`, `timeout`, `&`, an `awk` redirect, or running a script (`bash demo.sh`) crashes the interpreter instance. These are core, everyday shell features, and the failure mode (a wasm abort that poisons the module) is the worst kind. The browser build's own smoke suite never exercised any of these, which is why it shipped in `0.14.1`.

## Before / After

Browser wasm smoke suite (`crates/bashkit-wasm/__test__/`, which CI builds and runs on every PR):

**Before** — the first subshell/timer/job/awk-file command panics and cascades:
```
ok 5 - sync: stderr is captured
# panicked at std/src/sys/time/unsupported.rs: time not implemented on this platform
not ok 6 - child shell: bash -c runs without panicking
... (all subsequent tests fail — module poisoned)
# tests 26  # pass 5  # fail 21
```

**After** — new coverage for every fixed path, all green:
```
ok 6  - child shell: bash -c runs without panicking
ok 10 - sleep returns immediately (no timer driver on wasm)
ok 11 - timeout runs the command (no wall-clock enforcement on wasm)
ok 12 - background job runs and wait collects it
ok 13 - awk redirects a write into the VFS
ok 14 - awk getline reads from the VFS
# tests 31  # pass 31  # fail 0
```

Native regression check: `2906` lib + `980` integration tests pass, clippy clean, wasm check passes with `-D warnings`.

## Risk

- **Low.** Native code paths are untouched (kept under `cfg(not(target_family = "wasm"))`); the only cross-target change is the job table storing `ExecResult` instead of a `JoinHandle` — behaviorally identical, since background jobs already completed synchronously before being registered. Wasm behavior is documented in `specs/browser-package.md` and `specs/limitations.md` (L-WASM-001/003).
- What can break: nothing observed on native. On wasm, `sleep`/`timeout` no longer provide wall-clock semantics (they can't — no timer driver); runaway work is still bounded by parser fuel and `maxCommands` / `maxLoopIterations`.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered