### PR TITLE
feat(c-api): add native C ABI

### DIFF
--- a/.github/workflows/c-api-binaries.yml
+++ b/.github/workflows/c-api-binaries.yml
@@ -1,0 +1,183 @@
+# Native C ABI archives, dispatched from the verified release workflow.
+name: Publish C API Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (for example, v0.14.5)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-tag:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+    steps:
+      - name: Validate workflow input
+        id: validate
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: tag must match vMAJOR.MINOR.PATCH." >&2
+            exit 1
+          fi
+          echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.validate.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify tag source
+        env:
+          RELEASE_TAG: ${{ steps.validate.outputs.tag }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$VERSION" != "$CARGO_VERSION" ]; then
+            echo "Error: tag $RELEASE_TAG does not match Cargo.toml $CARGO_VERSION" >&2
+            exit 1
+          fi
+          git fetch --force origin main:refs/remotes/origin/main \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          TAG_SHA=$(git rev-list -n 1 "$RELEASE_TAG")
+          if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+            echo "Error: workflow ref does not match $RELEASE_TAG" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "Error: $RELEASE_TAG is not reachable from origin/main" >&2
+            exit 1
+          fi
+
+  build:
+    name: Build C API (${{ matrix.target }})
+    needs: validate-tag
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            library: libbashkit.dylib
+            archive: bashkit-capi-aarch64-apple-darwin.tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-latest
+            library: libbashkit.dylib
+            archive: bashkit-capi-x86_64-apple-darwin.tar.gz
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            library: libbashkit.so
+            archive: bashkit-capi-x86_64-unknown-linux-gnu.tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            library: libbashkit.so
+            archive: bashkit-capi-aarch64-unknown-linux-gnu.tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            library: bashkit.dll
+            archive: bashkit-capi-x86_64-pc-windows-msvc.zip
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate-tag.outputs.tag }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "c-api-${{ matrix.target }}"
+
+      - name: Build shared library
+        if: runner.os != 'Windows'
+        run: ./scripts/build-c-api.sh --release --target ${{ matrix.target }}
+
+      - name: Build Windows shared library
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p bashkit-capi
+          copy target\${{ matrix.target }}\release\bashkit_capi.dll target\${{ matrix.target }}\release\bashkit.dll
+          lib /nologo /def:crates\bashkit-capi\include\bashkit.def /machine:x64 /out:target\${{ matrix.target }}\release\bashkit.lib
+
+      - name: Smoke test C consumer
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          cc -std=c11 -Wall -Wextra -Werror \
+            -I crates/bashkit-capi/include \
+            crates/bashkit-capi/examples/hello.c \
+            -L target/c-api/release -lbashkit \
+            -o target/c-api-smoke
+          OUTPUT=$(LD_LIBRARY_PATH="target/c-api/release" target/c-api-smoke)
+          [[ "$OUTPUT" =~ ^Hello\ from\ Bashkit!\ User:\ sandbox\ Time:\ [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+
+      - name: Smoke test C consumer on Windows
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: cmd
+        run: |
+          cl /nologo /W4 /WX /I crates\bashkit-capi\include crates\bashkit-capi\examples\hello.c target\${{ matrix.target }}\release\bashkit.lib /Fe:target\c-api-smoke.exe
+          copy target\${{ matrix.target }}\release\bashkit.dll target\bashkit.dll
+          for /f "delims=" %%i in ('target\c-api-smoke.exe') do set OUTPUT=%%i
+          echo %OUTPUT% | findstr /b /c:"Hello from Bashkit! User: sandbox Time:" >nul
+          if errorlevel 1 exit /b 1
+
+      - name: Package Unix library
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          PACKAGE="bashkit-capi-${{ matrix.target }}"
+          mkdir -p "$PACKAGE/include" "$PACKAGE/examples" "$PACKAGE/lib"
+          cp crates/bashkit-capi/include/bashkit.h "$PACKAGE/include/"
+          cp crates/bashkit-capi/examples/*.c "$PACKAGE/examples/"
+          cp crates/bashkit-capi/README.md "$PACKAGE/"
+          cp LICENSE NOTICE "$PACKAGE/"
+          cp -R THIRD_PARTY_LICENSES "$PACKAGE/"
+          cp "target/c-api/release/${{ matrix.library }}" "$PACKAGE/lib/"
+          tar czf "${{ matrix.archive }}" "$PACKAGE"
+          shasum -a 256 "${{ matrix.archive }}" > "${{ matrix.archive }}.sha256"
+
+      - name: Package Windows library
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $package = "bashkit-capi-${{ matrix.target }}"
+          New-Item -ItemType Directory -Force "$package/include", "$package/examples", "$package/lib"
+          Copy-Item crates/bashkit-capi/include/bashkit.h "$package/include/"
+          Copy-Item crates/bashkit-capi/include/bashkit.def "$package/include/"
+          Copy-Item crates/bashkit-capi/examples/*.c "$package/examples/"
+          Copy-Item crates/bashkit-capi/README.md "$package/"
+          Copy-Item LICENSE, NOTICE "$package/"
+          Copy-Item -Recurse THIRD_PARTY_LICENSES "$package/"
+          Copy-Item "target/${{ matrix.target }}/release/bashkit.dll" "$package/lib/"
+          Copy-Item "target/${{ matrix.target }}/release/bashkit.lib" "$package/lib/"
+          Compress-Archive -Path $package -DestinationPath "${{ matrix.archive }}"
+          $hash = (Get-FileHash "${{ matrix.archive }}" -Algorithm SHA256).Hash.ToLower()
+          "$hash  ${{ matrix.archive }}" | Out-File -Encoding ascii "${{ matrix.archive }}.sha256"
+
+      - name: Upload to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.validate-tag.outputs.tag }}
+        run: |
+          gh release upload "$RELEASE_TAG" \
+            "${{ matrix.archive }}" \
+            "${{ matrix.archive }}.sha256" \
+            --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,9 @@ jobs:
       - name: Build examples
         run: cargo build --examples --features "git,http_client,ssh,sqlite"
 
+      - name: Run C API examples
+        run: ./scripts/run-c-api-examples.sh
+
       - name: Run examples
         run: |
           cargo run --example basic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,3 +141,10 @@ jobs:
           echo "Triggering CLI binary builds for tag $TAG..."
           gh workflow run cli-binaries.yml --ref "$TAG" -f "tag=$TAG"
           echo "CLI binary builds triggered for $TAG"
+
+      - name: Trigger C API binary builds for release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.version }}"
+          gh workflow run c-api-binaries.yml --ref "$TAG" -f "tag=$TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Fix root cause. Unsure: read more code; if stuck, ask w/ short options. Unrecogn
 | operations/performance-results | Benchmark/eval result locations and `/benches` site aggregation contract |
 | runtimes/emscripten-wheels | Reduced-feature Pyodide/Emscripten Python wheel |
 | runtimes/browser-package | Slim single-threaded wasm package (`@everruns/bashkit-wasm`) for browsers + JS runtimes, no COOP/COEP |
+| runtimes/c-api | Versioned native C ABI, ownership rules, packaging, and compatibility boundaries |
 
 ### Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bashkit-capi"
+version = "0.14.5"
+dependencies = [
+ "bashkit",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "bashkit-cli"
 version = "0.14.5"
 dependencies = [

--- a/README.md
+++ b/README.md
@@ -532,6 +532,13 @@ See [crates/bashkit-bench/README.md](crates/bashkit-bench/README.md) for methodo
 
 ## Language Bindings
 
+### C API
+
+The experimental `libbashkit` native C ABI exposes opaque handles, synchronous
+execution, and binary-safe virtual filesystem access. See
+[`crates/bashkit-capi`](crates/bashkit-capi/README.md), including two runnable C
+examples.
+
 ### Python
 
 Python bindings with LangChain integration are available in [crates/bashkit-python](crates/bashkit-python/README.md).

--- a/crates/bashkit-capi/Cargo.toml
+++ b/crates/bashkit-capi/Cargo.toml
@@ -1,0 +1,20 @@
+# Bashkit stable C ABI.
+
+[package]
+name = "bashkit-capi"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "C ABI for the Bashkit sandboxed bash interpreter"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bashkit = { path = "../bashkit", default-features = false, features = ["git", "jq"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/bashkit-capi/README.md
+++ b/crates/bashkit-capi/README.md
@@ -1,0 +1,208 @@
+# Bashkit C API
+
+`bashkit-capi` exposes Bashkit through a versioned native C ABI. It is intended
+for language bindings and applications that cannot link Rust crates directly.
+
+The ABI is experimental. Its opaque handles and explicit free functions keep
+Rust layouts and allocators private, so compatible v1 additions do not require
+callers to rebuild their own object layouts.
+
+## Install a release archive
+
+Download the archive for your platform from the
+[Bashkit GitHub Releases](https://github.com/everruns/bashkit/releases):
+
+| Platform | Archive | Runtime library |
+|---|---|---|
+| macOS Apple Silicon | `bashkit-capi-aarch64-apple-darwin.tar.gz` | `libbashkit.dylib` |
+| macOS Intel | `bashkit-capi-x86_64-apple-darwin.tar.gz` | `libbashkit.dylib` |
+| Linux x86-64 | `bashkit-capi-x86_64-unknown-linux-gnu.tar.gz` | `libbashkit.so` |
+| Linux ARM64 | `bashkit-capi-aarch64-unknown-linux-gnu.tar.gz` | `libbashkit.so` |
+| Windows x86-64 | `bashkit-capi-x86_64-pc-windows-msvc.zip` | `bashkit.dll` |
+
+Verify the adjacent `.sha256` file before extracting:
+
+```sh
+sha256sum -c bashkit-capi-*.sha256       # Linux
+shasum -a 256 -c bashkit-capi-*.sha256  # macOS
+```
+
+On Windows, compare `Get-FileHash <archive> -Algorithm SHA256` with the value in
+the `.sha256` file. A release archive contains:
+
+```text
+include/bashkit.h
+examples/hello.c
+examples/files.c
+lib/libbashkit.so       # Linux
+lib/libbashkit.dylib    # macOS
+lib/bashkit.dll         # Windows runtime
+lib/bashkit.lib         # Windows import library
+```
+
+The shared library contains the complete Bashkit runtime. Applications do not
+need a separate Rust installation or another Bashkit library.
+
+### Linux
+
+The recommended deployment keeps the library beside the application:
+
+```sh
+export BASHKIT_SDK=/path/to/extracted/bashkit-capi-target
+mkdir -p dist/lib
+cc -std=c11 -I "$BASHKIT_SDK/include" \
+  "$BASHKIT_SDK/examples/hello.c" \
+  -L "$BASHKIT_SDK/lib" -lbashkit \
+  -Wl,-rpath,'$ORIGIN/lib' -o dist/hello
+cp "$BASHKIT_SDK/lib/libbashkit.so" dist/lib/
+./dist/hello
+```
+
+Set `BASHKIT_SDK` to the extracted archive directory. The embedded `$ORIGIN`
+rpath makes the executable find `dist/lib/libbashkit.so` without modifying
+`LD_LIBRARY_PATH` or installing anything system-wide.
+
+### macOS
+
+```sh
+mkdir -p dist/lib
+cc -std=c11 -I "$BASHKIT_SDK/include" \
+  "$BASHKIT_SDK/examples/hello.c" \
+  -L "$BASHKIT_SDK/lib" -lbashkit \
+  -Wl,-rpath,@loader_path/lib -o dist/hello
+cp "$BASHKIT_SDK/lib/libbashkit.dylib" dist/lib/
+./dist/hello
+```
+
+The library identity is `@rpath/libbashkit.dylib`, so the application-local
+layout works without `DYLD_LIBRARY_PATH`.
+
+### Windows
+
+Run these commands from an x64 Native Tools Command Prompt for Visual Studio:
+
+```bat
+set BASHKIT_SDK=C:\path\to\extracted\bashkit-capi-target
+mkdir dist
+cl /nologo /W4 /I "%BASHKIT_SDK%\include" ^
+  "%BASHKIT_SDK%\examples\hello.c" ^
+  "%BASHKIT_SDK%\lib\bashkit.lib" /Fe:dist\hello.exe
+copy "%BASHKIT_SDK%\lib\bashkit.dll" dist\bashkit.dll
+dist\hello.exe
+```
+
+`bashkit.lib` is the link-time import library. `bashkit.dll` must be beside the
+executable or in another directory on `PATH` when the application starts.
+
+## Build from source
+
+Building requires the repository's pinned Rust toolchain plus a C compiler.
+On macOS or Linux, from the repository root:
+
+```sh
+./scripts/build-c-api.sh --release
+```
+
+The consumer artifact is written to `target/c-api/release/` under its canonical
+name. The internal Cargo target remains `bashkit_capi` to avoid colliding with
+Bashkit's Rust and Python workspace artifacts.
+
+On Windows, the release workflow builds the internal DLL, renames it to
+`bashkit.dll`, and creates `bashkit.lib` from `include/bashkit.def`; release
+archives are the recommended Windows developer input.
+
+## Build and run repository examples
+
+From the repository root on macOS or Linux:
+
+```sh
+./scripts/run-c-api-examples.sh
+```
+
+This builds `libbashkit`, compiles both C programs with warnings denied,
+and runs them:
+
+- [`examples/hello.c`](examples/hello.c) creates a shell and prints its virtual
+  user and current UTC time.
+- [`examples/files.c`](examples/files.c) configures a shell, exchanges files
+  through the binary-safe VFS API, and runs a transformation.
+
+For direct development compilation after `./scripts/build-c-api.sh`:
+
+```sh
+cc -std=c11 -I crates/bashkit-capi/include \
+  crates/bashkit-capi/examples/hello.c \
+  -L target/c-api/debug -lbashkit -o /tmp/bashkit-hello
+LD_LIBRARY_PATH=target/c-api/debug /tmp/bashkit-hello       # Linux
+DYLD_LIBRARY_PATH=target/c-api/debug /tmp/bashkit-hello     # macOS
+```
+
+## Verify compatibility
+
+Call `bashkit_abi_version()` before using a dynamically discovered library and
+require `BASHKIT_ABI_VERSION_1`. `bashkit_version()` reports the Bashkit package
+version; package and ABI versions intentionally evolve independently.
+
+The architecture of the application and library must match. For example, an
+x86-64 application cannot load an ARM64 Bashkit library.
+
+## Loader troubleshooting
+
+- Linux `libbashkit.so: cannot open shared object file`: deploy the library at
+  the compiled rpath, or temporarily set `LD_LIBRARY_PATH` to its directory.
+- macOS `Library not loaded: @rpath/libbashkit.dylib`: add an application rpath
+  or temporarily set `DYLD_LIBRARY_PATH`.
+- Windows error 126: put `bashkit.dll` beside the executable and confirm both
+  are x86-64.
+- Undefined `bashkit_*` symbols while linking: place `-lbashkit` after source or
+  object inputs on Unix, and verify that the header and library came from the
+  same release archive.
+
+## Configuration
+
+`bashkit_create_default()` creates the standard isolated in-memory shell.
+`bashkit_create_json()` accepts UTF-8 JSON with this v1 shape:
+
+```json
+{
+  "schema_version": 1,
+  "cwd": "/workspace",
+  "env": {"CI": "true"},
+  "files": {"/workspace/input.txt": "hello\n"},
+  "limits": {
+    "timeout_ms": 30000,
+    "parser_timeout_ms": 5000,
+    "max_commands": 10000,
+    "max_input_bytes": 10000000,
+    "max_output_bytes": 1048576
+  },
+  "username": "sandbox",
+  "hostname": "bashkit",
+  "readonly_filesystem": false,
+  "capture_final_env": true
+}
+```
+
+Unknown fields and schema versions are rejected. Text files may be initialized
+through `files`; use `bashkit_write_file()` for arbitrary bytes. Configuration
+input is capped at `BASHKIT_MAX_CONFIG_BYTES` (10 MB).
+
+## Contract
+
+- Inputs are borrowed only for the duration of a call.
+- `out_error` may be `NULL` when the caller does not need diagnostic text.
+- Result, buffer, and error byte views remain valid until their owner is freed.
+- Call only Bashkit's matching free function; never pass Bashkit memory to the
+  host allocator.
+- A nonzero shell exit code is not an ABI failure. `bashkit_execute()` returns
+  `BASHKIT_OK`, and the code is available through
+  `bashkit_result_exit_code()`.
+- Calls on one `Bashkit` instance serialize. Separate instances may run in
+  parallel. The caller must not race `bashkit_free()` with another call.
+- A null pointer is valid only where documented or when the accompanying byte
+  length is zero. Other invalid pointers are caller undefined behavior.
+- No Rust panic unwinds through the ABI. Unexpected panics become
+  `BASHKIT_INTERNAL_ERROR` where the function can report a status.
+
+See [`include/bashkit.h`](include/bashkit.h) for the complete surface and the
+[C API guide](../../docs/c-api.md) for compatibility and scope.

--- a/crates/bashkit-capi/examples/files.c
+++ b/crates/bashkit-capi/examples/files.c
@@ -1,0 +1,74 @@
+#include "bashkit.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static BashkitBytes bytes(const void *ptr, size_t len) {
+    BashkitBytes value = {(const uint8_t *)ptr, len};
+    return value;
+}
+
+static BashkitBytes text(const char *value) {
+    return bytes(value, strlen(value));
+}
+
+static int check(BashkitStatus status, BashkitError *error) {
+    if (status == BASHKIT_OK) {
+        return 0;
+    }
+    BashkitBytes message = bashkit_error_message(error);
+    fprintf(stderr, "bashkit error %u: ", (unsigned)status);
+    fwrite(message.ptr, 1, message.len, stderr);
+    fputc('\n', stderr);
+    bashkit_error_free(error);
+    return 1;
+}
+
+int main(void) {
+    const char config[] =
+        "{\"schema_version\":1,\"cwd\":\"/workspace\","
+        "\"env\":{\"FORMAT\":\"upper\"}}";
+    Bashkit *bash = NULL;
+    BashkitError *error = NULL;
+    BashkitStatus status = bashkit_create_json(
+        bytes(config, sizeof(config) - 1), &bash, &error);
+    if (check(status, error)) {
+        return 1;
+    }
+
+    status = bashkit_mkdir(bash, text("/workspace"), 0, &error);
+    if (check(status, error)) {
+        bashkit_free(bash);
+        return 1;
+    }
+    status = bashkit_write_file(
+        bash, text("/workspace/input.txt"), text("hello c abi\n"), &error);
+    if (check(status, error)) {
+        bashkit_free(bash);
+        return 1;
+    }
+
+    BashkitResult *result = NULL;
+    const char script[] = "tr '[:lower:]' '[:upper:]' < input.txt > output.txt";
+    status = bashkit_execute(
+        bash, bytes(script, sizeof(script) - 1), &result, &error);
+    if (check(status, error)) {
+        bashkit_free(bash);
+        return 1;
+    }
+    bashkit_result_free(result);
+
+    BashkitBuffer *output = NULL;
+    status = bashkit_read_file(
+        bash, text("/workspace/output.txt"), &output, &error);
+    if (check(status, error)) {
+        bashkit_free(bash);
+        return 1;
+    }
+    BashkitBytes content = bashkit_buffer_bytes(output);
+    fwrite(content.ptr, 1, content.len, stdout);
+
+    bashkit_buffer_free(output);
+    bashkit_free(bash);
+    return 0;
+}

--- a/crates/bashkit-capi/examples/hello.c
+++ b/crates/bashkit-capi/examples/hello.c
@@ -1,0 +1,49 @@
+#include "bashkit.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static BashkitBytes bytes(const void *ptr, size_t len) {
+    BashkitBytes value = {(const uint8_t *)ptr, len};
+    return value;
+}
+
+static int report_error(BashkitStatus status, BashkitError *error) {
+    BashkitBytes message = bashkit_error_message(error);
+    fprintf(stderr, "bashkit error %u: ", (unsigned)status);
+    fwrite(message.ptr, 1, message.len, stderr);
+    fputc('\n', stderr);
+    bashkit_error_free(error);
+    return 1;
+}
+
+int main(void) {
+    Bashkit *bash = NULL;
+    BashkitError *error = NULL;
+    BashkitStatus status = bashkit_create_default(&bash, &error);
+    if (status != BASHKIT_OK) {
+        return report_error(status, error);
+    }
+
+    const char script[] =
+        "printf 'Hello from Bashkit! User: %s Time: ' \"$(whoami)\"; "
+        "date -u '+%Y-%m-%dT%H:%M:%SZ'";
+    BashkitResult *result = NULL;
+    status = bashkit_execute(
+        bash,
+        bytes(script, strlen(script)),
+        &result,
+        &error);
+    if (status != BASHKIT_OK) {
+        bashkit_free(bash);
+        return report_error(status, error);
+    }
+
+    BashkitBytes output = bashkit_result_stdout(result);
+    fwrite(output.ptr, 1, output.len, stdout);
+    int exit_code = bashkit_result_exit_code(result);
+
+    bashkit_result_free(result);
+    bashkit_free(bash);
+    return exit_code;
+}

--- a/crates/bashkit-capi/include/bashkit.def
+++ b/crates/bashkit-capi/include/bashkit.def
@@ -1,0 +1,24 @@
+LIBRARY bashkit.dll
+EXPORTS
+    bashkit_abi_version
+    bashkit_buffer_bytes
+    bashkit_buffer_free
+    bashkit_capabilities_json
+    bashkit_create_default
+    bashkit_create_json
+    bashkit_error_code
+    bashkit_error_free
+    bashkit_error_message
+    bashkit_execute
+    bashkit_free
+    bashkit_mkdir
+    bashkit_read_file
+    bashkit_remove
+    bashkit_result_exit_code
+    bashkit_result_final_env_json
+    bashkit_result_flags
+    bashkit_result_free
+    bashkit_result_stderr
+    bashkit_result_stdout
+    bashkit_version
+    bashkit_write_file

--- a/crates/bashkit-capi/include/bashkit.h
+++ b/crates/bashkit-capi/include/bashkit.h
@@ -1,0 +1,107 @@
+#ifndef BASHKIT_H
+#define BASHKIT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32) && !defined(BASHKIT_STATIC)
+#define BASHKIT_API __declspec(dllimport)
+#elif defined(__GNUC__)
+#define BASHKIT_API __attribute__((visibility("default")))
+#else
+#define BASHKIT_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define BASHKIT_ABI_VERSION_1 1u
+#define BASHKIT_MAX_CONFIG_BYTES 10000000u
+#define BASHKIT_RESULT_STDOUT_TRUNCATED (1u << 0)
+#define BASHKIT_RESULT_STDERR_TRUNCATED (1u << 1)
+
+typedef struct bashkit Bashkit;
+typedef struct bashkit_result BashkitResult;
+typedef struct bashkit_error BashkitError;
+typedef struct bashkit_buffer BashkitBuffer;
+
+typedef struct {
+    const uint8_t *ptr;
+    size_t len;
+} BashkitBytes;
+
+typedef uint32_t BashkitStatus;
+#define BASHKIT_OK 0u
+#define BASHKIT_INVALID_ARGUMENT 1u
+#define BASHKIT_INVALID_UTF8 2u
+#define BASHKIT_INVALID_CONFIG 3u
+#define BASHKIT_EXECUTION_ERROR 4u
+#define BASHKIT_IO_ERROR 5u
+#define BASHKIT_UNSUPPORTED 6u
+#define BASHKIT_INTERNAL_ERROR 255u
+
+/* Static views returned by these functions remain valid for process lifetime. */
+BASHKIT_API uint32_t bashkit_abi_version(void);
+BASHKIT_API BashkitBytes bashkit_version(void);
+BASHKIT_API BashkitBytes bashkit_capabilities_json(void);
+
+/* A nonzero shell exit code is a successful ABI call; inspect the result. */
+BASHKIT_API BashkitStatus bashkit_create_default(
+    Bashkit **out_bash,
+    BashkitError **out_error);
+BASHKIT_API BashkitStatus bashkit_create_json(
+    BashkitBytes config_json,
+    Bashkit **out_bash,
+    BashkitError **out_error);
+BASHKIT_API void bashkit_free(Bashkit *bash);
+BASHKIT_API BashkitStatus bashkit_execute(
+    Bashkit *bash,
+    BashkitBytes script,
+    BashkitResult **out_result,
+    BashkitError **out_error);
+
+/* Result byte views remain valid until bashkit_result_free(result). */
+BASHKIT_API int32_t bashkit_result_exit_code(const BashkitResult *result);
+BASHKIT_API BashkitBytes bashkit_result_stdout(const BashkitResult *result);
+BASHKIT_API BashkitBytes bashkit_result_stderr(const BashkitResult *result);
+BASHKIT_API uint32_t bashkit_result_flags(const BashkitResult *result);
+BASHKIT_API BashkitBytes bashkit_result_final_env_json(
+    const BashkitResult *result);
+BASHKIT_API void bashkit_result_free(BashkitResult *result);
+
+BASHKIT_API BashkitStatus bashkit_write_file(
+    Bashkit *bash,
+    BashkitBytes path,
+    BashkitBytes content,
+    BashkitError **out_error);
+BASHKIT_API BashkitStatus bashkit_read_file(
+    Bashkit *bash,
+    BashkitBytes path,
+    BashkitBuffer **out_buffer,
+    BashkitError **out_error);
+BASHKIT_API BashkitStatus bashkit_mkdir(
+    Bashkit *bash,
+    BashkitBytes path,
+    uint32_t recursive,
+    BashkitError **out_error);
+BASHKIT_API BashkitStatus bashkit_remove(
+    Bashkit *bash,
+    BashkitBytes path,
+    uint32_t recursive,
+    BashkitError **out_error);
+
+/* Buffer byte views remain valid until bashkit_buffer_free(buffer). */
+BASHKIT_API BashkitBytes bashkit_buffer_bytes(const BashkitBuffer *buffer);
+BASHKIT_API void bashkit_buffer_free(BashkitBuffer *buffer);
+
+/* Error message views remain valid until bashkit_error_free(error). */
+BASHKIT_API uint32_t bashkit_error_code(const BashkitError *error);
+BASHKIT_API BashkitBytes bashkit_error_message(const BashkitError *error);
+BASHKIT_API void bashkit_error_free(BashkitError *error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/crates/bashkit-capi/src/lib.rs
+++ b/crates/bashkit-capi/src/lib.rs
@@ -1,0 +1,688 @@
+// Decision: the public C ABI exposes opaque owned objects and borrowed byte
+// views only. Rust layouts, allocators, and async runtime types never cross it.
+// ABI v1's deliberately narrow surface is recorded as L-CAPI-001.
+// THREAT[TM-INT-008]: every exported operation contains Rust panics at the FFI
+// boundary and reports a generic error so unwinding cannot enter the foreign
+// caller and the returned error does not include panic details.
+
+use bashkit::{Bash, Error as BashError, ExecutionLimits, FileSystem};
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::Path;
+use std::ptr;
+use std::slice;
+use std::str;
+use std::sync::Mutex;
+use std::time::Duration;
+use tokio::runtime::{Builder, Runtime};
+
+pub const BASHKIT_ABI_VERSION_1: u32 = 1;
+pub const BASHKIT_MAX_CONFIG_BYTES: usize = 10_000_000;
+pub const BASHKIT_RESULT_STDOUT_TRUNCATED: u32 = 1 << 0;
+pub const BASHKIT_RESULT_STDERR_TRUNCATED: u32 = 1 << 1;
+
+const MAX_ERROR_BYTES: usize = 1024;
+const CAPABILITIES_JSON: &[u8] = br#"{"abi":1,"features":["git","jq","vfs"]}"#;
+const VERSION: &[u8] = env!("CARGO_PKG_VERSION").as_bytes();
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BashkitStatus {
+    Ok = 0,
+    InvalidArgument = 1,
+    InvalidUtf8 = 2,
+    InvalidConfig = 3,
+    ExecutionError = 4,
+    IoError = 5,
+    Unsupported = 6,
+    InternalError = 255,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct BashkitBytes {
+    pub ptr: *const u8,
+    pub len: usize,
+}
+
+impl BashkitBytes {
+    const EMPTY: Self = Self {
+        ptr: ptr::null(),
+        len: 0,
+    };
+
+    fn borrowed(value: &[u8]) -> Self {
+        if value.is_empty() {
+            Self::EMPTY
+        } else {
+            Self {
+                ptr: value.as_ptr(),
+                len: value.len(),
+            }
+        }
+    }
+}
+
+struct State {
+    runtime: Runtime,
+    bash: Bash,
+}
+
+pub struct Bashkit {
+    state: Mutex<State>,
+}
+
+pub struct BashkitResult {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    exit_code: i32,
+    flags: u32,
+    final_env_json: Vec<u8>,
+}
+
+pub struct BashkitBuffer {
+    bytes: Vec<u8>,
+}
+
+pub struct BashkitError {
+    code: BashkitStatus,
+    message: Vec<u8>,
+}
+
+struct ApiFailure {
+    status: BashkitStatus,
+    message: String,
+}
+
+impl ApiFailure {
+    fn new(status: BashkitStatus, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+        }
+    }
+
+    fn invalid_argument(message: impl Into<String>) -> Self {
+        Self::new(BashkitStatus::InvalidArgument, message)
+    }
+
+    fn from_bash(error: BashError) -> Self {
+        let status = match error {
+            BashError::Io(_) => BashkitStatus::IoError,
+            _ => BashkitStatus::ExecutionError,
+        };
+        Self::new(status, error.to_string())
+    }
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigV1 {
+    schema_version: u32,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    files: BTreeMap<String, String>,
+    #[serde(default)]
+    limits: LimitsConfigV1,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    hostname: Option<String>,
+    #[serde(default)]
+    readonly_filesystem: bool,
+    #[serde(default)]
+    capture_final_env: bool,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LimitsConfigV1 {
+    timeout_ms: Option<u64>,
+    parser_timeout_ms: Option<u64>,
+    max_commands: Option<u64>,
+    max_input_bytes: Option<u64>,
+    max_output_bytes: Option<u64>,
+}
+
+fn checked_usize(value: u64, name: &str) -> Result<usize, ApiFailure> {
+    usize::try_from(value).map_err(|_| {
+        ApiFailure::new(
+            BashkitStatus::InvalidConfig,
+            format!("{name} exceeds this platform's size limit"),
+        )
+    })
+}
+
+fn make_runtime() -> Result<Runtime, ApiFailure> {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| {
+            ApiFailure::new(
+                BashkitStatus::InternalError,
+                "failed to initialize execution runtime",
+            )
+        })
+}
+
+fn build_from_config(config: ConfigV1) -> Result<Bash, ApiFailure> {
+    if config.schema_version != 1 {
+        return Err(ApiFailure::new(
+            BashkitStatus::InvalidConfig,
+            format!(
+                "unsupported configuration schema version {}",
+                config.schema_version
+            ),
+        ));
+    }
+
+    let mut limits = ExecutionLimits::default();
+    if let Some(value) = config.limits.timeout_ms {
+        limits.timeout = Duration::from_millis(value);
+    }
+    if let Some(value) = config.limits.parser_timeout_ms {
+        limits.parser_timeout = Duration::from_millis(value);
+    }
+    if let Some(value) = config.limits.max_commands {
+        limits.max_commands = checked_usize(value, "max_commands")?;
+    }
+    if let Some(value) = config.limits.max_input_bytes {
+        limits.max_input_bytes = checked_usize(value, "max_input_bytes")?;
+    }
+    if let Some(value) = config.limits.max_output_bytes {
+        let value = checked_usize(value, "max_output_bytes")?;
+        limits.max_stdout_bytes = value;
+        limits.max_stderr_bytes = value;
+    }
+    limits.capture_final_env = config.capture_final_env;
+
+    let mut builder = Bash::builder()
+        .limits(limits)
+        .readonly_filesystem(config.readonly_filesystem);
+    if let Some(cwd) = config.cwd {
+        builder = builder.cwd(cwd);
+    }
+    if let Some(username) = config.username {
+        builder = builder.username(username);
+    }
+    if let Some(hostname) = config.hostname {
+        builder = builder.hostname(hostname);
+    }
+    for (key, value) in config.env {
+        builder = builder.env(key, value);
+    }
+    for (path, content) in config.files {
+        builder = builder.mount_text(path, content);
+    }
+    Ok(builder.build())
+}
+
+fn truncate_error(message: String) -> Vec<u8> {
+    if message.len() <= MAX_ERROR_BYTES {
+        return message.into_bytes();
+    }
+    let mut end = MAX_ERROR_BYTES;
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    message.as_bytes()[..end].to_vec()
+}
+
+unsafe fn initialize_output<T>(out: *mut *mut T, name: &str) -> Result<(), ApiFailure> {
+    if out.is_null() {
+        return Err(ApiFailure::invalid_argument(format!(
+            "{name} must not be NULL"
+        )));
+    }
+    unsafe { out.write(ptr::null_mut()) };
+    Ok(())
+}
+
+unsafe fn input_bytes<'a>(value: BashkitBytes, name: &str) -> Result<&'a [u8], ApiFailure> {
+    if value.len == 0 {
+        return Ok(&[]);
+    }
+    if value.ptr.is_null() {
+        return Err(ApiFailure::invalid_argument(format!(
+            "{name}.ptr must not be NULL when len is non-zero"
+        )));
+    }
+    if value.len > isize::MAX as usize {
+        return Err(ApiFailure::invalid_argument(format!(
+            "{name}.len exceeds the supported size"
+        )));
+    }
+    Ok(unsafe { slice::from_raw_parts(value.ptr, value.len) })
+}
+
+unsafe fn input_str<'a>(value: BashkitBytes, name: &str) -> Result<&'a str, ApiFailure> {
+    let bytes = unsafe { input_bytes(value, name)? };
+    str::from_utf8(bytes).map_err(|_| {
+        ApiFailure::new(
+            BashkitStatus::InvalidUtf8,
+            format!("{name} must be valid UTF-8"),
+        )
+    })
+}
+
+unsafe fn handle<'a>(bash: *mut Bashkit) -> Result<&'a Bashkit, ApiFailure> {
+    if bash.is_null() {
+        return Err(ApiFailure::invalid_argument("bash must not be NULL"));
+    }
+    Ok(unsafe { &*bash })
+}
+
+unsafe fn set_error(out_error: *mut *mut BashkitError, failure: ApiFailure) -> BashkitStatus {
+    if !out_error.is_null() {
+        let error = Box::new(BashkitError {
+            code: failure.status,
+            message: truncate_error(failure.message),
+        });
+        unsafe { out_error.write(Box::into_raw(error)) };
+    }
+    failure.status
+}
+
+unsafe fn ffi_boundary(
+    out_error: *mut *mut BashkitError,
+    operation: impl FnOnce() -> Result<(), ApiFailure>,
+) -> BashkitStatus {
+    if !out_error.is_null() {
+        unsafe { out_error.write(ptr::null_mut()) };
+    }
+    match catch_unwind(AssertUnwindSafe(operation)) {
+        Ok(Ok(())) => BashkitStatus::Ok,
+        Ok(Err(failure)) => unsafe { set_error(out_error, failure) },
+        Err(_) => unsafe {
+            set_error(
+                out_error,
+                ApiFailure::new(BashkitStatus::InternalError, "internal error"),
+            )
+        },
+    }
+}
+
+fn final_env_json(final_env: Option<HashMap<String, String>>) -> Result<Vec<u8>, ApiFailure> {
+    let Some(final_env) = final_env else {
+        return Ok(Vec::new());
+    };
+    let sorted: BTreeMap<_, _> = final_env.into_iter().collect();
+    serde_json::to_vec(&sorted).map_err(|_| {
+        ApiFailure::new(
+            BashkitStatus::InternalError,
+            "failed to serialize final environment",
+        )
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn bashkit_abi_version() -> u32 {
+    BASHKIT_ABI_VERSION_1
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn bashkit_version() -> BashkitBytes {
+    BashkitBytes::borrowed(VERSION)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn bashkit_capabilities_json() -> BashkitBytes {
+    BashkitBytes::borrowed(CAPABILITIES_JSON)
+}
+
+/// # Safety
+/// `out_bash` must be writable. `out_error`, when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_create_default(
+    out_bash: *mut *mut Bashkit,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            initialize_output(out_bash, "out_bash")?;
+            let bash = Bashkit {
+                state: Mutex::new(State {
+                    runtime: make_runtime()?,
+                    bash: Bash::new(),
+                }),
+            };
+            out_bash.write(Box::into_raw(Box::new(bash)));
+            Ok(())
+        })
+    }
+}
+
+/// # Safety
+/// Input bytes must remain readable for the call. `out_bash` must be writable;
+/// `out_error`, when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_create_json(
+    config_json: BashkitBytes,
+    out_bash: *mut *mut Bashkit,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            initialize_output(out_bash, "out_bash")?;
+            if config_json.len > BASHKIT_MAX_CONFIG_BYTES {
+                return Err(ApiFailure::new(
+                    BashkitStatus::InvalidConfig,
+                    "configuration exceeds 10000000 bytes",
+                ));
+            }
+            let config_bytes = input_bytes(config_json, "config_json")?;
+            let config: ConfigV1 = serde_json::from_slice(config_bytes).map_err(|error| {
+                ApiFailure::new(
+                    BashkitStatus::InvalidConfig,
+                    format!("invalid configuration: {error}"),
+                )
+            })?;
+            let bash = Bashkit {
+                state: Mutex::new(State {
+                    runtime: make_runtime()?,
+                    bash: build_from_config(config)?,
+                }),
+            };
+            out_bash.write(Box::into_raw(Box::new(bash)));
+            Ok(())
+        })
+    }
+}
+
+/// # Safety
+/// `bash` must be null or a live pointer returned by a Bashkit create function,
+/// and it must not be used after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_free(bash: *mut Bashkit) {
+    if bash.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+        drop(Box::from_raw(bash));
+    }));
+}
+
+/// # Safety
+/// `bash` must be live, script bytes readable, and `out_result` writable.
+/// `out_error`, when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_execute(
+    bash: *mut Bashkit,
+    script: BashkitBytes,
+    out_result: *mut *mut BashkitResult,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            initialize_output(out_result, "out_result")?;
+            let bash = handle(bash)?;
+            let script = input_str(script, "script")?;
+            let mut state = bash.state.lock().map_err(|_| {
+                ApiFailure::new(BashkitStatus::InternalError, "bash instance is unavailable")
+            })?;
+            let State { runtime, bash } = &mut *state;
+            let result = runtime
+                .block_on(bash.exec(script))
+                .map_err(ApiFailure::from_bash)?;
+            let stdout = result
+                .stdout_bytes
+                .unwrap_or_else(|| result.stdout.into_bytes());
+            let mut flags = 0;
+            if result.stdout_truncated {
+                flags |= BASHKIT_RESULT_STDOUT_TRUNCATED;
+            }
+            if result.stderr_truncated {
+                flags |= BASHKIT_RESULT_STDERR_TRUNCATED;
+            }
+            let result = BashkitResult {
+                stdout,
+                stderr: result.stderr.into_bytes(),
+                exit_code: result.exit_code,
+                flags,
+                final_env_json: final_env_json(result.final_env)?,
+            };
+            out_result.write(Box::into_raw(Box::new(result)));
+            Ok(())
+        })
+    }
+}
+
+/// # Safety
+/// `result` must be null or a live result pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_result_exit_code(result: *const BashkitResult) -> i32 {
+    unsafe { result.as_ref().map_or(0, |result| result.exit_code) }
+}
+
+/// # Safety
+/// `result` must be null or live. The returned view expires with `result`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_result_stdout(result: *const BashkitResult) -> BashkitBytes {
+    unsafe {
+        result.as_ref().map_or(BashkitBytes::EMPTY, |result| {
+            BashkitBytes::borrowed(&result.stdout)
+        })
+    }
+}
+
+/// # Safety
+/// `result` must be null or live. The returned view expires with `result`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_result_stderr(result: *const BashkitResult) -> BashkitBytes {
+    unsafe {
+        result.as_ref().map_or(BashkitBytes::EMPTY, |result| {
+            BashkitBytes::borrowed(&result.stderr)
+        })
+    }
+}
+
+/// # Safety
+/// `result` must be null or a live result pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_result_flags(result: *const BashkitResult) -> u32 {
+    unsafe { result.as_ref().map_or(0, |result| result.flags) }
+}
+
+/// # Safety
+/// `result` must be null or live. The returned view expires with `result`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_result_final_env_json(
+    result: *const BashkitResult,
+) -> BashkitBytes {
+    unsafe {
+        result.as_ref().map_or(BashkitBytes::EMPTY, |result| {
+            BashkitBytes::borrowed(&result.final_env_json)
+        })
+    }
+}
+
+/// # Safety
+/// `result` must be null or a live result pointer and not used afterward.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_result_free(result: *mut BashkitResult) {
+    if result.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+        drop(Box::from_raw(result));
+    }));
+}
+
+unsafe fn with_filesystem(
+    bash: *mut Bashkit,
+    operation: impl FnOnce(&Runtime, &dyn FileSystem) -> Result<(), BashError>,
+) -> Result<(), ApiFailure> {
+    let bash = unsafe { handle(bash)? };
+    let state = bash.state.lock().map_err(|_| {
+        ApiFailure::new(BashkitStatus::InternalError, "bash instance is unavailable")
+    })?;
+    operation(&state.runtime, state.bash.fs().as_ref()).map_err(ApiFailure::from_bash)
+}
+
+/// # Safety
+/// `bash` must be live; path and content bytes must remain readable for the call.
+/// `out_error`, when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_write_file(
+    bash: *mut Bashkit,
+    path: BashkitBytes,
+    content: BashkitBytes,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            let path = input_str(path, "path")?;
+            let content = input_bytes(content, "content")?;
+            with_filesystem(bash, |runtime, fs| {
+                runtime.block_on(fs.write_file(Path::new(path), content))
+            })
+        })
+    }
+}
+
+/// # Safety
+/// `bash` must be live, path readable, and `out_buffer` writable. `out_error`,
+/// when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_read_file(
+    bash: *mut Bashkit,
+    path: BashkitBytes,
+    out_buffer: *mut *mut BashkitBuffer,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            initialize_output(out_buffer, "out_buffer")?;
+            let path = input_str(path, "path")?;
+            let bash = handle(bash)?;
+            let state = bash.state.lock().map_err(|_| {
+                ApiFailure::new(BashkitStatus::InternalError, "bash instance is unavailable")
+            })?;
+            let bytes = state
+                .runtime
+                .block_on(state.bash.fs().read_file(Path::new(path)))
+                .map_err(ApiFailure::from_bash)?;
+            out_buffer.write(Box::into_raw(Box::new(BashkitBuffer { bytes })));
+            Ok(())
+        })
+    }
+}
+
+/// # Safety
+/// `bash` must be live and path readable. `out_error`, when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_mkdir(
+    bash: *mut Bashkit,
+    path: BashkitBytes,
+    recursive: u32,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            let path = input_str(path, "path")?;
+            with_filesystem(bash, |runtime, fs| {
+                runtime.block_on(fs.mkdir(Path::new(path), recursive != 0))
+            })
+        })
+    }
+}
+
+/// # Safety
+/// `bash` must be live and path readable. `out_error`, when non-null, must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_remove(
+    bash: *mut Bashkit,
+    path: BashkitBytes,
+    recursive: u32,
+    out_error: *mut *mut BashkitError,
+) -> BashkitStatus {
+    unsafe {
+        ffi_boundary(out_error, || {
+            let path = input_str(path, "path")?;
+            with_filesystem(bash, |runtime, fs| {
+                runtime.block_on(fs.remove(Path::new(path), recursive != 0))
+            })
+        })
+    }
+}
+
+/// # Safety
+/// `buffer` must be null or live. The returned view expires with `buffer`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_buffer_bytes(buffer: *const BashkitBuffer) -> BashkitBytes {
+    unsafe {
+        buffer.as_ref().map_or(BashkitBytes::EMPTY, |buffer| {
+            BashkitBytes::borrowed(&buffer.bytes)
+        })
+    }
+}
+
+/// # Safety
+/// `buffer` must be null or a live buffer pointer and not used afterward.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_buffer_free(buffer: *mut BashkitBuffer) {
+    if buffer.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+        drop(Box::from_raw(buffer));
+    }));
+}
+
+/// # Safety
+/// `error` must be null or a live error pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_error_code(error: *const BashkitError) -> u32 {
+    unsafe {
+        error
+            .as_ref()
+            .map_or(BashkitStatus::Ok as u32, |error| error.code as u32)
+    }
+}
+
+/// # Safety
+/// `error` must be null or live. The returned view expires with `error`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_error_message(error: *const BashkitError) -> BashkitBytes {
+    unsafe {
+        error.as_ref().map_or(BashkitBytes::EMPTY, |error| {
+            BashkitBytes::borrowed(&error.message)
+        })
+    }
+}
+
+/// # Safety
+/// `error` must be null or a live error pointer and not used afterward.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn bashkit_error_free(error: *mut BashkitError) {
+    if error.is_null() {
+        return;
+    }
+    let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+        drop(Box::from_raw(error));
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tm_int_008_contains_panics_at_the_foreign_boundary() {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let status = ffi_boundary(&mut error, || -> Result<(), ApiFailure> {
+                panic!("injected panic detail");
+            });
+
+            assert_eq!(status, BashkitStatus::InternalError);
+            assert!(!error.is_null());
+            assert_eq!((*error).message, b"internal error");
+            bashkit_error_free(error);
+        }
+    }
+}

--- a/crates/bashkit-capi/src/lib.rs
+++ b/crates/bashkit-capi/src/lib.rs
@@ -232,14 +232,15 @@ fn truncate_error(message: String) -> Vec<u8> {
     message.as_bytes()[..end].to_vec()
 }
 
-unsafe fn initialize_output<T>(out: *mut *mut T, name: &str) -> Result<(), ApiFailure> {
+unsafe fn output_slot<'a, T>(out: *mut *mut T, name: &str) -> Result<&'a mut *mut T, ApiFailure> {
     if out.is_null() {
         return Err(ApiFailure::invalid_argument(format!(
             "{name} must not be NULL"
         )));
     }
-    unsafe { out.write(ptr::null_mut()) };
-    Ok(())
+    let out = unsafe { &mut *out };
+    *out = ptr::null_mut();
+    Ok(out)
 }
 
 unsafe fn input_bytes<'a>(value: BashkitBytes, name: &str) -> Result<&'a [u8], ApiFailure> {
@@ -343,14 +344,14 @@ pub unsafe extern "C" fn bashkit_create_default(
 ) -> BashkitStatus {
     unsafe {
         ffi_boundary(out_error, || {
-            initialize_output(out_bash, "out_bash")?;
+            let out_bash = output_slot(out_bash, "out_bash")?;
             let bash = Bashkit {
                 state: Mutex::new(State {
                     runtime: make_runtime()?,
                     bash: Bash::new(),
                 }),
             };
-            out_bash.write(Box::into_raw(Box::new(bash)));
+            *out_bash = Box::into_raw(Box::new(bash));
             Ok(())
         })
     }
@@ -367,7 +368,7 @@ pub unsafe extern "C" fn bashkit_create_json(
 ) -> BashkitStatus {
     unsafe {
         ffi_boundary(out_error, || {
-            initialize_output(out_bash, "out_bash")?;
+            let out_bash = output_slot(out_bash, "out_bash")?;
             if config_json.len > BASHKIT_MAX_CONFIG_BYTES {
                 return Err(ApiFailure::new(
                     BashkitStatus::InvalidConfig,
@@ -387,7 +388,7 @@ pub unsafe extern "C" fn bashkit_create_json(
                     bash: build_from_config(config)?,
                 }),
             };
-            out_bash.write(Box::into_raw(Box::new(bash)));
+            *out_bash = Box::into_raw(Box::new(bash));
             Ok(())
         })
     }
@@ -418,7 +419,7 @@ pub unsafe extern "C" fn bashkit_execute(
 ) -> BashkitStatus {
     unsafe {
         ffi_boundary(out_error, || {
-            initialize_output(out_result, "out_result")?;
+            let out_result = output_slot(out_result, "out_result")?;
             let bash = handle(bash)?;
             let script = input_str(script, "script")?;
             let mut state = bash.state.lock().map_err(|_| {
@@ -445,7 +446,7 @@ pub unsafe extern "C" fn bashkit_execute(
                 flags,
                 final_env_json: final_env_json(result.final_env)?,
             };
-            out_result.write(Box::into_raw(Box::new(result)));
+            *out_result = Box::into_raw(Box::new(result));
             Ok(())
         })
     }
@@ -556,7 +557,7 @@ pub unsafe extern "C" fn bashkit_read_file(
 ) -> BashkitStatus {
     unsafe {
         ffi_boundary(out_error, || {
-            initialize_output(out_buffer, "out_buffer")?;
+            let out_buffer = output_slot(out_buffer, "out_buffer")?;
             let path = input_str(path, "path")?;
             let bash = handle(bash)?;
             let state = bash.state.lock().map_err(|_| {
@@ -566,7 +567,7 @@ pub unsafe extern "C" fn bashkit_read_file(
                 .runtime
                 .block_on(state.bash.fs().read_file(Path::new(path)))
                 .map_err(ApiFailure::from_bash)?;
-            out_buffer.write(Box::into_raw(Box::new(BashkitBuffer { bytes })));
+            *out_buffer = Box::into_raw(Box::new(BashkitBuffer { bytes }));
             Ok(())
         })
     }

--- a/crates/bashkit-capi/tests/abi.rs
+++ b/crates/bashkit-capi/tests/abi.rs
@@ -1,0 +1,267 @@
+use bashkit_capi::*;
+use std::ptr;
+
+fn bytes(value: &[u8]) -> BashkitBytes {
+    BashkitBytes {
+        ptr: value.as_ptr(),
+        len: value.len(),
+    }
+}
+
+unsafe fn borrowed(value: BashkitBytes) -> Vec<u8> {
+    if value.len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(value.ptr, value.len) }.to_vec()
+    }
+}
+
+unsafe fn error_message(error: *mut BashkitError) -> String {
+    let message = unsafe { borrowed(bashkit_error_message(error)) };
+    unsafe { bashkit_error_free(error) };
+    String::from_utf8(message).unwrap()
+}
+
+#[test]
+fn creates_executes_and_preserves_shell_exit_status() {
+    unsafe {
+        assert_eq!(bashkit_abi_version(), BASHKIT_ABI_VERSION_1);
+        assert!(!borrowed(bashkit_version()).is_empty());
+        let capabilities: serde_json::Value =
+            serde_json::from_slice(&borrowed(bashkit_capabilities_json())).unwrap();
+        assert_eq!(capabilities["abi"], 1);
+
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_default(&mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+        assert!(!bash.is_null());
+        assert!(error.is_null());
+
+        let mut result = ptr::null_mut();
+        let script = b"printf 'hello'; printf 'warning' >&2; exit 7";
+        assert_eq!(
+            bashkit_execute(bash, bytes(script), &mut result, &mut error),
+            BashkitStatus::Ok
+        );
+        assert_eq!(bashkit_result_exit_code(result), 7);
+        assert_eq!(borrowed(bashkit_result_stdout(result)), b"hello");
+        assert_eq!(borrowed(bashkit_result_stderr(result)), b"warning");
+
+        bashkit_result_free(result);
+        bashkit_free(bash);
+    }
+}
+
+#[test]
+fn configures_environment_files_limits_and_final_environment() {
+    unsafe {
+        let config = br#"{
+            "schema_version": 1,
+            "cwd": "/workspace",
+            "env": {"GREETING": "hello"},
+            "files": {"/workspace/name.txt": "bashkit\n"},
+            "limits": {"max_output_bytes": 128},
+            "capture_final_env": true
+        }"#;
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_json(bytes(config), &mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+
+        let mut result = ptr::null_mut();
+        assert_eq!(
+            bashkit_execute(
+                bash,
+                bytes(b"printf '%s ' \"$GREETING\"; cat name.txt; export DONE=yes"),
+                &mut result,
+                &mut error,
+            ),
+            BashkitStatus::Ok
+        );
+        assert_eq!(borrowed(bashkit_result_stdout(result)), b"hello bashkit\n");
+
+        let final_env = borrowed(bashkit_result_final_env_json(result));
+        let final_env: serde_json::Value = serde_json::from_slice(&final_env).unwrap();
+        assert_eq!(final_env["DONE"], "yes");
+
+        bashkit_result_free(result);
+        bashkit_free(bash);
+    }
+}
+
+#[test]
+fn reads_and_writes_binary_vfs_content() {
+    unsafe {
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_default(&mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+        assert_eq!(
+            bashkit_mkdir(bash, bytes(b"/data"), 0, &mut error),
+            BashkitStatus::Ok
+        );
+        assert_eq!(
+            bashkit_write_file(
+                bash,
+                bytes(b"/data/blob.bin"),
+                bytes(b"\0\x01bashkit"),
+                &mut error,
+            ),
+            BashkitStatus::Ok
+        );
+
+        let mut buffer = ptr::null_mut();
+        assert_eq!(
+            bashkit_read_file(bash, bytes(b"/data/blob.bin"), &mut buffer, &mut error),
+            BashkitStatus::Ok
+        );
+        assert_eq!(borrowed(bashkit_buffer_bytes(buffer)), b"\0\x01bashkit");
+
+        bashkit_buffer_free(buffer);
+
+        assert_eq!(
+            bashkit_remove(bash, bytes(b"/data/blob.bin"), 0, &mut error),
+            BashkitStatus::Ok
+        );
+        buffer = ptr::null_mut();
+        assert_eq!(
+            bashkit_read_file(bash, bytes(b"/data/blob.bin"), &mut buffer, &mut error),
+            BashkitStatus::IoError
+        );
+        assert!(buffer.is_null());
+        assert_eq!(bashkit_error_code(error), BashkitStatus::IoError as u32);
+        bashkit_error_free(error);
+
+        bashkit_free(bash);
+    }
+}
+
+#[test]
+fn rejects_bad_inputs_with_owned_errors() {
+    unsafe {
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_default(&mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+
+        let mut result = ptr::null_mut();
+        assert_eq!(
+            bashkit_execute(bash, bytes(&[0xff]), &mut result, &mut error,),
+            BashkitStatus::InvalidUtf8
+        );
+        assert!(result.is_null());
+        assert_eq!(error_message(error), "script must be valid UTF-8");
+
+        error = ptr::null_mut();
+        assert_eq!(
+            bashkit_execute(bash, bytes(b":"), ptr::null_mut(), &mut error),
+            BashkitStatus::InvalidArgument
+        );
+        assert_eq!(error_message(error), "out_result must not be NULL");
+
+        bashkit_free(bash);
+    }
+}
+
+#[test]
+fn rejects_unknown_config_fields_and_versions() {
+    unsafe {
+        for (config, expected) in [
+            (
+                br#"{"schema_version":1,"surprise":true}"#.as_slice(),
+                "invalid configuration",
+            ),
+            (
+                br#"{"schema_version":2}"#.as_slice(),
+                "unsupported configuration schema version 2",
+            ),
+        ] {
+            let mut bash = ptr::null_mut();
+            let mut error = ptr::null_mut();
+            assert_eq!(
+                bashkit_create_json(bytes(config), &mut bash, &mut error),
+                BashkitStatus::InvalidConfig
+            );
+            assert!(bash.is_null());
+            assert!(error_message(error).contains(expected));
+        }
+    }
+}
+
+#[test]
+fn rejects_oversized_config_before_reading_its_pointer() {
+    unsafe {
+        let config = BashkitBytes {
+            ptr: ptr::null(),
+            len: BASHKIT_MAX_CONFIG_BYTES + 1,
+        };
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_json(config, &mut bash, &mut error),
+            BashkitStatus::InvalidConfig
+        );
+        assert!(bash.is_null());
+        assert_eq!(error_message(error), "configuration exceeds 10000000 bytes");
+    }
+}
+
+#[test]
+fn reports_output_truncation_flags() {
+    unsafe {
+        let config = br#"{
+            "schema_version": 1,
+            "limits": {"max_output_bytes": 3}
+        }"#;
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_json(bytes(config), &mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+
+        let mut result = ptr::null_mut();
+        assert_eq!(
+            bashkit_execute(
+                bash,
+                bytes(b"printf '12345'; printf 'abcde' >&2"),
+                &mut result,
+                &mut error,
+            ),
+            BashkitStatus::Ok
+        );
+        assert_eq!(borrowed(bashkit_result_stdout(result)), b"123");
+        assert_eq!(borrowed(bashkit_result_stderr(result)), b"abc");
+        assert_eq!(
+            bashkit_result_flags(result),
+            BASHKIT_RESULT_STDOUT_TRUNCATED | BASHKIT_RESULT_STDERR_TRUNCATED
+        );
+
+        bashkit_result_free(result);
+        bashkit_free(bash);
+    }
+}
+
+#[test]
+fn null_destructors_and_accessors_are_safe() {
+    unsafe {
+        bashkit_free(ptr::null_mut());
+        bashkit_result_free(ptr::null_mut());
+        bashkit_buffer_free(ptr::null_mut());
+        bashkit_error_free(ptr::null_mut());
+        assert_eq!(bashkit_result_exit_code(ptr::null()), 0);
+        assert_eq!(bashkit_result_flags(ptr::null()), 0);
+        assert_eq!(bashkit_result_stdout(ptr::null()).len, 0);
+        assert_eq!(bashkit_buffer_bytes(ptr::null()).len, 0);
+        assert_eq!(bashkit_error_message(ptr::null()).len, 0);
+    }
+}

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -533,6 +533,7 @@ All unexpected errors are caught and converted to safe, human-readable messages.
 | Memory addr in errors (TM-INT-005) | Debug output shows addresses | Display impl hides addresses | MITIGATED |
 | Stack trace exposure (TM-INT-006) | Panic unwinds show call stack | `catch_unwind` prevents propagation | MITIGATED |
 | /dev/urandom empty with head -c (TM-INT-007) | `head -c 16 /dev/urandom` returns empty | Fix virtual device pipe handling | **MITIGATED** |
+| C ABI unwind (TM-INT-008) | Rust panic enters a foreign runtime or leaks details | Catch every exported operation and return a generic error | **MITIGATED** |
 
 **Panic Recovery:**
 

--- a/docs/c-api.md
+++ b/docs/c-api.md
@@ -1,0 +1,174 @@
+# C API
+
+Bashkit's experimental C ABI embeds the sandbox in native applications and
+provides a foundation for external language bindings. It is synchronous,
+binary-safe, and based on opaque handles.
+
+## Install
+
+Prebuilt archives are attached to each
+[GitHub Release](https://github.com/everruns/bashkit/releases):
+
+| Target | Archive |
+|---|---|
+| macOS Apple Silicon | `bashkit-capi-aarch64-apple-darwin.tar.gz` |
+| macOS Intel | `bashkit-capi-x86_64-apple-darwin.tar.gz` |
+| Linux x86-64 | `bashkit-capi-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `bashkit-capi-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86-64 | `bashkit-capi-x86_64-pc-windows-msvc.zip` |
+
+Download the adjacent `.sha256` file and verify it before extracting. Each
+archive contains the public header, both examples, notices, and the matching
+native library. Windows archives also contain the `bashkit.lib` import library.
+No Rust toolchain is required when using a release archive.
+
+The complete platform-specific compile and deployment commands are in the
+[`bashkit-capi` README](../crates/bashkit-capi/README.md).
+
+## Build from source
+
+```sh
+./scripts/build-c-api.sh --release
+```
+
+The shared library is `libbashkit.so` on Linux,
+`libbashkit.dylib` on macOS, and `bashkit.dll` on Windows. It contains the
+complete Bashkit runtime; no second Bashkit library is required. Include
+[`bashkit.h`](../crates/bashkit-capi/include/bashkit.h) in the host application.
+The Cargo adapter target remains internally named `bashkit_capi` to avoid
+colliding with Bashkit's Rust and Python workspace artifacts.
+
+Source builds require the repository's pinned Rust toolchain and a C compiler.
+The helper supports macOS and Linux and writes the native consumer artifact to
+`target/c-api/release/`.
+
+## Link and deploy
+
+On Linux and macOS, compile with the extracted `include/` and `lib/` directories:
+
+```sh
+cc -std=c11 -I "$BASHKIT_SDK/include" app.c \
+  -L "$BASHKIT_SDK/lib" -lbashkit -o app
+```
+
+At runtime the operating-system loader must be able to find `libbashkit.so` or
+`libbashkit.dylib`. Prefer deploying it in an application-local `lib/` directory
+and embedding `$ORIGIN/lib` on Linux or `@loader_path/lib` on macOS, as shown in
+the packaged README. On Windows, link `bashkit.lib` and put `bashkit.dll` beside
+the executable or on `PATH`.
+
+Applications and libraries must use the same architecture. The current Linux
+archives target GNU libc; a dynamic Bashkit library is self-contained with
+respect to Bashkit and Rust dependencies but still uses normal platform system
+libraries.
+
+### CMake
+
+Set `BASHKIT_ROOT` to the extracted archive directory:
+
+```cmake
+add_library(bashkit SHARED IMPORTED)
+target_include_directories(my_app PRIVATE "${BASHKIT_ROOT}/include")
+
+if(WIN32)
+  set_target_properties(bashkit PROPERTIES
+    IMPORTED_LOCATION "${BASHKIT_ROOT}/lib/bashkit.dll"
+    IMPORTED_IMPLIB "${BASHKIT_ROOT}/lib/bashkit.lib")
+elseif(APPLE)
+  set_target_properties(bashkit PROPERTIES
+    IMPORTED_LOCATION "${BASHKIT_ROOT}/lib/libbashkit.dylib")
+else()
+  set_target_properties(bashkit PROPERTIES
+    IMPORTED_LOCATION "${BASHKIT_ROOT}/lib/libbashkit.so")
+endif()
+
+target_link_libraries(my_app PRIVATE bashkit)
+```
+
+The application must still deploy the runtime library where the platform loader
+can locate it.
+
+## Run the examples
+
+The repository includes two real C programs:
+
+```sh
+./scripts/run-c-api-examples.sh
+```
+
+[`hello.c`](../crates/bashkit-capi/examples/hello.c) demonstrates instance and
+result lifetimes by printing the virtual user and current UTC time.
+[`files.c`](../crates/bashkit-capi/examples/files.c)
+demonstrates JSON configuration and binary-safe VFS exchange.
+
+## Surface
+
+The v1 ABI provides:
+
+- library ABI, package version, and compiled-capability queries;
+- default or JSON-configured Bashkit construction;
+- synchronous script execution;
+- exit code, exact stdout bytes, UTF-8 stderr, truncation flags, and optional final
+  environment JSON;
+- virtual filesystem read, write, directory creation, and removal;
+- explicit result, buffer, error, and instance destruction.
+
+All strings enter as a pointer plus length. Scripts, paths, configuration, and
+stderr are UTF-8; file contents and exact stdout may contain arbitrary bytes. A
+null pointer with zero length represents an empty byte sequence. Construction
+configuration is capped at `BASHKIT_MAX_CONFIG_BYTES` (10 MB).
+
+## Errors and shell status
+
+An ABI status describes whether Bashkit produced a result. A script ending in
+`exit 7` is a successful ABI operation whose `BashkitResult` has exit code 7.
+Invalid arguments, invalid UTF-8, invalid configuration, interpreter failures,
+and VFS failures return an owned `BashkitError`.
+
+Error messages are capped at 1 KiB. Free them with `bashkit_error_free()`.
+
+## Ownership and concurrency
+
+The library allocates every opaque object. Release each object with its matching
+function; do not use the host's `free()` or retain borrowed byte views after the
+owner is released.
+
+Calls against one Bashkit instance are serialized. Independent instances may
+run concurrently. The caller owns handle lifetime synchronization and must not
+free a handle while another thread is using it.
+
+## Initial exclusions
+
+ABI v1 does not expose callbacks, custom builtins, streaming output, async
+execution, host filesystem mounts, transport hooks, snapshots, or the existing
+cross-addon filesystem-handle ABI. These require separate callback, reentrancy,
+and library-unload contracts.
+
+## Compatibility
+
+Opaque object layouts are private. Existing functions, numeric status values,
+ownership rules, and v1 configuration meanings will not change incompatibly.
+New functions and status values may be added. An incompatible contract requires
+a new ABI major rather than changing v1 in place.
+
+When loading Bashkit dynamically, call `bashkit_abi_version()` and require
+`BASHKIT_ABI_VERSION_1` before using the rest of the API. The package version
+returned by `bashkit_version()` is informational and is independent of the ABI
+major.
+
+## Troubleshooting
+
+- Linux `libbashkit.so: cannot open shared object file`: set an application
+  rpath or point `LD_LIBRARY_PATH` at the library directory.
+- macOS `Library not loaded: @rpath/libbashkit.dylib`: add an application rpath
+  or point `DYLD_LIBRARY_PATH` at the library directory.
+- Windows error 126: place `bashkit.dll` beside the executable and ensure the
+  executable and DLL are both x86-64.
+- Undefined `bashkit_*` link symbols: place `-lbashkit` after object inputs on
+  Unix and use a header and library from the same release.
+
+## See also
+
+- [Get started](start.md) — choose another Bashkit package or runtime.
+- [Sandbox configuration and limits](configuration.md) — common sandbox controls.
+- [Security](security.md) — trust boundaries and resource protections.

--- a/docs/start.md
+++ b/docs/start.md
@@ -10,6 +10,7 @@ its quickstart to a first script in a couple of minutes.
 | Target | Install | Runs in | Quickstart |
 |--------|---------|---------|-----------|
 | **Rust** | `cargo add bashkit` | Any Rust app | [Get started in Rust](start-rust.md) |
+| **C ABI** | Native shared library | C-compatible native hosts | [C API](c-api.md) |
 | **Python** | `pip install bashkit` | CPython 3.9+ | [Get started in Python](start-python.md) |
 | **Node / Bun / Deno** | `npm i @everruns/bashkit` | Node ≥ 18, Bun, Deno | [Get started in Node](start-node.md) |
 | **Browser (WASM)** | `npm i @everruns/bashkit-wasm` | Browser, edge runtimes | [Get started in the browser](start-browser.md) |
@@ -18,7 +19,7 @@ its quickstart to a first script in a couple of minutes.
 
 **Which one?**
 
-- Embedding in a **Rust, Python, or Node/Bun/Deno** service → the native crate,
+- Embedding in a **Rust, C-compatible, Python, or Node/Bun/Deno** service → the native crate,
   wheel, or NAPI addon. These share the full feature set.
 - Running in a **browser or edge/serverless runtime** (Cloudflare Workers,
   Vercel Edge, Deno Deploy), or anywhere a native addon can't load → the

--- a/knowledge/foundations/architecture.md
+++ b/knowledge/foundations/architecture.md
@@ -25,6 +25,7 @@ Bashkit uses a Cargo workspace with multiple crates:
 | `crates/bashkit-cli/` | CLI binary |
 | `crates/bashkit-python/` | Python bindings (PyO3) |
 | `crates/bashkit-js/` | JavaScript bindings (NAPI-RS) |
+| `crates/bashkit-capi/` | Versioned native C ABI |
 | `crates/bashkit-eval/` | LLM eval study (mira framework) |
 
 Core library modules: `parser/`, `interpreter/`, `fs/`, `builtins/`,

--- a/knowledge/operations/limitations.md
+++ b/knowledge/operations/limitations.md
@@ -53,6 +53,7 @@ execution model. Evidence is a threat-model ID, a test, or `stance`
 | L-WASM-001 | Browser build (`@everruns/bashkit-wasm`, `wasm32-unknown-unknown`) has no wall-clock time: `sleep N` elapses instantly; `timeout N` and tool requests with `timeoutMs` fail closed with status 125 | No reliable timer driver on the target; silently accepting an unenforceable deadline could let an async callback suspend forever | [Browser Package](../runtimes/browser-package.md), stance |
 | L-WASM-002 | Browser build: `executeSync()` cannot run async custom builtins (fails with a clear message); use `execute()` | Single-threaded event loop can't settle a JS `Promise` without yielding | `crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs` |
 | L-WASM-003 | Browser build: background jobs (`cmd &`) run synchronously and `awk` file redirects drive the VFS inline; no work runs on a separate thread | `wasm32-unknown-unknown` is single-threaded — `std::thread::spawn`/`tokio::spawn` are unavailable; safe because the in-memory VFS never suspends | `crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs` |
+| L-CAPI-001 | C ABI v1 excludes callbacks, custom builtins, streaming, async cancellation, host mounts, transport hooks, snapshots, scripted tools, and external filesystem providers | These require explicit reentrancy, callback lifetime, and dynamic-library unload contracts | [C API](../runtimes/c-api.md), stance |
 
 ### Design Rationale
 

--- a/knowledge/operations/release-process.md
+++ b/knowledge/operations/release-process.md
@@ -83,11 +83,13 @@ silently failed.
 7. **Create PR** — same title, changelog excerpt + publish-readiness report in description.
 8. **Monitor post-merge publishing** — watch `release.yml` create the
    Release + tag, watch `publish.yml`, `publish-python.yml`, `publish-js.yml`,
-   `publish-wasm.yml`, and `cli-binaries.yml` to completion, run the
+   `publish-wasm.yml`, `cli-binaries.yml`, and `c-api-binaries.yml` to
+   completion, run the
    post-release verification commands, and only declare "shipped" when all
-   six published artifacts (`bashkit` + `bashkit-cli` on crates.io, `bashkit`
-   on PyPI, both npm packages, and Homebrew) report the new version. If one
-   fails, open a hotfix PR rather than leaving the release half-shipped.
+   published artifacts (`bashkit` + `bashkit-cli` on crates.io, `bashkit`
+   on PyPI, both npm packages, Homebrew, and the C ABI archives) report the new
+   version. If one fails, open a hotfix PR rather than leaving the release
+   half-shipped.
 
 ### CI Automation
 
@@ -115,6 +117,7 @@ Confirm each target (workflow → check):
 - npm browser (`publish-wasm.yml`): `npm view @everruns/bashkit-wasm version`;
   `npm dist-tags ls @everruns/bashkit-wasm` ("latest" points at it)
 - Homebrew (`cli-binaries.yml`): `everruns/homebrew-tap` formula bumped
+- C ABI (`c-api-binaries.yml`): five target archives and SHA-256 files attached
 
 If a workflow fails: `gh run view <run-id> --log-failed`, identify root
 cause, re-run (transient) or open a hotfix PR (code/packaging bug — see
@@ -137,6 +140,7 @@ Use the latest entries in `CHANGELOG.md` as the template. Rules:
 - `bashkit` on PyPI (pre-built wheels)
 - `@everruns/bashkit` on npm (native NAPI-RS bindings)
 - `@everruns/bashkit-wasm` on npm (single-threaded browser WebAssembly)
+- `bashkit-capi` native archives containing `libbashkit` on GitHub Releases
 
 ## Publishing Order
 
@@ -196,6 +200,13 @@ integration suite, and publishes `@everruns/bashkit-wasm` to npm with
 provenance. Uses the same `NPM_TOKEN` as `publish-js.yml`; the package version
 is synced manually from the workspace version during release preparation.
 
+### c-api-binaries.yml
+
+Dispatched by `release.yml` from the verified release tag. Builds and attaches
+the C header, examples, and shared library for macOS x86_64/Arm64, Linux
+x86_64/Arm64, and Windows x86_64. Each archive has a SHA-256 sidecar; Linux and
+Windows compile and run a C consumer before upload.
+
 ## Authentication
 
 - `CARGO_REGISTRY_TOKEN` (crates.io token, publish scopes) in GitHub Actions secrets.
@@ -226,5 +237,5 @@ selected for new projects.
 
 ## Release Artifacts
 
-GitHub Release (tag, notes, source archives, prebuilt CLI binaries),
+GitHub Release (tag, notes, source archives, prebuilt CLI and C ABI binaries),
 crates.io crates, PyPI wheels, Node and browser npm bindings, Homebrew formula.

--- a/knowledge/runtimes/c-api.md
+++ b/knowledge/runtimes/c-api.md
@@ -1,0 +1,73 @@
+---
+type: Interface Contract
+title: C API
+description: Versioned native C ABI, ownership rules, packaging, and compatibility boundaries.
+tags:
+  - bashkit
+  - ffi
+  - c-api
+  - abi
+---
+
+# C API
+
+## Status
+
+Experimental ABI v1.
+
+## Decision
+
+`crates/bashkit-capi` is the general-purpose native boundary. It publishes the
+canonical `libbashkit` shared library and exposes the checked-in
+`include/bashkit.h` contract. Its Cargo target remains uniquely named
+`bashkit_capi`; the build and release boundary renames the native artifact and
+sets its loader identity. This avoids collisions with the Rust core rlib and
+Python extension while keeping their developer experience unchanged. The existing
+`bashkit::interop::fs` ABI remains a narrower cross-addon filesystem exchange
+contract and is not the library entry point.
+
+The ABI uses opaque library-owned handles, pointer-plus-length byte views,
+fixed-width status values, and matching destruction functions. Rust object
+layouts, allocators, traits, futures, and Tokio types never cross the boundary.
+Each exported Rust function contains panics; fallible functions report a capped
+error object rather than unwinding into the host.
+
+Execution is synchronous in v1. Each handle owns a current-thread Tokio runtime
+and mutex-protected `Bash`; same-handle calls serialize, while distinct handles
+can execute concurrently. Callers own lifetime synchronization and cannot race
+destruction with use.
+
+Construction supports defaults or a strict, versioned JSON schema. Binary file
+data uses direct VFS functions rather than base64 configuration. Shell nonzero
+exit codes are successful ABI calls represented in `BashkitResult`; ABI status
+is reserved for boundary and execution failures.
+
+## Compatibility
+
+- ABI version is independent of the Bashkit package version.
+- Existing v1 symbols, numeric values, ownership, and semantics do not change
+  incompatibly.
+- Opaque layouts may change at any time.
+- Additive functions and status values are allowed.
+- Breaking changes require a parallel ABI major.
+
+## Deferred surface
+
+Callbacks, custom builtins, streaming, async cancellation, host mounts,
+transport hooks, snapshots, scripted tools, and external filesystem providers
+remain outside v1. They need explicit reentrancy, callback lifetime, and dynamic
+library unload rules before becoming permanent ABI.
+
+## Verification
+
+Rust contract tests cover success, shell failure, configuration, binary VFS
+content, invalid UTF-8, null outputs, and version rejection. The C example runner
+compiles the public header under C11 with warnings denied and executes two
+programs against the built shared library.
+
+## See also
+
+- [Architecture](../foundations/architecture.md) — crate boundaries and async-first core.
+- [Virtual Filesystem](../foundations/vfs.md) — the separate cross-addon filesystem ABI.
+- [Testing Strategy](../operations/testing.md) — repository test organization.
+- [Release Process](../operations/release-process.md) — native artifact publication.

--- a/knowledge/runtimes/index.md
+++ b/knowledge/runtimes/index.md
@@ -7,3 +7,4 @@
 * [Python Package](python-package.md) - Python bindings, PyPI wheels, ABI strategy, and platform build matrix.
 * [Emscripten Wheels](emscripten-wheels.md) - Reduced-feature Pyodide and Emscripten Python wheel design and build constraints.
 * [Browser Package](browser-package.md) - Slim single-threaded WebAssembly package design for browsers and JavaScript runtimes.
+* [C API](c-api.md) - Versioned native C ABI, ownership rules, packaging, and compatibility boundaries.

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -820,6 +820,7 @@ session's isolated VFS.
 | TM-INT-002 | Panic info leak | Panic message reveals sensitive data | Sanitized error messages (no panic details) | **MITIGATED** |
 | TM-INT-003 | Date format panic | Invalid strftime format causes chrono panic | Pre-validation with `StrftimeItems` | **MITIGATED** |
 | TM-INT-007 | `/dev/urandom` empty with `head -c` | `head -c 16 /dev/urandom` returns empty output; pipe from virtual device to builtin loses data | `read_file_for_builtin` (`builtins/mod.rs`) reads `/dev/urandom`/`/dev/random` as Latin-1 chars (each byte 0x00-0xFF maps 1:1 to a char) so `head -c N` returns N bytes of randomness in both the path-argument form and the `cat /dev/urandom \| head -c N` pipe form | **MITIGATED** |
+| TM-INT-008 | Panic crosses the C ABI boundary | Rust unwind enters a foreign runtime or exposes panic details | Every exported C operation uses `catch_unwind`; fallible calls return a generic, capped `BASHKIT_INTERNAL_ERROR` | **MITIGATED** |
 
 **Current Risk**: LOW. Implementation: `interpreter/mod.rs` wraps every builtin call in
 `AssertUnwindSafe(..).catch_unwind()` (TM-INT-001) and converts panics to the sanitized

--- a/scripts/build-c-api.sh
+++ b/scripts/build-c-api.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# The Cargo target stays uniquely named; this script creates the canonical
+# consumer artifact without colliding with Rust and Python workspace outputs.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+profile=debug
+cargo_args=(-p bashkit-capi)
+
+if [[ "${1:-}" == "--release" ]]; then
+    profile=release
+    cargo_args+=(--release)
+    shift
+fi
+
+target=""
+if [[ "${1:-}" == "--target" ]]; then
+    target=${2:?missing target triple}
+    cargo_args+=(--target "$target")
+    shift 2
+fi
+
+if [[ $# -ne 0 ]]; then
+    echo "usage: $0 [--release] [--target TARGET]" >&2
+    exit 2
+fi
+
+if [[ -n "$target" ]]; then
+    build_dir="$repo_root/target/$target/$profile"
+else
+    build_dir="$repo_root/target/$profile"
+fi
+native_dir="$repo_root/target/c-api/$profile"
+mkdir -p "$native_dir"
+
+case "$(uname -s)" in
+    Darwin)
+        cargo build --manifest-path "$repo_root/Cargo.toml" "${cargo_args[@]}"
+        cp "$build_dir/libbashkit_capi.dylib" "$native_dir/libbashkit.dylib"
+        install_name_tool -id @rpath/libbashkit.dylib "$native_dir/libbashkit.dylib"
+        ;;
+    Linux)
+        cargo rustc --manifest-path "$repo_root/Cargo.toml" \
+            "${cargo_args[@]}" --lib -- -C link-arg=-Wl,-soname,libbashkit.so
+        cp "$build_dir/libbashkit_capi.so" "$native_dir/libbashkit.so"
+        ;;
+    *)
+        echo "build-c-api.sh supports macOS and Linux" >&2
+        exit 1
+        ;;
+esac

--- a/scripts/run-c-api-examples.sh
+++ b/scripts/run-c-api-examples.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+example_dir="$repo_root/crates/bashkit-capi/examples"
+output_dir="$repo_root/target/c-api-examples"
+
+"$repo_root/scripts/build-c-api.sh"
+mkdir -p "$output_dir"
+
+c++ -std=c++17 -Wall -Wextra -Werror -x c++ \
+    -I "$repo_root/crates/bashkit-capi/include" \
+    -c "$example_dir/hello.c" \
+    -o "$output_dir/header-cxx.o"
+
+case "$(uname -s)" in
+    Darwin)
+        loader_variable=DYLD_LIBRARY_PATH
+        ;;
+    Linux)
+        loader_variable=LD_LIBRARY_PATH
+        ;;
+    *)
+        echo "run-c-api-examples.sh supports macOS and Linux" >&2
+        exit 1
+        ;;
+esac
+
+for example in hello files; do
+    cc -std=c11 -Wall -Wextra -Werror \
+        -I "$repo_root/crates/bashkit-capi/include" \
+        "$example_dir/$example.c" \
+        -L "$repo_root/target/c-api/debug" -lbashkit \
+        -o "$output_dir/$example"
+    env "$loader_variable=$repo_root/target/c-api/debug" "$output_dir/$example"
+done

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -11,6 +11,7 @@ import sitemapEnhance from "./integrations/sitemap-enhance.mjs";
 const DOC_LINKS = new Map([
   ["builtin_typescript.md", "/docs/builtin_typescript/"],
   ["clap-builtins.md", "/docs/clap-builtins/"],
+  ["c-api.md", "/docs/c-api/"],
   ["cli.md", "/docs/cli/"],
   ["compatibility.md", "/docs/compatibility/"],
   ["configuration.md", "/docs/configuration/"],
@@ -94,6 +95,11 @@ function repoUrl(url) {
 
   if (cleanUrl === "README.md" || cleanUrl === "SECURITY.md") {
     return `https://github.com/everruns/bashkit/blob/main/${cleanUrl}`;
+  }
+
+  const cratesIndex = cleanUrl.indexOf("crates/");
+  if (cratesIndex >= 0) {
+    return `https://github.com/everruns/bashkit/blob/main/${cleanUrl.slice(cratesIndex)}`;
   }
 
   const knowledgeIndex = cleanUrl.indexOf("knowledge/");

--- a/site/src/pages/docs/_meta.ts
+++ b/site/src/pages/docs/_meta.ts
@@ -60,6 +60,16 @@ export const DOC_META: DocMeta[] = [
     editPath: "docs/start-python.md",
   },
   {
+    slug: "c-api",
+    title: "C API",
+    summary: "Embed Bashkit through its versioned native ABI and opaque handles.",
+    seoTitle: "Bashkit native C API",
+    seoDescription:
+      "Embed the Bashkit sandbox through its versioned C ABI with explicit ownership, binary-safe output, virtual filesystem access, and runnable C examples.",
+    section: "Getting started",
+    editPath: "docs/c-api.md",
+  },
+  {
     slug: "start-node",
     title: "Node, Bun & Deno",
     summary: "Embed the sandbox in server-side JavaScript: npm i, first script, examples.",

--- a/site/src/pages/docs/_meta.ts
+++ b/site/src/pages/docs/_meta.ts
@@ -63,7 +63,7 @@ export const DOC_META: DocMeta[] = [
     slug: "c-api",
     title: "C API",
     summary: "Embed Bashkit through its versioned native ABI and opaque handles.",
-    seoTitle: "Bashkit native C API",
+    seoTitle: "Embed Bashkit with the native C API",
     seoDescription:
       "Embed the Bashkit sandbox through its versioned C ABI with explicit ownership, binary-safe output, virtual filesystem access, and runnable C examples.",
     section: "Getting started",


### PR DESCRIPTION
## What changed
Adds an experimental, versioned C ABI for embedding the complete Bashkit runtime through the canonical `libbashkit` dynamic library. Native callers can create configured shells, execute scripts, inspect byte-exact results and final environment state, exchange binary VFS files, and release every owned handle through explicit lifecycle functions.

Includes runnable C examples, normal PR CI coverage, Linux/macOS/Windows release archives, consumer setup documentation, ABI ownership rules, and the new FFI threat-model boundary. No .NET bindings are included.

Closes #2228

## Why
External runtimes need a small stable native boundary instead of depending on Rust layouts or embedding another language binding. Opaque handles and a versioned C contract provide that portable foundation while keeping the core Rust API independent.

## Before / After
Before: Bashkit had Rust, Python, JavaScript, and browser WASM packages but no general native API.

After, both checked-in C consumers compile with warnings denied and execute against `libbashkit`:

```text
Hello from Bashkit! User: sandbox Time: 2026-08-03T23:16:12Z
HELLO C ABI
```

`just pre-pr` passes with Bash 5.3, including 1,611 integration tests, C ABI contract tests, workspace doctests, Clippy, formatting, knowledge/doc-link validation, release-script tests, and dependency vetting.

## Risk
- Medium
- This introduces an unsafe foreign-function boundary and new cross-platform release packaging. Mitigations include opaque ownership, strict configuration/version validation, bounded diagnostics/configuration/output, panic containment, null/error tests, Linux and Windows native smoke tests, and explicit ABI lifetime documentation. Existing Rust and language-binding APIs are unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered