### PR TITLE
chore(release): prepare v0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.14.5] - 2026-08-01
 
 ### Highlights
 
@@ -9,14 +9,20 @@
   new on-disk format. This release teaches the reader that format and changes
   nothing else, so a deployment can take it first and still be able to read
   what the next release writes
-  ([#2223](https://github.com/everruns/bashkit/pull/2223)).
+  ([#2226](https://github.com/everruns/bashkit/pull/2226)).
+- **Scripts can be inspected before they run.** `analyze()` — in Rust, Node,
+  and Python — returns a static report of the commands, arguments, redirect
+  targets, and function definitions a script refers to, for host permission
+  prompts and audit logging. It is advisory by design: dynamic dispatch,
+  `eval`/`source`, nested shells, and truncated walks surface as unknown via
+  `is_opaque`, with the `before_tool` hook remaining the enforcement backstop
+  ([#2222](https://github.com/everruns/bashkit/pull/2222)).
 
 ### Upgrading
 
-- **Release this as a patch.** It adds no public API and changes no behavior:
-  `snapshot()` still writes the same bytes, and every existing snapshot restores
-  exactly as before. The new object-graph types are deliberately `pub(crate)`
-  and the new error cases reuse `Error::Internal` so that stays true.
+- Both additions are backward compatible. `snapshot()` still writes the same
+  bytes, every existing snapshot restores exactly as before, and `analyze()` is
+  purely additive.
 - **Take this release before the one that writes the new format.** Versions
   older than this one fail on the new format with `expected value at line 1
   column 1` — a JSON parse error naming neither the version nor the format —
@@ -24,6 +30,19 @@
 - From the new format onward this cannot recur: the container header records a
   `min_reader` version, so a reader too old for a snapshot says so and points at
   the upgrade instead of reporting corruption.
+
+### What's Changed
+
+* feat(snapshot): read the v2 container without writing it ([#2226](https://github.com/everruns/bashkit/pull/2226)) by @chaliy
+* fix(ci): unblock main — guard third-party LLM steps and refresh retired model id ([#2225](https://github.com/everruns/bashkit/pull/2225)) by @chaliy
+* chore(knowledge): repair dangling cross-links and enforce OKF trust metadata ([#2224](https://github.com/everruns/bashkit/pull/2224)) by @chaliy
+* feat(analysis): add analyze() for pre-execution script introspection ([#2222](https://github.com/everruns/bashkit/pull/2222)) by @chaliy
+* fix(docs): repoint broken cross-tree markdown links and guard them in CI ([#2220](https://github.com/everruns/bashkit/pull/2220)) by @chaliy
+* chore(deps): bump turso_core from 0.8.0-pre.1 to 0.8.0-pre.2 ([#2218](https://github.com/everruns/bashkit/pull/2218)) by @dependabot
+* chore(deps): bump the rust-dependencies group with 3 updates ([#2217](https://github.com/everruns/bashkit/pull/2217)) by @dependabot
+* chore(ci): bump taiki-e/install-action from 2.85.0 to 2.85.2 in the github-actions group ([#2216](https://github.com/everruns/bashkit/pull/2216)) by @dependabot
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.14.4...v0.14.5
 
 ## [0.14.4] - 2026-07-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,49 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "bashkit"
 version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17175a514a671777aabb125293aca393bfdf71223fa1289e23735ae523845ddc"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.23.0",
+ "bigdecimal",
+ "bitflags 2.13.1",
+ "chrono",
+ "clap",
+ "fancy-regex 0.18.0",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hmac",
+ "jaq-core",
+ "jaq-json",
+ "jaq-std",
+ "md-5",
+ "monty",
+ "monty-types",
+ "num-traits",
+ "os_display",
+ "regex",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "thiserror",
+ "tokio",
+ "tower",
+ "turso_core",
+ "unit-prefix",
+ "url",
+ "web-time",
+]
+
+[[package]]
+name = "bashkit"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -441,10 +484,10 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
- "bashkit",
+ "bashkit 0.14.5",
  "clap",
  "colored",
  "serde",
@@ -456,10 +499,10 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
- "bashkit",
+ "bashkit 0.14.4",
  "clap",
  "rustyline",
  "signal-hook",
@@ -470,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -484,11 +527,11 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",
- "bashkit",
+ "bashkit 0.14.5",
  "chrono",
  "mira-eval",
  "regex",
@@ -501,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
- "bashkit",
+ "bashkit 0.14.5",
  "napi",
  "napi-build",
  "napi-derive",
@@ -513,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
- "bashkit",
+ "bashkit 0.14.5",
  "num-bigint",
  "pyo3",
  "pyo3-async-runtimes",
@@ -525,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
- "bashkit",
+ "bashkit 0.14.5",
  "console_error_panic_hook",
  "futures-util",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.4"
+version = "0.14.5"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.14.4", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.14.5", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/crates/bashkit/fuzz/Cargo.lock
+++ b/crates/bashkit/fuzz/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bashkit"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What changed

Patch release **v0.14.5**, covering the 8 PRs merged since v0.14.4.

Two user-facing additions, both backward compatible:

- **Snapshots can be read in a format bashkit does not yet write** (#2226). The next release stores sessions as a content-addressed object graph; this release teaches the reader that format and changes nothing else, so a deployment can take it first and still read what the next release writes. `snapshot()` still emits identical bytes, and every existing snapshot restores exactly as before.
- **`analyze()` for pre-execution script introspection** (#2222), in Rust, Node, and Python — a static report of the commands, arguments, redirect targets, and function definitions a script refers to, for host permission prompts and audit logging. Advisory by design (TM-ESC-032); the `before_tool` hook remains the enforcement backstop.

Version bumped to `0.14.5` across workspace `Cargo.toml`, the `bashkit-cli` path-dep pin, both npm `package.json` files, and both lockfiles. Self-hosted API references regenerated (`just apidocs`) — no drift in either the Python or TypeScript reference.

## Why

Ships the v2 snapshot **reader** ahead of the writer (#2223). That ordering is the point: versions older than 0.14.5 fail on the new format with a bare `expected value at line 1 column 1` JSON parse error, so they are not usable rollback targets. 0.14.5 is.

## Before / After

No behavior change from the release prep itself — it is a version bump plus changelog. The shipped behavior is that of the already-merged PRs above.

Publish-readiness (the step that catches what local tests do not):

| Check | Result |
| --- | --- |
| `cargo publish --dry-run -p bashkit` | passes, packages `bashkit v0.14.5` |
| `bashkit-cli` packaging vs published core | passes — builds `bashkit-cli v0.14.5` against `bashkit v0.14.4` from crates.io |
| `just apidocs` | regenerates byte-identical Python + TypeScript references |
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets --features http_client,ssh,sqlite -- -D warnings` | clean |
| Tests (`--lib --bins --tests`, same feature slice) | 3369 lib + 1530 integration + 88 across the remaining binaries, 0 failures |
| Doc tests | 155 passed, 58 ignored |
| `just check-doc-links` | 145 relative links across 42 files OK |

Version sync — new version is ahead of every registry:

| Registry | Published | This release |
| --- | --- | --- |
| crates.io `bashkit` / `bashkit-cli` | 0.14.4 | 0.14.5 |
| PyPI `bashkit` | 0.14.4 | 0.14.5 |
| npm `@everruns/bashkit` | 0.14.4 | 0.14.5 |
| npm `@everruns/bashkit-wasm` | 0.14.4 | 0.14.5 |

## Risk

- **Low.** Additive only. No public API removed or changed, snapshot bytes unchanged, existing snapshots restore as before.
- Worth a reviewer's call: `analyze()` (#2222) is *new public API*, which strict semver would place in a MINOR. Shipping it as a patch is additive and breaks no consumer — `^0.14.x` resolves to it either way, and 0.x treats MINOR as the breaking boundary — but it does mean the API arrives without a minor bump to advertise it. The alternative is releasing this as v0.15.0.
- One pre-existing test gap, not a regression: `ssh_supabase_connects` cannot run here because this sandbox has no port-22 egress. CI gates that test on `nc -z supabase.sh 22` and skips it when unreachable, so it is unverified rather than failing.
- PyPI capacity note, unrelated to correctness: the project sits at 8.34 GiB of the default 10 GiB quota, leaving ~1.66 GiB. At the post-abi3 cost of ~94 MiB per release that is ~18 more releases. Separately, 0.14.3 is absent from PyPI (0.14.2 → 0.14.4), so that release's wheel publish never landed.

## Checklist
- [x] Tests added or updated — no new tests; release prep only, covered by the suites above
- [x] Backward compatibility considered — additive, snapshot bytes unchanged
