### PR TITLE
chore(release): prepare v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.14.3] - 2026-07-18
+
+### Highlights
+
+- **Unknown options are now rejected like real Bash + coreutils.** Invoking the
+  shell with an unrecognized option (`bash --verison`) and passing an unknown
+  option to 26 builtins (`wc -Q`, `sort -Z`, …) previously ignored the option
+  silently and continued as if it were absent. Both now print the real
+  Bash/GNU-coreutils diagnostic and exit non-zero (coreutils exit codes
+  preserved), so a mistyped flag in an agent-generated script surfaces instead
+  of hiding ([#2182](https://github.com/everruns/bashkit/pull/2182),
+  [#2184](https://github.com/everruns/bashkit/pull/2184)).
+- **Browser/WebAssembly npm package renamed** `@everruns/bashkit-web` →
+  **`@everruns/bashkit-wasm`**, matching the Rust crate and reflecting that the
+  build runs in any JavaScript runtime (browsers, edge/serverless workers,
+  Node/Deno/Bun), not just browsers
+  ([#2183](https://github.com/everruns/bashkit/pull/2183)).
+
+### What's Changed
+
+* fix(builtins): reject unknown options like real coreutils ([#2184](https://github.com/everruns/bashkit/pull/2184)) by @chaliy
+* chore(wasm): rename npm package to @everruns/bashkit-wasm ([#2183](https://github.com/everruns/bashkit/pull/2183)) by @chaliy
+* fix(interpreter): reject unknown bash/sh invocation options like real Bash ([#2182](https://github.com/everruns/bashkit/pull/2182)) by @chaliy
+* docs: polish the browser example showcase ([#2181](https://github.com/everruns/bashkit/pull/2181)) by @chaliy
+* chore(examples): rebuild browser example on @everruns/bashkit-web ([#2180](https://github.com/everruns/bashkit/pull/2180)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.14.2...v0.14.3
+
 ## [0.14.2] - 2026-07-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bashkit",
  "napi",
@@ -500,7 +500,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.2"
+version = "0.14.3"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.14.2", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.14.3", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## What changed
Patch release **v0.14.3**. Bumps the workspace version, the `bashkit-cli` path-dep pin, the `bashkit-js` + `bashkit-wasm` `package.json`s, and `Cargo.lock` to `0.14.3`, and adds the changelog entry. On merge, `release.yml` tags `v0.14.3` and dispatches the publish workflows.

### Included since v0.14.2 (5 PRs)
- **fix(builtins): reject unknown options like real coreutils** ([#2184](https://github.com/everruns/bashkit/pull/2184)) — 26 builtins now error on unknown options instead of silently ignoring them.
- **chore(wasm): rename npm package to @everruns/bashkit-wasm** ([#2183](https://github.com/everruns/bashkit/pull/2183)) — first release under the new name.
- **fix(interpreter): reject unknown bash/sh invocation options** ([#2182](https://github.com/everruns/bashkit/pull/2182)).
- **docs: polish the browser example showcase** ([#2181](https://github.com/everruns/bashkit/pull/2181)).
- **chore(examples): rebuild browser example** ([#2180](https://github.com/everruns/bashkit/pull/2180)).

## Why
Ship the accumulated fixes and the browser-package rename to all registries. The two option-handling fixes (#2182, #2184) narrow Bash/coreutils parity gaps where mistyped flags were silently ignored; #2183 renames the browser WASM npm package before it has consumers.

## Before / After
Release-prep only — no runtime code changes in this PR (version bumps + changelog).

- **Before:** manifests at `0.14.2`; latest published everywhere is `0.14.2`.
- **After:** manifests at `0.14.3`; publish workflows will push `0.14.3`. The browser package publishes to the new name `@everruns/bashkit-wasm` (first release; old `@everruns/bashkit-web` stays at `0.14.2`, unused).

## Publish-readiness report
- **Version sync:** workspace `Cargo.toml`, `bashkit-cli` pin, `bashkit-js`/`bashkit-wasm` `package.json`, and all 8 `Cargo.lock` crate entries read `0.14.3`.
- **Greater than latest published:** npm `@everruns/bashkit` `0.14.2`, crates.io `bashkit`/`bashkit-cli` `0.14.2`, PyPI `bashkit` `0.14.2`; `@everruns/bashkit-wasm` unpublished (valid first release under the new name). `0.14.3` > all.
- **Publish dry-run:** `cargo publish --dry-run -p bashkit` (after applying `publish.yml`'s git-only Monty transform) packages cleanly — `Packaged 511 files`.
- **Format:** `cargo fmt --check` clean. Full clippy/test are re-run by this PR's CI; the underlying source already passed CI on `main`.

## Risk
- Low — version/changelog only; the shipped code already merged and passed CI on `main`.

## Checklist
- [x] Tests added or updated — n/a for release prep; feature PRs carried their own tests
- [x] Backward compatibility considered — #2182/#2184 make previously-ignored bad options error (documented parity fixes, exit codes match real tools)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQYfPptuzU5SpqEM6PdEhe)_