### PR TITLE
docs(readme): fix agent friendly badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Crates.io](https://img.shields.io/crates/v/bashkit.svg)](https://crates.io/crates/bashkit)
 [![docs.rs](https://img.shields.io/docsrs/bashkit)](https://docs.rs/bashkit)
-[![Repo: Agent Friendly](https://img.shields.io/badge/Repo-Agent%20Friendly-blue)](AGENTS.md)
+[![Repo: Agent Friendly](https://img.shields.io/badge/Repo-Agent%20Friendly-blue)](https://github.com/everruns/bashkit/blob/main/AGENTS.md)
 
 Awesomely fast virtual sandbox with bash and file system. Written in Rust.
 

--- a/scripts/tests/test_check_doc_links.py
+++ b/scripts/tests/test_check_doc_links.py
@@ -17,6 +17,8 @@ import unittest
 
 REPO = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = REPO / "scripts" / "check_doc_links.py"
+AGENTS_URL = "https://github.com/everruns/bashkit/blob/main/AGENTS.md"
+AGENT_BADGE = "https://img.shields.io/badge/Repo-Agent%20Friendly-blue"
 
 
 def run(root: pathlib.Path, *trees: str) -> subprocess.CompletedProcess:
@@ -103,6 +105,12 @@ class CheckDocLinksTest(unittest.TestCase):
     def test_missing_root_rejected(self) -> None:
         result = run(self.root / "nope", "docs")
         self.assertEqual(result.returncode, 2)
+
+
+class ReadmeLinksTest(unittest.TestCase):
+    def test_agent_friendly_badge_targets_root_agents_file(self) -> None:
+        readme = (REPO / "README.md").read_text()
+        self.assertIn(f"[![Repo: Agent Friendly]({AGENT_BADGE})]({AGENTS_URL})", readme)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
The Agent Friendly badge now opens the root AGENTS.md through its canonical GitHub URL, including when the README is rendered outside the repository root.

## Why
The relative badge target resolved against package and mirror pages, producing a nonexistent AGENTS.md URL.

## Before / After
Before: the badge targeted relative `AGENTS.md` and could return 404 outside GitHub repository-root rendering.

After: the badge targets `https://github.com/everruns/bashkit/blob/main/AGENTS.md`; smoke check returned HTTP 200. A regression test locks the canonical target.

## Risk
- Low
- Only the README badge destination changes.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Verification
- `just test`
- `just pre-pr`
- Canonical AGENTS.md target: HTTP 200