### PR TITLE
chore(python): build abi3 wheels to cut PyPI storage ~6x

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -19,7 +19,10 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  PYTHON_VERSIONS: "3.9 3.10 3.11 3.12 3.13 3.14"
+  # abi3 (stable ABI): one interpreter builds a single cp39-abi3 wheel per
+  # platform that runs on Python 3.9+. No per-minor-version matrix. See
+  # specs/python-package.md § abi3.
+  BUILD_PYTHON: "3.12"
 
 jobs:
   # Source distribution (platform-independent)
@@ -101,7 +104,9 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist -i ${{ env.PYTHON_VERSIONS }}
+          # abi3: maturin reads pyo3's abi3-py39 feature and emits a single
+          # cp39-abi3 wheel per platform from one build interpreter. No -i list.
+          args: --release --out dist -i ${{ env.BUILD_PYTHON }}
           rust-toolchain: stable
           docker-options: -e CI
           working-directory: crates/bashkit-python

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -220,32 +220,26 @@ jobs:
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - run: uvx twine check dist/*
 
-  # Smoke-test wheels on each OS, including the new cp314 artifacts
+  # Smoke-test the single cp39-abi3 wheel on every targeted Python version.
+  # With abi3 there is one wheel per platform, so this is the check that it
+  # actually installs and runs across the full 3.9–3.14 range it claims — not
+  # just the build interpreter. os × python-version cross-product (18 jobs);
+  # the include entries only map each os to its runner.
   test-builds:
     name: Test wheel on ${{ matrix.os }} (Python ${{ matrix.python-version }})
     needs: [build]
     strategy:
       fail-fast: false
       matrix:
+        os: [linux, macos, windows]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: linux
             runs-on: ubuntu-latest
-            python-version: "3.12"
-          - os: linux
-            runs-on: ubuntu-latest
-            python-version: "3.14"
           - os: macos
             runs-on: macos-latest
-            python-version: "3.12"
-          - os: macos
-            runs-on: macos-latest
-            python-version: "3.14"
           - os: windows
             runs-on: windows-latest
-            python-version: "3.12"
-          - os: windows
-            runs-on: windows-latest
-            python-version: "3.14"
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -59,19 +59,32 @@ jobs:
           pip install mypy
           mypy crates/bashkit-python/bashkit/ --ignore-missing-imports
 
+  # Run the full pytest suite on every targeted Python version. The bashkit
+  # extension is abi3 (one cp39-abi3 wheel for all versions), so it is built
+  # ONCE by build-wheel and downloaded here instead of rebuilt per leg. Only
+  # the random-fs fixture — a separate, non-abi3 extension — is still built per
+  # version. Covers 3.9–3.14 (the full abi3 support range).
   test:
     name: Test (Python ${{ matrix.python-version }})
+    needs: [build-wheel]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
+
+      # The single abi3 wheel produced once by build-wheel; install it on each
+      # version to prove one wheel runs across the whole 3.9–3.14 range.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: python-wheel
+          path: crates/bashkit-python/dist
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
@@ -81,15 +94,13 @@ jobs:
       - name: Install maturin
         run: python -m pip install "maturin${MATURIN_VERSION}"
 
-      - name: Build wheel
-        working-directory: crates/bashkit-python
-        run: python -m maturin build --release --out dist -i python${{ matrix.python-version }}
-
       - name: Install wheel and test dependencies
         run: |
           pip install bashkit --no-index --find-links crates/bashkit-python/dist --force-reinstall
           pip install pytest pytest-asyncio langchain-core langgraph fastapi httpx maturin
 
+      # random-fs is a separate, non-abi3 pyo3 extension (own workspace, no
+      # abi3-py39), so it must be built against each interpreter.
       - name: Build random filesystem fixture
         run: |
           python -m maturin build --release --out /tmp/bashkit-random-fs \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,13 @@ turso_core = "0.7"
 serial_test = "3"
 
 # Python bindings
-pyo3 = { version = "0.29", features = ["extension-module", "generate-import-lib"] }
+# Important decision (PyPI storage): `abi3-py39` builds against CPython's stable
+# ABI (limited API), so ONE wheel per platform runs on Python 3.9+ instead of a
+# separate binary per minor version. Collapses the 6-version × 7-platform matrix
+# (42 native wheels/release, ~12 MB each) to 7, and future Python releases need
+# no rebuild. `generate-import-lib` kept for the Windows abi3 import lib.
+# See specs/python-package.md § abi3.
+pyo3 = { version = "0.29", features = ["extension-module", "generate-import-lib", "abi3-py39"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 
 # JavaScript/Node.js bindings (NAPI-RS)

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -206,25 +206,31 @@ fn _mark_interpreter_at_exit() {
     INTERPRETER_AT_EXIT.store(true, Ordering::Release);
 }
 
-/// Whether the current thread is attached to the Python interpreter (holds
-/// the GIL). Used by teardown paths to decide whether a blocking join must
-/// be wrapped in a detach.
-fn thread_attached_to_python() -> bool {
-    // SAFETY: PyGILState_Check only reads thread-local interpreter state and
-    // is documented as callable from any thread at any time.
-    unsafe { pyo3::ffi::PyGILState_Check() == 1 }
-}
-
 /// Run `f` (a blocking join) without holding the GIL, so threads that must
 /// attach to finish can make progress. Detaches first when the calling
 /// thread is attached (the pyclass-dealloc case); runs `f` directly when it
 /// is not. Callers must check `interpreter_at_exit()` first: once the
 /// interpreter is exiting, joining threads that may touch Python is unsafe.
+///
+/// abi3: `PyGILState_Check` is not in the limited API, and pyo3 documents it as
+/// unreliable for this purpose (spurious `1` once sub-interpreter APIs have been
+/// used). Probe with the public `Python::try_attach` instead: it attaches only
+/// when the interpreter is live and attachable (not finalizing, not mid
+/// `__traverse__`) — reattaching reentrantly when the caller already holds the
+/// GIL (the pyclass-dealloc path) — and `py.detach` then releases the GIL for
+/// the join regardless. When it can't attach, the closure never runs and we
+/// join directly (a plain thread join touches no Python state).
 fn join_without_gil<F: FnOnce() + Send>(f: F) {
-    if thread_attached_to_python() {
-        Python::attach(|py| py.detach(f));
-    } else {
-        f();
+    let mut f = Some(f);
+    let attached = Python::try_attach(|py| {
+        let f = f.take().expect("try_attach runs the closure at most once");
+        py.detach(f);
+    });
+    if attached.is_none() {
+        // Interpreter not attachable; run the join without touching Python.
+        if let Some(f) = f.take() {
+            f();
+        }
     }
 }
 
@@ -814,7 +820,10 @@ impl PythonLazyFilesFs {
                     normalized.display()
                 )
             })?;
-            let text = text.to_str().map_err(|e| e.to_string())?;
+            // `to_cow` (not `to_str`) for abi3: `PyString::to_str` needs the
+            // non-limited API on <3.10; `to_cow` is in the stable ABI and keeps
+            // the same UnicodeEncodeError on unpaired surrogates.
+            let text = text.to_cow().map_err(|e| e.to_string())?;
             let content_size = text.len();
             let max_file_size = FsLimits::default().max_file_size as usize;
             if content_size > max_file_size {

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -238,6 +238,12 @@ axis to one, cutting per-release native wheels 6× (42 → 7, ~500 MB → ~85 MB
 and shrinking the build matrix by the same factor. The perf cost of the limited
 API is negligible here because hot paths are in Rust, not Python dispatch.
 
+Because the build now emits one wheel instead of one-per-version, the
+`test-builds` job in `publish-python.yml` installs and smoke-tests that single
+wheel across the full 3.9–3.14 range on every OS (3 × 6 = 18 jobs) — the check
+that the abi3 wheel really runs everywhere it claims, not just on the build
+interpreter.
+
 Limited-API constraints observed in `crates/bashkit-python/src/lib.rs`:
 
 - **No `PyGILState_Check`** (not in the stable ABI, and pyo3 documents it as

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -204,10 +204,12 @@ invocation regardless of mechanism.
 ## CI
 
 `.github/workflows/python.yml` — on push to main and PRs (path-filtered).
-Jobs: lint (ruff check + format), test (maturin develop + pytest on
-3.9/3.12/3.13/3.14), examples (wheel + `crates/bashkit-python/examples/` +
+Jobs: lint (ruff check + format), test (installs the single abi3 wheel from
+build-wheel + pytest on 3.9–3.14; only the non-abi3 random-fs fixture is built
+per version), examples (wheel + `crates/bashkit-python/examples/` +
 `examples/*.ipynb` via `jupyter nbconvert --execute`, cell error fails CI),
-build-wheel (maturin + twine check), python-check (branch-protection gate).
+build-wheel (maturin + twine check, produces the shared abi3 wheel artifact),
+python-check (branch-protection gate).
 
 ## Linting
 

--- a/specs/python-package.md
+++ b/specs/python-package.md
@@ -31,9 +31,13 @@ workspace `Cargo.toml` → `bashkit-python` `Cargo.toml` (inherits) → maturin 
 
 ## Supported Platforms
 
-Python 3.9–3.14 × 7 platforms ≈ 42 wheels: Linux x86_64/aarch64 (manylinux
-glibc + musllinux_1_1), macOS x86_64/aarch64, Windows x86_64 MSVC. Exact
-matrix and runners: `.github/workflows/publish-python.yml`.
+7 platforms: Linux x86_64/aarch64 (manylinux glibc + musllinux_1_1), macOS
+x86_64/aarch64, Windows x86_64 MSVC. Exact matrix and runners:
+`.github/workflows/publish-python.yml`.
+
+Thanks to abi3 (below) this is **7 native wheels per release** (one
+`cp39-abi3` wheel per platform, each running on Python 3.9+), not one wheel per
+`{Python minor × platform}` combination.
 
 In addition, a **reduced-feature Pyodide/Emscripten wheel**
 (`wasm32-unknown-emscripten`) ships for browser / JupyterLite use — built and
@@ -217,6 +221,33 @@ cd crates/bashkit-python
 pip install maturin && maturin develop      # --release for optimized
 pip install pytest pytest-asyncio && pytest tests/ -v
 ```
+
+## abi3 (stable ABI)
+
+The extension is built against CPython's [limited API / stable
+ABI](https://docs.python.org/3/c-api/stable.html) via PyO3's `abi3-py39`
+feature (in the workspace `pyo3` dependency). One `cp39-abi3` wheel per
+platform runs on **every Python ≥ 3.9**, including versions released after the
+wheel was built — no per-minor-version rebuild.
+
+Why: PyPI keeps every historical release forever, and each native wheel is a
+~12 MB static binary (embedded jq / Monty / SQLite / SSH / TLS). Building one
+wheel per `{Python minor × platform}` was 6 × 7 = 42 native wheels (~500 MB)
+*per release*, growing unbounded across releases. abi3 collapses the Python
+axis to one, cutting per-release native wheels 6× (42 → 7, ~500 MB → ~85 MB)
+and shrinking the build matrix by the same factor. The perf cost of the limited
+API is negligible here because hot paths are in Rust, not Python dispatch.
+
+Limited-API constraints observed in `crates/bashkit-python/src/lib.rs`:
+
+- **No `PyGILState_Check`** (not in the stable ABI, and pyo3 documents it as
+  unreliable). Teardown's `join_without_gil` probes attachment via the public
+  `Python::try_attach` + `py.detach` instead.
+- **No `PyString::to_str`** on the `&self`-only path (needs the non-limited API
+  below 3.10). Lazy file providers use `to_cow()`, which is in the stable ABI.
+
+The emscripten/Pyodide wheel is unaffected — it already ships a single Python
+version on a separate toolchain (see `specs/emscripten-wheels.md`).
 
 ## Design Decisions
 


### PR DESCRIPTION
## What changed

The Python extension is now built against CPython's stable ABI (PyO3 `abi3-py39`). Instead of one native binary per Python minor version, we ship **one `cp39-abi3` wheel per platform** that runs on Python 3.9+ (including future releases, with no rebuild).

- `Cargo.toml`: add `abi3-py39` to the workspace `pyo3` feature set.
- `publish-python.yml`: build each platform wheel with a single interpreter (`BUILD_PYTHON`) instead of a per-version `-i` list; expand the release smoke-test to the full `os × version` cross-product (3 × 6 = 18 jobs) so the single wheel is proven on every version it claims.
- `python.yml`: build the abi3 wheel once (reuse the `build-wheel` artifact) and download it into each test leg rather than rebuilding per version; widen the pytest matrix to the full 3.9–3.14 range. The non-abi3 `random-fs` test fixture is still built per interpreter.
- `src/lib.rs`: two limited-API fixes abi3 surfaced —
  - `join_without_gil` probes attachment via the public `Python::try_attach` + `py.detach` instead of `PyGILState_Check`, which is not in the stable ABI (and pyo3 documents as unreliable). The GIL is still released for the blocking join.
  - Lazy file providers use `PyString::to_cow` (stable ABI) instead of `to_str` (needs the non-limited API below 3.10). Same `UnicodeEncodeError` on unpaired surrogates.
- `specs/python-package.md`: document the abi3 decision, its constraints, and the updated CI shape.

## Why

PyPI keeps every historical release forever, and each native wheel is a ~12 MB static binary (embedded jq / Monty / SQLite / SSH / TLS). Building one wheel per `{Python minor × platform}` was 6 × 7 = 42 native wheels (~500 MB) **per release**, growing unbounded. abi3 collapses the Python axis to one.

## Before / After

| | Before | After |
|---|--------|-------|
| Native wheels per release | 42 (6 versions × 7 platforms) | **7** (1 per platform) |
| Approx. size per release | ~500 MB | **~85 MB** |
| New Python version support | rebuild + republish | works with no rebuild |
| PR test matrix (`python.yml`) | full suite on 3.9/3.12/3.13/3.14, wheel rebuilt per leg | full suite on **3.9–3.14**, wheel built once |
| Release smoke-test | 3.12 + 3.14 | **3.9–3.14 × 3 OSes** |

Verification:
- `cp39-abi3` wheel builds, installs, and runs on Python 3.11 (`execute_sync('echo hello')` → exit 0), proving one wheel is cross-version.
- CI: `Test (Python 3.9 / 3.10 / 3.11 / 3.12 / 3.13 / 3.14)` all green — the single abi3 wheel installs and passes the full suite on every version.
- Full Python suite: **735 passed, 2 skipped**. `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `ruff check` + `ruff format --check` clean.
- The teardown-determinism suite (49 tests) passes, exercising the `join_without_gil` change specifically.
- One test (`test_tm_dos_021_fork_bomb_blocked`) segfaults **only in debug builds** — verified pre-existing: it segfaults identically on unmodified `main` (deep-recursion stack overflow; the release build's recursion guard catches it, which is why CI is green). Not a regression from this change, so it is deselected in the local debug runs above.

## Risk

- **Low.** No public API change. The two `lib.rs` edits are behavior-preserving limited-API substitutions covered by existing tests. abi3 is a widely-used, standard PyO3 mode. The only behavioral surface is packaging (wheel tags), validated across 3.9–3.14 in CI.
- What could break: an abi3 wheel failing to load on some interpreter — mitigated by the expanded 3.9–3.14 install/smoke matrix in both workflows.

## Checklist
- [x] Tests added or updated (existing coverage exercises both changed paths; CI matrix widened to 3.9–3.14)
- [x] Backward compatibility considered (no API change; internal greenfield code)