### PR TITLE
fix(fs): block namespace node copy destinations

### DIFF
--- a/crates/bashkit/src/fs/namespace.rs
+++ b/crates/bashkit/src/fs/namespace.rs
@@ -426,6 +426,9 @@ impl FileSystem for NamespaceFs {
     async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
         let from = self.normalized(from)?;
         let to = self.normalized(to)?;
+        if self.is_namespace_node(&to) {
+            return Err(Self::outside_write_error());
+        }
         if self.is_synthetic(&from) {
             return Err(super::fs_errors::is_a_directory());
         }

--- a/crates/bashkit/tests/integration/namespace_fs_tests.rs
+++ b/crates/bashkit/tests/integration/namespace_fs_tests.rs
@@ -337,6 +337,21 @@ async fn tm_esc_031_namespace_rejects_invalid_paths_and_protects_namespace_nodes
         };
         assert_eq!(error.kind(), ErrorKind::PermissionDenied, "{path}");
     }
+
+    source
+        .write_file(Path::new("/payload.txt"), b"attacker")
+        .await
+        .unwrap();
+    for path in ["/parent", "/parent/nested", "/parent/nested/mount"] {
+        let Error::Io(error) = namespace
+            .copy(Path::new("/parent/payload.txt"), Path::new(path))
+            .await
+            .unwrap_err()
+        else {
+            panic!("expected namespace-node copy destination protection");
+        };
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied, "{path}");
+    }
     assert!(source.exists(Path::new("/nested/file.txt")).await.unwrap());
 }
 


### PR DESCRIPTION
### Motivation

- Prevent bypass of namespace routing protections where `copy()` could write into synthetic or exact mount points and mutate hidden backing stores.

### Description

- Add a destination check in `NamespaceFs::copy()` that returns `outside_write_error()` when `is_namespace_node(&to)` is true to block copy targets that are namespace routing nodes.
- Keep the existing source-side synthetic-dir check and writable/resolve semantics and reject cross-mount directory/FIFO copies as before.
- Add an integration regression to `tm_esc_031_namespace_rejects_invalid_paths_and_protects_namespace_nodes` that asserts `copy()` to `/parent`, `/parent/nested`, and `/parent/nested/mount` yields `PermissionDenied`.
- Changes touch `crates/bashkit/src/fs/namespace.rs` and `crates/bashkit/tests/integration/namespace_fs_tests.rs` and are committed under the message `fix(fs): block namespace node copy destinations`.

### Testing

- Ran `cargo fmt --check`, which completed successfully.
- Ran `cargo test -p bashkit --test integration namespace --no-default-features`, and the integration test filter passed: all tests succeeded (`24 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ba9bd4d4c832b94cc292611dc5016)