### PR TITLE
chore(release): prepare v0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,59 @@
 
 ## Unreleased
 
-### Fixed
+## [0.14.4] - 2026-07-27
 
-- RealFs path resolution and metadata updates no longer perform synchronous
-  host filesystem I/O inside async backend methods, preventing stalls and
-  deadlocks on current-thread Tokio runtimes. Async embedders should use the
-  new `RealFs::open`; the blocking `RealFs::new` constructor is deprecated.
+### Highlights
+
+- **Python wheels now use CPython's stable ABI.** One `cp39-abi3` wheel per
+  platform supports every Python version from 3.9 onward, reducing native
+  release artifacts from 42 wheels (~500 MiB) to 7 (~85 MiB). This prevents
+  the partial PyPI publications that left 0.14.2 unavailable on Python
+  3.12–3.14 ([#2190](https://github.com/everruns/bashkit/pull/2190)).
+- **Browser files can persist across sessions.** The browser example stores
+  its virtual filesystem in browser storage, tolerates environments where
+  storage access is blocked, and rejects timeout guarantees that the
+  single-threaded WebAssembly runtime cannot enforce
+  ([#2192](https://github.com/everruns/bashkit/pull/2192),
+  [#2211](https://github.com/everruns/bashkit/pull/2211),
+  [#2213](https://github.com/everruns/bashkit/pull/2213)).
+- **Async filesystem operations no longer block current-thread runtimes.**
+  RealFs path resolution and metadata operations now use asynchronous host
+  filesystem I/O. Async embedders should use `RealFs::open`; the blocking
+  `RealFs::new` constructor is deprecated
+  ([#2205](https://github.com/everruns/bashkit/pull/2205)).
+
+### What's Changed
+
+* chore(deps): bump postcss to 8.5.23 to close path-traversal advisory ([#2215](https://github.com/everruns/bashkit/pull/2215)) by @chaliy
+* fix(examples): pin browser npm dependencies ([#2214](https://github.com/everruns/bashkit/pull/2214)) by @chaliy
+* fix(wasm): tolerate blocked browser storage ([#2213](https://github.com/everruns/bashkit/pull/2213)) by @chaliy
+* fix(release): remove invalid web workflow dispatch ([#2212](https://github.com/everruns/bashkit/pull/2212)) by @chaliy
+* fix(wasm): reject unenforceable timeouts ([#2211](https://github.com/everruns/bashkit/pull/2211)) by @chaliy
+* fix(python): stop teardown test flaking on unrelated thread reaps ([#2210](https://github.com/everruns/bashkit/pull/2210)) by @chaliy
+* chore(knowledge): group concepts into domain subfolders ([#2209](https://github.com/everruns/bashkit/pull/2209)) by @chaliy
+* chore(knowledge): make the knowledge bundle actually OKF v0.2 conformant ([#2206](https://github.com/everruns/bashkit/pull/2206)) by @chaliy
+* fix(realfs): avoid blocking async runtimes ([#2205](https://github.com/everruns/bashkit/pull/2205)) by @chaliy
+* chore(deps): bump the rust-dependencies group across 1 directory with 7 updates ([#2204](https://github.com/everruns/bashkit/pull/2204)) by @dependabot
+* chore(ci): bump the github-actions group across 1 directory with 3 updates ([#2203](https://github.com/everruns/bashkit/pull/2203)) by @dependabot
+* chore(knowledge): migrate specs to OKF ([#2202](https://github.com/everruns/bashkit/pull/2202)) by @chaliy
+* chore(deps): move monty to crates.io 0.0.19 ([#2201](https://github.com/everruns/bashkit/pull/2201)) by @chaliy
+* chore(deps): upgrade embedded runtimes ([#2200](https://github.com/everruns/bashkit/pull/2200)) by @chaliy
+* test(fuzz): constrain arithmetic expressions ([#2199](https://github.com/everruns/bashkit/pull/2199)) by @chaliy
+* fix(fs): block namespace node copy destinations ([#2198](https://github.com/everruns/bashkit/pull/2198)) by @chaliy
+* fix(wasm): reject async custom builtins before executeSync invocation ([#2197](https://github.com/everruns/bashkit/pull/2197)) by @chaliy
+* fix(deps): resolve npm security advisories ([#2195](https://github.com/everruns/bashkit/pull/2195)) by @chaliy
+* chore(deps): bump the rust-dependencies group with 14 updates ([#2194](https://github.com/everruns/bashkit/pull/2194)) by @dependabot
+* chore(ci): bump the github-actions group with 2 updates ([#2193](https://github.com/everruns/bashkit/pull/2193)) by @dependabot
+* feat(wasm): persist browser example files ([#2192](https://github.com/everruns/bashkit/pull/2192)) by @chaliy
+* docs: per-target Get started flow + linkable heading anchors ([#2191](https://github.com/everruns/bashkit/pull/2191)) by @chaliy
+* chore(python): build abi3 wheels to cut PyPI storage ~6x ([#2190](https://github.com/everruns/bashkit/pull/2190)) by @chaliy
+* Revert "build(python): ship abi3 stable-ABI wheels (#2187)" ([#2189](https://github.com/everruns/bashkit/pull/2189)) by @chaliy
+* docs: add Targets & bindings page with a live in-browser bash terminal ([#2188](https://github.com/everruns/bashkit/pull/2188)) by @chaliy
+* build(python): ship abi3 stable-ABI wheels ([#2187](https://github.com/everruns/bashkit/pull/2187)) by @chaliy
+* docs(examples): refresh browser screenshot for the bashkit-wasm rename ([#2186](https://github.com/everruns/bashkit/pull/2186)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.14.3...v0.14.4
 
 ## [0.14.3] - 2026-07-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "bashkit",
  "napi",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.14.3", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.14.4", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/justfile
+++ b/justfile
@@ -341,44 +341,8 @@ release-check:
     # Check nightly CI jobs (last 3 runs must be green)
     just check-nightly
 
-    # Match publish.yml locally: strip git-only publish blockers, dry-run, restore.
-    TMPDIR=$(mktemp -d)
-    LOCKFILE=Cargo.lock
-    BASHKIT_TOML=crates/bashkit/Cargo.toml
-    CLI_TOML=crates/bashkit-cli/Cargo.toml
-    JS_TOML=crates/bashkit-js/Cargo.toml
-    PY_TOML=crates/bashkit-python/Cargo.toml
-    cp "$LOCKFILE" "$TMPDIR/Cargo.lock"
-    cp "$BASHKIT_TOML" "$TMPDIR/bashkit.Cargo.toml"
-    cp "$CLI_TOML" "$TMPDIR/bashkit-cli.Cargo.toml"
-    cp "$JS_TOML" "$TMPDIR/bashkit-js.Cargo.toml"
-    cp "$PY_TOML" "$TMPDIR/bashkit-python.Cargo.toml"
-    trap 'cp "$TMPDIR/Cargo.lock" "$LOCKFILE"; \
-          cp "$TMPDIR/bashkit.Cargo.toml" "$BASHKIT_TOML"; \
-          cp "$TMPDIR/bashkit-cli.Cargo.toml" "$CLI_TOML"; \
-          cp "$TMPDIR/bashkit-js.Cargo.toml" "$JS_TOML"; \
-          cp "$TMPDIR/bashkit-python.Cargo.toml" "$PY_TOML"; \
-          rm -rf "$TMPDIR"' EXIT
-    perli() {
-        perl -0pi.bak -e "$1" "$2"
-        rm -f "$2.bak"
-    }
-
-    # --- bashkit core: remove monty dep and python feature ---
-    perli 's/^monty = .*?\n//m' "$BASHKIT_TOML"
-    perli 's/^python = \["dep:monty"\]\n//m' "$BASHKIT_TOML"
-    perli 's/\n\[\[example\]\]\nname = "python_scripts"\nrequired-features = \["python"\]\n//g' "$BASHKIT_TOML"
-    perli 's/\n\[\[example\]\]\nname = "python_external_functions"\nrequired-features = \["python"\]\n//g' "$BASHKIT_TOML"
-
-    # --- bashkit-cli: remove python feature ---
-    perli 's/^python = \["bashkit\/python"\]\n//m' "$CLI_TOML"
-    perli 's/, "python"//g; s/"python", //g; s/\["python"\]/[]/g' "$CLI_TOML"
-
-    # --- bashkit-js/bashkit-python: remove python from features list ---
-    perli 's/, "python"//g; s/"python", //g' "$JS_TOML"
-    perli 's/, "python"//g; s/"python", //g' "$PY_TOML"
-
-    # Dry-run publish
+    # Monty is a registry dependency, so verify the exact package that CI
+    # publishes. Rewriting manifests here can hide real packaging failures.
     echo ""
     echo "Dry-run publish bashkit..."
     cargo publish -p bashkit --dry-run --allow-dirty
@@ -387,9 +351,40 @@ release-check:
     echo "Dry-run publish bashkit-cli..."
     # bashkit-cli verifies against the registry package of bashkit.
     # Before the matching bashkit release is published, local dry-run cannot
-    # compile that packaged dependency graph. The real publish workflow keeps
-    # verification enabled after bashkit is live on crates.io.
-    cargo publish -p bashkit-cli --dry-run --allow-dirty --no-verify
+    # resolve that package. Package a disposable workspace against the latest
+    # published core as a structural proxy. The real workflow publishes and
+    # verifies the matching core before publishing the CLI.
+    CLI_VERIFY_ROOT=$(mktemp -d)
+    trap 'rm -rf "$CLI_VERIFY_ROOT"' EXIT
+    rsync -a \
+        --exclude .git \
+        --exclude node_modules \
+        --exclude target \
+        ./ "$CLI_VERIFY_ROOT/workspace/"
+    LATEST_CORE=$(cargo search bashkit --limit 1 | sed -n 's/^bashkit = "\([^"]*\)".*/\1/p')
+    if [ -z "$LATEST_CORE" ]; then
+        echo "Error: could not determine latest published bashkit version"
+        exit 1
+    fi
+    WORKSPACE_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+    CLI_TOML="$CLI_VERIFY_ROOT/workspace/crates/bashkit-cli/Cargo.toml"
+    sed -i.bak \
+        "s/version = \"$WORKSPACE_VERSION\"/version = \"$LATEST_CORE\"/" \
+        "$CLI_TOML"
+    rm "$CLI_TOML.bak"
+    # The latest published core predates Monty's crates.io publication and
+    # therefore lacks the Python feature. The exact new core package dry-run
+    # above validates that feature; omit it only from this CLI structure proxy.
+    perl -0pi.bak -e \
+        's/^python = \["bashkit\/python"\]\n//m; s/"python", //g; s/, "python"//g' \
+        "$CLI_TOML"
+    rm "$CLI_TOML.bak"
+    cargo publish \
+        --manifest-path "$CLI_VERIFY_ROOT/workspace/Cargo.toml" \
+        -p bashkit-cli \
+        --dry-run \
+        --allow-dirty \
+        --no-verify
 
     echo ""
     echo "All release checks passed!"


### PR DESCRIPTION
## What changed

Prepare Bashkit v0.14.4 across Cargo, Node.js, browser WebAssembly, and Python release surfaces. The release includes stable-ABI Python wheels, persistent browser files with safer storage and timeout handling, and non-blocking RealFs operations.

The release gate now dry-runs the exact core crate package. Before the matching core exists on crates.io, CLI packaging is checked from a disposable workspace against the latest published core instead of mutating the release manifests.

## Why

Ship the fixes merged since v0.14.3 and restore a trustworthy local publishing gate. Stable-ABI wheels reduce PyPI artifact volume and avoid the partial-version availability seen with v0.14.2.

## Before / After

- Python native artifacts: 42 platform/interpreter wheels (~500 MiB) → 7 `cp39-abi3` wheels (~85 MiB).
- Core dry-run: rewritten reduced-feature manifest → exact package CI will publish (511 files, 7.2 MiB unpacked / 1.4 MiB compressed).
- CLI dry-run proxy: completed successfully (6 files, 184.1 KiB unpacked / 48.3 KiB compressed).
- `just release-check`: passed in full, including format, clippy, feature-sliced tests, docs, security checks, OKF validation, vet, nightly/fuzz health, and publish dry-runs.

## Risk

- Medium
- Multi-registry publication could fail independently; release automation and post-merge registry monitoring cover GitHub, crates.io, PyPI, npm, and Homebrew.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered