### PR TITLE
test(fuzz): constrain arithmetic expressions

### DIFF
--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -91,11 +91,13 @@ from bashkit import Bash
 
 bash = Bash()
 
+
 def on_output(stdout: str, stderr: str) -> None:
     if stdout:
         print(stdout, end="", flush=True)
     if stderr:
         print(stderr, end="", flush=True)
+
 
 result = bash.execute_sync(
     "for i in 1 2 3; do echo out-$i; echo err-$i >&2; done",
@@ -171,10 +173,12 @@ and use `bashkit::interop::fs`.
 ```python
 from bashkit import Bash
 
-bash = Bash(files={
-    "/config/static.txt": "ready\n",
-    "/config/report.json": lambda: '{"ok": true}\n',
-})
+bash = Bash(
+    files={
+        "/config/static.txt": "ready\n",
+        "/config/report.json": lambda: '{"ok": true}\n',
+    }
+)
 
 print(bash.execute_sync("cat /config/static.txt").stdout)
 print(bash.execute_sync("cat /config/report.json").stdout)
@@ -185,10 +189,12 @@ print(bash.execute_sync("cat /config/report.json").stdout)
 ```python
 from bashkit import Bash
 
-bash = Bash(mounts=[
-    {"host_path": "/path/to/data", "vfs_path": "/data"},
-    {"host_path": "/path/to/workspace", "vfs_path": "/workspace", "writable": True},
-])
+bash = Bash(
+    mounts=[
+        {"host_path": "/path/to/data", "vfs_path": "/data"},
+        {"host_path": "/path/to/workspace", "vfs_path": "/workspace", "writable": True},
+    ]
+)
 
 print(bash.execute_sync("ls /workspace").stdout)
 ```
@@ -297,7 +303,7 @@ from bashkit import Bash
 
 bash = Bash()
 
-bash.cancel()        # abort in-flight execution (no-op if idle)
+bash.cancel()  # abort in-flight execution (no-op if idle)
 bash.clear_cancel()  # clear the sticky flag so subsequent executions work
 ```
 
@@ -376,9 +382,7 @@ def get_order(ctx):
     if not ctx.argv or ctx.argv[0] in {"help", "--help"}:
         return "usage: get-order <get|help> [args]\n"
     if ctx.argv[0] == "get" and len(ctx.argv) >= 2:
-        return json.dumps(
-            {"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}
-        ) + "\n"
+        return json.dumps({"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}) + "\n"
     return "usage: get-order <get|help> [args]\n"
 
 
@@ -449,9 +453,7 @@ from bashkit import Bash
 
 bash = Bash(username="agent", max_commands=100)
 bash.execute_sync(
-    "export BUILD_ID=42; "
-    "greet() { echo \"hi $1\"; }; "
-    "mkdir -p /workspace && cd /workspace && echo ready > state.txt"
+    'export BUILD_ID=42; greet() { echo "hi $1"; }; mkdir -p /workspace && cd /workspace && echo ready > state.txt'
 )
 
 snapshot = bash.snapshot()

--- a/crates/bashkit/fuzz/fuzz_targets/arithmetic_fuzz.rs
+++ b/crates/bashkit/fuzz/fuzz_targets/arithmetic_fuzz.rs
@@ -9,6 +9,7 @@
 
 #![no_main]
 
+use bashkit_fuzz::is_arithmetic_expression;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -20,37 +21,11 @@ fuzz_target!(|data: &[u8]| {
             return;
         }
 
-        // Reject inputs with deep nesting that can blow up parser memory
-        let depth: i32 = input
-            .bytes()
-            .map(|b| match b {
-                b'(' => 1,
-                b')' => -1,
-                _ => 0,
-            })
-            .scan(0i32, |acc, d| {
-                *acc += d;
-                Some(*acc)
-            })
-            .max()
-            .unwrap_or(0);
-        if depth > 20 {
+        // Keep this target inside arithmetic expansion. Shell syntax or
+        // unbalanced grouping could close `$((...))` and execute the remainder
+        // as a command, which belongs in the parser and interpreter fuzzers.
+        if !is_arithmetic_expression(input) {
             return;
-        }
-
-        // Reject inputs that themselves contain banned substrings — this
-        // target inlines `input` into `echo $((input))`. With unbalanced
-        // parens the arithmetic expansion can close early and the
-        // remainder is parsed as commands; bash then echoes the unknown
-        // command verbatim ("bash: /.rustup/toolchains/gww: No such file
-        // or directory"). That is real-shell stderr, not a TM-INF-022
-        // leak. Filtering at the fuzz-input layer keeps the harness's
-        // leak detector strict for real internals while avoiding false
-        // positives. (Mirrors glob_fuzz.)
-        for pat in bashkit::testing::UNIVERSAL_BANNED {
-            if input.contains(pat) {
-                return;
-            }
         }
 
         // Wrap input in arithmetic expansion context

--- a/crates/bashkit/fuzz/src/lib.rs
+++ b/crates/bashkit/fuzz/src/lib.rs
@@ -1,0 +1,91 @@
+// Fuzz-target input policies live here so their security boundaries are unit tested.
+
+/// Returns whether `input` is a self-contained Bash arithmetic expression.
+///
+/// The arithmetic fuzzer embeds accepted input inside `$((...))`. Restricting
+/// the alphabet and requiring balanced grouping prevents input from escaping
+/// that expansion and turning the focused target into a general shell fuzzer.
+pub fn is_arithmetic_expression(input: &str) -> bool {
+    if input.is_empty() {
+        return false;
+    }
+
+    const MAX_GROUPING_DEPTH: usize = 20;
+    let mut grouping = [0_u8; MAX_GROUPING_DEPTH];
+    let mut depth = 0;
+
+    for byte in input.bytes() {
+        match byte {
+            b'0'..=b'9'
+            | b'a'..=b'z'
+            | b'A'..=b'Z'
+            | b'_'
+            | b' '
+            | b'\t'
+            | b'+'
+            | b'-'
+            | b'*'
+            | b'/'
+            | b'%'
+            | b'<'
+            | b'>'
+            | b'='
+            | b'!'
+            | b'&'
+            | b'|'
+            | b'^'
+            | b'~'
+            | b'?'
+            | b':'
+            | b','
+            | b'#' => {}
+            b'(' | b'[' if depth < MAX_GROUPING_DEPTH => {
+                grouping[depth] = byte;
+                depth += 1;
+            }
+            b')' if depth > 0 && grouping[depth - 1] == b'(' => depth -= 1,
+            b']' if depth > 0 && grouping[depth - 1] == b'[' => depth -= 1,
+            _ => return false,
+        }
+    }
+
+    depth == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_arithmetic_expression;
+
+    #[test]
+    fn accepts_arithmetic_language() {
+        for expression in [
+            "1 + 2 * 3",
+            "(value << 2) | 0xff",
+            "array[index + 1]",
+            "total += condition ? 10 : 2",
+            "16#ff + 2#1010",
+            "++counter, mask & ~flag",
+        ] {
+            assert!(is_arithmetic_expression(expression), "{expression:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_shell_syntax_and_unbalanced_grouping() {
+        for expression in [
+            "",
+            "))/.rustup/toolchains/",
+            "1)) ; uname",
+            "$(uname)",
+            "`uname`",
+            "1\necho escaped",
+            "array[index",
+            "(1 + 2",
+            "1 + 2)",
+            "([1)]",
+            "(((((((((((((((((((((1)))))))))))))))))))))",
+        ] {
+            assert!(!is_arithmetic_expression(expression), "{expression:?}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- constrain arithmetic fuzz input to a self-contained arithmetic grammar
- reject shell syntax, mismatched grouping, and excessive nesting before interpolation
- remove the leak-signature input suppression so security-sensitive strings remain fuzzable

## Why
The arithmetic target could close `$((...))` early and turn arbitrary fuzz bytes into shell commands. That produced false-positive stderr leak failures and diluted coverage into general shell parsing.

## Before / After
**Before:** the crash artifact `))/.rustup/toolchains/...` escaped arithmetic expansion and was interpreted as a command.

**After:** the target rejects that input while accepting variables, array indexing, arithmetic operators, ternaries, and base notation.

## Testing
- `cargo test --manifest-path crates/bashkit/fuzz/Cargo.toml --lib`
- `cargo check --manifest-path crates/bashkit/fuzz/Cargo.toml --bin arithmetic_fuzz`
- `git diff --check`
- `just pre-pr`

Produced by [yolop](https://everruns.com/yolop)
