### PR TITLE
fix(release): remove invalid web workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,6 @@ jobs:
           gh workflow run publish-python.yml --ref "$TAG"
           gh workflow run publish-js.yml --ref "$TAG"
           gh workflow run publish-wasm.yml --ref "$TAG"
-          gh workflow run publish-web.yml --ref "$TAG"
 
       - name: Trigger CLI binary builds for release tag
         env:

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -18,11 +18,20 @@ class ReleaseWorkflowTests(unittest.TestCase):
             "publish.yml",
             "publish-python.yml",
             "publish-js.yml",
-            "publish-web.yml",
+            "publish-wasm.yml",
         ):
             with self.subTest(publish_workflow=publish_workflow):
                 self.assertIn(
                     f'gh workflow run {publish_workflow} --ref "$TAG"', workflow
+                )
+
+    def test_release_dispatch_targets_exist(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+        for dispatch_target in re.findall(r"gh workflow run ([^ ]+)", workflow):
+            with self.subTest(dispatch_target=dispatch_target):
+                self.assertTrue(
+                    (ROOT / ".github/workflows" / dispatch_target).is_file()
                 )
 
     def test_public_package_versions_match_workspace(self) -> None:


### PR DESCRIPTION
### Motivation

- The release job attempted to run a nonexistent workflow `publish-web.yml`, which causes `gh workflow run` to exit non-zero and abort subsequent release steps.
- The browser publish is already handled by `publish-wasm.yml`, so the extra dispatch is a duplicate and a regression.

### Description

- Remove the invalid dispatch line `gh workflow run publish-web.yml --ref "$TAG"` from `.github/workflows/release.yml`.
- Update `scripts/tests/test_release_workflow.py` to expect `publish-wasm.yml` instead of `publish-web.yml` and add `test_release_dispatch_targets_exist` to assert each `gh workflow run` target exists under `.github/workflows`.
- Keep existing browser/WASM publishing behavior intact by relying on `publish-wasm.yml`.

### Testing

- Reproduced the failure with `python3 -m unittest scripts.tests.test_release_workflow` before the fix and observed the missing `publish-web.yml` assertion fail.
- Ran `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` after the fix and all 8 tests passed.
- Ran `ruff check`/`ruff format --check` on the modified test file and `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63066d3c7c832bba556a8441b172b5)