### PR TITLE
Revert "build(python): ship abi3 stable-ABI wheels (#2187)"

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -92,20 +92,16 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # abi3 wheels target a fixed interpreter floor (py39), so a single build
-      # produces one `cp39-abi3` wheel per platform for all Python >= 3.9. Build
-      # with 3.9 (present in every manylinux image and installed here for the
-      # macOS/Windows host builds) to anchor the abi3 floor.
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist -i 3.9 --features abi3
+          args: --release --out dist -i ${{ env.PYTHON_VERSIONS }}
           rust-toolchain: stable
           docker-options: -e CI
           working-directory: crates/bashkit-python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -81,12 +81,9 @@ jobs:
       - name: Install maturin
         run: python -m pip install "maturin${MATURIN_VERSION}"
 
-      # Build the abi3 wheel (the actual release artifact) and run pytest against
-      # it on each version, so the single cp39-abi3 wheel is runtime-validated on
-      # 3.9-3.14, not just the version it was compiled with.
       - name: Build wheel
         working-directory: crates/bashkit-python
-        run: python -m maturin build --release --out dist -i python${{ matrix.python-version }} --features abi3
+        run: python -m maturin build --release --out dist -i python${{ matrix.python-version }}
 
       - name: Install wheel and test dependencies
         run: |
@@ -171,7 +168,7 @@ jobs:
 
       - name: Build wheel
         working-directory: crates/bashkit-python
-        run: python -m maturin build --release --out dist --features abi3
+        run: python -m maturin build --release --out dist
 
       - name: Verify wheel metadata
         run: |

--- a/crates/bashkit-python/Cargo.toml
+++ b/crates/bashkit-python/Cargo.toml
@@ -15,17 +15,6 @@ crate-type = ["cdylib"]
 name = "bashkit"
 doc = false  # Python extension, no Rust docs needed
 
-[features]
-# Stable-ABI (abi3) build. Enabling `abi3-py39` makes pyo3 target the CPython
-# limited API with a 3.9 floor, so a single forward-compatible `cp39-abi3` wheel
-# per platform serves every Python >= 3.9 — instead of one wheel per minor
-# (7 platforms x 6 versions = 42 wheels dropped to 7). Cuts per-release PyPI
-# storage ~6x. Off by default so local `maturin develop` keeps a fast,
-# version-specific build; the release/CI wheel builds pass `--features abi3`.
-# Safe here: the crate's only raw FFI symbol is `PyGILState_Check` (in the
-# limited API since 3.2); everything else goes through pyo3's abi3-safe bindings.
-abi3 = ["pyo3/abi3-py39"]
-
 [dependencies]
 # PyO3 native extension
 pyo3 = { workspace = true }

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -206,17 +206,26 @@ fn _mark_interpreter_at_exit() {
     INTERPRETER_AT_EXIT.store(true, Ordering::Release);
 }
 
+/// Whether the current thread is attached to the Python interpreter (holds
+/// the GIL). Used by teardown paths to decide whether a blocking join must
+/// be wrapped in a detach.
+fn thread_attached_to_python() -> bool {
+    // SAFETY: PyGILState_Check only reads thread-local interpreter state and
+    // is documented as callable from any thread at any time.
+    unsafe { pyo3::ffi::PyGILState_Check() == 1 }
+}
+
 /// Run `f` (a blocking join) without holding the GIL, so threads that must
-/// attach to finish can make progress. `Python::attach` is a no-op when the
-/// calling thread already holds the GIL (the pyclass-dealloc case) and
-/// otherwise briefly acquires it; either way `detach` releases the GIL for the
-/// duration of `f`. Callers must check `interpreter_at_exit()` first: once the
-/// interpreter is exiting, joining threads that may touch Python is unsafe and
-/// acquiring the GIL could abort during finalization. With that guard the
-/// interpreter is always alive here, so the unconditional attach is safe — and
-/// it avoids `PyGILState_Check`, which the CPython limited API (abi3) omits.
+/// attach to finish can make progress. Detaches first when the calling
+/// thread is attached (the pyclass-dealloc case); runs `f` directly when it
+/// is not. Callers must check `interpreter_at_exit()` first: once the
+/// interpreter is exiting, joining threads that may touch Python is unsafe.
 fn join_without_gil<F: FnOnce() + Send>(f: F) {
-    Python::attach(|py| py.detach(f));
+    if thread_attached_to_python() {
+        Python::attach(|py| py.detach(f));
+    } else {
+        f();
+    }
 }
 
 /// Pyclass-held handle to the shared per-instance tokio runtime.
@@ -805,9 +814,7 @@ impl PythonLazyFilesFs {
                     normalized.display()
                 )
             })?;
-            // `to_cow` (not `to_str`) so this compiles under the CPython
-            // limited API (abi3): `to_str` needs a non-limited symbol.
-            let text = text.to_cow().map_err(|e| e.to_string())?;
+            let text = text.to_str().map_err(|e| e.to_string())?;
             let content_size = text.len();
             let max_file_size = FsLimits::default().max_file_size as usize;
             if content_size > max_file_size {

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -31,21 +31,9 @@ workspace `Cargo.toml` → `bashkit-python` `Cargo.toml` (inherits) → maturin 
 
 ## Supported Platforms
 
-7 platforms: Linux x86_64/aarch64 (manylinux glibc + musllinux_1_1), macOS
-x86_64/aarch64, Windows x86_64 MSVC. Exact matrix and runners:
-`.github/workflows/publish-python.yml`.
-
-**Stable ABI (abi3).** Native wheels are built once per platform against the
-CPython limited API with a 3.9 floor (`pyo3/abi3-py39`, enabled by the crate's
-`abi3` feature), producing a single forward-compatible `cp39-abi3` wheel per
-platform that installs on every Python ≥ 3.9. This replaces the former
-per-minor matrix (3.9–3.14 × 7 ≈ 42 wheels → 7 wheels), cutting per-release
-PyPI storage ~6×. The `abi3` feature is off by default (local `maturin develop`
-stays a fast version-specific build); the release and PR-CI wheel builds pass
-`--features abi3`. PR CI (`python.yml`) still runs the test suite on
-3.9/3.12/3.13/3.14, each against the abi3 wheel, so the shipped artifact is
-runtime-validated across the range. abi3 is sound here because the extension's
-only raw FFI symbol is `PyGILState_Check` (limited API since 3.2).
+Python 3.9–3.14 × 7 platforms ≈ 42 wheels: Linux x86_64/aarch64 (manylinux
+glibc + musllinux_1_1), macOS x86_64/aarch64, Windows x86_64 MSVC. Exact
+matrix and runners: `.github/workflows/publish-python.yml`.
 
 In addition, a **reduced-feature Pyodide/Emscripten wheel**
 (`wasm32-unknown-emscripten`) ships for browser / JupyterLite use — built and


### PR DESCRIPTION
## What changed
Reverts #2187 (`cf4f5fad40c135eed7062aeab9ad6e880b7547b8`), backing the abi3 stable-ABI wheel work out of `main`.

Restores the pre-abi3 state:
- `crates/bashkit-python/Cargo.toml` — removes the `abi3` feature.
- `.github/workflows/publish-python.yml` / `python.yml` — back to the per-Python-version wheel matrix (`-i 3.9 3.10 … 3.14`, no `--features abi3`).
- `crates/bashkit-python/src/lib.rs` — restores the original `PyGILState_Check`-based `thread_attached_to_python` / `join_without_gil` and `PyString::to_str` (both were only changed to satisfy the abi3 limited-API build).
- `specs/python-package.md` — back to the 42-wheel description.

## Why
abi3 is being handled by another workstream; #2187 landed on `main` concurrently and should be reverted so that work is the single source of truth. No user-facing behavior change — this only affects how the Python wheels are built/packaged, and returns it to exactly the prior mechanism.

## Risk
- Low — pure revert of a build/packaging change; the reverted commit's own CI was green, and this restores the long-standing matrix.

## Checklist
- [x] Tests added or updated — n/a (revert of a packaging change)
- [x] Backward compatibility considered — returns to the prior wheel-build behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQYfPptuzU5SpqEM6PdEhe)_