### PR TITLE
feat(wasm): persist browser example files

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -26,7 +26,9 @@ cross-origin isolation** — there are no `COOP`/`COEP` headers in
 `vite.config.js`, and it drops into any static host or bundler (including
 embedded / third-party iframe contexts where those headers cannot be set).
 
-The terminal UI is a single `index.html` — no framework.
+The terminal UI is a single `index.html` — no framework. The `browserLocal`
+storage backend snapshots files under `/home/user` to `localStorage` after each
+command and restores them on the next page load.
 
 ## Feature Surface
 
@@ -45,6 +47,7 @@ mounts. Reach the network from a custom builtin that calls the app's own
 | `pnpm start` / `pnpm dev` | Start the Vite dev server |
 | `pnpm run build` | Production bundle |
 | `pnpm run preview` | Preview the production bundle |
+| `pnpm test` | Test the `browserLocal` storage backend |
 
 ## Requirements
 

--- a/examples/browser/browser-local.js
+++ b/examples/browser/browser-local.js
@@ -1,0 +1,76 @@
+// browserLocal persists the browser example's /home/user tree in localStorage.
+const DEFAULT_KEY = "bashkit:fs";
+const DEFAULT_ROOT = "/home/user";
+const FORMAT_VERSION = 1;
+
+function isStoredPath(path, root) {
+  if (typeof path !== "string" || typeof root !== "string") return false;
+  if (path !== root && !path.startsWith(`${root}/`)) return false;
+  return !path.split("/").includes("..");
+}
+
+function joinPath(parent, child) {
+  return parent === "/" ? `/${child}` : `${parent}/${child}`;
+}
+
+function readStoredFiles(storage, key, root) {
+  try {
+    const value = JSON.parse(storage.getItem(key));
+    if (value?.version !== FORMAT_VERSION || !value.files || Array.isArray(value.files)) {
+      return {};
+    }
+
+    return Object.fromEntries(Object.entries(value.files).filter(
+      ([path, contents]) => isStoredPath(path, root) && typeof contents === "string",
+    ));
+  } catch {
+    return {};
+  }
+}
+
+function snapshotDirectory(fs, directory, files) {
+  for (const name of fs.ls(directory)) {
+    const path = joinPath(directory, name);
+    try {
+      files[path] = fs.readFile(path);
+    } catch {
+      snapshotDirectory(fs, path, files);
+    }
+  }
+}
+
+/** Create a localStorage-backed persistence adapter for BashKit's browser VFS. */
+export function browserLocal({
+  storage = globalThis.localStorage,
+  key = DEFAULT_KEY,
+  root = DEFAULT_ROOT,
+} = {}) {
+  if (!storage) throw new Error("browserLocal requires a Storage implementation");
+
+  return {
+    load(defaultFiles = {}) {
+      return { ...defaultFiles, ...readStoredFiles(storage, key, root) };
+    },
+
+    save(fs) {
+      const files = {};
+      try {
+        snapshotDirectory(fs, root, files);
+      } catch {
+        // The persisted root may have been removed by the last command.
+      }
+
+      try {
+        storage.setItem(key, JSON.stringify({ version: FORMAT_VERSION, files }));
+        return true;
+      } catch {
+        // Storage can be unavailable or full; command execution should still succeed.
+        return false;
+      }
+    },
+
+    clear() {
+      storage.removeItem(key);
+    },
+  };
+}

--- a/examples/browser/browser-local.test.js
+++ b/examples/browser/browser-local.test.js
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { browserLocal } from "./browser-local.js";
+
+class MemoryStorage {
+  #values = new Map();
+
+  getItem(key) {
+    return this.#values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.#values.set(key, value);
+  }
+
+  removeItem(key) {
+    this.#values.delete(key);
+  }
+}
+
+function fakeFs(tree) {
+  return {
+    ls(path) {
+      const value = tree[path];
+      if (!Array.isArray(value)) throw new Error("not a directory");
+      return value;
+    },
+    readFile(path) {
+      const value = tree[path];
+      if (typeof value !== "string") throw new Error("not a file");
+      return value;
+    },
+  };
+}
+
+test("loads persisted files and overlays them on defaults", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("bashkit:fs", JSON.stringify({
+    version: 1,
+    files: {
+      "/home/user/welcome.txt": "edited\n",
+      "/home/user/notes/todo.txt": "ship it\n",
+    },
+  }));
+
+  const backend = browserLocal({ storage });
+
+  assert.deepEqual(backend.load({
+    "/home/user/welcome.txt": "default\n",
+    "/home/user/demo.sh": "echo demo\n",
+  }), {
+    "/home/user/welcome.txt": "edited\n",
+    "/home/user/demo.sh": "echo demo\n",
+    "/home/user/notes/todo.txt": "ship it\n",
+  });
+});
+
+test("saves nested files and replaces deleted persisted files", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("bashkit:fs", JSON.stringify({
+    version: 1,
+    files: { "/home/user/deleted.txt": "old\n" },
+  }));
+  const backend = browserLocal({ storage });
+
+  backend.save(fakeFs({
+    "/home/user": ["notes", "plain.txt"],
+    "/home/user/notes": ["todo.txt"],
+    "/home/user/notes/todo.txt": "ship it\n",
+    "/home/user/plain.txt": "hello\n",
+  }));
+
+  assert.deepEqual(JSON.parse(storage.getItem("bashkit:fs")), {
+    version: 1,
+    files: {
+      "/home/user/notes/todo.txt": "ship it\n",
+      "/home/user/plain.txt": "hello\n",
+    },
+  });
+});
+
+test("ignores malformed or incompatible local storage data", () => {
+  const storage = new MemoryStorage();
+  const backend = browserLocal({ storage });
+
+  storage.setItem("bashkit:fs", "not json");
+  assert.deepEqual(backend.load({ "/default": "value" }), { "/default": "value" });
+
+  storage.setItem("bashkit:fs", JSON.stringify({ version: 2, files: { "/bad": "data" } }));
+  assert.deepEqual(backend.load({ "/default": "value" }), { "/default": "value" });
+});
+
+test("clears persisted files when the storage root was removed", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("bashkit:fs", JSON.stringify({
+    version: 1,
+    files: { "/home/user/deleted.txt": "old\n" },
+  }));
+
+  assert.equal(browserLocal({ storage }).save(fakeFs({})), true);
+  assert.deepEqual(JSON.parse(storage.getItem("bashkit:fs")), {
+    version: 1,
+    files: {},
+  });
+});
+
+test("reports localStorage write failures without throwing", () => {
+  const storage = new MemoryStorage();
+  storage.setItem = () => { throw new Error("quota exceeded"); };
+
+  assert.equal(browserLocal({ storage }).save(fakeFs({
+    "/home/user": ["note.txt"],
+    "/home/user/note.txt": "hello\n",
+  })), false);
+});
+
+test("clear removes the persisted filesystem", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("bashkit:fs", "saved");
+
+  browserLocal({ storage }).clear();
+
+  assert.equal(storage.getItem("bashkit:fs"), null);
+});
+
+test("rejects unsafe persisted paths", () => {
+  const storage = new MemoryStorage();
+  storage.setItem("bashkit:fs", JSON.stringify({
+    version: 1,
+    files: {
+      "/home/user/ok.txt": "ok",
+      "/home/user/../outside.txt": "bad",
+      "/tmp/outside.txt": "bad",
+    },
+  }));
+
+  assert.deepEqual(browserLocal({ storage }).load(), {
+    "/home/user/ok.txt": "ok",
+  });
+});

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -99,6 +99,7 @@
 
   <script type="module">
     import { initBashkit, Bash } from "@everruns/bashkit-wasm";
+    import { browserLocal } from "./browser-local.js";
 
     const output = document.getElementById("output");
     const cmd = document.getElementById("cmd");
@@ -112,14 +113,16 @@
     // this resolves from any static host or bundler.
     await initBashkit();
 
-    // Initialize interpreter
+    // Persist the writable home directory between browser sessions.
+    const storage = browserLocal();
+    const defaultFiles = {
+      "/home/user/welcome.txt": "Welcome to Bashkit running in your browser!\nThis is a sandboxed Bash interpreter compiled to WebAssembly.\n",
+      "/home/user/demo.sh": '#!/bin/bash\nfor i in 1 2 3; do\n  echo "iteration $i"\ndone\necho "done!"',
+    };
     const bash = new Bash({
       username: "user",
       hostname: "browser",
-      files: {
-        "/home/user/welcome.txt": "Welcome to Bashkit running in your browser!\nThis is a sandboxed Bash interpreter compiled to WebAssembly.\n",
-        "/home/user/demo.sh": '#!/bin/bash\nfor i in 1 2 3; do\n  echo "iteration $i"\ndone\necho "done!"',
-      },
+      files: storage.load(defaultFiles),
     });
 
     versionEl.textContent = "single-threaded wasm · no COOP/COEP";
@@ -141,6 +144,7 @@
       appendLine(`$ ${command}`, "prompt-line");
 
       const result = await bash.execute(command);
+      storage.save(bash.fs());
 
       if (result.stdout) {
         appendLine(result.stdout.replace(/\n$/, ""), "stdout");

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "vite",
     "dev": "vite",
+    "test": "node --test browser-local.test.js",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/specs/browser-package.md
+++ b/specs/browser-package.md
@@ -117,7 +117,9 @@ Version tracks the workspace `Cargo.toml` (currently synced by the release
 prepare step, same as the other packages). `publish-wasm.yml` triggers on release
 published, builds `pkg/`, runs the smoke test, and `npm publish`es
 `@everruns/bashkit-wasm` with provenance (`NPM_TOKEN`, `id-token: write`) — same
-pattern as `publish-js.yml`.
+pattern as `publish-js.yml`. Browser example smoke testing writes a file under
+`/home/user`, reloads the page, and verifies `browserLocal` restores it from
+`localStorage`.
 
 ## Limitations (see `specs/limitations.md`)
 


### PR DESCRIPTION
## What

Add a `browserLocal` storage backend to the WASM browser example. Files under `/home/user` are restored from `localStorage` on startup and snapshotted after each command.

## Why

The browser example previously discarded its in-memory filesystem on every reload, making it difficult to demonstrate a useful persistent browser shell.

## How

- serialize the `/home/user` VFS tree into a versioned localStorage payload
- overlay persisted files on the example defaults during Bash initialization
- tolerate malformed, unavailable, or full browser storage without breaking command execution
- reject persisted paths outside the configured root
- document the browser persistence smoke test

## Before / After

**Before:** `echo persistent > /home/user/note.txt`, reload, then `cat` reported a missing file.

**After:** the same file survives a real Chromium page reload and `cat /home/user/note.txt` prints `persistent`.

## Verification

- `node --test examples/browser/browser-local.test.js` — 7 passed
- `npm run build` in `examples/browser` — passed
- headless Chromium write/reload/read smoke test — passed
- `just pre-pr` — Rust test suites passed; existing release-workflow assertion fails on current `origin/main` because `release.yml` dispatches `publish.yml` while `scripts/tests/test_release_workflow.py` expects `publish-crates.yml`

Produced by [yolop](https://everruns.com/yolop)
