### PR TITLE
docs: add Targets & bindings page with a live in-browser bash terminal

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -13,6 +13,9 @@ Bashkit ships three bindings with the same core semantics:
 - **TypeScript / JavaScript** — a NAPI runtime for Node, Bun, and Deno
   (`npm i @everruns/bashkit`)
 
+For browser, edge, and Pyodide targets — and a side-by-side comparison of every
+package — see [Targets & bindings](targets.md).
+
 ## Rust
 
 ```bash
@@ -145,6 +148,7 @@ console.log(bash.executeSync("echo $X").stdout);
 
 ## Next steps
 
+- [Targets & bindings](targets.md) — pick a package for browser, edge, or Pyodide targets.
 - [Custom builtins](custom_builtins.md) — add your own Rust commands to the shell.
 - [Snapshotting](snapshotting.md) — serialize and restore interpreter state for
   checkpoint/resume flows.

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -94,6 +94,13 @@ const result = bash.executeSync('echo "Hello, browser!" | tr a-z A-Z');
 console.log(result.stdout); // HELLO, BROWSER!
 ```
 
+### Try it live
+
+This is the exact package above, running in your browser — no server, nothing
+you type leaves this page. Launch it and run some bash:
+
+<div data-bashkit-terminal></div>
+
 No bundler, straight from a CDN:
 
 ```html

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,0 +1,177 @@
+# Targets & bindings
+
+Bashkit is a single Rust core shipped as several distribution artifacts. The
+shell semantics, virtual filesystem, and sandbox are the same everywhere — you
+pick a package by **where your code runs** and **what host language you use**.
+
+## At a glance
+
+| Target | Install | Runs in | Notes |
+|--------|---------|---------|-------|
+| **Rust crate** | `cargo add bashkit` | Any Rust app | Core crate. Opt-in features for HTTP, git, Python, SQLite, real FS. |
+| **CLI** | `cargo install bashkit-cli` | Terminal | Standalone binary, three modes. See [CLI](cli.md). |
+| **Python (native)** | `pip install bashkit` | CPython 3.9+ | PyO3 wheel, native extension, no Rust toolchain. |
+| **Node / Bun / Deno** | `npm i @everruns/bashkit` | Node ≥ 18, Bun, Deno | NAPI native addon — the fastest JS binding. |
+| **WebAssembly** | `npm i @everruns/bashkit-wasm` | Browser, edge runtimes, Node/Bun/Deno | Single-threaded `wasm-bindgen` module. No `SharedArrayBuffer`, no COOP/COEP. |
+| **Pyodide / JupyterLite** | `micropip.install("bashkit")` | Pyodide, JupyterLite, WASM Python hosts | Reduced-feature Emscripten wheel. |
+
+**Which one?**
+
+- Embedding in a **Rust, Python, or Node/Bun/Deno** service → the native crate,
+  wheel, or NAPI addon. These share the full feature set — see
+  [Embedding](embedding.md) for the API.
+- Running in a **browser or edge/serverless runtime** (Cloudflare Workers,
+  Vercel Edge, Deno Deploy), or anywhere a native addon can't load → the
+  [WebAssembly package](#webassembly-browser--edge).
+- Running inside **Pyodide or JupyterLite** (Python in the browser) → the
+  [Pyodide wheel](#pyodide--emscripten-wheel).
+
+## Rust
+
+```bash
+cargo add bashkit
+```
+
+The core crate. Heavier capabilities are opt-in features (`http_client`, `git`,
+`typescript`, `sqlite`, `realfs`, `scripted_tool`). Full walkthrough —
+persistent state, the sandbox builder, network allowlist — in
+[Embedding › Rust](embedding.md#rust).
+
+## Python (native)
+
+```bash
+pip install bashkit
+```
+
+```python
+from bashkit import Bash
+
+bash = Bash()
+print(bash.execute_sync("echo 'Hello, World!'").stdout)
+```
+
+Pre-built binary wheels on PyPI — no Rust toolchain needed. See
+[Embedding › Python](embedding.md#python).
+
+## Node / Bun / Deno
+
+```bash
+npm i @everruns/bashkit
+```
+
+```typescript
+import { Bash } from "@everruns/bashkit";
+
+const bash = new Bash();
+console.log(bash.executeSync('echo "Hello, World!"').stdout);
+```
+
+A NAPI native addon — the fastest JavaScript binding, for server-side runtimes
+(Node ≥ 18, Bun, Deno). For browsers and edge runtimes, use the WebAssembly
+package below instead. See [Embedding › TypeScript](embedding.md#typescript--javascript).
+
+## WebAssembly (browser & edge)
+
+```bash
+npm i @everruns/bashkit-wasm
+```
+
+`@everruns/bashkit-wasm` is a slim, **single-threaded** `wasm-bindgen` module.
+Unlike a WASI-threads build it needs **no `SharedArrayBuffer` and no
+cross-origin isolation** (`COOP`/`COEP`) headers, so it drops into any web app —
+including embedded and third-party iframe contexts where those headers can't be
+set — and into edge/serverless runtimes that can't use threads.
+
+Load the `.wasm` once with `initBashkit()` before constructing `Bash`:
+
+```js
+import { initBashkit, Bash } from "@everruns/bashkit-wasm";
+
+await initBashkit();
+
+const bash = new Bash();
+const result = bash.executeSync('echo "Hello, browser!" | tr a-z A-Z');
+console.log(result.stdout); // HELLO, BROWSER!
+```
+
+No bundler, straight from a CDN:
+
+```html
+<script type="module">
+  import { initBashkit, Bash } from "https://esm.sh/@everruns/bashkit-wasm";
+  await initBashkit();
+  const bash = new Bash();
+  document.body.textContent = bash.executeSync("seq 1 5 | paste -sd+ | bc").stdout;
+</script>
+```
+
+Register JS callbacks as bash commands. Async callbacks (e.g. issuing a `fetch`)
+are awaited by the async `execute()` API:
+
+```js
+const bash = new Bash({
+  customBuiltins: {
+    graphql: async (ctx) => {
+      const res = await fetch("/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: ctx.stdin ?? "{}",
+      });
+      return await res.text();
+    },
+  },
+});
+
+const out = await bash.execute('echo "{ me { id } }" | graphql | jq .data');
+console.log(out.stdout);
+```
+
+**Caveats**
+
+- It's a `wasm-bindgen` module: it runs in any **JavaScript** host but **not** a
+  non-JS/WASI wasm runtime (`wasmtime`, `wasmer`).
+- Reduced feature set relative to the native bindings. Prefer
+  [`@everruns/bashkit`](#node--bun--deno) when a native addon can load
+  (server-side Node/Bun/Deno); reach for this package when it can't — browsers
+  and edge runtimes.
+
+A full interactive terminal built on this package lives in
+[`examples/browser`](https://github.com/everruns/bashkit/tree/main/examples/browser)
+(single `index.html` on Vite, no build step, no special headers).
+
+## Pyodide / Emscripten wheel
+
+For **Python running in the browser** (Pyodide, JupyterLite), Bashkit also
+ships an Emscripten (`wasm32-unknown-emscripten`) wheel:
+
+```python
+import micropip
+await micropip.install("bashkit")   # pulls the Pyodide-ABI wheel
+
+from bashkit import Bash
+print(Bash(python=True).execute_sync("echo hello && echo 1 | jq .").stdout)
+```
+
+If your Pyodide host doesn't resolve the ABI wheel automatically, pass the wheel
+URL to `micropip.install(...)`.
+
+This is a reduced-feature variant of the native PyPI wheel — the in-VFS shell
+plus embedded `jq` and Monty `python`, driven through blocking `execute_sync()`.
+
+**Present on both native and wasm:** `Bash` / `BashTool` / `ScriptedTool`,
+`execute_sync()`, Monty `python=True`, `jq`, and sync/async custom-builtin
+callbacks.
+
+**Absent on wasm:** the async `execute()` / `execute_or_throw()` methods,
+`FileSystem.real()`, and capsule `to/from_capsule`. Gated-off configuration
+kwargs — `network=`, `sqlite=True`, `mounts=`, `external_handler=` — **fail
+loudly** with `RuntimeError` at construction rather than silently no-op, so you
+learn immediately that the WASM build can't do it.
+
+## Next steps
+
+- [Embedding](embedding.md) — the library API for Rust, Python, and JS: persistent
+  state, the sandbox builder, resource limits, and the network allowlist.
+- [CLI](cli.md) — run scripts from the terminal with `bashkit-cli`.
+- [LLM tools](llm-tools.md) — expose Bashkit as a sandboxed tool for agent frameworks.
+- [Security](security.md) — sandbox boundaries and what scripts cannot do.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -13,6 +13,7 @@ const DOC_LINKS = new Map([
   ["compatibility.md", "/docs/compatibility/"],
   ["credential-injection.md", "/docs/credential-injection/"],
   ["custom_builtins.md", "/docs/custom-builtins/"],
+  ["embedding.md", "/docs/embedding/"],
   ["filesystem.md", "/docs/filesystem/"],
   ["git.md", "/docs/git/"],
   ["hooks.md", "/docs/hooks/"],
@@ -30,6 +31,7 @@ const DOC_LINKS = new Map([
   ["sqlite.md", "/docs/sqlite/"],
   ["ssh.md", "/docs/ssh/"],
   ["structured-data.md", "/docs/structured-data/"],
+  ["targets.md", "/docs/targets/"],
   ["threat-model.md", "/docs/security/"],
   ["typescript.md", "/docs/builtin_typescript/"],
 ]);
@@ -42,9 +44,12 @@ function normalizeGuideMarkdown() {
       }
 
       if (node.type === "link" && typeof node.url === "string") {
-        const target = DOC_LINKS.get(node.url.split("/").pop());
+        const hashIndex = node.url.indexOf("#");
+        const urlPath = hashIndex >= 0 ? node.url.slice(0, hashIndex) : node.url;
+        const hash = hashIndex >= 0 ? node.url.slice(hashIndex) : "";
+        const target = DOC_LINKS.get(urlPath.split("/").pop());
         if (target) {
-          node.url = target;
+          node.url = `${target}${hash}`;
           return;
         }
 

--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/sitemap": "^3.7.3",
+    "@everruns/bashkit-wasm": "0.14.3",
     "astro": "^7.0.0"
   },
   "devDependencies": {

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.7.3
         version: 3.7.3
+      '@everruns/bashkit-wasm':
+        specifier: 0.14.3
+        version: 0.14.3
       astro:
         specifier: ^7.0.0
         version: 7.0.0(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.9.1)(rollup@4.60.4)(yaml@2.9.0)
@@ -438,6 +441,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@everruns/bashkit-wasm@0.14.3':
+    resolution: {integrity: sha512-EboN/dXeA9YBBceM+MXPdyl+ptqpw9HZbaxxYkow/l2G6eEECEFF5NQVaRtMgcUQ9X4ajHIUjSRV2ZcLOg/DWA==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2572,6 +2578,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@everruns/bashkit-wasm@0.14.3': {}
 
   '@img/colour@1.1.0': {}
 

--- a/site/src/components/BashkitTerminal.astro
+++ b/site/src/components/BashkitTerminal.astro
@@ -1,0 +1,275 @@
+---
+// Live, in-browser bash terminal powered by @everruns/bashkit-wasm.
+//
+// Decision: docs are plain Markdown (no MDX), so pages opt in by dropping a
+// `<div data-bashkit-terminal></div>` marker where the terminal should appear.
+// This component ships only a small hydrator script (included site-wide via
+// DocsLayout); it no-ops when no marker is present. The WebAssembly module is
+// pulled in via dynamic import ONLY on click, so it never touches initial page
+// load — other docs pages pay nothing for it.
+---
+
+<script>
+  const mounts = document.querySelectorAll<HTMLElement>("[data-bashkit-terminal]");
+  if (mounts.length > 0) {
+    mounts.forEach(setupLauncher);
+  }
+
+  function setupLauncher(mount: HTMLElement) {
+    mount.classList.add("bk-term");
+    mount.innerHTML = `
+      <div class="bk-term__chrome" aria-hidden="true">
+        <span class="bk-term__dot"></span>
+        <span class="bk-term__dot"></span>
+        <span class="bk-term__dot"></span>
+        <span class="bk-term__label">bash — WebAssembly</span>
+      </div>
+      <div class="bk-term__stage">
+        <p class="bk-term__pitch">Real bash, running entirely in your browser. No server — nothing you type leaves this page.</p>
+        <button type="button" class="bk-term__launch">▶ Launch terminal</button>
+      </div>`;
+
+    const stage = mount.querySelector<HTMLElement>(".bk-term__stage")!;
+    const launch = mount.querySelector<HTMLButtonElement>(".bk-term__launch")!;
+
+    launch.addEventListener("click", async () => {
+      launch.disabled = true;
+      launch.textContent = "Loading WebAssembly…";
+      try {
+        const { initBashkit, Bash } = await import("@everruns/bashkit-wasm");
+        await initBashkit();
+        const bash = new Bash();
+        renderRepl(stage, bash);
+      } catch (err) {
+        stage.innerHTML = `<p class="bk-term__pitch">Couldn't load the WebAssembly module: ${escapeHtml(
+          String(err),
+        )}</p>`;
+      }
+    });
+  }
+
+  const EXAMPLES = [
+    'echo "Hello, browser!" | tr a-z A-Z',
+    "seq 1 5 | paste -sd+ | bc",
+    "echo '{\"tool\":\"bashkit\"}' | jq .tool",
+    "mkdir -p demo && echo hi > demo/a.txt && cat demo/a.txt",
+    "ls -la /",
+  ];
+
+  function renderRepl(stage: HTMLElement, bash: any) {
+    stage.classList.add("bk-term__stage--live");
+    stage.innerHTML = `
+      <div class="bk-term__out" role="log" aria-live="polite" aria-label="Terminal output"></div>
+      <div class="bk-term__chips">
+        ${EXAMPLES.map(
+          (ex) => `<button type="button" class="bk-term__chip">${escapeHtml(ex)}</button>`,
+        ).join("")}
+      </div>
+      <form class="bk-term__form">
+        <span class="bk-term__ps1" aria-hidden="true">$</span>
+        <input class="bk-term__input" type="text" autocomplete="off" autocapitalize="off"
+               spellcheck="false" aria-label="bash command" placeholder="type a command and press Enter" />
+        <button type="submit" class="bk-term__run">Run</button>
+      </form>`;
+
+    const out = stage.querySelector<HTMLElement>(".bk-term__out")!;
+    const form = stage.querySelector<HTMLFormElement>(".bk-term__form")!;
+    const input = stage.querySelector<HTMLInputElement>(".bk-term__input")!;
+
+    function append(text: string, cls: string) {
+      if (text === "") return;
+      const line = document.createElement("div");
+      line.className = cls;
+      line.textContent = text.replace(/\n+$/, "");
+      out.appendChild(line);
+      out.scrollTop = out.scrollHeight;
+    }
+
+    function show(res: any) {
+      append(res.stdout, "bk-term__stdout");
+      append(res.stderr, "bk-term__stderr");
+      if (res.stdoutTruncated || res.stderrTruncated) {
+        append("[output truncated by resource limit]", "bk-term__meta");
+      }
+    }
+
+    function run(cmd: string) {
+      const echo = document.createElement("div");
+      echo.className = "bk-term__echo";
+      echo.innerHTML = `<span class="bk-term__ps1">$</span> ${escapeHtml(cmd)}`;
+      out.appendChild(echo);
+      try {
+        show(bash.executeSync(cmd));
+      } catch {
+        // Script yielded (e.g. an async builtin) — retry on the async path.
+        bash
+          .execute(cmd)
+          .then(show)
+          .catch((err: unknown) => append(String(err), "bk-term__stderr"));
+      }
+      out.scrollTop = out.scrollHeight;
+    }
+
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const cmd = input.value.trim();
+      if (!cmd) return;
+      run(cmd);
+      input.value = "";
+      input.focus();
+    });
+
+    stage.querySelectorAll<HTMLButtonElement>(".bk-term__chip").forEach((chip) => {
+      chip.addEventListener("click", () => {
+        const cmd = chip.textContent ?? "";
+        input.value = cmd;
+        run(cmd);
+        input.value = "";
+        input.focus();
+      });
+    });
+
+    append("bashkit — sandboxed bash in WebAssembly. Try a command below.", "bk-term__meta");
+    input.focus();
+  }
+
+  function escapeHtml(s: string): string {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+</script>
+
+<style is:global>
+  .bk-term {
+    margin: var(--space-md) 0 var(--space-lg);
+    border: 1px solid rgb(10 22 54 / 0.15);
+    border-radius: 8px;
+    overflow: hidden;
+    background: #0d1117;
+    box-shadow: 0 12px 30px rgb(10 22 54 / 0.12);
+    font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  }
+  .bk-term__chrome {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 0.85rem;
+    background: #161b22;
+    border-bottom: 1px solid rgb(255 255 255 / 0.06);
+  }
+  .bk-term__dot {
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 50%;
+    background: #3a4150;
+  }
+  .bk-term__dot:nth-child(1) { background: #ff5f57; }
+  .bk-term__dot:nth-child(2) { background: #febc2e; }
+  .bk-term__dot:nth-child(3) { background: #28c840; }
+  .bk-term__label {
+    margin-left: 0.5rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    color: #8b949e;
+  }
+  .bk-term__stage {
+    padding: 1.3rem;
+  }
+  .bk-term__pitch {
+    margin: 0 0 1rem;
+    color: #adbac7;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    font-family: var(--font-sans, system-ui, sans-serif);
+  }
+  .bk-term__launch {
+    appearance: none;
+    border: 1px solid #2f81f7;
+    background: #1f6feb;
+    color: #fff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0.55rem 1.1rem;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .bk-term__launch:hover { background: #388bfd; }
+  .bk-term__launch:disabled { opacity: 0.6; cursor: progress; }
+
+  .bk-term__stage--live { padding: 0; }
+  .bk-term__out {
+    padding: 0.9rem 1rem;
+    min-height: 8rem;
+    max-height: 20rem;
+    overflow-y: auto;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    color: #d1d5db;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .bk-term__meta { color: #6e7681; font-style: italic; margin-bottom: 0.4rem; }
+  .bk-term__echo { color: #e6edf3; margin-top: 0.35rem; }
+  .bk-term__stdout { color: #adbac7; }
+  .bk-term__stderr { color: #ff7b72; }
+  .bk-term__ps1 { color: #3fb950; font-weight: 700; margin-right: 0.4rem; }
+
+  .bk-term__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.5rem 1rem;
+    border-top: 1px solid rgb(255 255 255 / 0.06);
+    background: #11161d;
+  }
+  .bk-term__chip {
+    appearance: none;
+    border: 1px solid rgb(255 255 255 / 0.12);
+    background: #1c2530;
+    color: #9db3c9;
+    font-family: inherit;
+    font-size: 0.72rem;
+    padding: 0.28rem 0.55rem;
+    border-radius: 999px;
+    cursor: pointer;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .bk-term__chip:hover { border-color: #2f81f7; color: #cfe0f2; }
+
+  .bk-term__form {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1rem;
+    border-top: 1px solid rgb(255 255 255 / 0.08);
+    background: #0d1117;
+  }
+  .bk-term__input {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #e6edf3;
+    font-family: inherit;
+    font-size: 0.85rem;
+  }
+  .bk-term__input::placeholder { color: #4d5765; }
+  .bk-term__run {
+    appearance: none;
+    border: 1px solid rgb(255 255 255 / 0.14);
+    background: #21262d;
+    color: #c9d1d9;
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 0.35rem 0.8rem;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .bk-term__run:hover { background: #2d333b; }
+</style>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "./BaseLayout.astro";
+import BashkitTerminal from "../components/BashkitTerminal.astro";
 import { DOC_META, DOC_META_BY_SLUG } from "../pages/docs/_meta";
 
 type NavLink = { href: string; title: string };
@@ -123,6 +124,7 @@ const editUrl =
       </footer>
     </div>
   </article>
+  <BashkitTerminal />
 </BaseLayout>
 
 <style>

--- a/site/src/pages/docs/_meta.ts
+++ b/site/src/pages/docs/_meta.ts
@@ -49,6 +49,16 @@ export const DOC_META: DocMeta[] = [
     editPath: "docs/embedding.md",
   },
   {
+    slug: "targets",
+    title: "Targets & bindings",
+    summary: "Pick a package: Rust, Python, Node/Bun/Deno, WebAssembly, or Pyodide.",
+    seoTitle: "Bashkit distribution targets: Rust, Python, npm, WASM, Pyodide",
+    seoDescription:
+      "Choose a Bashkit package by runtime: the Rust crate, PyPI wheel, npm NAPI addon, the @everruns/bashkit-wasm browser/edge package, or the Pyodide wheel.",
+    section: "Getting started",
+    editPath: "docs/targets.md",
+  },
+  {
     slug: "llm-tools",
     title: "LLM tools",
     summary: "Expose Bashkit as a sandboxed tool for agent frameworks.",


### PR DESCRIPTION
## What changed

A new **Targets & bindings** docs page (`/docs/targets`) that presents every Bashkit distribution artifact side-by-side — the Rust crate, PyPI wheel, npm NAPI addon (`@everruns/bashkit`), the WebAssembly package (`@everruns/bashkit-wasm`), and the Pyodide/Emscripten wheel — each with install command, a hello-world, and capability caveats.

Its WASM section carries a **live, in-browser bash terminal** built on `@everruns/bashkit-wasm`: readers click "Launch", then run real bash that executes entirely in their browser — no server, nothing typed leaves the page. The package demonstrates itself.

- The WebAssembly package and the Pyodide wheel had full specs and were published, but no public docs — this closes that gap.
- `BashkitTerminal.astro`: docs are plain Markdown (no MDX), so pages opt in with a `<div data-bashkit-terminal>` marker that a site-wide hydrator fills in. Only a tiny hydrator script ships on docs pages; the 5.9 MB WASM loads via **dynamic import only on click**, code-split into its own chunk — no other page (and not even the Targets page until you click) pays for it.
- Persistent `Bash` instance across commands, preset example chips, sync path with an async fallback, resource-limit-aware output.
- Fixed the site's markdown link rewriter to preserve `#anchor` fragments, so deep links like `embedding.md#rust` resolve to `/docs/embedding/#rust`.
- Wired into `DOC_META` (nav, index, prev/next), `/llms.txt`, and the markdown routes; cross-linked with `embedding.md`.
- `@everruns/bashkit-wasm` pinned to the workspace version (0.14.3).

## Why

The docs described language/platform targets only in prose buried in `embedding.md`, and the browser/edge WASM package and Pyodide wheel weren't documented at all despite being published. A dedicated targets hub makes distribution discoverable; a live terminal turns "runs bash safely in the browser" from a claim into something the reader can try in one click.

## Before / After

**Before:** static code snippets only; no WASM/Pyodide docs.

**After:** live terminal verified end-to-end in headless Chromium (launch → WASM loads → commands run):

```
$ echo "hello, browser!" | tr a-z A-Z    → HELLO, BROWSER!
$ seq 1 5 | paste -sd+ | bc              → 15
$ mkdir -p demo && echo hi > demo/a.txt && cat demo/a.txt   → hi
$ echo '{"tool":"bashkit"}' | jq .tool   → "bashkit"
$ X=42                                   (then...)
$ echo "state: $X"                       → state: 42     (persistent instance)
```

Zero page/console errors. Full site build + all nine postbuild verifiers pass locally (mirrors the `Site` CI workflow).

## Risk

- **Low.** Docs + Astro site only; no library, CLI, or binding code changed. The WASM binary is lazy-loaded on click, so page-load performance is unaffected. The one `innerHTML` sink (command echo) is `escapeHtml`-guarded; output is rendered via `textContent`.

## Checklist

- [x] Tests added or updated — site build verifiers + end-to-end browser drive of the terminal (no Rust code changed)
- [x] Backward compatibility considered — additive; no existing routes or APIs altered


---
_Generated by [Claude Code](https://claude.ai/code/session_01SdnkEKQVZjWip2SUEzkCMN)_