### PR TITLE
fix(wasm): tolerate blocked browser storage

### DIFF
--- a/examples/browser/browser-local.js
+++ b/examples/browser/browser-local.js
@@ -40,12 +40,20 @@ function snapshotDirectory(fs, directory, files) {
 }
 
 /** Create a localStorage-backed persistence adapter for BashKit's browser VFS. */
-export function browserLocal({
-  storage = globalThis.localStorage,
-  key = DEFAULT_KEY,
-  root = DEFAULT_ROOT,
-} = {}) {
-  if (!storage) throw new Error("browserLocal requires a Storage implementation");
+export function browserLocal({ storage: configuredStorage, key = DEFAULT_KEY, root = DEFAULT_ROOT } = {}) {
+  let storage = configuredStorage;
+  let storageBlocked = false;
+  if (storage === undefined) {
+    try {
+      storage = globalThis.localStorage;
+    } catch {
+      // Access itself can throw in sandboxed or storage-blocked browser contexts.
+      storageBlocked = true;
+    }
+  }
+  if (!storage && !storageBlocked) {
+    throw new Error("browserLocal requires a Storage implementation");
+  }
 
   return {
     load(defaultFiles = {}) {
@@ -70,7 +78,11 @@ export function browserLocal({
     },
 
     clear() {
-      storage.removeItem(key);
+      try {
+        storage.removeItem(key);
+      } catch {
+        // Unavailable storage must not prevent the browser shell from running.
+      }
     },
   };
 }

--- a/examples/browser/browser-local.test.js
+++ b/examples/browser/browser-local.test.js
@@ -115,6 +115,26 @@ test("reports localStorage write failures without throwing", () => {
   })), false);
 });
 
+test("tolerates blocked access to the global localStorage", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() { throw new DOMException("blocked", "SecurityError"); },
+  });
+
+  try {
+    const backend = browserLocal();
+    assert.deepEqual(backend.load({ "/home/user/welcome.txt": "hello\n" }), {
+      "/home/user/welcome.txt": "hello\n",
+    });
+    assert.equal(backend.save(fakeFs({})), false);
+    assert.doesNotThrow(() => backend.clear());
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, "localStorage", descriptor);
+    else delete globalThis.localStorage;
+  }
+});
+
 test("clear removes the persisted filesystem", () => {
   const storage = new MemoryStorage();
   storage.setItem("bashkit:fs", "saved");


### PR DESCRIPTION
### Motivation

- The browser persistence adapter read `globalThis.localStorage` as a default parameter, which can throw a `SecurityError` in sandboxed/opaque-origin/storage-blocked contexts and abort shell initialization.

### Description

- Move storage resolution out of the parameter list and into a guarded initialization that catches thrown errors when reading `globalThis.localStorage` and treats storage as unavailable in that case.
- Accept an explicit `storage` (`configuredStorage`) parameter while preserving existing behavior when callers pass a valid `Storage` instance.
- Make `save()` and `clear()` tolerant of unavailable storage by having `save()` return `false` on write errors and wrapping `clear()` in a `try/catch` so failures do not throw.
- Add a regression test that installs a throwing `globalThis.localStorage` getter and verifies `load()` returns defaults, `save()` reports `false`, and `clear()` does not throw.

### Testing

- Ran `node --test examples/browser/browser-local.test.js` and observed all tests pass (`8` passed).
- Installed example deps and ran the browser example build (`npm install` then `npm run build` in `examples/browser`), and the `vite build` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6307d890d4832b9130b02af67b6194)