### PR TITLE
fix(docs): repoint broken cross-tree markdown links and guard them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
           python3 scripts/check_okf.py knowledge
           okf-lint knowledge --max-line-length 10000
 
+      # The site rewrites doc links by basename, so a cross-tree link written as
+      # a bare `jq.md` renders fine on bashkit.sh while 404-ing for anyone
+      # reading the markdown on GitHub. site/scripts/verify-doc-*.mjs check the
+      # built routes and cannot see this; these check the source-relative form.
+      - name: Check doc links
+        run: python3 scripts/check_doc_links.py
+
+      - name: Test repo scripts
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
   wasm:
     # std::time panics on wasm32-unknown-unknown, so bashkit routes clock reads
     # through src/time_compat.rs (web-time on wasm32). This job keeps the crate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,10 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 - Rustdoc guides embedded via `include_str!` (see `knowledge/operations/documentation.md`)
 - Edit `crates/bashkit/docs/*.md`, not the doc modules in `lib.rs`
 - Add "See also" cross-links when creating new guides
+- Cross-tree links must be source-relative (`../crates/bashkit/docs/jq.md`, not
+  a bare `jq.md`) — the site rewrites by basename and hides the breakage, GitHub
+  does not. Titles/descriptions go in `site/src/pages/docs/_meta.ts`, never in
+  markdown frontmatter. Enforced by `just check-doc-links`
 - Run `cargo doc --open` to preview rustdoc changes
 
 ### Bashkit Principles

--- a/crates/bashkit/docs/namespace_filesystems.md
+++ b/crates/bashkit/docs/namespace_filesystems.md
@@ -85,5 +85,5 @@ access.
 - [`FileSystem`] — filesystem operation contract.
 - [`MountableFs`] — dynamic live mounts with a fallback root filesystem.
 - [`ReadOnlyFs`] — deny mutations for an entire filesystem.
-- [Live mounts](live-mounts.md) — attach and detach filesystems after build.
+- [Live mounts](live_mounts.md) — attach and detach filesystems after build.
 - [VFS specification](https://github.com/everruns/bashkit/blob/main/knowledge/foundations/vfs.md).

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -65,7 +65,7 @@ semantics.
 |----------------|---------|
 | **InMemoryFs** | Default (`Bash::new()`). `HashMap`-backed, thread-safe, no persistence. Seeds `/`, `/tmp`, `/home`, `/home/user`, `/dev`. |
 | **OverlayFs** | Copy-on-write over another filesystem, with whiteout tracking for deletes. |
-| **MountableFs** | Mount multiple filesystems at different paths (longest-prefix match). Always the outermost layer, enabling [live mounts](live-mounts.md). |
+| **MountableFs** | Mount multiple filesystems at different paths (longest-prefix match). Always the outermost layer, enabling [live mounts](../crates/bashkit/docs/live_mounts.md). |
 | **NamespaceFs** | Compose a static visible tree from rebased filesystem subtrees, with per-mount access and synthetic ancestors. |
 | **ReadOnlyFs** | Delegates reads, denies every mutation with `PermissionDenied` — even writes to `/tmp`, `cp`, `mv`, `rm`, `chmod`. For inspection-only sessions. |
 | **RealFs** (`realfs` feature) | Direct access to a host directory. Read-only (safe) or read-write (dangerous); path traversal blocked by canonicalisation + root-prefix checks. |
@@ -150,7 +150,7 @@ readonly_filesystem: bool                       # deny all VFS mutations after s
 ## See also
 
 - [Security](security.md) — the boundaries built on top of the VFS.
-- [Live mounts](live-mounts.md) — attach and detach filesystems at runtime.
+- [Live mounts](../crates/bashkit/docs/live_mounts.md) — attach and detach filesystems at runtime.
 - [Filesystem namespaces](https://docs.rs/bashkit/latest/bashkit/namespace_filesystems_guide/) — compose and rebase static mount trees.
 - [Snapshotting](snapshotting.md) — serialise and restore VFS + shell state.
 - Spec: [`knowledge/foundations/vfs.md`](https://github.com/everruns/bashkit/blob/main/knowledge/foundations/vfs.md).

--- a/docs/llm-tools.md
+++ b/docs/llm-tools.md
@@ -107,7 +107,7 @@ npx skills add everruns/bashkit
 
 ## Next steps
 
-- [Hooks](hooks.md) — observe, rewrite, or cancel tool calls and HTTP requests.
+- [Hooks](../crates/bashkit/docs/hooks.md) — observe, rewrite, or cancel tool calls and HTTP requests.
 - [Security](security.md) — the sandbox boundaries every tool call runs inside.
 - Examples: [agent and tool flows](https://github.com/everruns/bashkit/tree/main/examples).
 - Full API reference: [docs.rs/bashkit](https://docs.rs/bashkit/latest/bashkit/).

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -107,13 +107,13 @@ exposes the coarse `--http-allow-all` switch for trusted use.
 
 ## Observing and rewriting requests
 
-HTTP requests flow through the same [hooks](hooks.md) pipeline as the rest of the
+HTTP requests flow through the same [hooks](../crates/bashkit/docs/hooks.md) pipeline as the rest of the
 interpreter, so a host can observe, rewrite, or cancel an outbound request before
 it leaves — useful for logging, header injection, or policy enforcement.
 
 ## See also
 
-- [Credential injection](credential-injection.md) — attach secrets to outbound
+- [Credential injection](../crates/bashkit/docs/credential-injection.md) — attach secrets to outbound
   requests without exposing them to the script.
 - [Request signing](request-signing.md) — cryptographic bot identity for signed
   outbound requests.

--- a/docs/request-signing.md
+++ b/docs/request-signing.md
@@ -115,7 +115,7 @@ The nonce defends against replay; the expiry window bounds signature validity.
 ## See also
 
 - [Networking & HTTP](networking.md) — the allowlist that gates every request.
-- [Credential injection](credential-injection.md) — attach bearer tokens without
+- [Credential injection](../crates/bashkit/docs/credential-injection.md) — attach bearer tokens without
   exposing them to scripts.
 - Spec: [`knowledge/security/request-signing.md`](https://github.com/everruns/bashkit/blob/main/knowledge/security/request-signing.md).
 - [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421) ·

--- a/docs/start-pyodide.md
+++ b/docs/start-pyodide.md
@@ -42,4 +42,4 @@ learn immediately that the WASM build can't do it.
 
 - [Get started in Python](start-python.md) — the full-featured native PyPI wheel.
 - [Get started in the browser](start-browser.md) — the JavaScript WASM package.
-- [Python builtin](python.md) — the embedded Monty runtime in depth.
+- [Python builtin](../crates/bashkit/docs/python.md) — the embedded Monty runtime in depth.

--- a/docs/start-python.md
+++ b/docs/start-python.md
@@ -45,7 +45,7 @@ result = await bash.execute("echo hi | my_async_tool")
 
 Bashkit can also run Python *inside* the shell via the embedded Monty runtime —
 enable it with `Bash(python=True)`. That is a different feature from embedding
-Bashkit in your Python app; see the [Python builtin](python.md) guide.
+Bashkit in your Python app; see the [Python builtin](../crates/bashkit/docs/python.md) guide.
 
 ## Examples
 

--- a/docs/start-rust.md
+++ b/docs/start-rust.md
@@ -24,7 +24,7 @@ cargo add bashkit --features scripted_tool
 
 `http_client` enables `curl`/`wget` and the network allowlist. `python`
 embeds the [Monty](https://github.com/pydantic/monty) interpreter — see the
-[Python builtin](python.md) guide to run Python inside the shell, and [Get
+[Python builtin](../crates/bashkit/docs/python.md) guide to run Python inside the shell, and [Get
 started in Python](start-python.md) to embed Bashkit *in* a Python app.
 
 ## First script
@@ -102,7 +102,7 @@ Runnable Rust examples in the repo:
 ## Next steps
 
 - [Sandbox configuration & limits](configuration.md) — resource limits, filesystem, allowlist.
-- [Custom builtins](custom_builtins.md) — add your own Rust commands to the shell.
+- [Custom builtins](../crates/bashkit/docs/custom_builtins.md) — add your own Rust commands to the shell.
 - [Snapshotting](snapshotting.md) — serialize and restore interpreter state.
 - [Security](security.md) — sandbox boundaries and what scripts cannot do.
 - Full API reference: [docs.rs/bashkit](https://docs.rs/bashkit/latest/bashkit/).

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -7,7 +7,7 @@ file argument or from stdin so they pipe naturally.
 
 | Builtin | Format | Reach for it when |
 |---------|--------|-------------------|
-| [`jq`](jq.md) | JSON | You need real JSON transformation — filters, construction, reduction. |
+| [`jq`](../crates/bashkit/docs/jq.md) | JSON | You need real JSON transformation — filters, construction, reduction. |
 | `json` | JSON | You want a quick `get` / `set` / `keys` / `length` without jq syntax. |
 | `csv` | CSV | Selecting columns, filtering rows, counting, sorting tabular data. |
 | `yaml` | YAML | Reading a value out of a config file by dotted path. |
@@ -76,7 +76,7 @@ echo "starting on $port"
 
 ## See also
 
-- [jq builtin](jq.md) — the full JSON query engine, with its own compatibility
+- [jq builtin](../crates/bashkit/docs/jq.md) — the full JSON query engine, with its own compatibility
   reference.
-- [Compatibility](compatibility.md) — the complete builtin coverage matrix.
+- [Compatibility](../crates/bashkit/docs/compatibility.md) — the complete builtin coverage matrix.
 - [Browse all builtins](/builtins) — every registered command.

--- a/justfile
+++ b/justfile
@@ -45,6 +45,14 @@ check:
     cargo test
     python3 -m unittest discover -s scripts/tests -p 'test_*.py'
     just check-okf
+    just check-doc-links
+
+# The site rewrites doc links by basename, so a cross-tree link written as a
+# bare `jq.md` renders fine on bashkit.sh while 404-ing on GitHub. This checks
+# the source-relative form the site rewriter also accepts.
+# Validate relative markdown links in docs/ and crates/bashkit/docs/
+check-doc-links:
+    python3 scripts/check_doc_links.py
 
 # okf-lint covers the spec rules; check_okf.py covers the bundle-local
 # conventions it does not enforce (see knowledge/knowledge-contract.md).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,10 @@
 # Bashkit Knowledge Update Log
 
+## 2026-07-29
+
+* **Enforcement**: Added `scripts/check_doc_links.py` (`just check-doc-links`, wired into `just check` and CI) to reject dangling relative markdown links in `docs/`, `crates/bashkit/docs/`, and root markdown — the site's basename-matching link rewriter hid 14 of them from every existing verifier. Rule and rationale recorded in [Documentation](operations/documentation.md) and [Maintenance](operations/maintenance.md).
+* **Decision**: Page titles/descriptions stay in `DOC_META`; markdown frontmatter is rejected for both doc trees so rustdoc `include_str!` embedding stays clean.
+
 ## 2026-07-26
 
 * **Restructure**: Grouped the 29 domain concepts into `foundations/`, `security/`, `runtimes/`, `integrations/`, and `operations/`, each with its own `index.md`; the root index now enumerates root concepts and subdirectories only. Frontmatter `type` values are unchanged — directory conveys domain, `type` conveys kind.

--- a/knowledge/operations/documentation.md
+++ b/knowledge/operations/documentation.md
@@ -32,6 +32,18 @@ Repo-root `docs/` is for user-facing site articles.
 - Each guide markdown starts with a "See also" section linking related guides/API docs
 - Doc module gets a `///` summary above the `#[doc = include_str!]` for rustdoc cross-links; reference types with `` [`TypeName`] `` syntax
 - New guides: add file in `crates/bashkit/docs/`, add doc module in `lib.rs`, link it from the crate docs `# Guides` section, preview with `cargo doc --open`
+- Cross-tree markdown links are written **source-relative**
+  (`../crates/bashkit/docs/jq.md`, not a bare `jq.md`). Both trees are browsed
+  as source on GitHub *and* flattened to `/docs/<slug>/` on the site; the site's
+  `DOC_LINKS` rewriter (`site/astro.config.mjs`) matches on basename, so it
+  accepts either form while only the source-relative one works on GitHub.
+  Enforced by `just check-doc-links` (`scripts/check_doc_links.py`, in
+  `just check` and CI) — the `site/scripts/verify-doc-*.mjs` verifiers check
+  built routes and cannot see this class of breakage.
+- Page titles and descriptions live in `DOC_META`
+  (`site/src/pages/docs/_meta.ts`), never in markdown frontmatter: the canonical
+  files must stay frontmatter-free so `crates/bashkit/docs/*.md` embed cleanly
+  via `include_str!` into rustdoc.
 
 ## Code Examples
 

--- a/knowledge/operations/maintenance.md
+++ b/knowledge/operations/maintenance.md
@@ -78,6 +78,17 @@ dependency rot, or security gaps ship in a release.
 - Python docstrings match behavior
 - `README.md` feature list matches implemented builtins
 - Public docs (`docs/`) match current code: CLI flags, security boundaries, feature descriptions, test counts, and examples all reflect reality
+- Relative markdown links resolve as source: `just check-doc-links` green. The
+  site rewrites link targets by *basename* (`DOC_LINKS` in
+  `site/astro.config.mjs`), so a cross-tree link written as a bare `jq.md`
+  renders correctly on bashkit.sh while 404-ing for anyone reading the markdown
+  on GitHub — `site/scripts/verify-doc-*.mjs` check the built routes and cannot
+  see it. Write cross-tree links source-relative
+  (`../crates/bashkit/docs/jq.md`); the site rewriter accepts that form too.
+  Do **not** add YAML frontmatter to `docs/` or `crates/bashkit/docs/` to carry
+  titles or descriptions: page metadata lives in `site/src/pages/docs/_meta.ts`,
+  and frontmatter in `crates/bashkit/docs/` would leak into rustdoc via
+  `include_str!`
 - Agent surfaces (`/llms.txt`, `/llms-full.txt`, Markdown routes) regenerate and pass `verify-llms` (auto-enforced in CI); refresh the agent-skills tarball/`index.json` digest if `skills/bashkit/` changed (see `knowledge/documentation.md` § Agent-facing site surfaces)
 - `CONTRIBUTING.md` instructions accurate
 - `CHANGELOG.md` has entries for all changes since last release

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Validate relative markdown links in the repo's prose trees.
+
+Why this exists: `docs/` and `crates/bashkit/docs/` render both on GitHub
+(source-relative paths) and on bashkit.sh (flattened to `/docs/<slug>/`).
+The site's `DOC_LINKS` map in `site/astro.config.mjs` resolves link targets by
+*basename*, so a cross-tree link written as a bare `jq.md` still renders
+correctly on the site while 404-ing for anyone reading the markdown on GitHub.
+That asymmetry let 14 broken links accumulate unnoticed; this check closes it by
+validating the source-relative form, which the site rewriter accepts too.
+
+Not a replacement for `site/scripts/verify-doc-*.mjs` — those verify the built
+routes. This one needs no build and runs in `just check`.
+
+Skipped: URLs with a scheme (including rustdoc `crate::` intra-doc links),
+protocol-relative and site-absolute paths, bare anchors, and anything inside
+fenced or inline code.
+
+No third-party dependencies, so the check runs anywhere `python3` does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# Trees whose markdown is browsed as source on GitHub. Root files are included
+# because README/CONTRIBUTING link into them.
+DEFAULT_ROOTS = ("docs", "crates/bashkit/docs", ".")
+
+LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+# A scheme (`https:`, and rustdoc's `crate::`), protocol-relative, site-absolute,
+# or a bare anchor — none of these name a file on disk.
+EXTERNAL = re.compile(r"\A(?:[a-z][a-z0-9+.-]*:|//|/|#)")
+# Fenced blocks first, then inline spans: prose about markdown (and shell
+# examples containing `](`) must not be read as links.
+CODE = re.compile(r"^```.*?^```|``.*?``|`[^`\n]*`", re.DOTALL | re.MULTILINE)
+
+
+def strip_code(text: str) -> str:
+    """Blank out fenced and inline code so link scanning ignores it."""
+    return CODE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+
+
+def check_file(path: pathlib.Path, rel: str, errors: list[str]) -> int:
+    """Append an error for every relative link target that does not exist."""
+    text = strip_code(path.read_text())
+    checked = 0
+    for match in LINK.finditer(text):
+        target = match.group(1).strip()
+        if not target or EXTERNAL.match(target):
+            continue
+        resolved = target.split("#", 1)[0]
+        if not resolved:
+            continue
+        checked += 1
+        if not (path.parent / resolved).exists():
+            line = text[: match.start()].count("\n") + 1
+            errors.append(f"{rel}:{line}: link target does not exist: {target}")
+    return checked
+
+
+def markdown_files(root: pathlib.Path, tree: str) -> list[pathlib.Path]:
+    """Markdown under `tree`; non-recursive for `.` so only root files match."""
+    base = root / tree
+    if not base.is_dir():
+        return []
+    pattern = "*.md" if tree == "." else "**/*.md"
+    return sorted(base.glob(pattern))
+
+
+def check_trees(root: pathlib.Path, trees: tuple[str, ...]) -> tuple[list[str], dict[str, int]]:
+    errors: list[str] = []
+    stats = {"files": 0, "links": 0}
+    for tree in trees:
+        for path in markdown_files(root, tree):
+            stats["files"] += 1
+            stats["links"] += check_file(path, str(path.relative_to(root)), errors)
+    return errors, stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", default=".", help="repository root")
+    parser.add_argument(
+        "--tree",
+        action="append",
+        dest="trees",
+        help="tree to scan, relative to root (repeatable; defaults to docs trees + root files)",
+    )
+    args = parser.parse_args(argv)
+
+    root = pathlib.Path(args.root)
+    if not root.is_dir():
+        print(f"not a directory: {root}", file=sys.stderr)
+        return 2
+
+    errors, stats = check_trees(root, tuple(args.trees or DEFAULT_ROOTS))
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        print(f"\n{len(errors)} broken relative link(s)", file=sys.stderr)
+        return 1
+    print(f"doc links OK: {stats['links']} relative links across {stats['files']} files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_doc_links.py
+++ b/scripts/tests/test_check_doc_links.py
@@ -1,0 +1,109 @@
+"""Tests for scripts/check_doc_links.py (relative markdown link check).
+
+One case per skip class and rejection class, plus a positive control —
+without it, a validator that errored on everything would pass every negative
+test. The real trees are covered by `just check-doc-links` and CI, not
+duplicated here.
+
+unittest.TestCase so `python3 -m unittest discover -s scripts/tests` (wired
+into `just check`) actually executes them; pytest runs them too.
+"""
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "check_doc_links.py"
+
+
+def run(root: pathlib.Path, *trees: str) -> subprocess.CompletedProcess:
+    args = [sys.executable, str(SCRIPT), str(root)]
+    for tree in trees:
+        args += ["--tree", tree]
+    return subprocess.run(args, capture_output=True, text=True)
+
+
+class CheckDocLinksTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self._tmp.name)
+        (self.root / "docs").mkdir()
+        (self.root / "guides").mkdir()
+        (self.root / "guides" / "jq.md").write_text("# jq\n")
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, body: str) -> None:
+        (self.root / "docs" / "page.md").write_text(body)
+
+    def check(self) -> subprocess.CompletedProcess:
+        return run(self.root, "docs", "guides")
+
+    def test_resolvable_link_accepted(self) -> None:
+        self.write("See [jq](../guides/jq.md).\n")
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("doc links OK", result.stdout)
+
+    def test_dangling_link_rejected(self) -> None:
+        self.write("See [jq](jq.md).\n")
+        result = self.check()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("docs/page.md:1: link target does not exist: jq.md", result.stderr)
+
+    def test_anchor_is_stripped_before_resolving(self) -> None:
+        self.write("See [jq](../guides/jq.md#usage) and [here](#top).\n")
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_dangling_link_with_anchor_rejected(self) -> None:
+        self.write("See [jq](jq.md#usage).\n")
+        result = self.check()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not exist: jq.md#usage", result.stderr)
+
+    def test_external_and_site_absolute_links_skipped(self) -> None:
+        """Schemes, protocol-relative, and site-absolute paths name no file."""
+        self.write(
+            "[web](https://example.com/a.md) [proto](//example.com/a.md) "
+            "[site](/builtins) [mail](mailto:x@example.com)\n"
+        )
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_rustdoc_intra_doc_links_skipped(self) -> None:
+        """`crate::x` is a rustdoc path, not a file."""
+        self.write("See [`threat_model`](crate::threat_model).\n")
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_links_inside_code_are_not_links(self) -> None:
+        """Prose about markdown, and shell examples containing `](`, are not links."""
+        self.write(
+            "Write it as `[Title](gone.md)`.\n\n```sh\necho '[x](gone.md)'\n```\n"
+        )
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_line_number_reported_after_fenced_block(self) -> None:
+        """Blanked code keeps its newlines so later line numbers stay accurate."""
+        self.write("```sh\necho hi\n```\n\nSee [jq](jq.md).\n")
+        result = self.check()
+        self.assertIn("docs/page.md:5:", result.stderr)
+
+    def test_root_tree_is_not_recursive(self) -> None:
+        """`.` scans root files only; nested trees are named explicitly."""
+        (self.root / "README.md").write_text("See [jq](guides/jq.md).\n")
+        self.write("See [jq](jq.md).\n")
+        result = run(self.root, ".")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_missing_tree_is_not_an_error(self) -> None:
+        result = run(self.root, "docs", "nonexistent")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_missing_root_rejected(self) -> None:
+        result = run(self.root / "nope", "docs")
+        self.assertEqual(result.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

14 relative markdown links across `docs/` and `crates/bashkit/docs/` pointed at
files that do not exist relative to the source file. Anyone reading these guides
on GitHub — the primary path for contributors and for agents fetching raw
markdown — got a 404 on `jq`, `hooks`, `python`, `credential-injection`,
`live_mounts`, `compatibility`, and `custom_builtins`. They are now written
source-relative.

A new `just check-doc-links` (`scripts/check_doc_links.py`) validates every
relative link in `docs/`, `crates/bashkit/docs/`, and root markdown. It runs in
`just check` and in CI, so this class of breakage cannot recur. CI now also runs
the `scripts/tests` suite, which previously only executed via `just check`
locally.

The link rule and the accompanying no-frontmatter decision are recorded in
`AGENTS.md`, `knowledge/operations/documentation.md`, and the pre-release
maintenance checklist.

## Why

The breakage was invisible to every existing verifier. The site rewrites doc
links by **basename** (`DOC_LINKS` in `site/astro.config.mjs`), so a bare
`jq.md` written inside `docs/structured-data.md` resolves to `/docs/jq/` and
renders correctly on bashkit.sh. `site/scripts/verify-doc-*.mjs` check the built
routes, which were fine. Only the GitHub-rendered source was broken, and nothing
looked at that.

The fix uses the source-relative form because the site rewriter accepts it too
(it takes the basename either way), so both surfaces work from one spelling.

Surfaced while reviewing a downstream fork's PR that had spotted the same links.

## Before / After

Before — the checker on `main`:

```
$ python3 scripts/check_doc_links.py
docs/filesystem.md:68: link target does not exist: live-mounts.md
docs/filesystem.md:153: link target does not exist: live-mounts.md
docs/llm-tools.md:110: link target does not exist: hooks.md
docs/networking.md:110: link target does not exist: hooks.md
docs/networking.md:116: link target does not exist: credential-injection.md
docs/request-signing.md:118: link target does not exist: credential-injection.md
docs/start-pyodide.md:45: link target does not exist: python.md
docs/start-python.md:48: link target does not exist: python.md
docs/start-rust.md:27: link target does not exist: python.md
docs/start-rust.md:105: link target does not exist: custom_builtins.md
docs/structured-data.md:10: link target does not exist: jq.md
docs/structured-data.md:79: link target does not exist: jq.md
docs/structured-data.md:81: link target does not exist: compatibility.md
crates/bashkit/docs/namespace_filesystems.md:88: link target does not exist: live-mounts.md

14 broken relative link(s)
```

After:

```
$ just check-doc-links
doc links OK: 134 relative links across 40 files
```

Site rendering is unchanged — the rewriter resolves the new paths to the same
routes, confirmed in the built HTML: `docs/structured-data` still emits
`href="/docs/jq/"`, and `docs/filesystem` still emits `/docs/live-mounts/`.
`pnpm run build` in `site/` is green, including all ten `postbuild` verifiers,
and the Workers preview deploy succeeded.

## Risk

- Low
- Documentation content and tooling only; no library, binding, or CLI code
  changes. `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
  is green (`crates/bashkit/docs/` is embedded into rustdoc via `include_str!`).
- The new check is additive: it fails only on a relative link whose target is
  missing on disk. Schemes (including rustdoc `crate::` intra-doc links),
  protocol-relative and site-absolute paths, bare anchors, and anything inside
  fenced or inline code are skipped, each with a test.

## Checklist

- [x] Tests added or updated — 11 unit tests in
      `scripts/tests/test_check_doc_links.py`, one per skip and rejection class
      plus a positive control
- [x] Backward compatibility considered — internal docs and tooling, no public
      surface affected