### PR TITLE
chore(release): prepare v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.14.2] - 2026-07-18
+
+### Fixed
+
+- **Browser wasm crashes on core shell features** — subshells (`bash -c`,
+  `sh -c`, `bash script.sh`, pipe-into-`bash`), `sleep`, `timeout`,
+  background jobs (`cmd &` / `wait`), and `awk` file redirects
+  (`print > "f"` / `getline < "f"`) hard-panicked on the single-threaded
+  `@everruns/bashkit-web` build, poisoning the whole module. These paths now
+  run inline on wasm instead of assuming a multi-threaded tokio runtime with a
+  timer driver; native behavior is unchanged
+  ([#2178](https://github.com/everruns/bashkit/pull/2178)).
+
+### What's Changed
+
+* fix(wasm): make bashkit run on single-threaded browser wasm ([#2178](https://github.com/everruns/bashkit/pull/2178)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.14.1...v0.14.2
+
 ## [0.14.1] - 2026-07-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bashkit",
  "napi",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.14.1", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.14.2", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-web",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## What changed

Prepares the **v0.14.2** patch release. Bumps the workspace version from
`0.14.1` → `0.14.2` across every manifest (workspace `Cargo.toml`, the
`bashkit-cli` path-dep pin on `bashkit`, `@everruns/bashkit` and
`@everruns/bashkit-web` `package.json`, and `Cargo.lock`) and adds the
`[0.14.2]` CHANGELOG entry.

The release ships a single fix merged since v0.14.1:

* fix(wasm): make bashkit run on single-threaded browser wasm — subshells
  (`bash -c`, `sh -c`, `bash script.sh`, pipe-into-`bash`), `sleep`,
  `timeout`, background jobs (`cmd &` / `wait`), and `awk` file redirects no
  longer hard-panic on the `@everruns/bashkit-web` build
  ([#2178](https://github.com/everruns/bashkit/pull/2178)) by @chaliy

**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.14.1...v0.14.2

## Why

Ship the browser-wasm crash fix to users. The `@everruns/bashkit-web` package
was unusable for anything beyond a single plain command in `0.14.1`; this
patch gets that fix onto crates.io, PyPI, npm, and Homebrew.

## Before / After

Publish-readiness verified locally (replicating `publish.yml`'s git-only
Monty/Python manifest transform in a disposable copy):

**Before** — CLI dry-run against the not-yet-published core fails as expected:
```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `bashkit = "^0.14.2"`
  candidate versions found which didn't match: 0.14.1, 0.14.0, ...
```

**After** — both crates package cleanly:
```
Uploading bashkit v0.14.2        (core dry-run OK)
Uploading bashkit-cli v0.14.2    (packaged against published core 0.14.1 as a structural proxy)
```

Version sync confirmed: all manifests read `0.14.2`, greater than the latest
published on every registry (crates.io `bashkit`/`bashkit-cli`, PyPI `bashkit`,
npm `@everruns/bashkit` + `@everruns/bashkit-web` all at `0.14.1`). `cargo fmt
--check` clean.

## Risk

- **Low.** Version/CHANGELOG-only change; no source is modified. The shipped
  fix (#2178) already passed CI on merge.
- What can break: nothing in this diff. Post-merge, publishing is watched to
  completion across all six artifacts.

## Checklist
- [x] Tests added or updated — n/a (release prep; fix's tests landed in #2178)
- [x] Backward compatibility considered — patch release, no API changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJQeTD579vAZcYn4uxMyAz)_