### PR TITLE
fix(builtins): reject unknown options like real coreutils

### DIFF
--- a/crates/bashkit/src/builtins/column.rs
+++ b/crates/bashkit/src/builtins/column.rs
@@ -26,7 +26,10 @@ struct ColumnOptions {
     output_sep: String,
 }
 
-fn parse_column_args(args: &[String]) -> (ColumnOptions, Vec<String>) {
+#[allow(clippy::result_large_err)]
+fn parse_column_args(
+    args: &[String],
+) -> std::result::Result<(ColumnOptions, Vec<String>), ExecResult> {
     let mut opts = ColumnOptions {
         table: false,
         input_sep: None,
@@ -46,12 +49,17 @@ fn parse_column_args(args: &[String]) -> (ColumnOptions, Vec<String>) {
             if let Some(arg) = p.positional() {
                 files.push(arg.to_string());
             }
+        } else if p.current() == Some("--") {
+            p.advance(); // end-of-options marker; ignore (preserve behavior)
+        } else if let Some(flag) = p.current() {
+            // Reject unknown options instead of silently swallowing them.
+            return Err(super::invalid_option("column", flag, 1));
         } else {
             p.advance();
         }
     }
 
-    (opts, files)
+    Ok((opts, files))
 }
 
 fn format_table(text: &str, opts: &ColumnOptions) -> String {
@@ -152,7 +160,10 @@ impl Builtin for Column {
         ) {
             return Ok(r);
         }
-        let (opts, files) = parse_column_args(ctx.args);
+        let (opts, files) = match parse_column_args(ctx.args) {
+            Ok(v) => v,
+            Err(e) => return Ok(e),
+        };
 
         // Collect all input
         let mut input = String::new();
@@ -297,6 +308,13 @@ mod tests {
         let result = run_column(&["-t"], None).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "");
+    }
+
+    #[tokio::test]
+    async fn test_column_unknown_option() {
+        let result = run_column(&["-Q"], Some("a b\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/comm.rs
+++ b/crates/bashkit/src/builtins/comm.rs
@@ -26,7 +26,8 @@ struct CommOptions {
     suppress_3: bool,
 }
 
-fn parse_comm_args(args: &[String]) -> (CommOptions, Vec<String>) {
+#[allow(clippy::result_large_err)]
+fn parse_comm_args(args: &[String]) -> std::result::Result<(CommOptions, Vec<String>), ExecResult> {
     let mut opts = CommOptions {
         suppress_1: false,
         suppress_2: false,
@@ -44,12 +45,15 @@ fn parse_comm_args(args: &[String]) -> (CommOptions, Vec<String>) {
                     _ => {}
                 }
             }
+        } else if arg.starts_with('-') && arg.len() > 1 && arg != "--" {
+            // Option-shaped token that isn't a -1/-2/-3 combination → reject.
+            return Err(super::invalid_option("comm", arg, 1));
         } else {
             files.push(arg.clone());
         }
     }
 
-    (opts, files)
+    Ok((opts, files))
 }
 
 #[async_trait]
@@ -62,7 +66,10 @@ impl Builtin for Comm {
         ) {
             return Ok(r);
         }
-        let (opts, files) = parse_comm_args(ctx.args);
+        let (opts, files) = match parse_comm_args(ctx.args) {
+            Ok(v) => v,
+            Err(e) => return Ok(e),
+        };
 
         if files.len() < 2 {
             return Ok(Self::err("missing operand", 1));
@@ -342,6 +349,18 @@ mod tests {
         let result = run_comm(&["/a.txt"], None, &[("/a.txt", b"a\n")]).await;
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("missing operand"));
+    }
+
+    #[tokio::test]
+    async fn test_comm_invalid_option() {
+        let result = run_comm(
+            &["-Q", "/a.txt", "/b.txt"],
+            None,
+            &[("/a.txt", b"a\n"), ("/b.txt", b"b\n")],
+        )
+        .await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/cuttr.rs
+++ b/crates/bashkit/src/builtins/cuttr.rs
@@ -87,6 +87,16 @@ impl Builtin for Cut {
             } else if let Some(arg) = p.current().filter(|s| !s.starts_with('-')) {
                 files.push(arg.to_string());
                 p.advance();
+            } else if p.current() == Some("-") || p.current() == Some("--") {
+                // "-" stdin operand / "--" end-of-options: preserve handling.
+                p.advance();
+            } else if p.is_flag() {
+                // Reject unknown options instead of dropping them silently.
+                return Ok(super::invalid_option(
+                    "cut",
+                    p.current().unwrap_or_default(),
+                    1,
+                ));
             } else {
                 p.advance();
             }
@@ -316,6 +326,14 @@ impl Builtin for Tr {
                         _ => {}
                     }
                 }
+            } else if non_flag_args.is_empty() && p.is_flag() && p.current() != Some("--") {
+                // Reject unknown options only in the option phase (before any
+                // SET is read); once SETs are collected a leading `-` is an operand.
+                return Ok(super::invalid_option(
+                    "tr",
+                    p.current().unwrap_or_default(),
+                    1,
+                ));
             } else if let Some(arg) = p.positional() {
                 non_flag_args.push(arg.to_string());
             }
@@ -935,5 +953,19 @@ mod tests {
     fn test_expand_char_set_multibyte() {
         let chars = expanded("äöü");
         assert_eq!(chars, vec!['ä', 'ö', 'ü']);
+    }
+
+    #[tokio::test]
+    async fn test_cut_rejects_unknown_option() {
+        let result = run_cut(&["-Q", "-f1"], Some("a\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_tr_rejects_unknown_option() {
+        let result = run_tr(&["-Q", "a", "b"], Some("a\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -433,6 +433,12 @@ impl Builtin for Date {
             } else if let Some(arg) = p.current().filter(|s| s.starts_with('+')) {
                 format_arg = Some(arg.to_string());
                 p.advance();
+            } else if let Some(arg) = p
+                .current()
+                .filter(|s| s.starts_with('-') && s.len() > 1 && *s != "--")
+            {
+                // Unknown option-shaped token → reject (date exits 1).
+                return Ok(super::invalid_option("date", arg, 1));
             } else {
                 p.advance();
             }
@@ -575,6 +581,13 @@ mod tests {
         // Just check it outputs something with a newline
         assert!(result.stdout.ends_with('\n'));
         assert!(result.stdout.len() > 10);
+    }
+
+    #[tokio::test]
+    async fn test_date_invalid_option() {
+        let result = run_date(&["-Q"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     /// TM-INF-018: fixed_epoch wins over real clock.

--- a/crates/bashkit/src/builtins/diff.rs
+++ b/crates/bashkit/src/builtins/diff.rs
@@ -23,7 +23,8 @@ struct DiffOptions {
     brief: bool,
 }
 
-fn parse_diff_args(args: &[String]) -> (DiffOptions, Vec<String>) {
+#[allow(clippy::result_large_err)]
+fn parse_diff_args(args: &[String]) -> std::result::Result<(DiffOptions, Vec<String>), ExecResult> {
     let mut opts = DiffOptions {
         unified: false,
         brief: false,
@@ -34,12 +35,14 @@ fn parse_diff_args(args: &[String]) -> (DiffOptions, Vec<String>) {
         match arg.as_str() {
             "-u" => opts.unified = true,
             "-q" | "--brief" => opts.brief = true,
+            "--" => {} // end-of-options marker
             _ if !arg.starts_with('-') || arg == "-" => files.push(arg.clone()),
-            _ => {} // ignore unknown options
+            // Reject genuinely unknown option-shaped tokens (diff exits 2).
+            _ => return Err(super::invalid_option("diff", arg, 2)),
         }
     }
 
-    (opts, files)
+    Ok((opts, files))
 }
 
 /// Simple LCS-based diff algorithm
@@ -327,7 +330,10 @@ impl Builtin for Diff {
         ) {
             return Ok(r);
         }
-        let (opts, files) = parse_diff_args(ctx.args);
+        let (opts, files) = match parse_diff_args(ctx.args) {
+            Ok(v) => v,
+            Err(e) => return Ok(e),
+        };
 
         if files.len() < 2 {
             return Ok(ExecResult::err("diff: missing operand\n".to_string(), 1));
@@ -613,6 +619,18 @@ mod tests {
         assert!(!result.stdout.contains("---  "));
         assert!(!result.stdout.contains("+++"));
         assert!(!result.stdout.contains("@@"));
+    }
+
+    #[tokio::test]
+    async fn test_diff_invalid_option() {
+        let result = run_diff(
+            &["-Q", "/a.txt", "/b.txt"],
+            None,
+            &[("/a.txt", b"hello\n"), ("/b.txt", b"world\n")],
+        )
+        .await;
+        assert_eq!(result.exit_code, 2);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/envsubst.rs
+++ b/crates/bashkit/src/builtins/envsubst.rs
@@ -39,6 +39,11 @@ impl Builtin for Envsubst {
                         .collect();
                     restrict_vars = Some(vars);
                 }
+                "--help" | "--version" => {}
+                s if s.starts_with('-') && s.len() > 1 && s != "--" => {
+                    // Reject unknown options like GNU envsubst.
+                    return Ok(super::invalid_option("envsubst", s, 1));
+                }
                 _ => {}
             }
         }
@@ -256,5 +261,13 @@ mod tests {
         let result = run_envsubst(&[], Some("no variables here"), env).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "no variables here");
+    }
+
+    #[tokio::test]
+    async fn test_rejects_unknown_option() {
+        let env = HashMap::new();
+        let result = run_envsubst(&["-Q"], Some("x"), env).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/expand.rs
+++ b/crates/bashkit/src/builtins/expand.rs
@@ -52,6 +52,16 @@ impl Builtin for Expand {
                         Err(e) => return Ok(Self::err(e, 1)),
                     };
                 }
+                // Reject unknown options. `-N` (all-digit) is the obsolete
+                // tab-size form expand still accepts, so leave it to fall
+                // through; `--`/`-` and operands also fall through.
+                s if s.starts_with('-')
+                    && s.len() > 1
+                    && s != "--"
+                    && !s[1..].chars().all(|c| c.is_ascii_digit()) =>
+                {
+                    return Ok(super::invalid_option("expand", s, 1));
+                }
                 _ => files.push(&ctx.args[i]),
             }
             i += 1;
@@ -166,6 +176,21 @@ impl Builtin for Unexpand {
                     };
                     tab_stops = parsed_tab_stops;
                     all = true; // -t implies -a
+                }
+                s if s.starts_with("-t") && s.len() > 2 => {
+                    // Attached form `-tN`; known option, not an unknown token.
+                    tab_stops = match parse_tab_stops(&s[2..]) {
+                        Ok(stops) => stops,
+                        Err(_) => {
+                            return Ok(Self::err(format!("invalid tab size: '{}'", &s[2..]), 1));
+                        }
+                    };
+                    all = true; // -t implies -a
+                }
+                // Reject unknown options. unexpand takes no numeric operand,
+                // so `-N` is also unknown; `--`/`-` and operands fall through.
+                s if s.starts_with('-') && s.len() > 1 && s != "--" => {
+                    return Ok(super::invalid_option("unexpand", s, 1));
                 }
                 _ => files.push(&ctx.args[i]),
             }
@@ -388,6 +413,20 @@ mod tests {
         let result = run_unexpand(&["-t", "1000000000"], Some("        hello")).await;
         assert_eq!(result.exit_code, 1);
         assert_eq!(result.stderr, "unexpand: invalid tab size: '1000000000'\n");
+    }
+
+    #[tokio::test]
+    async fn test_expand_unknown_option() {
+        let result = run_expand(&["-Q"], Some("hi")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_unexpand_unknown_option() {
+        let result = run_unexpand(&["-Q"], Some("hi")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/fileops.rs
+++ b/crates/bashkit/src/builtins/fileops.rs
@@ -35,8 +35,35 @@ impl Builtin for Mkdir {
             return Ok(ExecResult::err("mkdir: missing operand\n".to_string(), 1));
         }
 
-        let recursive = ctx.args.iter().any(|a| a == "-p");
-        let dirs: Vec<_> = ctx.args.iter().filter(|a| !a.starts_with('-')).collect();
+        // Reject unknown options like GNU mkdir. Only -p/--parents has an
+        // effect in the VFS; other real-mkdir flags are accepted and ignored.
+        // '--' ends option parsing.
+        let mut recursive = false;
+        let mut dirs: Vec<&String> = Vec::new();
+        let mut opts_done = false;
+        for arg in ctx.args {
+            if opts_done {
+                dirs.push(arg);
+            } else if arg == "--" {
+                opts_done = true;
+            } else if let Some(long) = arg.strip_prefix("--") {
+                match long.split('=').next().unwrap_or("") {
+                    "parents" => recursive = true,
+                    "mode" | "verbose" | "context" => {}
+                    _ => return Ok(super::invalid_option("mkdir", arg, 1)),
+                }
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                for c in arg[1..].chars() {
+                    match c {
+                        'p' => recursive = true,
+                        'm' | 'v' | 'Z' => {}
+                        _ => return Ok(super::invalid_option("mkdir", &format!("-{c}"), 1)),
+                    }
+                }
+            } else {
+                dirs.push(arg);
+            }
+        }
 
         if dirs.is_empty() {
             return Ok(ExecResult::err("mkdir: missing operand\n".to_string(), 1));
@@ -103,18 +130,38 @@ impl Builtin for Rm {
             return Ok(ExecResult::err("rm: missing operand\n".to_string(), 1));
         }
 
-        let recursive = ctx.args.iter().any(|a| {
-            a == "-r"
-                || a == "-R"
-                || a == "-rf"
-                || a == "-fr"
-                || a.contains('r') && a.starts_with('-')
-        });
-        let force = ctx.args.iter().any(|a| {
-            a == "-f" || a == "-rf" || a == "-fr" || a.contains('f') && a.starts_with('-')
-        });
-
-        let files: Vec<_> = ctx.args.iter().filter(|a| !a.starts_with('-')).collect();
+        // Reject unknown options like GNU rm; parse short bundles per-char.
+        // '--' ends option parsing; a lone '-' is a file operand.
+        let mut recursive = false;
+        let mut force = false;
+        let mut files: Vec<&String> = Vec::new();
+        let mut opts_done = false;
+        for arg in ctx.args {
+            if opts_done {
+                files.push(arg);
+            } else if arg == "--" {
+                opts_done = true;
+            } else if let Some(long) = arg.strip_prefix("--") {
+                match long.split('=').next().unwrap_or("") {
+                    "recursive" => recursive = true,
+                    "force" => force = true,
+                    "dir" | "interactive" | "verbose" | "one-file-system" | "no-preserve-root"
+                    | "preserve-root" => {}
+                    _ => return Ok(super::invalid_option("rm", arg, 1)),
+                }
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                for c in arg[1..].chars() {
+                    match c {
+                        'r' | 'R' => recursive = true,
+                        'f' => force = true,
+                        'i' | 'I' | 'd' | 'v' => {}
+                        _ => return Ok(super::invalid_option("rm", &format!("-{c}"), 1)),
+                    }
+                }
+            } else {
+                files.push(arg);
+            }
+        }
 
         if files.is_empty() {
             return Ok(ExecResult::err("rm: missing operand\n".to_string(), 1));
@@ -180,13 +227,60 @@ impl Builtin for Cp {
             return Ok(r);
         }
 
-        if ctx.args.len() < 2 {
-            return Ok(ExecResult::err("cp: missing file operand\n".to_string(), 1));
+        // Reject unknown options like GNU cp; accept-and-ignore the rest (cp
+        // copies non-recursively in the VFS regardless). '--' ends options.
+        let mut files: Vec<&String> = Vec::new();
+        let mut opts_done = false;
+        for arg in ctx.args {
+            if opts_done {
+                files.push(arg);
+            } else if arg == "--" {
+                opts_done = true;
+            } else if let Some(long) = arg.strip_prefix("--") {
+                match long.split('=').next().unwrap_or("") {
+                    "archive"
+                    | "attributes-only"
+                    | "backup"
+                    | "copy-contents"
+                    | "dereference"
+                    | "no-dereference"
+                    | "force"
+                    | "interactive"
+                    | "link"
+                    | "no-clobber"
+                    | "one-file-system"
+                    | "parents"
+                    | "preserve"
+                    | "no-preserve"
+                    | "recursive"
+                    | "reflink"
+                    | "remove-destination"
+                    | "sparse"
+                    | "strip-trailing-slashes"
+                    | "symbolic-link"
+                    | "target-directory"
+                    | "no-target-directory"
+                    | "update"
+                    | "verbose"
+                    | "context" => {}
+                    _ => return Ok(super::invalid_option("cp", arg, 1)),
+                }
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                for c in arg[1..].chars() {
+                    match c {
+                        'a' | 'd' | 'f' | 'H' | 'i' | 'l' | 'L' | 'n' | 'P' | 'p' | 'r' | 'R'
+                        | 's' | 't' | 'T' | 'u' | 'v' | 'x' | 'Z' => {}
+                        _ => return Ok(super::invalid_option("cp", &format!("-{c}"), 1)),
+                    }
+                }
+            } else {
+                files.push(arg);
+            }
         }
 
-        let _recursive = ctx.args.iter().any(|a| a == "-r" || a == "-R");
-        let files: Vec<_> = ctx.args.iter().filter(|a| !a.starts_with('-')).collect();
-
+        if files.is_empty() {
+            return Ok(ExecResult::err("cp: missing file operand\n".to_string(), 1));
+        }
         if files.len() < 2 {
             return Ok(ExecResult::err(
                 "cp: missing destination file operand\n".to_string(),
@@ -256,12 +350,45 @@ impl Builtin for Mv {
             return Ok(r);
         }
 
-        if ctx.args.len() < 2 {
-            return Ok(ExecResult::err("mv: missing file operand\n".to_string(), 1));
+        // Reject unknown options like GNU mv; accept-and-ignore the rest.
+        // '--' ends option parsing.
+        let mut files: Vec<&String> = Vec::new();
+        let mut opts_done = false;
+        for arg in ctx.args {
+            if opts_done {
+                files.push(arg);
+            } else if arg == "--" {
+                opts_done = true;
+            } else if let Some(long) = arg.strip_prefix("--") {
+                match long.split('=').next().unwrap_or("") {
+                    "backup"
+                    | "force"
+                    | "interactive"
+                    | "no-clobber"
+                    | "no-target-directory"
+                    | "strip-trailing-slashes"
+                    | "suffix"
+                    | "target-directory"
+                    | "update"
+                    | "verbose"
+                    | "context" => {}
+                    _ => return Ok(super::invalid_option("mv", arg, 1)),
+                }
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                for c in arg[1..].chars() {
+                    match c {
+                        'b' | 'f' | 'i' | 'n' | 'T' | 't' | 'u' | 'v' | 'Z' => {}
+                        _ => return Ok(super::invalid_option("mv", &format!("-{c}"), 1)),
+                    }
+                }
+            } else {
+                files.push(arg);
+            }
         }
 
-        let files: Vec<_> = ctx.args.iter().filter(|a| !a.starts_with('-')).collect();
-
+        if files.is_empty() {
+            return Ok(ExecResult::err("mv: missing file operand\n".to_string(), 1));
+        }
         if files.len() < 2 {
             return Ok(ExecResult::err(
                 "mv: missing destination file operand\n".to_string(),
@@ -752,14 +879,33 @@ impl Builtin for Chown {
             return Ok(r);
         }
 
+        // Reject unknown options like GNU chown; accept-and-ignore the rest
+        // (ownership is a no-op in the VFS). '--' ends option parsing.
         let mut recursive = false;
         let mut positional: Vec<&str> = Vec::new();
-
+        let mut opts_done = false;
         for arg in ctx.args {
-            match arg.as_str() {
-                "-R" | "--recursive" => recursive = true,
-                _ if arg.starts_with('-') => {} // ignore other flags
-                _ => positional.push(arg),
+            if opts_done {
+                positional.push(arg);
+            } else if arg == "--" {
+                opts_done = true;
+            } else if let Some(long) = arg.strip_prefix("--") {
+                match long.split('=').next().unwrap_or("") {
+                    "recursive" => recursive = true,
+                    "changes" | "dereference" | "no-dereference" | "from" | "silent" | "quiet"
+                    | "reference" | "verbose" => {}
+                    _ => return Ok(super::invalid_option("chown", arg, 1)),
+                }
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                for c in arg[1..].chars() {
+                    match c {
+                        'R' => recursive = true,
+                        'c' | 'f' | 'h' | 'v' | 'H' | 'L' | 'P' => {}
+                        _ => return Ok(super::invalid_option("chown", &format!("-{c}"), 1)),
+                    }
+                }
+            } else {
+                positional.push(arg);
             }
         }
         let _ = recursive; // accepted but irrelevant in VFS
@@ -1387,5 +1533,62 @@ mod tests {
     fn test_mktemp_name_template_without_xxxxxx_appends_suffix() {
         let name = mktemp_name(Some("/tmp/myapp"), "abcdef1234");
         assert_eq!(name, "/tmp/myapp.abcdef");
+    }
+
+    async fn run_fileop<B: Builtin>(builtin: &B, args: &[&str]) -> ExecResult {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+        let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs: fs.clone(),
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+        builtin.execute(ctx).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_mkdir_rejects_unknown_option() {
+        let result = run_fileop(&Mkdir, &["-Q", "dir"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_rm_rejects_unknown_option() {
+        let result = run_fileop(&Rm, &["-Q", "file"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_cp_rejects_unknown_option() {
+        let result = run_fileop(&Cp, &["-Q", "a", "b"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_mv_rejects_unknown_option() {
+        let result = run_fileop(&Mv, &["-Q", "a", "b"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_chown_rejects_unknown_option() {
+        let result = run_fileop(&Chown, &["-Q", "user", "file"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/fold.rs
+++ b/crates/bashkit/src/builtins/fold.rs
@@ -49,6 +49,10 @@ impl Builtin for Fold {
                 s if s.starts_with("-w") && s.len() > 2 => {
                     width = s[2..].parse().unwrap_or(80);
                 }
+                // Reject unknown options; `-`/`--` and operands fall through.
+                s if s.starts_with('-') && s.len() > 1 && s != "--" => {
+                    return Ok(super::invalid_option("fold", s, 1));
+                }
                 _ => files.push(&ctx.args[i]),
             }
             i += 1;
@@ -207,6 +211,13 @@ mod tests {
         let result = run_fold(&["-w", "80"], Some("short line\n")).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "short line\n");
+    }
+
+    #[tokio::test]
+    async fn test_fold_unknown_option() {
+        let result = run_fold(&["-Q"], Some("hello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -91,7 +91,7 @@ struct GrepOptions {
 }
 
 impl GrepOptions {
-    fn parse(args: &[String]) -> Result<Self> {
+    fn parse(args: &[String]) -> Result<std::result::Result<Self, ExecResult>> {
         let mut opts = GrepOptions {
             patterns: Vec::new(),
             files: Vec::new(),
@@ -215,7 +215,8 @@ impl GrepOptions {
                             opts.pattern_file = Some(file_path);
                             break;
                         }
-                        _ => {} // Ignore unknown flags
+                        // Unknown short flag → reject (grep exits 2).
+                        _ => return Ok(Err(super::invalid_option("grep", &format!("-{c}"), 2))),
                     }
                     j += 1;
                 }
@@ -312,8 +313,8 @@ impl GrepOptions {
                         &mut i,
                         args,
                     )?)),
-                    // Ignore other unknown long options.
-                    _ => {}
+                    // Unknown long option → reject (grep exits 2).
+                    _ => return Ok(Err(super::invalid_option("grep", arg, 2))),
                 }
             } else {
                 positional.push(arg.clone());
@@ -332,7 +333,7 @@ impl GrepOptions {
         // Rest are files
         opts.files = positional;
 
-        Ok(opts)
+        Ok(Ok(opts))
     }
 
     /// Select the pattern syntax, clearing any previously-selected type so the
@@ -549,7 +550,10 @@ impl Builtin for Grep {
         ) {
             return Ok(r);
         }
-        let mut opts = GrepOptions::parse(ctx.args)?;
+        let mut opts = match GrepOptions::parse(ctx.args)? {
+            Ok(o) => o,
+            Err(e) => return Ok(e),
+        };
 
         // Load patterns from file if -f was specified
         if let Some(ref pattern_file) = opts.pattern_file {
@@ -1255,6 +1259,15 @@ mod tests {
             .unwrap();
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "hello world\n");
+    }
+
+    #[tokio::test]
+    async fn test_grep_invalid_option() {
+        let result = run_grep(&["-Q", "hello"], Some("hello world"))
+            .await
+            .unwrap();
+        assert_eq!(result.exit_code, 2);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -29,7 +29,10 @@ impl Builtin for Head {
         ) {
             return Ok(r);
         }
-        let (count, byte_mode, files) = parse_head_args(ctx.args, DEFAULT_LINES)?;
+        let (count, byte_mode, files) = match parse_head_args(ctx.args, DEFAULT_LINES) {
+            Ok(v) => v,
+            Err(e) => return Ok(e),
+        };
 
         let mut output = String::new();
 
@@ -105,7 +108,10 @@ impl Builtin for Tail {
         ) {
             return Ok(r);
         }
-        let (num_lines, from_start, files) = parse_tail_args(ctx.args, DEFAULT_LINES)?;
+        let (num_lines, from_start, files) = match parse_tail_args(ctx.args, DEFAULT_LINES) {
+            Ok(v) => v,
+            Err(e) => return Ok(e),
+        };
 
         let mut output = String::new();
 
@@ -154,7 +160,11 @@ impl Builtin for Tail {
 
 /// Parse arguments for head command, including -c (byte count) mode.
 /// Returns (count, byte_mode, file_list)
-fn parse_head_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<String>)> {
+#[allow(clippy::result_large_err)]
+fn parse_head_args(
+    args: &[String],
+    default: usize,
+) -> std::result::Result<(usize, bool, Vec<String>), ExecResult> {
     let mut count = default;
     let mut byte_mode = false;
     let mut files = Vec::new();
@@ -171,9 +181,16 @@ fn parse_head_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<
             if let Some(num_str) = arg.strip_prefix('-')
                 && let Ok(n) = num_str.parse::<usize>()
             {
+                // Obsolete `-NUM` line-count form.
                 count = n;
+                p.advance();
+            } else if arg == "-" || arg == "--" {
+                // "-" is the stdin operand; "--" ends options.
+                p.advance();
+            } else {
+                // Unknown option-shaped token (e.g. -Q) → reject like GNU head.
+                return Err(super::invalid_option("head", arg, 1));
             }
-            p.advance();
         } else if let Some(arg) = p.positional() {
             files.push(arg.to_string());
         }
@@ -239,7 +256,11 @@ fn looks_like_latin1_binary(text: &str) -> bool {
 
 /// Parse arguments for tail command, including +N "from start" syntax.
 /// Returns (num_lines, from_start, file_list)
-fn parse_tail_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<String>)> {
+#[allow(clippy::result_large_err)]
+fn parse_tail_args(
+    args: &[String],
+    default: usize,
+) -> std::result::Result<(usize, bool, Vec<String>), ExecResult> {
     let mut num_lines = default;
     let mut from_start = false;
     let mut files = Vec::new();
@@ -258,9 +279,16 @@ fn parse_tail_args(args: &[String], default: usize) -> Result<(usize, bool, Vec<
             if let Some(num_str) = arg.strip_prefix('-')
                 && let Ok(n) = num_str.parse::<usize>()
             {
+                // Obsolete `-NUM` line-count form.
                 num_lines = n;
+                p.advance();
+            } else if arg == "-" || arg == "--" {
+                // "-" is the stdin operand; "--" ends options.
+                p.advance();
+            } else {
+                // Unknown option-shaped token (e.g. -Q) → reject like GNU tail.
+                return Err(super::invalid_option("tail", arg, 1));
             }
-            p.advance();
         } else if let Some(arg) = p.positional() {
             files.push(arg.to_string());
         }
@@ -405,6 +433,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_head_invalid_option() {
+        let result = run_head(&["-Q"], Some("a\nb\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
     async fn test_head_c_multibyte_stdin_respects_byte_limit() {
         let result = run_head(&["-c", "1"], Some("éX")).await;
         assert_eq!(result.exit_code, 0);
@@ -449,6 +484,13 @@ mod tests {
         let result = run_tail(&["-2"], Some(input)).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "d\ne\n");
+    }
+
+    #[tokio::test]
+    async fn test_tail_invalid_option() {
+        let result = run_tail(&["-Q"], Some("a\nb\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/helpers.rs
+++ b/crates/bashkit/src/builtins/helpers.rs
@@ -11,6 +11,28 @@
 use super::check_help_version;
 use crate::interpreter::ExecResult;
 
+/// Build the error real GNU coreutils/util-linux print for an unrecognized
+/// command-line option, so builtins reject typos the way the real tools do
+/// instead of silently ignoring the bad flag.
+///
+/// `arg` is the offending token as the user wrote it. A `--long` token yields
+/// `"{cmd}: unrecognized option '--long'"`; a `-xyz` token reports the first
+/// character as `"{cmd}: invalid option -- 'x'"` (matching getopt, which fails
+/// on the first unknown char in a bundle). `code` is the tool's exit status —
+/// most coreutils use 1, a few (sort, grep, diff, patch) use 2.
+pub(crate) fn invalid_option(cmd: &str, arg: &str, code: i32) -> ExecResult {
+    let msg = if let Some(long) = arg.strip_prefix("--") {
+        format!("{cmd}: unrecognized option '--{long}'\n")
+    } else if let Some(short) = arg.strip_prefix('-') {
+        let ch = short.chars().next().unwrap_or('-');
+        format!("{cmd}: invalid option -- '{ch}'\n")
+    } else {
+        // Not option-shaped; report verbatim (rare).
+        format!("{cmd}: invalid option -- '{arg}'\n")
+    };
+    ExecResult::err(msg, code)
+}
+
 /// Default helpers shared by builtin commands.
 ///
 /// Each impl binds the command name to the type, removing the need to
@@ -63,6 +85,26 @@ mod tests {
     fn err_path_includes_path() {
         let r = Demo::err_path("/etc/foo", "permission denied", 1);
         assert_eq!(r.stderr, "demo: /etc/foo: permission denied\n");
+    }
+
+    #[test]
+    fn invalid_option_short() {
+        let r = invalid_option("wc", "-Q", 1);
+        assert_eq!(r.stderr, "wc: invalid option -- 'Q'\n");
+        assert_eq!(r.exit_code, 1);
+    }
+
+    #[test]
+    fn invalid_option_short_reports_first_char() {
+        let r = invalid_option("sort", "-lQ", 2);
+        assert_eq!(r.stderr, "sort: invalid option -- 'l'\n");
+        assert_eq!(r.exit_code, 2);
+    }
+
+    #[test]
+    fn invalid_option_long() {
+        let r = invalid_option("wc", "--foo", 1);
+        assert_eq!(r.stderr, "wc: unrecognized option '--foo'\n");
     }
 
     #[test]

--- a/crates/bashkit/src/builtins/hextools.rs
+++ b/crates/bashkit/src/builtins/hextools.rs
@@ -307,12 +307,29 @@ fn parse_xxd_args(args: &[String]) -> std::result::Result<(XxdOptions, Vec<Strin
             opts.plain = true;
         } else if p.flag("-r") {
             opts.reverse = true;
+        } else if p.is_flag() && p.current() != Some("--") {
+            // Reject unknown options instead of treating them as filenames.
+            return Err(invalid_option_msg("xxd", p.current().unwrap_or_default()));
         } else if let Some(arg) = p.positional() {
             files.push(arg.to_string());
         }
     }
 
     Ok((opts, files))
+}
+
+/// Build an unrecognized-option message (no trailing newline; callers append
+/// it via `format!("{}\n", e)`). Mirrors `super::invalid_option`.
+fn invalid_option_msg(cmd: &str, arg: &str) -> String {
+    if let Some(long) = arg.strip_prefix("--") {
+        format!("{cmd}: unrecognized option '--{long}'")
+    } else {
+        let ch = arg
+            .strip_prefix('-')
+            .and_then(|s| s.chars().next())
+            .unwrap_or('-');
+        format!("{cmd}: invalid option -- '{ch}'")
+    }
 }
 
 fn xxd_dump(data: &[u8], opts: &XxdOptions) -> String {
@@ -487,6 +504,12 @@ fn parse_hexdump_args(
             opts.offset = val
                 .parse()
                 .map_err(|_| format!("hexdump: invalid offset: '{}'", val))?;
+        } else if p.is_flag() && p.current() != Some("--") {
+            // Reject unknown options instead of treating them as filenames.
+            return Err(invalid_option_msg(
+                "hexdump",
+                p.current().unwrap_or_default(),
+            ));
         } else if let Some(arg) = p.positional() {
             files.push(arg.to_string());
         }
@@ -916,6 +939,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_xxd_unknown_option() {
+        let result = run_xxd(&["-Q"], Some("Hi")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
     async fn test_xxd_reverse_normal() {
         // Normal xxd output format
         let result = run_xxd(
@@ -972,6 +1002,13 @@ mod tests {
         let result = run_hexdump(&[], Some("")).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "");
+    }
+
+    #[tokio::test]
+    async fn test_hexdump_unknown_option() {
+        let result = run_hexdump(&["-Q"], Some("Hi")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/join.rs
+++ b/crates/bashkit/src/builtins/join.rs
@@ -61,6 +61,13 @@ impl Builtin for Join {
                 }
             } else if let Some(val) = p.flag_value_opt("-e") {
                 opts.empty = val.to_string();
+            } else if p.is_flag() && p.current() != Some("--") {
+                // Reject unknown options instead of treating them as files.
+                return Ok(super::invalid_option(
+                    "join",
+                    p.current().unwrap_or_default(),
+                    1,
+                ));
             } else if let Some(arg) = p.positional() {
                 files.push(arg);
             }
@@ -274,5 +281,13 @@ mod tests {
 
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("invalid field number"));
+    }
+
+    #[tokio::test]
+    async fn test_join_rejects_unknown_option() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        let result = run_join(&["-Q", "/f1", "/f2"], fs).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -113,7 +113,7 @@ mod yes;
 mod zip_cmd;
 
 mod helpers;
-pub(crate) use helpers::{invalid_option, BuiltinHelper};
+pub(crate) use helpers::{BuiltinHelper, invalid_option};
 
 pub(crate) mod limits;
 pub(crate) use limits::MAX_FORMAT_WIDTH;

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -113,7 +113,7 @@ mod yes;
 mod zip_cmd;
 
 mod helpers;
-pub(crate) use helpers::BuiltinHelper;
+pub(crate) use helpers::{invalid_option, BuiltinHelper};
 
 pub(crate) mod limits;
 pub(crate) use limits::MAX_FORMAT_WIDTH;

--- a/crates/bashkit/src/builtins/nl.rs
+++ b/crates/bashkit/src/builtins/nl.rs
@@ -95,12 +95,29 @@ fn parse_nl_args(args: &[String]) -> std::result::Result<(NlOptions, Vec<String>
                     opts.width, MAX_FORMAT_WIDTH
                 ));
             }
+        } else if p.is_flag() && p.current() != Some("--") {
+            // Reject unknown options instead of treating them as files.
+            return Err(invalid_option_msg("nl", p.current().unwrap_or_default()));
         } else if let Some(arg) = p.positional() {
             files.push(arg.to_string());
         }
     }
 
     Ok((opts, files))
+}
+
+/// Build an unrecognized-option message (no trailing newline; the caller
+/// appends it via `format!("{}\n", e)`). Mirrors `super::invalid_option`.
+fn invalid_option_msg(cmd: &str, arg: &str) -> String {
+    if let Some(long) = arg.strip_prefix("--") {
+        format!("{cmd}: unrecognized option '--{long}'")
+    } else {
+        let ch = arg
+            .strip_prefix('-')
+            .and_then(|s| s.chars().next())
+            .unwrap_or('-');
+        format!("{cmd}: invalid option -- '{ch}'")
+    }
 }
 
 fn format_number(num: usize, format: NumberFormat, width: usize) -> String {
@@ -428,5 +445,12 @@ mod tests {
         let result = run_nl(&["-ba", "-nrz", "-w4"], Some("x\ny\n")).await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "0001\tx\n0002\ty\n");
+    }
+
+    #[tokio::test]
+    async fn test_nl_rejects_unknown_option() {
+        let result = run_nl(&["-Q"], Some("a\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/paste.rs
+++ b/crates/bashkit/src/builtins/paste.rs
@@ -35,6 +35,9 @@ fn parse_paste_args(args: &[String]) -> std::result::Result<(PasteOptions, Vec<S
             opts.serial = true;
         } else if try_parse_combined_flags(&mut p, &mut opts)? {
             // handled combined flags like -sd, or -sd ,
+        } else if p.is_flag() && p.current() != Some("--") {
+            // Reject unknown options instead of treating them as files.
+            return Err(invalid_option_msg("paste", p.current().unwrap_or_default()));
         } else if let Some(arg) = p.positional() {
             files.push(arg.to_string());
         }
@@ -96,6 +99,20 @@ fn try_parse_combined_flags(
     }
     p.advance();
     Ok(true)
+}
+
+/// Build an unrecognized-option message (no trailing newline; the caller
+/// appends it via `format!("{msg}\n")`). Mirrors `super::invalid_option`.
+fn invalid_option_msg(cmd: &str, arg: &str) -> String {
+    if let Some(long) = arg.strip_prefix("--") {
+        format!("{cmd}: unrecognized option '--{long}'")
+    } else {
+        let ch = arg
+            .strip_prefix('-')
+            .and_then(|s| s.chars().next())
+            .unwrap_or('-');
+        format!("{cmd}: invalid option -- '{ch}'")
+    }
 }
 
 fn parse_delim_spec(spec: &str) -> Vec<char> {
@@ -422,6 +439,13 @@ mod tests {
         .await;
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "x\ny\nz\n");
+    }
+
+    #[tokio::test]
+    async fn test_paste_rejects_unknown_option() {
+        let result = run_paste(&["-Q"], Some("a\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/patch.rs
+++ b/crates/bashkit/src/builtins/patch.rs
@@ -24,7 +24,8 @@ struct PatchOptions {
     target_file: Option<String>,
 }
 
-fn parse_patch_args(args: &[String]) -> PatchOptions {
+#[allow(clippy::result_large_err)]
+fn parse_patch_args(args: &[String]) -> std::result::Result<PatchOptions, ExecResult> {
     let mut opts = PatchOptions {
         strip: 0,
         dry_run: false,
@@ -40,6 +41,12 @@ fn parse_patch_args(args: &[String]) -> PatchOptions {
             opts.dry_run = true;
         } else if p.flag_any(&["-R", "--reverse"]) {
             opts.reverse = true;
+        } else if let Some(arg) = p
+            .current()
+            .filter(|a| a.starts_with('-') && a.len() > 1 && *a != "--")
+        {
+            // Unknown option-shaped token → reject (patch exits 2).
+            return Err(super::invalid_option("patch", arg, 2));
         } else if let Some(arg) = p.positional() {
             opts.target_file = Some(arg.to_string());
         } else {
@@ -47,7 +54,7 @@ fn parse_patch_args(args: &[String]) -> PatchOptions {
         }
     }
 
-    opts
+    Ok(opts)
 }
 
 /// A single hunk from a unified diff
@@ -296,7 +303,10 @@ impl Builtin for Patch {
         ) {
             return Ok(r);
         }
-        let opts = parse_patch_args(ctx.args);
+        let opts = match parse_patch_args(ctx.args) {
+            Ok(o) => o,
+            Err(e) => return Ok(e),
+        };
 
         let input = match ctx.stdin {
             Some(s) if !s.is_empty() => s.to_string(),
@@ -546,6 +556,14 @@ mod tests {
         assert_eq!(strip_path("a/b/c.txt", 1), "b/c.txt");
         assert_eq!(strip_path("a/b/c.txt", 2), "c.txt");
         assert_eq!(strip_path("a/b/c.txt", 5), "c.txt");
+    }
+
+    #[tokio::test]
+    async fn test_patch_invalid_option() {
+        let diff = "--- a/test.txt\n+++ b/test.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n";
+        let (result, _fs) = run_patch(&["-Q"], diff, &[("/test.txt", b"old\n")]).await;
+        assert_eq!(result.exit_code, 2);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/sed.rs
+++ b/crates/bashkit/src/builtins/sed.rs
@@ -257,7 +257,7 @@ struct SedOptions {
 }
 
 impl SedOptions {
-    fn parse(args: &[String]) -> Result<Self> {
+    fn parse(args: &[String]) -> Result<std::result::Result<Self, ExecResult>> {
         let mut opts = SedOptions {
             commands: Vec::new(),
             files: Vec::new(),
@@ -288,8 +288,11 @@ impl SedOptions {
                     let (addr, negate, cmd) = parse_sed_command(&args[i], opts.extended_regex)?;
                     opts.commands.push((addr, negate, cmd));
                 }
-            } else if arg.starts_with('-') {
-                // Unknown option - ignore
+            } else if arg == "-" || arg == "--" {
+                // "-" is the stdin operand; "--" ends options. Neither is a flag.
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                // Unknown option-shaped token → reject (sed exits 1).
+                return Ok(Err(super::invalid_option("sed", arg, 1)));
             } else if opts.commands.is_empty() {
                 // First non-option is the command (may contain multiple commands separated by ;)
                 for cmd_str in split_sed_commands(arg) {
@@ -310,7 +313,7 @@ impl SedOptions {
             return Err(Error::Execution("sed: no command given".to_string()));
         }
 
-        Ok(opts)
+        Ok(Ok(opts))
     }
 }
 
@@ -944,7 +947,10 @@ impl Builtin for Sed {
         ) {
             return Ok(r);
         }
-        let opts = SedOptions::parse(ctx.args)?;
+        let opts = match SedOptions::parse(ctx.args)? {
+            Ok(o) => o,
+            Err(e) => return Ok(e),
+        };
 
         // Determine input
         let inputs: Vec<(Option<String>, String)> = if opts.files.is_empty() {
@@ -1199,6 +1205,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.stdout, "goodbye world\ngoodbye again\n");
+    }
+
+    #[tokio::test]
+    async fn test_sed_invalid_option() {
+        let result = run_sed(&["-Q", "s/a/b/"], Some("a\n")).await.unwrap();
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/sortuniq.rs
+++ b/crates/bashkit/src/builtins/sortuniq.rs
@@ -378,6 +378,13 @@ impl Builtin for Sort {
                             _ => {}
                         }
                     }
+                } else if p.is_flag() && p.current() != Some("--") {
+                    // Reject unknown options instead of treating them as files.
+                    return Ok(super::invalid_option(
+                        "sort",
+                        p.current().unwrap_or_default(),
+                        2,
+                    ));
                 } else if let Some(arg) = p.positional() {
                     files.push(arg.to_string());
                 }
@@ -674,6 +681,13 @@ impl Builtin for Uniq {
                             _ => {}
                         }
                     }
+                } else if p.is_flag() && p.current() != Some("--") {
+                    // Reject unknown options instead of treating them as files.
+                    return Ok(super::invalid_option(
+                        "uniq",
+                        p.current().unwrap_or_default(),
+                        1,
+                    ));
                 } else if let Some(arg) = p.positional() {
                     files.push(arg.to_string());
                 }
@@ -1005,5 +1019,19 @@ mod tests {
         assert_eq!(month_ordinal("feb"), 2);
         assert_eq!(month_ordinal("Dec"), 12);
         assert_eq!(month_ordinal("xyz"), 0);
+    }
+
+    #[tokio::test]
+    async fn test_sort_rejects_unknown_option() {
+        let result = run_sort(&["-Q"], Some("a\n")).await;
+        assert_eq!(result.exit_code, 2);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_uniq_rejects_unknown_option() {
+        let result = run_uniq(&["-Q"], Some("a\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/split.rs
+++ b/crates/bashkit/src/builtins/split.rs
@@ -63,6 +63,10 @@ impl Builtin for Split {
                     num_chunks = ctx.args.get(i).and_then(|s| s.parse().ok());
                 }
                 "-d" | "--numeric-suffixes" => numeric_suffix = true,
+                // Reject unknown options; `-` (stdin) and `--` fall through.
+                s if s.starts_with('-') && s.len() > 1 && s != "--" => {
+                    return Ok(super::invalid_option("split", s, 1));
+                }
                 _ => positional.push(&ctx.args[i]),
             }
             i += 1;
@@ -259,6 +263,14 @@ mod tests {
         let result = run_split(&["/nonexistent"], None, fs).await;
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("cannot open"));
+    }
+
+    #[tokio::test]
+    async fn test_split_unknown_option() {
+        let fs = Arc::new(InMemoryFs::new()) as Arc<dyn FileSystem>;
+        let result = run_split(&["-Q"], Some("data"), fs).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -75,6 +75,11 @@ fn parse_strings_args(
                     .parse()
                     .map_err(|_| format!("strings: invalid minimum string length: '{}'", rest))?;
                 p.advance();
+            } else if arg != "--" && arg.starts_with('-') && arg.chars().count() == 2 {
+                // Reject an unknown single short option (e.g. `-Q`) like GNU
+                // strings. Multi-char dash tokens stay filenames (`-data.bin`).
+                let ch = arg[1..].chars().next().unwrap_or('-');
+                return Err(format!("strings: invalid option -- '{ch}'"));
             } else if let Some(file) = p.positional() {
                 files.push(file.to_string());
             } else {
@@ -424,5 +429,12 @@ mod tests {
         let result = run_strings(&["-n", "abc"], Some("test")).await;
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("invalid minimum string length"));
+    }
+
+    #[tokio::test]
+    async fn test_strings_rejects_unknown_option() {
+        let result = run_strings(&["-Q"], Some("test")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/system.rs
+++ b/crates/bashkit/src/builtins/system.rs
@@ -130,15 +130,37 @@ impl Builtin for Uname {
         let mut show_machine = false;
         let mut show_os = false;
 
+        // Reject unknown options like GNU uname; short flags bundle per-char.
         for arg in ctx.args {
             match arg.as_str() {
                 "-a" | "--all" => show_all = true,
-                "-s" | "--kernel-name" => show_kernel = true,
-                "-n" | "--nodename" => show_nodename = true,
-                "-r" | "--kernel-release" => show_release = true,
-                "-v" | "--kernel-version" => show_version = true,
-                "-m" | "--machine" => show_machine = true,
-                "-o" | "--operating-system" => show_os = true,
+                "--kernel-name" => show_kernel = true,
+                "--nodename" => show_nodename = true,
+                "--kernel-release" => show_release = true,
+                "--kernel-version" => show_version = true,
+                "--machine" => show_machine = true,
+                "--operating-system" => show_os = true,
+                "--processor" | "--hardware-platform" => {}
+                _ if arg.starts_with("--") => {
+                    return Ok(super::invalid_option("uname", arg, 1));
+                }
+                _ if arg.starts_with('-') && arg.len() > 1 => {
+                    for c in arg[1..].chars() {
+                        match c {
+                            'a' => show_all = true,
+                            's' => show_kernel = true,
+                            'n' => show_nodename = true,
+                            'r' => show_release = true,
+                            'v' => show_version = true,
+                            'm' => show_machine = true,
+                            'o' => show_os = true,
+                            'p' | 'i' => {}
+                            _ => {
+                                return Ok(super::invalid_option("uname", &format!("-{c}"), 1));
+                            }
+                        }
+                    }
+                }
                 _ => {}
             }
         }
@@ -257,6 +279,24 @@ impl Builtin for Id {
             Some("id (bashkit) 0.1"),
         ) {
             return Ok(r);
+        }
+
+        // Reject unknown options like GNU id; -u/-g/-n (and -un/-gn combos)
+        // are honored below, other real-id flags are accepted and ignored.
+        for arg in ctx.args {
+            if let Some(long) = arg.strip_prefix("--") {
+                match long.split('=').next().unwrap_or("") {
+                    "user" | "group" | "groups" | "name" | "real" | "zero" => {}
+                    _ => return Ok(super::invalid_option("id", arg, 1)),
+                }
+            } else if arg.starts_with('-') && arg.len() > 1 {
+                for c in arg[1..].chars() {
+                    match c {
+                        'u' | 'g' | 'G' | 'n' | 'r' | 'a' | 'z' => {}
+                        _ => return Ok(super::invalid_option("id", &format!("-{c}"), 1)),
+                    }
+                }
+            }
         }
 
         // Check for specific flags
@@ -411,5 +451,19 @@ mod tests {
     async fn test_id_group() {
         let result = run_builtin(&Id::new(), &["-g"]).await;
         assert_eq!(result.stdout, "1000\n");
+    }
+
+    #[tokio::test]
+    async fn test_uname_rejects_unknown_option() {
+        let result = run_builtin(&Uname::new(), &["-Q"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
+    async fn test_id_rejects_unknown_option() {
+        let result = run_builtin(&Id::new(), &["-Q"]).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/textrev.rs
+++ b/crates/bashkit/src/builtins/textrev.rs
@@ -19,6 +19,9 @@ async fn read_input(ctx: &Context<'_>) -> std::result::Result<String, ExecResult
     for arg in ctx.args {
         if !arg.starts_with('-') {
             files.push(arg);
+        } else if arg.len() > 1 && arg != "--" {
+            // rev takes no options → reject unknown option-shaped tokens (exits 1).
+            return Err(super::invalid_option("rev", arg, 1));
         }
     }
 
@@ -198,5 +201,55 @@ impl Builtin for Rev {
         output.push('\n');
 
         Ok(ExecResult::ok(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use crate::fs::InMemoryFs;
+
+    async fn run_rev(args: &[&str], stdin: Option<&str>) -> ExecResult {
+        let fs = Arc::new(InMemoryFs::new());
+        let mut variables = HashMap::new();
+        let env = HashMap::new();
+        let mut cwd = PathBuf::from("/");
+
+        let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs,
+            stdin,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        Rev.execute(ctx).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_rev_basic() {
+        let result = run_rev(&[], Some("hello\n")).await;
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout, "olleh\n");
+    }
+
+    #[tokio::test]
+    async fn test_rev_invalid_option() {
+        let result = run_rev(&["-Q"], Some("hello\n")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 }

--- a/crates/bashkit/src/builtins/wc.rs
+++ b/crates/bashkit/src/builtins/wc.rs
@@ -30,7 +30,8 @@ struct WcFlags {
 }
 
 impl WcFlags {
-    fn parse(args: &[String]) -> Self {
+    #[allow(clippy::result_large_err)]
+    fn parse(args: &[String]) -> std::result::Result<Self, ExecResult> {
         let mut lines = false;
         let mut words = false;
         let mut bytes = false;
@@ -42,12 +43,18 @@ impl WcFlags {
                 continue;
             }
             match arg.as_str() {
+                // Operand-shaped: "-" is stdin, "--" ends options; neither is a flag.
+                "-" | "--" => {}
                 "--lines" => lines = true,
                 "--words" => words = true,
                 "--bytes" => bytes = true,
                 "--chars" => chars = true,
                 "--max-line-length" => max_line_length = true,
-                _ if arg.starts_with('-') && !arg.starts_with("--") => {
+                // Unknown long option → reject (wc exits 1).
+                _ if arg.starts_with("--") => {
+                    return Err(super::invalid_option("wc", arg, 1));
+                }
+                _ => {
                     for ch in arg[1..].chars() {
                         match ch {
                             'l' => lines = true,
@@ -55,11 +62,10 @@ impl WcFlags {
                             'c' => bytes = true,
                             'm' => chars = true,
                             'L' => max_line_length = true,
-                            _ => {}
+                            _ => return Err(super::invalid_option("wc", &format!("-{ch}"), 1)),
                         }
                     }
                 }
-                _ => {}
             }
         }
 
@@ -70,13 +76,13 @@ impl WcFlags {
             bytes = true;
         }
 
-        Self {
+        Ok(Self {
             lines,
             words,
             bytes,
             chars,
             max_line_length,
-        }
+        })
     }
 
     /// Number of active count fields
@@ -104,7 +110,10 @@ impl Builtin for Wc {
         ) {
             return Ok(r);
         }
-        let flags = WcFlags::parse(ctx.args);
+        let flags = match WcFlags::parse(ctx.args) {
+            Ok(f) => f,
+            Err(e) => return Ok(e),
+        };
 
         let files: Vec<_> = ctx
             .args
@@ -339,6 +348,13 @@ mod tests {
         let result = run_wc(&["-L"], Some("short\nlongerline\n")).await;
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.trim().contains("10"));
+    }
+
+    #[tokio::test]
+    async fn test_wc_invalid_option() {
+        let result = run_wc(&["-Q"], Some("hello")).await;
+        assert_eq!(result.exit_code, 1);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/zip_cmd.rs
+++ b/crates/bashkit/src/builtins/zip_cmd.rs
@@ -70,23 +70,35 @@ struct UnzipOptions {
     overwrite: bool,
 }
 
-fn parse_zip_args(args: &[String]) -> std::result::Result<ZipOptions, String> {
+#[allow(clippy::result_large_err)]
+fn parse_zip_args(args: &[String]) -> std::result::Result<ZipOptions, ExecResult> {
     let mut recursive = false;
     let mut positional = Vec::new();
 
     for arg in args {
         match arg.as_str() {
             "-r" => recursive = true,
-            _ if !arg.starts_with('-') => positional.push(arg.clone()),
-            _ => {} // ignore unknown
+            // Preserve prior behavior for `-`/`--` (no-op), reject other
+            // option-shaped tokens like real Info-ZIP (bad command line -> 16).
+            "-" | "--" => {}
+            s if s.starts_with('-') && s.len() > 1 => {
+                return Err(super::invalid_option("zip", s, 16));
+            }
+            _ => positional.push(arg.clone()),
         }
     }
 
     if positional.is_empty() {
-        return Err("zip: missing archive name".to_string());
+        return Err(ExecResult::err(
+            "zip: missing archive name\n".to_string(),
+            1,
+        ));
     }
     if positional.len() < 2 {
-        return Err("zip: missing files to add".to_string());
+        return Err(ExecResult::err(
+            "zip: missing files to add\n".to_string(),
+            1,
+        ));
     }
 
     let archive = positional.remove(0);
@@ -97,7 +109,8 @@ fn parse_zip_args(args: &[String]) -> std::result::Result<ZipOptions, String> {
     })
 }
 
-fn parse_unzip_args(args: &[String]) -> std::result::Result<UnzipOptions, String> {
+#[allow(clippy::result_large_err)]
+fn parse_unzip_args(args: &[String]) -> std::result::Result<UnzipOptions, ExecResult> {
     let mut list_only = false;
     let mut extract_dir = None;
     let mut overwrite = false;
@@ -109,17 +122,30 @@ fn parse_unzip_args(args: &[String]) -> std::result::Result<UnzipOptions, String
             list_only = true;
         } else if p.flag("-o") {
             overwrite = true;
-        } else if let Some(val) = p.flag_value("-d", "unzip")? {
+        } else if let Some(val) = p
+            .flag_value("-d", "unzip")
+            .map_err(|e| ExecResult::err(format!("{e}\n"), 1))?
+        {
             extract_dir = Some(val.to_string());
+        } else if p.is_flag() && p.current() != Some("--") {
+            // Reject unknown options like real unzip (bad command line -> 10).
+            return Err(super::invalid_option(
+                "unzip",
+                p.current().unwrap_or_default(),
+                10,
+            ));
         } else if let Some(arg) = p.positional() {
             positional.push(arg.to_string());
         } else {
-            p.advance(); // ignore unknown
+            p.advance();
         }
     }
 
     if positional.is_empty() {
-        return Err("unzip: missing archive name".to_string());
+        return Err(ExecResult::err(
+            "unzip: missing archive name\n".to_string(),
+            1,
+        ));
     }
 
     Ok(UnzipOptions {
@@ -257,7 +283,7 @@ impl Builtin for Zip {
         }
         let opts = match parse_zip_args(ctx.args) {
             Ok(o) => o,
-            Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),
+            Err(e) => return Ok(e),
         };
 
         let mut entries = Vec::new();
@@ -322,7 +348,7 @@ impl Builtin for Unzip {
         }
         let opts = match parse_unzip_args(ctx.args) {
             Ok(o) => o,
-            Err(e) => return Ok(ExecResult::err(format!("{}\n", e), 1)),
+            Err(e) => return Ok(e),
         };
 
         let archive_path = resolve_path(ctx.cwd, &opts.archive);
@@ -551,6 +577,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_zip_unknown_option() {
+        let (result, _fs) = run_zip(&["-Q", "/archive.zip", "/a.txt"], &[]).await;
+        assert_eq!(result.exit_code, 16);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
+    }
+
+    #[tokio::test]
     async fn test_zip_file_not_found() {
         let (result, _fs) = run_zip(&["/archive.zip", "/nonexistent.txt"], &[]).await;
         assert_eq!(result.exit_code, 1);
@@ -721,6 +754,14 @@ mod tests {
         let result = Unzip.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 1);
         assert!(result.stderr.contains("missing archive"));
+    }
+
+    #[tokio::test]
+    async fn test_unzip_unknown_option() {
+        let fs = Arc::new(InMemoryFs::new());
+        let result = run_unzip(&["-Q", "/archive.zip"], fs).await;
+        assert_eq!(result.exit_code, 10);
+        assert!(result.stderr.contains("invalid option -- 'Q'"));
     }
 
     #[tokio::test]

--- a/specs/limitations.md
+++ b/specs/limitations.md
@@ -106,6 +106,8 @@ pass in CI); only divergences and boundaries are recorded here.
 | L-JQ-001 | jq | Alternative `//`: jaq errors on `.foo` applied to null instead of returning null (upstream jaq divergence) | 1 skipped spec test |
 | L-GREP-001 | grep | `--color`/`--colour`, `--line-buffered` accepted as no-ops | `l_grep_001_noop_flags` |
 | L-CURL-001 | curl | Spec-test coverage for methods/headers/payloads/auth/redirects not ported (needs `http_client` + allowlist in harness); behavior covered by integration tests | stance |
+| L-CURL-002 | curl/wget | Unknown options are ignored for compatibility, not rejected (real curl/wget error); deliberate leniency | `curl.rs` |
+| L-STR-001 | strings | Accepts dash-prefixed filenames (e.g. `-data.bin`), so only a lone unknown short option (`-Q`) is rejected as invalid; GNU rejects `-data.bin` too | `strings.rs` |
 
 Safety boundaries (enforced, not bugs): printf width/precision caps,
 output buffer caps, getline file-cache cap, shared regex size limit,


### PR DESCRIPTION
## What changed
A large set of builtin text/file utilities used to **silently swallow an unrecognized option as an operand** — `wc -Q` ran as if no option were given, `mkdir -Q d` created a dir, etc. They now reject unknown options the way real GNU coreutils do: print `"<cmd>: invalid option -- 'x'"` (short) / `"<cmd>: unrecognized option '--foo'"` (long) to stderr and exit with the tool's real status.

Commands fixed (26): `sort`, `uniq`, `cut`, `tr`, `nl`, `paste`, `join`, `strings`, `xxd`, `hexdump`, `column`, `fold`, `split`, `expand`, `unexpand`, `zip`, `unzip`, `diff`, `grep`, `wc`, `comm`, `head`, `tail`, `sed`, `date`, `rev`, `patch`, `mkdir`, `rm`, `cp`, `mv`, `chown`, `uname`, `id`, `envsubst`.

A shared `invalid_option(cmd, arg, code)` helper (added in the first commit) produces the exact GNU diagnostic so every tool is consistent.

## Why
This is the follow-up to the shell-invocation fix (#2182). The same class of bug — a mistyped option silently ignored — existed across the builtin surface, which hides typos in agent-generated scripts. This brings wrong-argument handling for tools/builtins close to real Bash + coreutils.

## Before / After

Before:
```
$ wc -Q; echo $?
0            # option silently ignored
```

After (matches real GNU coreutils, verified against this environment's tools):
```
$ wc -Q; echo $?
wc: invalid option -- 'Q'
1
$ sort -Q; echo $?
sort: invalid option -- 'Q'
2
```

Valid usage is preserved — `mkdir -p`, `rm -rf`, `head -2`, `tail -n1`, `--` end-of-options, `-`/stdin operands, and obsolete numeric forms (`head -5`, `tail -5`) all still work.

## Exit-code fidelity
Exit codes match the real tools captured from this environment: most coreutils use **1**; `sort`/`grep`/`diff`/`patch` use **2**; Info-ZIP `zip` uses **16**, `unzip` uses **10**.

## Deliberately out of scope / lenient (documented in `specs/limitations.md`)
- **curl/wget** stay intentionally lenient on unknown options (L-CURL-002).
- **strings** accepts dash-prefixed filenames, so only a lone unknown short option is rejected (L-STR-001).
- Deferred (need per-tool judgment, a leading `-` can be a valid operand or they're partial builtins): `printf`, `echo`, `seq`, `awk`, `dirs`, `mapfile`, `export`/`unset`, and custom tools (`csv`, `tomlq`, `git`, `ssh`).

## Risk
- Medium — behavioral change across many builtins, but each only newly errors on options the tool never recognized; no currently-accepted flag was touched (verified against all repo tests/examples). A script that fed a bad option and relied on it being ignored will now see the real coreutils error + exit code.

## Checklist
- [x] Tests added or updated (a unit test per command asserting the diagnostic + exit code)
- [x] Backward compatibility considered

Verified: 2761 lib tests + 1116 integration/spec tests pass; `clippy -D warnings` clean; `cargo fmt --check` clean; CLI smoke test confirms exact GNU parity and that valid flags still work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PapHJYVjgE7tgvLVefMKZi)_