### PR TITLE
fix(ci): unblock main — guard third-party LLM steps and refresh retired model id

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,8 +315,12 @@ jobs:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: doppler run --only-secrets ANTHROPIC_API_KEY -- cargo run --example agent_tool --features http_client
 
+      # External API dependency — same rationale as the LLM agent example
+      # above: an OpenAI outage, quota exhaustion, or billing lapse is not a
+      # bashkit regression and must not turn main red.
       - name: Run harness OpenAI joke example
         if: github.event_name == 'push' && env.DOPPLER_AVAILABLE == 'true'
+        continue-on-error: true
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |

--- a/crates/bashkit-python/bashkit/langchain.py
+++ b/crates/bashkit-python/bashkit/langchain.py
@@ -19,7 +19,7 @@ Use with a LangChain agent::
     >>> from langgraph.prebuilt import create_react_agent
     >>>
     >>> tool = create_bash_tool()
-    >>> agent = create_react_agent(ChatAnthropic(model="claude-sonnet-4-20250514"), [tool])
+    >>> agent = create_react_agent(ChatAnthropic(model="claude-sonnet-5"), [tool])
 
 Wrap a ScriptedTool for multi-tool orchestration::
 

--- a/crates/bashkit-python/bashkit/pydantic_ai.py
+++ b/crates/bashkit-python/bashkit/pydantic_ai.py
@@ -9,7 +9,7 @@ Create a tool and attach it to a PydanticAI agent::
     >>> from pydantic_ai import Agent
     >>>
     >>> tool = create_bash_tool(timeout_seconds=30)
-    >>> agent = Agent('anthropic:claude-sonnet-4-20250514', tools=[tool])
+    >>> agent = Agent('anthropic:claude-sonnet-5', tools=[tool])
 
 The agent can then run bash commands in a sandboxed VFS::
 
@@ -56,7 +56,7 @@ def create_bash_tool(
         >>> from bashkit.pydantic_ai import create_bash_tool
         >>> tool = create_bash_tool(timeout_seconds=30)
         >>> from pydantic_ai import Agent
-        >>> agent = Agent('anthropic:claude-sonnet-4-20250514', tools=[tool])
+        >>> agent = Agent('anthropic:claude-sonnet-5', tools=[tool])
     """
     if not PYDANTIC_AI_AVAILABLE:
         raise ImportError(

--- a/crates/bashkit-python/examples/k8s_orchestrator.py
+++ b/crates/bashkit-python/examples/k8s_orchestrator.py
@@ -490,7 +490,9 @@ def run_langchain_demo(tool: ScriptedTool) -> None:
     print(f"\nLangChain tool: name={lc_tool.name!r}, tools={tool.tool_count()}")
 
     # Create agent with Claude
-    model = ChatAnthropic(model="claude-sonnet-4-20250514", temperature=0)
+    # Claude Sonnet 5 rejects non-default sampling params (temperature/top_p/top_k)
+    # with a 400.
+    model = ChatAnthropic(model="claude-sonnet-5")
     agent = create_react_agent(model, [lc_tool])
 
     # Ask the agent to investigate the cluster

--- a/crates/bashkit/examples/agent_tool.rs
+++ b/crates/bashkit/examples/agent_tool.rs
@@ -142,7 +142,7 @@ impl Agent {
 
     async fn call_claude(&self, messages: &[Message]) -> anyhow::Result<MessagesResponse> {
         let request = MessagesRequest {
-            model: "claude-sonnet-4-20250514",
+            model: "claude-sonnet-5",
             max_tokens: 1024,
             system: "You are an agent with access to a virtual bash environment. \
                     Your task is to create a few text files with short poems about different topics. \

--- a/examples/bashkit-pi/README.md
+++ b/examples/bashkit-pi/README.md
@@ -35,7 +35,7 @@ pi --provider openai --model gpt-5.4 \
   --api-key "$OPENAI_API_KEY"
 
 # With Anthropic
-pi --provider anthropic --model claude-sonnet-4-20250514 \
+pi --provider anthropic --model claude-sonnet-5 \
   -e examples/bashkit-pi/bashkit-extension.ts \
   --api-key "$ANTHROPIC_API_KEY"
 

--- a/examples/deepagent_coding_agent.py
+++ b/examples/deepagent_coding_agent.py
@@ -48,7 +48,7 @@ async def main():
     bashkit_middleware = backend.create_middleware()
 
     agent = create_deep_agent(
-        model="anthropic:claude-sonnet-4-20250514",
+        model="anthropic:claude-sonnet-5",
         backend=backend,
         middleware=[bashkit_middleware],
         system_prompt=SYSTEM_PROMPT,

--- a/examples/pydantic_ai_bash_agent.py
+++ b/examples/pydantic_ai_bash_agent.py
@@ -48,7 +48,7 @@ async def main():
     bash_tool = create_bash_tool(username="agent", hostname="sandbox")
 
     agent = Agent(
-        "anthropic:claude-sonnet-4-20250514",
+        "anthropic:claude-sonnet-5",
         system_prompt=SYSTEM_PROMPT,
         tools=[bash_tool],
     )

--- a/examples/treasure_hunt_agent.py
+++ b/examples/treasure_hunt_agent.py
@@ -197,7 +197,7 @@ async def run_agent():
 
     # Create the agent
     agent = create_agent(
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-5",
         tools=[bash_tool],
         system_prompt=SYSTEM_PROMPT,
     )

--- a/knowledge/operations/testing.md
+++ b/knowledge/operations/testing.md
@@ -93,6 +93,22 @@ Uploaded to Codecov from three sources: Rust unit/integration coverage via
 `cargo tarpaulin`; Rust coverage exercised through Python and Node binding
 tests via `cargo llvm-cov`.
 
+## Third-Party API Steps in CI
+
+The `Examples` job runs a few steps that call third-party LLM APIs (Anthropic
+via `cargo run --example agent_tool`, OpenAI via `examples/harness-openai-joke.sh`).
+Their credentials come from Doppler, so they only run on pushes to `main`.
+
+Every such step must set `continue-on-error: true`. An upstream outage, quota
+exhaustion, or billing lapse is not a bashkit regression, and letting it fail
+the `Check` gate makes main red for a cause no commit can fix. The steps stay
+in CI as smoke signals — read their logs when they fail rather than trusting
+the job conclusion.
+
+Corollary: these steps do not protect against a broken model id. Pin only model
+ids that are current, and re-check them when a model is retired — a retired id
+surfaces as a 404 in an already-green job.
+
 ## Adding New Tests
 
 1. Create or edit `.test.sh` file in appropriate category, standard format


### PR DESCRIPTION
## What changed

Main goes green again, and the LLM agent example starts working again.

Two independent problems, neither a bashkit regression:

1. **An exhausted OpenAI quota could fail the `Check` gate.** The `Examples` job's OpenAI harness step now sets `continue-on-error: true`, matching the Anthropic step beside it. Upstream outages, quota exhaustion, and billing lapses no longer turn main red — the steps stay in CI as smoke signals you read from the logs.
2. **`claude-sonnet-4-20250514` has been retired** and returns `404 not_found_error`. Every caller and doc snippet now pins `claude-sonnet-5` (9 sites: `agent_tool.rs`, 4 standalone Python examples, 2 binding docstrings, the k8s orchestrator example, the bashkit-pi README). The LangChain example also drops `temperature=0` — Sonnet 5 rejects non-default sampling parameters with a 400.

`knowledge/operations/testing.md` gains a *Third-Party API Steps in CI* section recording the rule and its corollary: because these steps can't fail the build, they don't protect against a stale model id — a retired id shows up as a 404 inside an already-green job, which is exactly how this one survived.

## Why

Run 30589234169 on `2be2427` failed on `Run harness OpenAI joke example`:

```
error: openai API error: You have no credits remaining.
```

Investigating that surfaced the second, longer-standing failure hiding behind the guard that already existed on the Anthropic step.

## Before / After

**Before** — `Examples` job, both LLM steps failing, one of them fatally:

```
Run LLM agent example ........... failure (continue-on-error → job continues)
  Error: API error 404 Not Found: {"type":"error","error":{"type":"not_found_error",
  "message":"model: claude-sonnet-4-20250514"}}

Run harness OpenAI joke example . failure  ← fails the job
  provider: openai / model: gpt-4o
  error: openai API error: You have no credits remaining.

Check → Verify all jobs passed .. failure   ← main red
```

**After** — the model id resolves, and a credit/outage problem can no longer fail the gate. The Doppler-gated steps only run on pushes to `main`, so this PR's own CI does not exercise them; the model-id fix is verified by `cargo check --example agent_tool --features http_client` compiling and by the id being current per Anthropic's model list.

## Risk

- **Low**
- The workflow change makes CI strictly more permissive on one step — a genuine bashkit break in that example would now surface as a yellow step rather than a red job. That's the intended trade: the step calls a third-party API and cannot distinguish our bugs from their outages. Its logs remain the signal.
- The model-id change touches example and documentation code only; no library or interpreter code paths are affected.

## Checklist

- [x] Tests added or updated — n/a: no new code paths. The diff is a workflow flag, a knowledge doc, and model-id string literals in examples/docstrings. Full suite re-run green (`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`, 38 script unit tests, `check_okf.py`, `check_doc_links.py`, `ruff check`/`format` on `crates/bashkit-python`).
- [x] Backward compatibility considered — internal examples only; no public API surface changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_012JqsHLAYghPtrtZLv7gsQ1)_