### PR TITLE
chore(wasm): rename npm package to @everruns/bashkit-wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           RUSTFLAGS: --cfg getrandom_backend="wasm_js" -D warnings
 
   wasm-web:
-    # Build the browser package (@everruns/bashkit-web) and run its headless
+    # Build the browser package (@everruns/bashkit-wasm) and run its headless
     # integration tests, proving the single-threaded bundle loads with no
     # COOP/COEP headers and that sync + async execution both work. See
     # specs/browser-package.md. Keep wasm-bindgen-cli in lockstep with the
@@ -96,7 +96,7 @@ jobs:
         run: bash crates/bashkit-wasm/scripts/build.sh release
 
       - name: Integration tests (headless Node)
-        run: node --test crates/bashkit-wasm/__test__/bashkit-web.test.mjs
+        run: node --test crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
 
   audit:
     name: Audit

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -1,4 +1,4 @@
-# NPM publishing workflow for the browser package @everruns/bashkit-web.
+# NPM publishing workflow for the browser package @everruns/bashkit-wasm.
 # Builds a single-threaded wasm32-unknown-unknown bundle via wasm-bindgen and
 # publishes to npm. Triggered alongside publish.yml on GitHub Release.
 #
@@ -41,7 +41,7 @@ jobs:
           fi
           echo "Publish source verified on origin/main: $SOURCE_SHA"
 
-  build-web:
+  build-wasm:
     name: Build web bundle
     needs: verify-source
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
         run: bash crates/bashkit-wasm/scripts/build.sh release
 
       - name: Integration tests (headless Node)
-        run: node --test crates/bashkit-wasm/__test__/bashkit-web.test.mjs
+        run: node --test crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
 
       - name: Upload pkg
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -74,9 +74,9 @@ jobs:
           path: crates/bashkit-wasm/pkg
           if-no-files-found: error
 
-  publish-web:
+  publish-wasm:
     name: Publish to npm
-    needs: build-web
+    needs: build-wasm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -129,7 +129,7 @@ jobs:
         working-directory: pkg
         run: |
           TAG="${{ steps.dist-tag.outputs.tag }}"
-          echo "Publishing @everruns/bashkit-web with dist-tag: $TAG"
+          echo "Publishing @everruns/bashkit-wasm with dist-tag: $TAG"
           if [ "$TAG" = "latest" ]; then
             npm publish --provenance --access public
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           gh workflow run publish.yml --ref "$TAG"
           gh workflow run publish-python.yml --ref "$TAG"
           gh workflow run publish-js.yml --ref "$TAG"
-          gh workflow run publish-web.yml --ref "$TAG"
+          gh workflow run publish-wasm.yml --ref "$TAG"
 
       - name: Trigger CLI binary builds for release tag
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 | http-transport | Pluggable HTTP transport: route curl/wget via host egress boundary |
 | performance-results | Benchmark/eval result locations and `/benches` site aggregation contract |
 | emscripten-wheels | Reduced-feature Pyodide/Emscripten Python wheel |
-| browser-package | Slim single-threaded browser wasm package (`@everruns/bashkit-web`), no COOP/COEP |
+| browser-package | Slim single-threaded wasm package (`@everruns/bashkit-wasm`) for browsers + JS runtimes, no COOP/COEP |
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -538,6 +538,26 @@ const content = await tool.readFile('/tmp/data.txt');
 Platform matrix: macOS (x86_64, aarch64), Linux (x86_64, aarch64), Windows (x86_64), WASM.
 See [crates/bashkit-js](crates/bashkit-js/) for details.
 
+### Browser / edge (WebAssembly)
+
+A slim, single-threaded WebAssembly build for the browser and any other
+JavaScript runtime — edge/serverless workers (Cloudflare Workers, Vercel Edge,
+Deno Deploy), Node, Deno, and Bun. Available as `@everruns/bashkit-wasm` on npm.
+It needs **no `SharedArrayBuffer` and no `COOP`/`COEP` headers**, so it drops
+into any web app (including iframes) and into thread-less edge runtimes.
+
+```js
+import { initBashkit, Bash } from "@everruns/bashkit-wasm";
+
+await initBashkit();
+const bash = new Bash();
+console.log(bash.executeSync('echo "Hello, browser!" | tr a-z A-Z').stdout); // HELLO, BROWSER!
+```
+
+Use this when a native addon can't load (browsers, edge); for a native
+Node.js / Bun / Deno addon use `@everruns/bashkit` above. See
+[crates/bashkit-wasm](crates/bashkit-wasm/README.md) for details.
+
 ## Security
 
 Bashkit is built for running untrusted scripts from AI agents and users. Security is a core design goal, not an afterthought.

--- a/crates/bashkit-wasm/README.md
+++ b/crates/bashkit-wasm/README.md
@@ -1,14 +1,21 @@
-# @everruns/bashkit-web
+# @everruns/bashkit-wasm
 
-Sandboxed bash interpreter for the **browser**, compiled to WebAssembly.
+Sandboxed bash interpreter compiled to WebAssembly, for the **browser and any
+other JavaScript runtime** — edge/serverless workers (Cloudflare Workers, Vercel
+Edge, Deno Deploy), Node, Deno, and Bun.
 
 Unlike a WASI-threads build, this package is **single-threaded**: it needs no
 `SharedArrayBuffer` and **no cross-origin isolation** (`COOP`/`COEP`) headers.
 That makes it a drop-in for any web app — including embedded and third-party
-iframe contexts where those headers can't be set.
+iframe contexts where those headers can't be set — and for the constrained edge
+runtimes that can't use threads either.
 
-For Node.js / Bun / Deno, use the native package
-[`@everruns/bashkit`](https://www.npmjs.com/package/@everruns/bashkit) instead.
+It's a `wasm-bindgen` module, so it runs in any JS host but **not** a
+non-JS/WASI wasm runtime (`wasmtime`, `wasmer`). For a native Node.js / Bun /
+Deno addon (faster, no wasm), use
+[`@everruns/bashkit`](https://www.npmjs.com/package/@everruns/bashkit) instead;
+reach for this package when a native addon can't load — browsers and edge
+runtimes.
 
 ## Live demo
 
@@ -22,13 +29,13 @@ and no special headers.
 ## Install
 
 ```bash
-npm install @everruns/bashkit-web
+npm install @everruns/bashkit-wasm
 ```
 
 ## Quick start
 
 ```js
-import { initBashkit, Bash } from "@everruns/bashkit-web";
+import { initBashkit, Bash } from "@everruns/bashkit-wasm";
 
 // Load the .wasm once before constructing Bash.
 await initBashkit();
@@ -42,7 +49,7 @@ console.log(result.stdout); // HELLO, BROWSER!
 
 ```html
 <script type="module">
-  import { initBashkit, Bash } from "https://esm.sh/@everruns/bashkit-web";
+  import { initBashkit, Bash } from "https://esm.sh/@everruns/bashkit-wasm";
   await initBashkit();
   const bash = new Bash();
   document.body.textContent = bash.executeSync("seq 1 5 | paste -sd+ | bc").stdout;
@@ -165,9 +172,9 @@ custom builtin (see above) so requests go through your app's own `fetch`.
 ```bash
 # Build the bundle and run the headless integration tests:
 bash scripts/build.sh
-node --test __test__/bashkit-web.test.mjs
+node --test __test__/bashkit-wasm.test.mjs
 # or, from the repo root:
-just build-web
+just build-wasm
 ```
 
 ## License

--- a/crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
+++ b/crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
@@ -1,4 +1,4 @@
-// Integration tests for the browser wasm bundle (@everruns/bashkit-web).
+// Integration tests for the browser wasm bundle (@everruns/bashkit-wasm).
 //
 // Run against the real built package (crates/bashkit-wasm/pkg, produced by
 // scripts/build.sh) under Node's built-in test runner:

--- a/crates/bashkit-wasm/example/README.md
+++ b/crates/bashkit-wasm/example/README.md
@@ -1,6 +1,6 @@
 # Browser examples
 
-Self-contained demos of `@everruns/bashkit-web`. They load the package as a
+Self-contained demos of `@everruns/bashkit-wasm`. They load the package as a
 plain ES module and need **no bundler and no cross-origin isolation** (no
 `COOP`/`COEP` headers) — any static file server works.
 
@@ -29,4 +29,4 @@ directory must exist (build it first).
 
 The same imports work under Vite/webpack/esbuild — the `.wasm` is resolved via
 `import.meta.url`, which bundlers understand. Install the published package
-(`npm install @everruns/bashkit-web`) and import from `@everruns/bashkit-web`.
+(`npm install @everruns/bashkit-wasm`) and import from `@everruns/bashkit-wasm`.

--- a/crates/bashkit-wasm/js/index.d.ts
+++ b/crates/bashkit-wasm/js/index.d.ts
@@ -1,4 +1,4 @@
-// Public TypeScript surface for @everruns/bashkit-web.
+// Public TypeScript surface for @everruns/bashkit-wasm.
 
 /** A live handle to a `Bash` instance's virtual filesystem. */
 export interface FileSystem {

--- a/crates/bashkit-wasm/js/index.js
+++ b/crates/bashkit-wasm/js/index.js
@@ -1,4 +1,4 @@
-// Hand-authored entry point for @everruns/bashkit-web.
+// Hand-authored entry point for @everruns/bashkit-wasm.
 //
 // Wraps the wasm-bindgen glue so consumers get a single, bundler-friendly
 // module. The .wasm URL is resolved relative to this file via import.meta.url,

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@everruns/bashkit-web",
+  "name": "@everruns/bashkit-wasm",
   "version": "0.14.2",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",

--- a/crates/bashkit-wasm/scripts/build.sh
+++ b/crates/bashkit-wasm/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the browser wasm bundle for @everruns/bashkit-web.
+# Build the browser wasm bundle for @everruns/bashkit-wasm.
 #
 # Produces an ES-module package under `pkg/` via `wasm-bindgen --target web`,
 # which needs NO bundler and NO cross-origin isolation headers to load.

--- a/examples/browser/.gitignore
+++ b/examples/browser/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 dist/
 # Relaxed on purpose: no committed lockfile, so `pnpm install` always resolves
-# the latest published @everruns/bashkit-web (see specs/maintenance.md).
+# the latest published @everruns/bashkit-wasm (see specs/maintenance.md).
 pnpm-lock.yaml

--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -16,7 +16,7 @@ pulls the prebuilt wasm.
 
 ## How It Works
 
-The example depends on [`@everruns/bashkit-web`](https://www.npmjs.com/package/@everruns/bashkit-web),
+The example depends on [`@everruns/bashkit-wasm`](https://www.npmjs.com/package/@everruns/bashkit-wasm),
 a slim, **single-threaded** WebAssembly build (`wasm32-unknown-unknown` via
 `wasm-bindgen`). It ships the compiled `.wasm` in the npm package, so there is
 nothing to compile locally.

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -98,7 +98,7 @@
   </div>
 
   <script type="module">
-    import { initBashkit, Bash } from "@everruns/bashkit-web";
+    import { initBashkit, Bash } from "@everruns/bashkit-wasm";
 
     const output = document.getElementById("output");
     const cmd = document.getElementById("cmd");
@@ -134,7 +134,7 @@
 
     // Startup message
     appendLine("Bashkit — sandboxed Bash interpreter in the browser", "info");
-    appendLine("Slim single-threaded wasm build (@everruns/bashkit-web) — no SharedArrayBuffer, no COOP/COEP.", "info");
+    appendLine("Slim single-threaded wasm build (@everruns/bashkit-wasm) — no SharedArrayBuffer, no COOP/COEP.", "info");
     appendLine("Type 'cat /home/user/welcome.txt' or 'bash /home/user/demo.sh' to get started.\n", "info");
 
     async function runCommand(command) {

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@everruns/bashkit-web": "latest"
+    "@everruns/bashkit-wasm": "latest"
   },
   "devDependencies": {
     "vite": "^6.4.3"

--- a/examples/browser/vite.config.js
+++ b/examples/browser/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 
-// @everruns/bashkit-web is a slim, single-threaded wasm build. It needs NO
+// @everruns/bashkit-wasm is a slim, single-threaded wasm build. It needs NO
 // SharedArrayBuffer and NO cross-origin isolation, so — unlike the old
 // wasm32-wasip1-threads example — there are no COOP/COEP headers here.
 //
@@ -9,7 +9,7 @@ import { defineConfig } from "vite";
 // the URL resolves in both dev and build.
 export default defineConfig({
   optimizeDeps: {
-    exclude: ["@everruns/bashkit-web"],
+    exclude: ["@everruns/bashkit-wasm"],
   },
   build: {
     target: "esnext",

--- a/justfile
+++ b/justfile
@@ -12,11 +12,11 @@ default:
 build:
     cargo build
 
-# Build the browser wasm package (@everruns/bashkit-web) and run its tests.
+# Build the browser wasm package (@everruns/bashkit-wasm) and run its tests.
 # Requires: rustup target add wasm32-unknown-unknown; cargo install wasm-bindgen-cli
-build-web:
+build-wasm:
     bash crates/bashkit-wasm/scripts/build.sh release
-    node --test crates/bashkit-wasm/__test__/bashkit-web.test.mjs
+    node --test crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
 
 # Run all tests (including fail-point tests)
 test:

--- a/specs/browser-package.md
+++ b/specs/browser-package.md
@@ -1,19 +1,31 @@
-# Browser Package (`@everruns/bashkit-web`)
+# WebAssembly Package (`@everruns/bashkit-wasm`)
+
+> Naming: the crate is `bashkit-wasm` and the npm package is
+> `@everruns/bashkit-wasm` — the `wasm` stem is deliberate. This is a
+> `wasm-bindgen` module that runs in **any JavaScript host**, not just the
+> browser (edge/serverless workers, Node, Deno, Bun), so the earlier `-web`
+> name under-described its reach. It does **not** run in a non-JS/WASI wasm
+> runtime (`wasmtime`, `wasmer`), which is why `-wasm` is scoped as "JS-host
+> wasm", not "any wasm runtime". The spec filename stays `browser-package.md`
+> for continuity; the browser is still the primary target.
 
 ## Status
 
 Implemented (reduced feature set). Local build + headless smoke test green.
-npm publish wired via `publish-web.yml`.
+npm publish wired via `publish-wasm.yml`.
 
 ## Abstract
 
-Bashkit ships a slim, **single-threaded** WebAssembly package for the browser,
-built with `wasm-bindgen` for `wasm32-unknown-unknown`. Unlike the WASI-threads
-example (`examples/browser`, napi + `wasm32-wasip1-threads`), it needs **no
+Bashkit ships a slim, **single-threaded** WebAssembly package built with
+`wasm-bindgen` for `wasm32-unknown-unknown`. The browser is the primary target,
+but because it's a plain wasm-bindgen module it also runs in other JavaScript
+runtimes — edge/serverless workers (Cloudflare Workers, Vercel Edge, Deno
+Deploy), Node, Deno, and Bun. Unlike the WASI-threads example
+(`examples/browser`, napi + `wasm32-wasip1-threads`), it needs **no
 `SharedArrayBuffer` and no cross-origin isolation** (`COOP`/`COEP`) headers, so
 it drops into any web app — including embedded and third-party iframe contexts
-where those headers cannot be set. This is the distribution answer to issue
-\#2172.
+where those headers cannot be set — and into the constrained edge runtimes that
+can't use threads either. This is the distribution answer to issue \#2172.
 
 ## Why a separate package (not the napi `bashkit-js`)
 
@@ -25,9 +37,10 @@ The napi `@everruns/bashkit` package is Node/Bun/Deno-first. Its browser story i
 - was never actually published (the wasm matrix entry in `publish-js.yml` is
   disabled because the native binding pulls tokio `full` features).
 
-`@everruns/bashkit-web` is a distinct, browser-only artifact with a distinct
-consumer contract. Keeping it separate avoids dragging the five native `.node`
-binaries and the threads/headers requirement into browser bundles.
+`@everruns/bashkit-wasm` is a distinct, pure-wasm artifact with a distinct
+consumer contract (browsers plus any other JS runtime). Keeping it separate
+avoids dragging the five native `.node` binaries and the threads/headers
+requirement into browser and edge bundles.
 
 ## Feature surface
 
@@ -76,11 +89,11 @@ core already gates off under `cfg(target_family = "wasm")` (see
 - `js/index.js`, `js/index.d.ts` — hand-authored ESM wrapper + TS types. The
   wrapper resolves the `.wasm` relative to itself (`import.meta.url`), so it
   loads from a CDN, a bundler, or a plain `<script type="module">`.
-- `package.json` — the published `@everruns/bashkit-web` manifest (copied into
+- `package.json` — the published `@everruns/bashkit-wasm` manifest (copied into
   `pkg/` at build time).
 - `scripts/build.sh` — `cargo build` → `wasm-bindgen --target web` → optional
   `wasm-opt -Oz`, emitting `pkg/`.
-- `__test__/bashkit-web.test.mjs` — headless Node integration suite
+- `__test__/bashkit-wasm.test.mjs` — headless Node integration suite
   (`node --test`) that feeds the `.wasm` bytes to init (no fetch, no headers),
   proving the no-configuration contract and covering sync/async execution, the
   VFS, custom builtins, and `ctx.fs`.
@@ -92,7 +105,7 @@ core already gates off under `cfg(target_family = "wasm")` (see
 rustup target add wasm32-unknown-unknown
 cargo install wasm-bindgen-cli
 bash crates/bashkit-wasm/scripts/build.sh                          # -> pkg/
-node --test crates/bashkit-wasm/__test__/bashkit-web.test.mjs      # verify
+node --test crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs      # verify
 ```
 
 `--target web` output is a bundler-agnostic ES module; the consumer calls
@@ -101,9 +114,9 @@ node --test crates/bashkit-wasm/__test__/bashkit-web.test.mjs      # verify
 ## Versioning & publish
 
 Version tracks the workspace `Cargo.toml` (currently synced by the release
-prepare step, same as the other packages). `publish-web.yml` triggers on release
+prepare step, same as the other packages). `publish-wasm.yml` triggers on release
 published, builds `pkg/`, runs the smoke test, and `npm publish`es
-`@everruns/bashkit-web` with provenance (`NPM_TOKEN`, `id-token: write`) — same
+`@everruns/bashkit-wasm` with provenance (`NPM_TOKEN`, `id-token: write`) — same
 pattern as `publish-js.yml`.
 
 ## Limitations (see `specs/limitations.md`)

--- a/specs/limitations.md
+++ b/specs/limitations.md
@@ -40,9 +40,9 @@ execution model. Evidence is a threat-model ID, a test, or `stance`
 | L-NET-001 | No raw network sockets; HTTP only via `curl`/`wget`/`http` builtins | Allowlist-mediated egress is the only network surface | `l_net_001_no_raw_sockets` |
 | L-NET-002 | No DNS resolution; hosts must appear in the allowlist | Resolution would bypass allowlist intent | `l_net_002_default_deny_no_resolution` |
 | L-SIG-001 | `trap` stores INT/TERM handlers but no signal delivery in virtual mode (EXIT, ERR fire) | No host signals exist inside the sandbox | `l_sig_001_signal_traps_not_delivered` |
-| L-WASM-001 | Browser build (`@everruns/bashkit-web`, `wasm32-unknown-unknown`) has no wall-clock time: `sleep N` elapses instantly, and neither the `timeout N` builtin nor `timeoutMs` is enforced | No reliable timer driver on the target; parser fuel + `maxCommands`/`maxLoopIterations` still bound runaway scripts | `specs/browser-package.md`, stance |
-| L-WASM-002 | Browser build: `executeSync()` cannot run async custom builtins (fails with a clear message); use `execute()` | Single-threaded event loop can't settle a JS `Promise` without yielding | `crates/bashkit-wasm/__test__/bashkit-web.test.mjs` |
-| L-WASM-003 | Browser build: background jobs (`cmd &`) run synchronously and `awk` file redirects drive the VFS inline; no work runs on a separate thread | `wasm32-unknown-unknown` is single-threaded — `std::thread::spawn`/`tokio::spawn` are unavailable; safe because the in-memory VFS never suspends | `crates/bashkit-wasm/__test__/bashkit-web.test.mjs` |
+| L-WASM-001 | Browser build (`@everruns/bashkit-wasm`, `wasm32-unknown-unknown`) has no wall-clock time: `sleep N` elapses instantly, and neither the `timeout N` builtin nor `timeoutMs` is enforced | No reliable timer driver on the target; parser fuel + `maxCommands`/`maxLoopIterations` still bound runaway scripts | `specs/browser-package.md`, stance |
+| L-WASM-002 | Browser build: `executeSync()` cannot run async custom builtins (fails with a clear message); use `execute()` | Single-threaded event loop can't settle a JS `Promise` without yielding | `crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs` |
+| L-WASM-003 | Browser build: background jobs (`cmd &`) run synchronously and `awk` file redirects drive the VFS inline; no work runs on a separate thread | `wasm32-unknown-unknown` is single-threaded — `std::thread::spawn`/`tokio::spawn` are unavailable; safe because the in-memory VFS never suspends | `crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs` |
 
 ### Design Rationale
 

--- a/specs/maintenance.md
+++ b/specs/maintenance.md
@@ -78,14 +78,14 @@ dependency rot, or security gaps ship in a release.
 - Feature-gated examples work (python, git)
 - Python agent examples run end-to-end
 - Code examples in docs/rustdoc still accurate
-- `examples/browser` tracks the latest published `@everruns/bashkit-web`
+- `examples/browser` tracks the latest published `@everruns/bashkit-wasm`
   (relaxed dep, no committed lockfile): run `pnpm install && pnpm start`, load
   the page, and confirm it runs a plain command, a pipe through `jq`, **and a
   subshell** (`bash /home/user/demo.sh`). The subshell path exercises the wasm
   child-shell parse that a top-level command does not — the smoke suite in
   `crates/bashkit-wasm/__test__/` covers the same ground headlessly. If the
   published package lags a fix the example depends on, hold the example until
-  the next `bashkit-web` release rather than pinning to an old version.
+  the next `bashkit-wasm` release rather than pinning to an old version.
 
 ### Specs
 

--- a/specs/release-process.md
+++ b/specs/release-process.md
@@ -66,7 +66,7 @@ silently failed.
    - Version sync: all manifests read the same `X.Y.Z`, and it is greater
      than the latest published version on every registry (`cargo search
      bashkit`, `pip index versions bashkit`, `npm view @everruns/bashkit
-     version`, `npm view @everruns/bashkit-web version`). A missing registry
+     version`, `npm view @everruns/bashkit-wasm version`). A missing registry
      entry is valid only for a package's first release.
    - On any failure, fix root cause and re-run before opening the PR — do
      **not** merge a release PR with a known-broken publish path.
@@ -74,7 +74,7 @@ silently failed.
 7. **Create PR** — same title, changelog excerpt + publish-readiness report in description.
 8. **Monitor post-merge publishing** — watch `release.yml` create the
    Release + tag, watch `publish.yml`, `publish-python.yml`, `publish-js.yml`,
-   `publish-web.yml`, and `cli-binaries.yml` to completion, run the
+   `publish-wasm.yml`, and `cli-binaries.yml` to completion, run the
    post-release verification commands, and only declare "shipped" when all
    six published artifacts (`bashkit` + `bashkit-cli` on crates.io, `bashkit`
    on PyPI, both npm packages, and Homebrew) report the new version. If one
@@ -84,7 +84,7 @@ silently failed.
 
 - On merge to main, `release.yml` detects the `chore(release): prepare vX.Y.Z` commit, extracts notes from CHANGELOG.md, creates the GitHub Release + tag.
 - On Release published, `publish.yml` / `publish-js.yml` /
-  `publish-web.yml` / `publish-python.yml` publish to crates.io, npm, PyPI;
+  `publish-wasm.yml` / `publish-python.yml` publish to crates.io, npm, PyPI;
   each includes a published-version verification step.
 
 ## Pre-Release Checklist
@@ -103,8 +103,8 @@ Confirm each target (workflow → check):
 - PyPI (`publish-python.yml`): `pip index versions bashkit`
 - npm Node (`publish-js.yml`): `npm view @everruns/bashkit version`;
   `npm dist-tags ls @everruns/bashkit` ("latest" points at it)
-- npm browser (`publish-web.yml`): `npm view @everruns/bashkit-web version`;
-  `npm dist-tags ls @everruns/bashkit-web` ("latest" points at it)
+- npm browser (`publish-wasm.yml`): `npm view @everruns/bashkit-wasm version`;
+  `npm dist-tags ls @everruns/bashkit-wasm` ("latest" points at it)
 - Homebrew (`cli-binaries.yml`): `everruns/homebrew-tap` formula bumped
 
 If a workflow fails: `gh run view <run-id> --log-failed`, identify root
@@ -127,7 +127,7 @@ Use the latest entries in `CHANGELOG.md` as the template. Rules:
 - `bashkit-cli` on crates.io (CLI tool)
 - `bashkit` on PyPI (pre-built wheels)
 - `@everruns/bashkit` on npm (native NAPI-RS bindings)
-- `@everruns/bashkit-web` on npm (single-threaded browser WebAssembly)
+- `@everruns/bashkit-wasm` on npm (single-threaded browser WebAssembly)
 
 ## Publishing Order
 
@@ -179,11 +179,11 @@ wasm32-wasip1-threads), tests on Node 20/22/24, publishes to npm. Secret:
 `--provenance`, same pattern as everruns/sdk. JS package version is synced
 from the workspace `Cargo.toml` by `build.rs` updating `package.json`.
 
-### publish-web.yml
+### publish-wasm.yml
 
 Dispatched by `release.yml` from the verified release tag. Builds the
 single-threaded `wasm32-unknown-unknown` browser bundle, runs the headless Node
-integration suite, and publishes `@everruns/bashkit-web` to npm with
+integration suite, and publishes `@everruns/bashkit-wasm` to npm with
 provenance. Uses the same `NPM_TOKEN` as `publish-js.yml`; the package version
 is synced manually from the workspace version during release preparation.
 
@@ -198,7 +198,7 @@ is synced manually from the workspace version during release preparation.
 ```bash
 cargo search bashkit; cargo search bashkit-cli
 npm view @everruns/bashkit version; npm dist-tags ls @everruns/bashkit
-npm view @everruns/bashkit-web version; npm dist-tags ls @everruns/bashkit-web
+npm view @everruns/bashkit-wasm version; npm dist-tags ls @everruns/bashkit-wasm
 pip index versions bashkit
 gh release view --repo everruns/bashkit
 ```


### PR DESCRIPTION
## What changed
Aligns the published npm package name with its Rust crate: `@everruns/bashkit-web` → **`@everruns/bashkit-wasm`** (the crate has always been `bashkit-wasm`). Also broadens the package's positioning from "browser-only" to "browser **and any other JavaScript runtime**" — edge/serverless workers (Cloudflare Workers, Vercel Edge, Deno Deploy), Node, Deno, and Bun.

No consumer relies on the old name yet, so this is a free rename before adoption.

- `package.json` name → `@everruns/bashkit-wasm`
- Renamed `__test__/bashkit-web.test.mjs` → `bashkit-wasm.test.mjs`
- Renamed workflow `publish-web.yml` → `publish-wasm.yml` (+ its jobs, the `release.yml` dispatch, and the `just build-web` → `build-wasm` recipe)
- Updated every live reference: crate README, `js/index.{js,ts}`, `scripts/build.sh`, `example/README.md`, `examples/browser/*`, specs (`browser-package`, `limitations`, `maintenance`, `release-process`), `AGENTS.md`, `ci.yml`
- Added a **Browser / edge (WebAssembly)** entry to the root README's Language Bindings, which previously never mentioned this package
- Broadened README + spec framing to cover browsers + JS runtimes, with the precise caveat that it's a `wasm-bindgen` module (runs in any JS host, **not** a non-JS/WASI runtime like `wasmtime`/`wasmer`)

## Why
The `-web` name under-described the artifact's reach. It's a `wasm-bindgen` build for `wasm32-unknown-unknown` that runs in any JS host — the headless smoke suite already runs it under Node, and its single-threaded / no-`SharedArrayBuffer` / no-COOP/COEP design is exactly what thread-less edge runtimes need too. `-wasm` names it accurately and matches the crate, so the crate and package no longer diverge. It slots cleanly next to the native `bashkit-js` (napi) package: `js` = native Node addon, `wasm` = portable JS-host build.

## Before / After
Pure rename + docs; no runtime behavior changes.

- **Before:** crate `bashkit-wasm` published as npm `@everruns/bashkit-web`; README/spec framed browser-only.
- **After:** crate `bashkit-wasm` published as npm `@everruns/bashkit-wasm`; framed for browsers + JS runtimes.

`CHANGELOG.md` is intentionally left untouched — its `@everruns/bashkit-web` entries document versions already released under that name; the rename applies going forward. The next publish starts a fresh npm package and orphans the unused `-web` 0.14.x entries (harmless, nothing consumes them).

## Risk
- Low
- No Rust source changed (0 `.rs` files); crate name and emitted `bashkit_wasm*` artifacts are unchanged, so the build pipeline is unaffected. Only risk is a missed string reference — verified none remain outside `CHANGELOG.md`. The `wasm-web` CI job builds the bundle and runs the renamed headless test.

## Checklist
- [x] Tests added or updated — n/a (no code change); renamed headless test file, references updated across CI/justfile/specs; `node --check` passes and its internal `../pkg/...` imports are intact
- [x] Backward compatibility considered — internal-only; old npm name has no consumers yet

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQYfPptuzU5SpqEM6PdEhe)_