### PR TITLE
chore(deps): upgrade embedded runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "assoc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,7 @@ dependencies = [
  "jaq-std",
  "md-5",
  "monty",
+ "monty-types",
  "num-traits",
  "os_display",
  "pretty_assertions",
@@ -937,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -1820,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.9.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f8ab1b98a1284961d722ce994d9a0f3018ab1917618d4113824a72b9f71bc9"
+checksum = "c736d226c32e496b8377813b52269e11ad3a48d8373b68862d0364f04fd1229d"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -1831,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "get-size2"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0cd0777a1057362cab35a779e0d79dacecb8d73e2c733eaafeb7ea917b08f03"
+checksum = "823645bc6404ae2915707777061a47d3a031a9ee0bff51b34ec973df3d8d2990"
 dependencies = [
  "compact_str",
  "get-size-derive2",
@@ -2437,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,18 +2934,19 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.18"
-source = "git+https://github.com/pydantic/monty?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663"
+version = "0.0.19-beta.6"
+source = "git+https://github.com/pydantic/monty?tag=v0.0.19-beta.6#344f91d17919d88ad7de4e13432d73c7c2ed9a4a"
 dependencies = [
  "ahash",
  "chrono",
  "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
- "indexmap",
  "itertools 0.14.0",
+ "itoa",
  "jiter",
  "libm",
  "monty-macros",
+ "monty-types",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2939,20 +2956,37 @@ dependencies = [
  "ruff_python_stdlib",
  "ruff_text_size",
  "serde",
- "serde_json",
  "smallvec",
  "speedate",
  "strum 0.27.2",
+ "unicode-general-category",
+ "unicode-normalization",
+ "unicode_names2",
 ]
 
 [[package]]
 name = "monty-macros"
-version = "0.0.18"
-source = "git+https://github.com/pydantic/monty?tag=v0.0.18#45a3b2d57e6ce723fed4166fb032242ece74a663"
+version = "0.0.19-beta.6"
+source = "git+https://github.com/pydantic/monty?tag=v0.0.19-beta.6#344f91d17919d88ad7de4e13432d73c7c2ed9a4a"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "monty-types"
+version = "0.0.19-beta.6"
+source = "git+https://github.com/pydantic/monty?tag=v0.0.19-beta.6#344f91d17919d88ad7de4e13432d73c7c2ed9a4a"
+dependencies = [
+ "chrono",
+ "monty-macros",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "strum 0.27.2",
+ "unicode-general-category",
+ "web-time",
 ]
 
 [[package]]
@@ -4281,10 +4315,12 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_ast"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10ab966362319801f5e85ce5c6aeac69f0cf50936a31e888f5d004e9279f337"
 dependencies = [
  "aho-corasick",
+ "arrayvec",
  "bitflags 2.13.1",
  "compact_str",
  "get-size2",
@@ -4300,8 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_parser"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3b8436fb010636ea79ce545acc3e391296ef4e804f7cef336dd5f9c8a4aa3a"
 dependencies = [
  "bitflags 2.13.1",
  "bstr",
@@ -4321,8 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_stdlib"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c8860927bf42efdabb31ccb2ac9b8f98ee43897b45536f8023e217b158e49a4"
 dependencies = [
  "bitflags 2.13.1",
  "unicode-ident",
@@ -4330,10 +4368,11 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_trivia"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969e4a14b2550818efea99b9e2361c714c72e4f1fb94799251d55aed20345189"
 dependencies = [
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "ruff_source_file",
  "ruff_text_size",
  "unicode-ident",
@@ -4341,8 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_source_file"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c194e02d121e4a1744464ce3a982c4c196eb039bbf67532d18c8ce09f8da6381"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -4350,8 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "ruff_text_size"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91652ad39be604bc4d5299a5d19feccdd89e255609d89a031e7bb8e0d0aef9f"
 dependencies = [
  "get-size2",
 ]
@@ -5609,9 +5650,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso_core"
-version = "0.7.0"
+version = "0.8.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77f2106de5a3014261be18283999fde0d06c24ae5d4cb85a6eff1aaeaff453d"
+checksum = "2a29ab6d5a49ba2c756279891a7fa160e3460af167983f283b9a55e3747be03a"
 dependencies = [
  "aegis",
  "aes 0.8.4",
@@ -5678,9 +5719,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.7.0"
+version = "0.8.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d367d863b095a9893690fc6c52bbf27edf422c135a58ba5ed2b03dbec8faac"
+checksum = "ed8f1265e0b6ee172063cdc93099f7f1a0f1a7af140bd16c47aa563c65d36e2e"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -5689,9 +5730,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.7.0"
+version = "0.8.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a817815d9ca218cb971ed2a0a41a89a5160966b5b4bd103c82792fd2f230f1c"
+checksum = "86ed2bab22e6d8ff94f1e966525fb14f192737977475ae57bcd0fc4c021b3589"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5700,9 +5741,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.7.0"
+version = "0.8.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad90c0e6eea7ab131214804c70edad5372acecdcad8d4ccc75b0ded55b0df8f"
+checksum = "2bdac2a5acfeb180bf7e86369fdfd40ae08a893c8e1c642d85e72a85c9dbf4df"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
@@ -5748,6 +5789,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-id-start"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ tower = { version = "0.5", features = ["util"] }
 russh = "0.62"
 # Embedded SQLite engine (Turso, pure Rust). Upstream is BETA — gated behind
 # the `sqlite` feature and disabled by default; see specs/sqlite-builtin.md.
-turso_core = "0.7"
+turso_core = "0.8.0-pre.1"
 
 # Serial test execution
 serial_test = "3"

--- a/crates/bashkit-python/README.md
+++ b/crates/bashkit-python/README.md
@@ -91,11 +91,13 @@ from bashkit import Bash
 
 bash = Bash()
 
+
 def on_output(stdout: str, stderr: str) -> None:
     if stdout:
         print(stdout, end="", flush=True)
     if stderr:
         print(stderr, end="", flush=True)
+
 
 result = bash.execute_sync(
     "for i in 1 2 3; do echo out-$i; echo err-$i >&2; done",
@@ -171,10 +173,12 @@ and use `bashkit::interop::fs`.
 ```python
 from bashkit import Bash
 
-bash = Bash(files={
-    "/config/static.txt": "ready\n",
-    "/config/report.json": lambda: '{"ok": true}\n',
-})
+bash = Bash(
+    files={
+        "/config/static.txt": "ready\n",
+        "/config/report.json": lambda: '{"ok": true}\n',
+    }
+)
 
 print(bash.execute_sync("cat /config/static.txt").stdout)
 print(bash.execute_sync("cat /config/report.json").stdout)
@@ -185,10 +189,12 @@ print(bash.execute_sync("cat /config/report.json").stdout)
 ```python
 from bashkit import Bash
 
-bash = Bash(mounts=[
-    {"host_path": "/path/to/data", "vfs_path": "/data"},
-    {"host_path": "/path/to/workspace", "vfs_path": "/workspace", "writable": True},
-])
+bash = Bash(
+    mounts=[
+        {"host_path": "/path/to/data", "vfs_path": "/data"},
+        {"host_path": "/path/to/workspace", "vfs_path": "/workspace", "writable": True},
+    ]
+)
 
 print(bash.execute_sync("ls /workspace").stdout)
 ```
@@ -297,7 +303,7 @@ from bashkit import Bash
 
 bash = Bash()
 
-bash.cancel()        # abort in-flight execution (no-op if idle)
+bash.cancel()  # abort in-flight execution (no-op if idle)
 bash.clear_cancel()  # clear the sticky flag so subsequent executions work
 ```
 
@@ -376,9 +382,7 @@ def get_order(ctx):
     if not ctx.argv or ctx.argv[0] in {"help", "--help"}:
         return "usage: get-order <get|help> [args]\n"
     if ctx.argv[0] == "get" and len(ctx.argv) >= 2:
-        return json.dumps(
-            {"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}
-        ) + "\n"
+        return json.dumps({"id": ctx.argv[1], "status": "shipped", "items": ["widget"]}) + "\n"
     return "usage: get-order <get|help> [args]\n"
 
 
@@ -449,9 +453,7 @@ from bashkit import Bash
 
 bash = Bash(username="agent", max_commands=100)
 bash.execute_sync(
-    "export BUILD_ID=42; "
-    "greet() { echo \"hi $1\"; }; "
-    "mkdir -p /workspace && cd /workspace && echo ready > state.txt"
+    'export BUILD_ID=42; greet() { echo "hi $1"; }; mkdir -p /workspace && cd /workspace && echo ready > state.txt'
 )
 
 snapshot = bash.snapshot()

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -100,10 +100,11 @@ unit-prefix = "0.5"
 os_display = "0.1.3"
 
 # Embedded Python interpreter (optional)
-monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.18", optional = true }
+monty = { git = "https://github.com/pydantic/monty", tag = "v0.0.19-beta.6", optional = true }
+monty-types = { git = "https://github.com/pydantic/monty", tag = "v0.0.19-beta.6", optional = true }
 
 # Embedded TypeScript interpreter (optional)
-zapcode-core = { version = "1.5", optional = true }
+zapcode-core = { version = "1.5.1", optional = true }
 
 # Embedded SQLite engine via Turso (optional, BETA upstream).
 # Pulls a multi-MB transitive dep tree only when the `sqlite` feature is active.
@@ -143,7 +144,7 @@ ssh = ["russh"]
 scripted_tool = ["bash_tool"]
 # Enable python/python3 builtins via embedded Monty interpreter
 # Monty is a git dep (not yet on crates.io) — feature unavailable from registry
-python = ["dep:monty"]
+python = ["dep:monty", "dep:monty-types"]
 # Enable ts/node/deno/bun builtins via embedded ZapCode TypeScript interpreter
 # Usage: cargo build --features typescript
 typescript = ["dep:zapcode-core"]

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -21,10 +21,11 @@
 use crate::time_compat::Instant;
 use async_trait::async_trait;
 use chrono::{Datelike, Timelike};
-use monty::{
-    ExcType, ExtFunctionResult, FileMode, LimitedTracker, MontyDate, MontyDateTime, MontyException,
-    MontyFileHandle, MontyObject, MontyRun, NameLookupResult, OsFunctionCall, PrintWriter,
-    ResourceLimits, RunProgress, dir_stat, file_stat, symlink_stat,
+use monty::{MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, FileMode, LimitedTracker, MontyDate, MontyDateTime,
+    MontyException, MontyFileHandle, MontyObject, NameLookupResult, OsFunctionCall, PrintWriter,
+    ResourceLimits, dir_stat, file_stat, symlink_stat,
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -486,7 +487,7 @@ async fn run_python(
         code
     };
 
-    let runner = match MontyRun::new(code.to_owned(), filename, vec![]) {
+    let runner = match MontyRun::new(code.to_owned(), filename, vec![], CompileOptions::default()) {
         Ok(r) => r,
         Err(e) => return Ok(format_exception(e)),
     };
@@ -516,8 +517,9 @@ async fn run_python(
 
     loop {
         match progress {
-            RunProgress::OsCall(mut os_call) => {
-                let result = handle_os_call(os_call.take_function_call(), &fs, cwd, env).await;
+            RunProgress::OsCall(os_call) => {
+                let function_call = os_call.function_call.clone();
+                let result = handle_os_call(function_call, &fs, cwd, env).await;
                 match os_call.resume(result, PrintWriter::CollectString(&mut buf)) {
                     Ok(next) => {
                         progress = next;
@@ -677,7 +679,7 @@ async fn handle_os_call(
     };
 
     match name {
-        "Open" => {
+        "open" => {
             let mode = match parse_open_mode(args) {
                 Ok(mode) => mode,
                 Err(err) => return err,

--- a/crates/bashkit/src/builtins/sqlite/engine.rs
+++ b/crates/bashkit/src/builtins/sqlite/engine.rs
@@ -19,7 +19,9 @@ use crate::time_compat::Instant;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use turso_core::{Connection, Database, IO, MemoryIO, Numeric, OpenFlags, StepResult, Value};
+use turso_core::{
+    Connection, Database, IO, MemoryIO, Numeric, OpenFlags, SqliteDialect, StepResult, Value,
+};
 
 use super::vfs_io::BashkitVfsIO;
 
@@ -122,7 +124,7 @@ impl SqliteEngine {
             seed_memory_io(&io, &path, bytes).map_err(turso_msg)?;
         }
         let io_dyn: Arc<dyn IO> = io.clone();
-        let db = Database::open_file(io_dyn, &path).map_err(turso_msg)?;
+        let db = Database::open_file(io_dyn, &path, Arc::new(SqliteDialect)).map_err(turso_msg)?;
         let conn = db.connect().map_err(turso_msg)?;
         Ok(Self {
             backend: Backend::Memory(io),
@@ -137,7 +139,8 @@ impl SqliteEngine {
     pub(super) fn open_pure_memory() -> EngineResult<Self> {
         let io: Arc<MemoryIO> = Arc::new(MemoryIO::new());
         let io_dyn: Arc<dyn IO> = io.clone();
-        let db = Database::open_file(io_dyn, ":memory:").map_err(turso_msg)?;
+        let db =
+            Database::open_file(io_dyn, ":memory:", Arc::new(SqliteDialect)).map_err(turso_msg)?;
         let conn = db.connect().map_err(turso_msg)?;
         Ok(Self {
             backend: Backend::Memory(io),
@@ -152,7 +155,8 @@ impl SqliteEngine {
     /// a key in the VFS).
     pub(super) fn open_vfs(io: Arc<BashkitVfsIO>, path_in_io: &str) -> EngineResult<Self> {
         let io_dyn: Arc<dyn IO> = io.clone();
-        let db = Database::open_file(io_dyn, path_in_io).map_err(turso_msg)?;
+        let db =
+            Database::open_file(io_dyn, path_in_io, Arc::new(SqliteDialect)).map_err(turso_msg)?;
         let conn = db.connect().map_err(turso_msg)?;
         Ok(Self {
             backend: Backend::Vfs(io),

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -540,7 +540,7 @@ pub use builtins::{Sqlite, SqliteBackend, SqliteLimits};
 // **Unstable:** These types come from monty (git-pinned, not on crates.io).
 // They may change in breaking ways between bashkit releases.
 #[cfg(feature = "python")]
-pub use monty::{ExcType, ExtFunctionResult, MontyException, MontyObject};
+pub use monty_types::{ExcType, ExtFunctionResult, MontyException, MontyObject};
 
 #[cfg(feature = "typescript")]
 pub use builtins::{

--- a/crates/bashkit/tests/integration/python_integration_tests.rs
+++ b/crates/bashkit/tests/integration/python_integration_tests.rs
@@ -796,7 +796,7 @@ mod vfs_bridging {
             .exec("python3 -c \"with open('/tmp/open-read.txt', 'r') as f:\n    print(f.read())\"")
             .await
             .unwrap();
-        assert_eq!(r.exit_code, 0);
+        assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
         assert_eq!(r.stdout, "from vfs\n");
     }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -131,6 +131,10 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.arrayvec]]
+version = "0.7.8"
+criteria = "safe-to-deploy"
+
 [[exemptions.assoc]]
 version = "0.1.3"
 criteria = "safe-to-deploy"
@@ -356,7 +360,7 @@ version = "4.6.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.compact_str]]
-version = "0.9.1"
+version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.concurrent-queue]]
@@ -433,10 +437,6 @@ criteria = "safe-to-run"
 
 [[exemptions.crossbeam-epoch]]
 version = "0.9.20"
-criteria = "safe-to-deploy"
-
-[[exemptions.crossbeam-skiplist]]
-version = "0.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.crossbeam-utils]]
@@ -712,11 +712,11 @@ version = "1.4.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.get-size-derive2]]
-version = "0.7.4"
+version = "0.10.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.get-size2]]
-version = "0.7.4"
+version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.getopts]]
@@ -933,6 +933,10 @@ criteria = "safe-to-run"
 
 [[exemptions.itertools]]
 version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.15.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.itoa]]
@@ -1599,6 +1603,30 @@ criteria = "safe-to-deploy"
 version = "0.10.0-rc.18"
 criteria = "safe-to-deploy"
 
+[[exemptions.ruff_python_ast]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ruff_python_parser]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ruff_python_stdlib]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ruff_python_trivia]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ruff_source_file]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ruff_text_size]]
+version = "0.0.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.russh]]
 version = "0.62.2"
 criteria = "safe-to-deploy"
@@ -1971,10 +1999,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.tokio]]
-version = "1.53.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.tokio-macros]]
 version = "2.7.0"
 criteria = "safe-to-deploy"
@@ -1993,14 +2017,6 @@ criteria = "safe-to-run"
 
 [[exemptions.tokio-util]]
 version = "0.7.18"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml]]
-version = "1.1.3+spec-1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml_writer]]
-version = "1.1.2+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tower]]
@@ -2044,19 +2060,19 @@ version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_core]]
-version = "0.7.0"
+version = "0.8.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_ext]]
-version = "0.7.0"
+version = "0.8.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_macros]]
-version = "0.7.0"
+version = "0.8.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_parser]]
-version = "0.7.0"
+version = "0.8.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.twox-hash]]
@@ -2077,6 +2093,10 @@ criteria = "safe-to-run"
 
 [[exemptions.uncased]]
 version = "0.9.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-general-category]]
+version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.unicode-id-start]]
@@ -2121,10 +2141,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.urlencoding]]
 version = "2.1.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.utf16_iter]]
-version = "1.0.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.utf8parse]]
@@ -2309,10 +2325,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wnaf]]
 version = "0.14.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.write16]]
-version = "1.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.writeable]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,15 +9,15 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.tokio]]
-version = "1.52.3"
-when = "2026-05-08"
+version = "1.53.0"
+when = "2026-07-17"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
 
 [[publisher.toml]]
-version = "1.1.2+spec-1.1.0"
-when = "2026-04-01"
+version = "1.1.3+spec-1.1.0"
+when = "2026-07-14"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -37,8 +37,8 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.toml_writer]]
-version = "1.1.1+spec-1.1.0"
-when = "2026-03-31"
+version = "1.1.2+spec-1.1.0"
+when = "2026-07-14"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -440,3 +440,17 @@ who = "Jan-Erik Rediger <jrediger@mozilla.com>"
 criteria = "safe-to-deploy"
 version = "0.1.5"
 aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.utf16_iter]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+version = "1.0.5"
+notes = "I, Henri Sivonen, wrote this crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.write16]]
+who = "Henri Sivonen <hsivonen@hsivonen.fi>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "I, Henri Sivonen, wrote this (safe-code-only) crate."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"


### PR DESCRIPTION
## Summary
- upgrade Monty to `v0.0.19-beta.6`, ZapCode to `1.5.1`, and Turso to `0.8.0-pre.1`
- adapt the Python bridge to Monty's split public types and lowercase OS-call names
- provide Turso's required SQLite dialect and refresh supply-chain exemptions

## Before / After
Before: upgraded dependencies did not compile against the existing Monty and Turso integration APIs.

After:
- Python integration suite: 102 passed
- TypeScript integration suite: 73 passed
- SQLite integration suite: 120 passed
- Python, TypeScript, and SQLite end-to-end examples/CLI smoke tests passed
- `just pre-pr` passed

## Security
Dependency and bridge changes only. VFS-backed Python file access remains sandboxed; `cargo vet --locked` passes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Security review performed
- [x] `just pre-pr` passes

Produced by [yolop](https://everruns.com/yolop)
