### PR TITLE
feat: close the adoption gaps behind embedding bashkit as an agent's shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,11 @@ jobs:
       - name: Run realfs tests
         run: cargo test --features realfs -p bashkit --test realfs_tests -p bashkit-cli
 
+      # The third-party adoption and host-mount suites are `cfg(realfs)`, so
+      # the main "Run tests" step (no realfs) compiles them out entirely.
+      - name: Run realfs integration tests
+        run: cargo test -p bashkit --test integration --features realfs -- host_mounts_tests thirdparty_adoption_tests
+
       - name: Run fail-point tests (single-threaded)
         run: cargo test --features failpoints --test security_failpoint_tests -- --test-threads=1
 
@@ -222,6 +227,31 @@ jobs:
         run: cargo test --test proptest_security -- --test-threads=1
         env:
           PROPTEST_CASES: 50
+
+  # The adoption shape this covers — bashkit as an agent's shell, with commands
+  # bridged to host processes — exists to work on Windows without a real bash.
+  # Every other job is ubuntu-only, so that claim was never checked. Scoped to
+  # the adoption suites rather than the whole workspace: this job is here to
+  # keep the embedding contract honest, not to port every test to Windows.
+  test-windows:
+    name: Test (Windows adoption shape)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Run third-party adoption tests
+        run: cargo test -p bashkit --test integration --features realfs -- thirdparty_adoption_tests
+
+      - name: Run host mount mapping tests
+        run: cargo test -p bashkit --test integration --features realfs -- host_mounts_tests
+
+      - name: Run command resolver tests
+        run: cargo test -p bashkit --test integration -- command_resolver_tests
 
   examples:
     name: Examples
@@ -353,7 +383,7 @@ jobs:
   check:
     name: Check
     if: always()
-    needs: [lint, audit, test, examples, fuzz-check]
+    needs: [lint, audit, test, test-windows, examples, fuzz-check]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed
@@ -361,6 +391,7 @@ jobs:
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.audit.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
+             [[ "${{ needs.test-windows.result }}" != "success" ]] || \
              [[ "${{ needs.examples.result }}" != "success" ]] || \
              [[ "${{ needs.fuzz-check.result }}" != "success" ]]; then
             echo "One or more required jobs failed"

--- a/crates/bashkit/src/analysis.rs
+++ b/crates/bashkit/src/analysis.rs
@@ -676,7 +676,10 @@ mod tests {
         // The wrapped name is visible one argument to the right, so nothing is
         // hidden — flagging this opaque would make every `env FOO=1 cmd` prompt.
         assert!(!analysis.is_opaque());
-        assert_eq!(analysis.commands[0].args, [Some("cargo".into()), Some("--version".into())]);
+        assert_eq!(
+            analysis.commands[0].args,
+            [Some("cargo".into()), Some("--version".into())]
+        );
     }
 
     #[test]

--- a/crates/bashkit/src/analysis.rs
+++ b/crates/bashkit/src/analysis.rs
@@ -28,6 +28,37 @@ use crate::parser::{
 /// limit while deciding whether to run it.
 pub const MAX_ANALYSIS_NODES: usize = 4096;
 
+/// Commands that run another command named in their own arguments.
+///
+/// Decision: published as data rather than folded into
+/// [`ScriptAnalysis::is_opaque`]. These are not opaque — the command they run
+/// *is* statically visible, just one argument to the right — so flagging them
+/// as opaque would make every `env FOO=1 cmd` prompt. A host that allowlists
+/// command names must instead walk the wrapper's arguments itself.
+///
+/// Published because the alternative is every embedder hardcoding its own copy
+/// and silently drifting from ours across releases. `is_command_wrapper` is the
+/// supported way to ask.
+///
+/// Not listed: `time`, which is a Bash *keyword* — the parser already reports
+/// the timed command as the command name, so there is no wrapper to see
+/// through.
+///
+/// Not covered: wrappers that take a command in a non-prefix position
+/// (`find -exec`), or inside a language payload (`awk 'system(…)'`,
+/// `make`, `xargs -I{}` templates). Those need per-tool argument knowledge.
+pub const COMMAND_WRAPPERS: &[&str] = &[
+    "command", "doas", "env", "exec", "nice", "nohup", "setsid", "stdbuf", "sudo", "timeout",
+    "xargs",
+];
+
+/// True when `name` runs another command named in its own arguments.
+///
+/// See [`COMMAND_WRAPPERS`] for the list and its limits.
+pub fn is_command_wrapper(name: &str) -> bool {
+    COMMAND_WRAPPERS.contains(&name)
+}
+
 /// Where a command sits in the script.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -173,6 +204,20 @@ impl ScriptAnalysis {
     /// true, regardless of what `commands` contains.
     pub fn is_opaque(&self) -> bool {
         self.has_dynamic_commands || self.has_interpreter_reentry || self.truncated
+    }
+
+    /// Distinct [command wrappers](COMMAND_WRAPPERS) the script invokes, in
+    /// first-seen order.
+    ///
+    /// Non-empty means some command name this script runs is one argument to
+    /// the right of a name in [`command_names`](Self::command_names). A host
+    /// gating on an allowlist must either walk those arguments or treat the
+    /// script as it would an opaque one.
+    pub fn command_wrappers(&self) -> Vec<&str> {
+        self.command_names()
+            .into_iter()
+            .filter(|name| is_command_wrapper(name))
+            .collect()
     }
 }
 
@@ -622,6 +667,50 @@ mod tests {
     fn partial_literals_are_not_reconstructed() {
         let analysis = a("cat /tmp/$name.txt");
         assert_eq!(analysis.commands[0].args, vec![None]);
+    }
+
+    #[test]
+    fn command_wrappers_are_reported_but_not_opaque() {
+        let analysis = a("command cargo --version");
+        assert_eq!(analysis.command_wrappers(), ["command"]);
+        // The wrapped name is visible one argument to the right, so nothing is
+        // hidden — flagging this opaque would make every `env FOO=1 cmd` prompt.
+        assert!(!analysis.is_opaque());
+        assert_eq!(analysis.commands[0].args, [Some("cargo".into()), Some("--version".into())]);
+    }
+
+    #[test]
+    fn every_published_wrapper_is_recognized() {
+        for name in COMMAND_WRAPPERS {
+            assert!(is_command_wrapper(name), "{name} should be a wrapper");
+            assert_eq!(
+                a(&format!("{name} cargo --version")).command_wrappers(),
+                [*name]
+            );
+        }
+    }
+
+    #[test]
+    fn non_wrappers_are_not_reported() {
+        assert!(!is_command_wrapper("echo"));
+        assert!(a("echo command").command_wrappers().is_empty());
+        // `find -exec` takes its command in a non-prefix position: documented
+        // as out of scope, so it must not be silently reported as handled.
+        assert!(!is_command_wrapper("find"));
+    }
+
+    #[test]
+    fn time_keyword_needs_no_wrapper_entry() {
+        // `time` is parsed as a keyword, so the timed command is already the
+        // reported command name — there is nothing for a host to see through.
+        assert_eq!(a("time cargo --version").command_names(), ["cargo"]);
+        assert!(!is_command_wrapper("time"));
+    }
+
+    #[test]
+    fn command_wrappers_are_deduplicated_in_first_seen_order() {
+        let analysis = a("env A=1 cargo build; xargs rm; env B=2 ls");
+        assert_eq!(analysis.command_wrappers(), ["env", "xargs"]);
     }
 
     #[test]

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -386,6 +386,63 @@ impl BuiltinRegistry {
     }
 }
 
+/// Resolve a command name to a builtin at dispatch time.
+///
+/// [`BuiltinRegistry`] answers "which names are registered" from a map fixed
+/// before the name is known. A resolver is asked *about a specific name*, after
+/// every other dispatch route has missed and immediately before the 127
+/// "command not found" path — so an embedder can decide at runtime, per name,
+/// without enumerating the set in advance.
+///
+/// Decision: resolvers return a [`Builtin`] rather than executing directly.
+/// The resolved builtin runs through the same dispatch path as every other
+/// builtin, so `before_tool` hooks fire with the resolved name and can veto it,
+/// `catch_unwind` still contains panics, and redirects and stdin behave
+/// identically. A bespoke execution path would have to re-earn all of that.
+///
+/// Returning `None` falls through to the normal `command not found` error.
+///
+/// # Security
+///
+/// A resolver is embedder-supplied host code, exactly like a builtin passed to
+/// [`BashBuilder::builtin`](crate::BashBuilder::builtin) — it grants no
+/// capability the embedder did not already have. What it *does* change is that
+/// the set of names reaching host code stops being enumerable in advance, so
+/// `Bash::builtin_names()` no longer bounds it. `before_tool` remains the
+/// enforcement backstop; see `knowledge/integrations/script-analysis.md`.
+///
+/// # Example
+///
+/// ```
+/// use bashkit::{Builtin, BuiltinContext, CommandResolver, ExecResult, async_trait};
+/// use std::sync::Arc;
+///
+/// struct Echoer(String);
+///
+/// #[async_trait]
+/// impl Builtin for Echoer {
+///     async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+///         Ok(ExecResult::ok(format!("ran {}\n", self.0)))
+///     }
+/// }
+///
+/// struct AnyToolResolver;
+///
+/// impl CommandResolver for AnyToolResolver {
+///     fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+///         name.starts_with("tool-").then(|| Arc::new(Echoer(name.into())) as Arc<dyn Builtin>)
+///     }
+/// }
+/// ```
+pub trait CommandResolver: Send + Sync {
+    /// Return a builtin to run for `name`, or `None` to fall through to
+    /// `command not found`.
+    ///
+    /// Called on every unresolved command, so keep it cheap — cache rather
+    /// than probing the filesystem on each call.
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>>;
+}
+
 /// Typed, per-execution data exposed to builtin implementations.
 ///
 /// This is intentionally separate from shell state: extensions live for one

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1104,6 +1104,10 @@ pub struct Interpreter {
     /// override baked-in commands. Survives `reset_transient_state` because
     /// it lives behind an `Arc<RwLock>` shared with the embedder.
     host_builtins: Option<crate::builtins::BuiltinRegistry>,
+    /// Optional last-chance name resolver. Consulted only after every other
+    /// dispatch route has missed, immediately before `command not found`, so
+    /// it can never shadow a function, builtin, or `$PATH` script.
+    command_resolver: Option<Arc<dyn crate::builtins::CommandResolver>>,
     /// Call stack for local variable scoping
     call_stack: Vec<CallFrame>,
     /// Source file stack for BASH_SOURCE array
@@ -1585,6 +1589,7 @@ impl Interpreter {
             last_exit_code: 0,
             builtins,
             host_builtins,
+            command_resolver: None,
             call_stack: Vec::new(),
             bash_source_stack: Vec::new(),
             limits: ExecutionLimits::default(),
@@ -1986,6 +1991,14 @@ impl Interpreter {
     /// Set an environment variable.
     pub fn set_env(&mut self, key: &str, value: &str) {
         self.env.insert(key.to_string(), value.to_string());
+    }
+
+    /// Install the last-chance command resolver (public API for builder).
+    pub(crate) fn set_command_resolver(
+        &mut self,
+        resolver: Arc<dyn crate::builtins::CommandResolver>,
+    ) {
+        self.command_resolver = Some(resolver);
     }
 
     /// Set a shell variable (public API for builder).
@@ -6327,6 +6340,15 @@ impl Interpreter {
                     .await;
             }
 
+            // The `$PATH` search consumes `stdin`, so keep a copy for the
+            // resolver — but only when one is installed, so the common path
+            // does not pay to clone piped input.
+            let resolver_stdin = self
+                .command_resolver
+                .is_some()
+                .then(|| stdin.clone())
+                .flatten();
+
             // $PATH search
             if !self.shell_profile.is_logic_only()
                 && let Some(result) = self
@@ -6334,6 +6356,25 @@ impl Interpreter {
                     .await?
             {
                 return Ok(result);
+            }
+
+            // Last-chance resolver. Dispatches through `execute_builtin_arc`
+            // like every other builtin, so `before_tool` fires with the
+            // resolved name and can veto it.
+            if let Some(builtin) = self
+                .command_resolver
+                .as_ref()
+                .and_then(|resolver| resolver.resolve(name))
+            {
+                return self
+                    .execute_builtin_arc(
+                        name,
+                        builtin,
+                        &args,
+                        resolver_stdin.as_deref(),
+                        &command.redirects,
+                    )
+                    .await;
             }
 
             // Command not found

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -464,8 +464,8 @@ pub use async_trait::async_trait;
 pub use builtins::git::GitConfig;
 pub use builtins::ssh::{SshAllowlist, SshConfig, TrustedHostKey};
 pub use builtins::{
-    BashkitContext, Builtin, BuiltinRegistry, ClapBuiltin, Context as BuiltinContext,
-    ExecutionExtensions, Extension,
+    BashkitContext, Builtin, BuiltinRegistry, ClapBuiltin, CommandResolver,
+    Context as BuiltinContext, ExecutionExtensions, Extension,
 };
 pub use clap;
 #[cfg(feature = "http_client")]
@@ -1617,6 +1617,8 @@ pub struct BashBuilder {
     /// Optional host-owned mutable registry. Entries here are consulted at
     /// dispatch time, so embedders can register/remove builtins after build.
     host_builtins: Option<BuiltinRegistry>,
+    /// Optional last-chance name resolver, consulted just before the 127 path.
+    command_resolver: Option<Arc<dyn CommandResolver>>,
     /// Files to mount in the virtual filesystem
     mounted_files: Vec<MountedFile>,
     /// Lazy files to mount (loaded on first read)
@@ -2337,6 +2339,50 @@ impl BashBuilder {
         self
     }
 
+    /// Install a last-chance [`CommandResolver`].
+    ///
+    /// [`BashBuilder::builtin`] and [`BashBuilder::builtin_registry`] both map
+    /// *known names* to builtins. A resolver is asked about a name the
+    /// interpreter could not otherwise resolve, so an embedder bridging an
+    /// open-ended command space (host executables, a remote tool catalog) does
+    /// not have to enumerate it before execution.
+    ///
+    /// Consulted last — after shell functions, special builtins, the host
+    /// registry, baked-in builtins, path-based scripts, and the `$PATH` search
+    /// — and only when all of those miss. It therefore cannot shadow an
+    /// existing command; use [`BashBuilder::builtin`] to override one.
+    ///
+    /// The resolved builtin runs through the normal builtin path, so
+    /// [`before_tool`](BashBuilder::before_tool) hooks fire with the resolved
+    /// name and can veto the call.
+    ///
+    /// Note that resolver-provided names are not enumerable, so they do not
+    /// appear in [`Bash::builtin_names`] or in `command not found` suggestions.
+    ///
+    /// ```
+    /// # use bashkit::{Bash, Builtin, BuiltinContext, CommandResolver, ExecResult, async_trait};
+    /// # use std::sync::Arc;
+    /// # struct Stub;
+    /// # #[async_trait]
+    /// # impl Builtin for Stub {
+    /// #     async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+    /// #         Ok(ExecResult::ok("stub\n".to_string()))
+    /// #     }
+    /// # }
+    /// struct Resolver;
+    /// impl CommandResolver for Resolver {
+    ///     fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+    ///         (name == "deploy").then(|| Arc::new(Stub) as Arc<dyn Builtin>)
+    ///     }
+    /// }
+    ///
+    /// let bash = Bash::builder().command_resolver(Arc::new(Resolver)).build();
+    /// ```
+    pub fn command_resolver(mut self, resolver: Arc<dyn CommandResolver>) -> Self {
+        self.command_resolver = Some(resolver);
+        self
+    }
+
     /// Register a capability extension.
     ///
     /// Extensions contribute a related set of builtins as one unit. Commands
@@ -2942,6 +2988,7 @@ impl BashBuilder {
             self.trace_callback,
             self.custom_builtins,
             self.host_builtins,
+            self.command_resolver,
             self.history_file,
             #[cfg(feature = "http_client")]
             self.network_allowlist,
@@ -3186,6 +3233,7 @@ impl BashBuilder {
         trace_callback: Option<TraceCallback>,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
         host_builtins: Option<BuiltinRegistry>,
+        command_resolver: Option<Arc<dyn CommandResolver>>,
         history_file: Option<PathBuf>,
         #[cfg(feature = "http_client")] network_allowlist: Option<NetworkAllowlist>,
         #[cfg(feature = "http_client")] http_transport: Option<Arc<dyn network::HttpTransport>>,
@@ -3216,6 +3264,10 @@ impl BashBuilder {
             host_builtins,
             shell_profile,
         );
+
+        if let Some(resolver) = command_resolver {
+            interpreter.set_command_resolver(resolver);
+        }
 
         // Set environment variables (also override shell variable defaults)
         for (key, value) in &env {

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -784,6 +784,9 @@ pub struct Bash {
     /// Operator-approved in-process SQLite opt-in captured at build time.
     #[cfg(feature = "sqlite")]
     sqlite_inprocess_opt_in: bool,
+    /// Real host directories mounted into the VFS, for host-path resolution.
+    #[cfg(feature = "realfs")]
+    host_mounts: HostMounts,
 }
 
 impl Default for Bash {
@@ -829,6 +832,8 @@ impl Bash {
             python_inprocess_opt_in: false,
             #[cfg(feature = "sqlite")]
             sqlite_inprocess_opt_in: false,
+            #[cfg(feature = "realfs")]
+            host_mounts: HostMounts::default(),
         }
     }
 
@@ -1467,6 +1472,30 @@ impl Bash {
         self.interpreter.restore_shell_state(state);
     }
 
+    /// Real host directories mounted into this instance's VFS.
+    ///
+    /// Empty unless a `mount_real_*` builder method was used. Mounts that were
+    /// skipped at build time (allowlist rejection, canonicalize failure) are
+    /// absent, so what this reports is what is actually reachable.
+    #[cfg(feature = "realfs")]
+    pub fn host_mounts(&self) -> &HostMounts {
+        &self.host_mounts
+    }
+
+    /// Map a VFS path to the host path backing it.
+    ///
+    /// Shorthand for [`host_mounts().resolve()`](HostMounts::resolve). Returns
+    /// `None` for a relative path or one no mount covers — treat that as an
+    /// error, not a cue to fall back to a default directory.
+    ///
+    /// The typical use is an embedder bridging commands to host processes:
+    /// a builtin receives the VFS cwd in [`BuiltinContext::cwd`] and needs the
+    /// host directory to spawn in.
+    #[cfg(feature = "realfs")]
+    pub fn host_path_for(&self, vfs_path: impl AsRef<Path>) -> Option<PathBuf> {
+        self.host_mounts.resolve(vfs_path.as_ref())
+    }
+
     /// Names of all builtins dispatchable in this instance, sorted.
     ///
     /// Reflects what this build + configuration actually dispatches:
@@ -1583,6 +1612,89 @@ struct MountedLazyFile {
     size_hint: u64,
     mode: u32,
     loader: LazyLoader,
+}
+
+/// Where a real host directory ended up in the VFS.
+///
+/// Produced by the `mount_real_*` builder methods; `host_path` is the
+/// canonicalized host directory actually mounted, which may differ from the
+/// path passed in (symlinks, `/tmp` → `/private/tmp` on macOS).
+#[cfg(feature = "realfs")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostMount {
+    /// Canonicalized host directory.
+    pub host_path: PathBuf,
+    /// VFS path it is reachable at. `/` for a root overlay mount.
+    pub vfs_path: PathBuf,
+}
+
+/// The real host directories mounted into a [`Bash`] instance.
+///
+/// Decision: published because embedders bridging commands to host processes
+/// must map a VFS cwd back to a host directory, and hand-rolling that mapping
+/// is a trap — a naive string prefix match puts `/home/u/proj2` inside
+/// `/home/u/proj`. [`resolve`](Self::resolve) matches whole path components and
+/// prefers the longest match, so a specific mount always beats a root overlay.
+#[cfg(feature = "realfs")]
+#[derive(Debug, Clone, Default)]
+pub struct HostMounts {
+    mounts: Vec<HostMount>,
+}
+
+#[cfg(feature = "realfs")]
+impl HostMounts {
+    /// Build a table from mounts the caller already knows.
+    ///
+    /// Useful for the chicken-and-egg case: a [`CommandResolver`] is passed
+    /// *into* the builder, so the builtins it produces cannot call
+    /// [`Bash::host_mounts`] on an instance that does not exist yet. Construct
+    /// the table first, share one `Arc` between the resolver and the
+    /// `mount_real_*` calls, and both agree by construction.
+    ///
+    /// `host_path` should be canonicalized if the VFS mount was; compare
+    /// against [`Bash::host_mounts`] after building to confirm what actually
+    /// mounted.
+    pub fn new(mounts: impl IntoIterator<Item = HostMount>) -> Self {
+        Self {
+            mounts: mounts.into_iter().collect(),
+        }
+    }
+
+    /// Every mount, in the order the builder applied them.
+    pub fn all(&self) -> &[HostMount] {
+        &self.mounts
+    }
+
+    /// True when no real host directory is mounted.
+    pub fn is_empty(&self) -> bool {
+        self.mounts.is_empty()
+    }
+
+    /// Map a VFS path to the host path backing it.
+    ///
+    /// Returns `None` for a relative path, or when no mount covers it. Callers
+    /// must treat `None` as an error rather than falling back to a default
+    /// directory — running a host command in the wrong directory is worse than
+    /// refusing to run it.
+    ///
+    /// When mounts overlap (a workspace mounted inside a root overlay), the
+    /// longest matching VFS prefix wins.
+    pub fn resolve(&self, vfs_path: &Path) -> Option<PathBuf> {
+        if !vfs_path.is_absolute() {
+            return None;
+        }
+        self.mounts
+            .iter()
+            .filter_map(|mount| {
+                let rest = vfs_path.strip_prefix(&mount.vfs_path).ok()?;
+                Some((
+                    mount.vfs_path.components().count(),
+                    mount.host_path.join(rest),
+                ))
+            })
+            .max_by_key(|(depth, _)| *depth)
+            .map(|(_, host)| host)
+    }
 }
 
 /// A real host directory to mount in the VFS during builder construction.
@@ -2936,7 +3048,7 @@ impl BashBuilder {
 
         // Layer 1: Apply real filesystem mounts (if any)
         #[cfg(feature = "realfs")]
-        let base_fs = Self::apply_real_mounts(
+        let (base_fs, host_mounts) = Self::apply_real_mounts(
             &self.real_mounts,
             self.mount_path_allowlist.as_deref(),
             base_fs,
@@ -3005,6 +3117,12 @@ impl BashBuilder {
             #[cfg(feature = "ssh")]
             self.ssh_handler,
         );
+
+        // Set after build — avoids adding another arg to build_with_fs.
+        #[cfg(feature = "realfs")]
+        {
+            result.host_mounts = host_mounts;
+        }
 
         // Set hooks after build — avoids adding another arg to build_with_fs.
         let hooks = hooks::Hooks {
@@ -3100,13 +3218,16 @@ impl BashBuilder {
         real_mounts: &[MountedRealDir],
         mount_allowlist: Option<&[PathBuf]>,
         base_fs: Arc<dyn FileSystem>,
-    ) -> Arc<dyn FileSystem> {
+    ) -> (Arc<dyn FileSystem>, HostMounts) {
         if real_mounts.is_empty() {
-            return base_fs;
+            return (base_fs, HostMounts::default());
         }
 
         let mut current_fs = base_fs;
         let mut mount_points: Vec<(PathBuf, Arc<dyn FileSystem>)> = Vec::new();
+        // Only mounts that actually applied are recorded: a path skipped by the
+        // allowlist or a failed canonicalize must not look resolvable.
+        let mut host_mounts = HostMounts::default();
         let canonical_allowlist: Option<Vec<PathBuf>> = mount_allowlist.map(|allowlist| {
             allowlist
                 .iter()
@@ -3188,9 +3309,17 @@ impl BashBuilder {
                     // Overlay at root: real fs becomes the lower layer,
                     // existing VFS content overlaid on top
                     current_fs = Arc::new(OverlayFs::new(real_fs));
+                    host_mounts.mounts.push(HostMount {
+                        host_path: canonical_host,
+                        vfs_path: PathBuf::from("/"),
+                    });
                 }
                 Some(mount_point) => {
                     mount_points.push((mount_point.clone(), real_fs));
+                    host_mounts.mounts.push(HostMount {
+                        host_path: canonical_host,
+                        vfs_path: mount_point.clone(),
+                    });
                 }
             }
         }
@@ -3207,9 +3336,9 @@ impl BashBuilder {
                     );
                 }
             }
-            Arc::new(mountable)
+            (Arc::new(mountable), host_mounts)
         } else {
-            current_fs
+            (current_fs, host_mounts)
         }
     }
 
@@ -3355,6 +3484,8 @@ impl BashBuilder {
             python_inprocess_opt_in,
             #[cfg(feature = "sqlite")]
             sqlite_inprocess_opt_in,
+            #[cfg(feature = "realfs")]
+            host_mounts: HostMounts::default(),
         }
     }
 }

--- a/crates/bashkit/tests/integration/command_resolver_tests.rs
+++ b/crates/bashkit/tests/integration/command_resolver_tests.rs
@@ -1,0 +1,246 @@
+//! Integration tests for [`CommandResolver`] — the last-chance name resolver.
+//!
+//! The contract under test, in order of importance:
+//! 1. it runs only when every other dispatch route missed (never shadows),
+//! 2. resolved commands go through the normal builtin path, so `before_tool`
+//!    fires with the resolved name and can veto them,
+//! 3. returning `None` leaves the 127 behavior untouched.
+
+use async_trait::async_trait;
+use bashkit::hooks::HookAction;
+use bashkit::{Bash, Builtin, BuiltinContext, CommandResolver, ExecResult};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Echoes which name it was resolved under, plus any args and stdin.
+struct Resolved {
+    name: String,
+}
+
+#[async_trait]
+impl Builtin for Resolved {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let mut out = format!("resolved:{}", self.name);
+        if !ctx.args.is_empty() {
+            out.push_str(&format!(" args:{}", ctx.args.join(",")));
+        }
+        if let Some(stdin) = ctx.stdin {
+            out.push_str(&format!(" stdin:{}", stdin.trim_end()));
+        }
+        out.push('\n');
+        Ok(ExecResult::ok(out))
+    }
+}
+
+/// Resolves every name, counting calls so tests can assert it was not consulted.
+struct ResolveAll {
+    calls: Arc<AtomicUsize>,
+}
+
+impl CommandResolver for ResolveAll {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Some(Arc::new(Resolved { name: name.into() }))
+    }
+}
+
+/// Resolves nothing — the fall-through case.
+struct ResolveNothing;
+
+impl CommandResolver for ResolveNothing {
+    fn resolve(&self, _name: &str) -> Option<Arc<dyn Builtin>> {
+        None
+    }
+}
+
+fn resolve_all() -> (Bash, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::clone(&calls),
+        }))
+        .build();
+    (bash, calls)
+}
+
+#[tokio::test]
+async fn resolver_handles_an_otherwise_unknown_command() {
+    let (mut bash, calls) = resolve_all();
+    let result = bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.stdout, "resolved:definitely-not-a-command-xyz\n");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn resolver_receives_args_and_pipeline_stdin() {
+    let (mut bash, _) = resolve_all();
+    let result = bash
+        .exec("echo piped | some-host-tool --flag v")
+        .await
+        .unwrap();
+    assert_eq!(
+        result.stdout,
+        "resolved:some-host-tool args:--flag,v stdin:piped\n"
+    );
+}
+
+#[tokio::test]
+async fn resolver_never_shadows_a_baked_in_builtin() {
+    let (mut bash, calls) = resolve_all();
+    let result = bash.exec("echo hello").await.unwrap();
+    assert_eq!(result.stdout, "hello\n");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "resolver must not be consulted for a command that already resolves"
+    );
+}
+
+#[tokio::test]
+async fn resolver_never_shadows_a_shell_function() {
+    let (mut bash, calls) = resolve_all();
+    let result = bash
+        .exec("greet() { echo from-function; }; greet")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "from-function\n");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn resolver_never_shadows_a_builder_registered_builtin() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut bash = Bash::builder()
+        .builtin(
+            "deploy",
+            Box::new(Resolved {
+                name: "registered".into(),
+            }),
+        )
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::clone(&calls),
+        }))
+        .build();
+    let result = bash.exec("deploy").await.unwrap();
+    assert_eq!(result.stdout, "resolved:registered\n");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn resolver_returning_none_keeps_command_not_found() {
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveNothing))
+        .build();
+    let result = bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.exit_code, 127);
+    assert!(
+        result.stderr.contains("command not found"),
+        "unexpected: {}",
+        result.stderr
+    );
+}
+
+#[tokio::test]
+async fn no_resolver_keeps_command_not_found() {
+    let mut bash = Bash::new();
+    let result = bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.exit_code, 127);
+}
+
+/// The security contract from `knowledge/integrations/script-analysis.md`:
+/// `before_tool` is the enforcement backstop, and it must keep working for
+/// names that only exist because a resolver produced them.
+#[tokio::test]
+async fn before_tool_veto_blocks_a_resolved_command() {
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }))
+        .before_tool(Box::new(|event| {
+            if event.name == "forbidden-tool" {
+                HookAction::Cancel("blocked by policy".into())
+            } else {
+                HookAction::Continue(event)
+            }
+        }))
+        .build();
+
+    let blocked = bash.exec("forbidden-tool").await.unwrap();
+    assert_ne!(blocked.exit_code, 0, "veto must not succeed");
+    assert!(
+        !blocked.stdout.contains("resolved:"),
+        "vetoed command still ran: {}",
+        blocked.stdout
+    );
+
+    let allowed = bash.exec("permitted-tool").await.unwrap();
+    assert_eq!(allowed.stdout, "resolved:permitted-tool\n");
+}
+
+/// `before_tool` sees the *resolved* name, so an allowlist keyed on names
+/// works the same for resolver-provided commands as for registered ones.
+#[tokio::test]
+async fn before_tool_observes_the_resolved_name() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let recorder = Arc::clone(&seen);
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }))
+        .before_tool(Box::new(move |event| {
+            recorder.lock().unwrap().push(event.name.clone());
+            HookAction::Continue(event)
+        }))
+        .build();
+
+    bash.exec("host-tool --version").await.unwrap();
+    assert_eq!(seen.lock().unwrap().as_slice(), ["host-tool"]);
+}
+
+/// A resolved command is an ordinary command: its exit code drives `&&`/`||`
+/// and `if`, and a non-zero code does not abort the script.
+#[tokio::test]
+async fn resolved_exit_codes_drive_control_flow() {
+    struct Failing;
+    #[async_trait]
+    impl Builtin for Failing {
+        async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+            Ok(ExecResult::err("boom", 3))
+        }
+    }
+    struct FailResolver;
+    impl CommandResolver for FailResolver {
+        fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+            (name == "failing-tool").then(|| Arc::new(Failing) as Arc<dyn Builtin>)
+        }
+    }
+
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(FailResolver))
+        .build();
+
+    let result = bash.exec("failing-tool; echo after").await.unwrap();
+    assert!(
+        result.stdout.contains("after"),
+        "script aborted: {result:?}"
+    );
+
+    let result = bash.exec("failing-tool || echo recovered").await.unwrap();
+    assert!(result.stdout.contains("recovered"));
+
+    let result = bash.exec("failing-tool").await.unwrap();
+    assert_eq!(result.exit_code, 3);
+}
+
+/// Resolver names are not enumerable, so they must not appear in
+/// `builtin_names()` — an embedder gating on that list needs to know.
+#[tokio::test]
+async fn resolved_names_are_not_enumerable() {
+    let (bash, _) = resolve_all();
+    assert!(
+        !bash
+            .builtin_names()
+            .contains(&"anything-at-all".to_string())
+    );
+}

--- a/crates/bashkit/tests/integration/host_mounts_tests.rs
+++ b/crates/bashkit/tests/integration/host_mounts_tests.rs
@@ -1,0 +1,138 @@
+//! Tests for [`HostMounts`] — mapping a VFS path back to the host path.
+//!
+//! The traps being pinned here are the ones an embedder hits when hand-rolling
+//! this mapping: string-prefix matching that swallows sibling directories, and
+//! overlapping mounts where the wrong one wins.
+
+#![cfg(feature = "realfs")]
+
+use bashkit::{Bash, HostMount, HostMounts};
+use std::path::{Path, PathBuf};
+
+fn mounts() -> HostMounts {
+    HostMounts::new([
+        HostMount {
+            host_path: PathBuf::from("/srv/root"),
+            vfs_path: PathBuf::from("/"),
+        },
+        HostMount {
+            host_path: PathBuf::from("/home/user/proj"),
+            vfs_path: PathBuf::from("/workspace"),
+        },
+    ])
+}
+
+#[test]
+fn resolves_a_path_under_a_mount() {
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace/src/main.rs")),
+        Some(PathBuf::from("/home/user/proj/src/main.rs"))
+    );
+}
+
+#[test]
+fn resolves_the_mount_point_itself() {
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace")),
+        Some(PathBuf::from("/home/user/proj"))
+    );
+}
+
+/// The trap: a plain string prefix match puts `/workspace2` inside
+/// `/workspace`. Matching whole components sends it to the root mount instead.
+#[test]
+fn sibling_of_a_mount_does_not_land_inside_it() {
+    let resolved = mounts().resolve(Path::new("/workspace2/src")).unwrap();
+    assert_ne!(resolved, PathBuf::from("/home/user/proj2/src"));
+    assert_ne!(resolved, PathBuf::from("/home/user/proj/src"));
+    assert_eq!(resolved, PathBuf::from("/srv/root/workspace2/src"));
+}
+
+/// A specific mount nested inside a root overlay must win over the overlay.
+#[test]
+fn longest_matching_mount_wins() {
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace/deep/file")),
+        Some(PathBuf::from("/home/user/proj/deep/file"))
+    );
+    // …and a path the specific mount does not cover still falls to the root.
+    assert_eq!(
+        mounts().resolve(Path::new("/tmp/scratch")),
+        Some(PathBuf::from("/srv/root/tmp/scratch"))
+    );
+}
+
+#[test]
+fn relative_paths_do_not_resolve() {
+    assert_eq!(mounts().resolve(Path::new("src")), None);
+    assert_eq!(mounts().resolve(Path::new("../escape")), None);
+}
+
+#[test]
+fn unmapped_path_is_none_when_nothing_is_mounted() {
+    let empty = HostMounts::default();
+    assert!(empty.is_empty());
+    assert_eq!(empty.resolve(Path::new("/anywhere")), None);
+}
+
+/// Without a root overlay there is no catch-all, so an uncovered path must
+/// report `None` rather than silently landing in some other mount.
+#[test]
+fn uncovered_path_without_a_root_mount_is_none() {
+    let only_workspace = HostMounts::new([HostMount {
+        host_path: PathBuf::from("/home/user/proj"),
+        vfs_path: PathBuf::from("/workspace"),
+    }]);
+    assert_eq!(only_workspace.resolve(Path::new("/etc/passwd")), None);
+}
+
+#[test]
+fn a_plain_instance_reports_no_host_mounts() {
+    let bash = Bash::new();
+    assert!(bash.host_mounts().is_empty());
+    assert_eq!(bash.host_path_for("/anything"), None);
+}
+
+/// The table reflects what actually mounted, resolving through the real
+/// builder path (including canonicalization).
+#[test]
+fn builder_records_real_mounts() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("hello.txt"), "hi\n").unwrap();
+    let host = std::fs::canonicalize(dir.path()).unwrap();
+
+    let bash = Bash::builder()
+        .allowed_mount_paths([host.clone()])
+        .mount_real_readwrite_at(host.clone(), "/workspace")
+        .build();
+
+    assert_eq!(bash.host_mounts().all().len(), 1);
+    assert_eq!(
+        bash.host_path_for("/workspace/hello.txt"),
+        Some(host.join("hello.txt"))
+    );
+}
+
+/// A mount rejected by the allowlist must not appear resolvable — reporting a
+/// host path for a directory that was never mounted is worse than reporting
+/// nothing.
+#[test]
+fn skipped_mounts_are_not_recorded() {
+    let allowed = tempfile::tempdir().unwrap();
+    let rejected = tempfile::tempdir().unwrap();
+    let allowed_host = std::fs::canonicalize(allowed.path()).unwrap();
+    let rejected_host = std::fs::canonicalize(rejected.path()).unwrap();
+
+    let bash = Bash::builder()
+        .allowed_mount_paths([allowed_host.clone()])
+        .mount_real_readwrite_at(allowed_host.clone(), "/allowed")
+        .mount_real_readwrite_at(rejected_host, "/rejected")
+        .build();
+
+    assert_eq!(bash.host_mounts().all().len(), 1);
+    assert_eq!(bash.host_path_for("/rejected/x"), None);
+    assert_eq!(
+        bash.host_path_for("/allowed/x"),
+        Some(allowed_host.join("x"))
+    );
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -29,6 +29,7 @@ pub mod builtin_registry_tests;
 pub mod byte_range_panic_tests;
 pub mod cancellation_tests;
 pub mod cmdsub_quote_test;
+pub mod command_resolver_tests;
 pub mod compgen_tests;
 pub mod coproc_tests;
 pub mod coreutils_differential_tests;

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -99,6 +99,7 @@ pub mod sqlite_security_tests;
 pub mod stack_overflow_regression_tests;
 pub mod subst_depth_limit_tests;
 pub mod symlink_overlay_security_tests;
+pub mod thirdparty_adoption_tests;
 pub mod threat_model_doc_tests;
 pub mod threat_model_tests;
 pub mod time_compat_scan_tests;

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -49,6 +49,7 @@ pub mod git_security_tests;
 pub mod glob_intermediate_component_tests;
 pub mod harness_example_tests;
 pub mod history_tests;
+pub mod host_mounts_tests;
 pub mod issue_1175_test;
 pub mod issue_1776_test;
 pub mod issue_1777_test;

--- a/crates/bashkit/tests/integration/thirdparty_adoption_tests.rs
+++ b/crates/bashkit/tests/integration/thirdparty_adoption_tests.rs
@@ -1,0 +1,364 @@
+//! End-to-end test of the "agent bash tool" adoption shape.
+//!
+//! This is the integration an embedder writes when it wants bashkit to *be*
+//! its shell — a real workspace mounted read-write, and commands bashkit does
+//! not implement bridged to host executables so the same code path works on
+//! Windows without a real `bash`.
+//!
+//! Decision: this exists because the shape was only ever validated downstream.
+//! The first adopter to write it (crabot) shipped two defects bashkit's own
+//! tests could not see: a harness that emptied `PATH`, and a stdin pipe to a
+//! host process that never reached EOF and hung the suite. Both are behaviors
+//! of *this* composition — `CommandResolver` + `HostMounts` + `realfs` — so
+//! they belong here, and this file runs on Windows in CI too.
+//!
+//! The bridge below is deliberately the whole thing: if bridging a host
+//! command needs more code than this, that is a gap in bashkit's API.
+
+#![cfg(feature = "realfs")]
+
+use async_trait::async_trait;
+use bashkit::{Bash, Builtin, BuiltinContext, CommandResolver, ExecResult, HostMount, HostMounts};
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Bound on a bridged host command.
+///
+/// A real bridge needs one regardless; here it also keeps a defect from
+/// turning into a hung CI job. A leaked stdin pipe means the child waits for
+/// EOF forever, and a test that hangs reports nothing — this turns it into a
+/// named failure.
+const HOST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Run a script through the host shell.
+///
+/// `sh`/`cmd` rather than a bare binary because the set of standalone
+/// executables shared by Linux, macOS, and Windows is effectively empty.
+fn shell_out(script: &str) -> (String, Vec<String>) {
+    if cfg!(windows) {
+        ("cmd".into(), vec!["/C".into(), script.into()])
+    } else {
+        ("sh".into(), vec!["-c".into(), script.into()])
+    }
+}
+
+/// Map a bridged name to the host program it runs.
+///
+/// The `host-` prefix matters: bashkit implements `cat`, `echo`, `pwd` and
+/// `false` itself, so a test using those names would never reach the bridge —
+/// it would silently assert on builtins instead. Returning `None` for
+/// unprefixed names also keeps the normal 127 path observable.
+fn host_program(name: &str) -> Option<&'static str> {
+    Some(match name.strip_prefix("host-")? {
+        // Reads stdin to EOF on every platform.
+        "cat" => {
+            if cfg!(windows) {
+                "sort"
+            } else {
+                "cat"
+            }
+        }
+        "pwd" => {
+            if cfg!(windows) {
+                "cd"
+            } else {
+                "pwd"
+            }
+        }
+        "false" => {
+            if cfg!(windows) {
+                "exit 1"
+            } else {
+                "false"
+            }
+        }
+        "echo" => "echo",
+        _ => return None,
+    })
+}
+
+/// Bridges one command name to a host process.
+///
+/// The interesting parts, all of which the first adopter got wrong at least
+/// once: the cwd comes from the mount table (never a default), stdin is fed
+/// through a pipe that must reach EOF, and the exit code is passed through.
+struct HostCommand {
+    name: String,
+    program: &'static str,
+    mounts: Arc<HostMounts>,
+}
+
+#[async_trait]
+impl Builtin for HostCommand {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        // A cwd on no mount is an error. Falling back to some default would
+        // run the command in the wrong directory.
+        let Some(dir) = self.mounts.resolve(ctx.cwd) else {
+            return Ok(ExecResult::err(
+                format!("{}: cwd is not on a host mount", self.name),
+                1,
+            ));
+        };
+
+        let script = std::iter::once(self.program.to_string())
+            .chain(ctx.args.iter().cloned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let (program, args) = shell_out(&script);
+
+        let stdin_data = ctx.stdin.map(str::to_owned);
+        let output = tokio::task::spawn_blocking(move || {
+            let mut cmd = std::process::Command::new(program);
+            cmd.args(args)
+                .current_dir(dir)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .stdin(if stdin_data.is_some() {
+                    Stdio::piped()
+                } else {
+                    Stdio::null()
+                });
+
+            let mut child = cmd.spawn()?;
+            if let Some(data) = stdin_data {
+                use std::io::Write;
+                // Dropping the handle closes the pipe. Without that the child
+                // waits for EOF forever — the exact hang this file exists for.
+                let mut pipe = child.stdin.take().expect("stdin piped");
+                pipe.write_all(data.as_bytes())?;
+                drop(pipe);
+            }
+
+            let deadline = Instant::now() + HOST_TIMEOUT;
+            let status = loop {
+                if let Some(status) = child.try_wait()? {
+                    break Some(status);
+                }
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            };
+
+            // Only drain on a clean exit. After a timeout kill, a grandchild
+            // the shell spawned can still hold the write end, and reading
+            // would block forever — turning the bounded wait back into a hang.
+            //
+            // Reading after exit is safe here because the outputs are small.
+            // A production bridge must drain concurrently with the wait, or a
+            // child that fills the pipe buffer blocks before it can exit.
+            let mut stdout = String::new();
+            let mut stderr = String::new();
+            if status.is_some() {
+                if let Some(mut pipe) = child.stdout.take() {
+                    let _ = pipe.read_to_string(&mut stdout);
+                }
+                if let Some(mut pipe) = child.stderr.take() {
+                    let _ = pipe.read_to_string(&mut stderr);
+                }
+            }
+            Ok::<_, std::io::Error>((status, stdout, stderr))
+        })
+        .await
+        .expect("spawn_blocking");
+
+        Ok(match output {
+            Ok((Some(status), stdout, stderr)) => ExecResult {
+                stdout,
+                stderr,
+                exit_code: status.code().unwrap_or(1),
+                ..Default::default()
+            },
+            Ok((None, _, _)) => ExecResult::err(
+                format!(
+                    "{}: host command exceeded {}s — did stdin reach EOF?",
+                    self.name,
+                    HOST_TIMEOUT.as_secs()
+                ),
+                124,
+            ),
+            // Bash's convention for a command that could not be executed.
+            Err(e) => ExecResult::err(format!("{}: {e}", self.name), 127),
+        })
+    }
+}
+
+/// Bridges any name bashkit did not resolve, exactly as an agent tool would.
+struct HostBridge {
+    mounts: Arc<HostMounts>,
+}
+
+impl CommandResolver for HostBridge {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+        let program = host_program(name)?;
+        Some(Arc::new(HostCommand {
+            name: name.to_owned(),
+            program,
+            mounts: Arc::clone(&self.mounts),
+        }))
+    }
+}
+
+struct Fixture {
+    bash: Bash,
+    workspace: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = std::fs::canonicalize(dir.path()).unwrap();
+    std::fs::create_dir(workspace.join("sub")).unwrap();
+
+    // Built up front and shared: the resolver is passed *into* the builder, so
+    // it cannot ask the not-yet-existing instance where things are mounted.
+    let mounts = Arc::new(HostMounts::new([HostMount {
+        host_path: workspace.clone(),
+        vfs_path: PathBuf::from("/workspace"),
+    }]));
+
+    let bash = Bash::builder()
+        .allowed_mount_paths([workspace.clone()])
+        .mount_real_readwrite_at(workspace.clone(), "/workspace")
+        .cwd("/workspace")
+        .command_resolver(Arc::new(HostBridge {
+            mounts: Arc::clone(&mounts),
+        }))
+        .build();
+
+    // The bridge and the real mount must agree, or every cwd mapping is wrong.
+    assert_eq!(bash.host_path_for("/workspace"), Some(workspace.clone()));
+
+    Fixture {
+        bash,
+        workspace,
+        _dir: dir,
+    }
+}
+
+#[tokio::test]
+async fn bridged_host_command_runs_and_returns_output() {
+    let mut f = fixture();
+    let result = f.bash.exec("host-echo hello from host").await.unwrap();
+    assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
+    assert!(
+        result.stdout.contains("hello from host"),
+        "unexpected: {result:?}"
+    );
+}
+
+/// A builtin bashkit implements must win over the bridge — the resolver runs
+/// last, so it must never be consulted for `echo`.
+#[tokio::test]
+async fn builtins_win_over_the_bridge() {
+    let mut f = fixture();
+    let result = f.bash.exec("echo bridged").await.unwrap();
+    assert_eq!(result.stdout, "bridged\n");
+}
+
+/// A name the bridge declines still gets the normal `command not found`.
+#[tokio::test]
+async fn undeclined_names_keep_command_not_found() {
+    let mut f = fixture();
+    let result = f.bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.exit_code, 127, "unexpected: {result:?}");
+}
+
+/// Stdin must reach the host process *and* hit EOF. A bridge that leaks the
+/// write end hangs here instead of failing, so the timeout is the assertion.
+#[tokio::test]
+async fn pipeline_stdin_reaches_the_host_process_and_reaches_eof() {
+    let mut f = fixture();
+    let result = f.bash.exec("echo piped-payload | host-cat").await.unwrap();
+    assert_eq!(
+        result.exit_code, 0,
+        "host command did not complete: {result:?}"
+    );
+    assert!(
+        result.stdout.contains("piped-payload"),
+        "unexpected: {result:?}"
+    );
+}
+
+/// `cd` moves the VFS cwd; the bridge must map the *new* cwd to the host, not
+/// silently keep spawning in the workspace root.
+#[tokio::test]
+async fn cd_changes_the_host_spawn_directory() {
+    let mut f = fixture();
+    let result = f.bash.exec("cd sub && host-pwd").await.unwrap();
+    assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
+    let printed = result.stdout.trim().replace('\\', "/");
+    assert!(
+        printed.ends_with("/sub"),
+        "host command ran in the wrong directory: {printed}"
+    );
+}
+
+/// Writes through bashkit's own builtins must land on the real filesystem —
+/// the reason the workspace is mounted read-write rather than overlaid.
+#[tokio::test]
+async fn builtin_writes_reach_the_real_filesystem() {
+    let mut f = fixture();
+    let result = f
+        .bash
+        .exec("echo written > out.txt && mkdir -p sub2 && cp out.txt sub2/copy.txt")
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
+
+    assert_eq!(
+        std::fs::read_to_string(f.workspace.join("out.txt")).unwrap(),
+        "written\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(f.workspace.join("sub2/copy.txt")).unwrap(),
+        "written\n"
+    );
+}
+
+/// A non-zero host exit code behaves like any other command: it does not abort
+/// the script, and it drives `&&` / `||`.
+#[tokio::test]
+async fn host_exit_codes_drive_control_flow() {
+    let mut f = fixture();
+    let result = f.bash.exec("host-false || echo recovered").await.unwrap();
+    assert!(
+        result.stdout.contains("recovered"),
+        "unexpected: {result:?}"
+    );
+
+    let result = f.bash.exec("host-false; echo after").await.unwrap();
+    assert!(
+        result.stdout.contains("after"),
+        "script aborted: {result:?}"
+    );
+
+    let result = f.bash.exec("host-false").await.unwrap();
+    assert_ne!(result.exit_code, 0);
+}
+
+/// The whole point of the composition: syntax bashkit implements (heredocs,
+/// command substitution, pipelines) works with bridged commands mixed in,
+/// with no real `bash` process anywhere.
+#[tokio::test]
+async fn bashkit_syntax_composes_with_bridged_commands() {
+    let mut f = fixture();
+    let result = f
+        .bash
+        .exec("cat <<'EOF'\nheredoc line\nEOF\necho \"host says: $(host-echo ok)\"")
+        .await
+        .unwrap();
+    assert!(
+        result.stdout.contains("heredoc line"),
+        "unexpected: {result:?}"
+    );
+    assert!(
+        result.stdout.contains("host says: ok"),
+        "unexpected: {result:?}"
+    );
+}

--- a/knowledge/foundations/builtins.md
+++ b/knowledge/foundations/builtins.md
@@ -27,7 +27,8 @@ genuinely mean help/version handle them directly in `execute()`.
 
 ### Command Dispatch Order
 
-functions → special commands → builtins → path execution → $PATH search → "command not found"
+functions → special commands → builtins → path execution → $PATH search →
+`CommandResolver` → "command not found"
 
 Scripts containing `/` are resolved against VFS. Commands without `/` are
 searched in `$PATH` directories. Shebang lines are stripped; content executed
@@ -94,6 +95,7 @@ Command-resolution order (see `Interpreter::dispatch_command`):
 3. **Host registry** (`BuiltinRegistry::lookup`)
 4. Baked-in + builder-registered builtins
 5. Script execution by path / `$PATH` search
+6. `CommandResolver::resolve` (last chance, see below)
 
 So registry entries can override baked-in commands (e.g. wrap `cat` with
 tracing) but shell functions still win — matching standard bash
@@ -112,6 +114,39 @@ Implementation notes:
   `reset_transient_state` leaves it untouched and snapshots do not
   serialize it. Restoring from a snapshot requires re-attaching the
   registry handle.
+
+### CommandResolver — Last-Chance Name Resolution
+
+`BuiltinRegistry` answers "which names are registered" from a map fixed before
+the name is known. `CommandResolver` is asked *about a specific name*, after
+every other route has missed and immediately before the 127 path, so an
+embedder bridging an open-ended command space (host executables, a remote tool
+catalog) does not have to enumerate it up front.
+
+```rust
+pub trait CommandResolver: Send + Sync {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>>;
+}
+```
+
+Decision: resolvers return a `Builtin` rather than executing directly. The
+resolved builtin runs through `execute_builtin_arc` — the same path as every
+other builtin — so `before_tool` fires with the resolved name and can veto it,
+`catch_unwind` still contains panics, and stdin/redirects behave identically. A
+bespoke execution path would have to re-earn all of that.
+
+Consequences to keep in mind:
+
+- Resolver-provided names are **not enumerable**: they do not appear in
+  `Bash::builtin_names()` or in `command not found` suggestions. Security
+  implications are in `../integrations/script-analysis.md`.
+- Being last, a resolver can never shadow a function, builtin, or `$PATH`
+  script. Use `BashBuilder::builtin` to override one.
+- `resolve` is called for every unresolved command, so it must be cheap;
+  cache rather than probing the filesystem per call.
+- The `$PATH` search consumes the pipeline stdin, so the interpreter clones it
+  for the resolver **only when a resolver is installed** — the common path does
+  not pay for the clone.
 
 ### Execution Extensions
 

--- a/knowledge/foundations/vfs.md
+++ b/knowledge/foundations/vfs.md
@@ -182,6 +182,39 @@ Symlinks are stored but intentionally not followed for security:
 - Prevents symlink escape attacks (TM-ESC-002)
 - Prevents symlink loop DoS (TM-DOS-011)
 
+## Host Mount Table (`HostMounts`)
+
+`realfs` mounts are recorded as a `HostMounts` table on the `Bash` instance:
+`Bash::host_mounts()` lists them, `Bash::host_path_for(vfs)` maps a VFS path
+back to the host path backing it.
+
+Decision: published because embedders that bridge commands to host processes
+must map a VFS cwd to a host directory to spawn in, and hand-rolling it is a
+trap — a naive string prefix match puts `/workspace2` inside `/workspace`.
+`HostMounts::resolve` matches whole path components and prefers the longest
+match, so a specific mount beats a root overlay.
+
+Rules:
+
+- Only mounts that actually applied are recorded. A path skipped by the
+  allowlist or a failed `canonicalize` is absent, so the table never reports a
+  host path for something that was never mounted.
+- `host_path` is the canonicalized host directory, which may differ from the
+  path passed to the builder (symlinks, `/tmp` → `/private/tmp` on macOS).
+- A root overlay mount (`mount_real_readonly` with no VFS path) is recorded at
+  `/`, so it acts as the catch-all. Without one, an uncovered path resolves to
+  `None`.
+- `None` means "no mount covers this". Callers must treat it as an error rather
+  than falling back to a default directory: spawning a host process in the
+  wrong directory is worse than refusing to spawn it.
+- `HostMounts::new` lets an embedder build the table up front. A
+  `CommandResolver` is passed *into* the builder, so builtins it produces
+  cannot call `Bash::host_mounts()` on an instance that does not exist yet;
+  sharing one `Arc` between the resolver and the `mount_real_*` calls makes
+  both agree by construction.
+
+Tests: `crates/bashkit/tests/integration/host_mounts_tests.rs`.
+
 ## Binding API Parity
 
 All language bindings must expose the same filesystem concepts:

--- a/knowledge/integrations/script-analysis.md
+++ b/knowledge/integrations/script-analysis.md
@@ -70,10 +70,32 @@ recognized dangerous command" as "safe" without checking those flags builds a
 bypassable gate.
 
 Enforcement primitives remain: the builtin registry (a command that does not
-exist cannot run), `NetworkAllowlist`, the filesystem mount policy, and the
-`before_tool` hook, which fires with the **resolved** command name at
-execution time. Recommended pattern: `analyze()` for the pre-execution UX
-decision, `before_tool` for the enforcement backstop.
+exist cannot run — unless a `CommandResolver` is installed, see below),
+`NetworkAllowlist`, the filesystem mount policy, and the `before_tool` hook,
+which fires with the **resolved** command name at execution time. Recommended
+pattern: `analyze()` for the pre-execution UX decision, `before_tool` for the
+enforcement backstop.
+
+### `CommandResolver` and the enumerable-name assumption
+
+`BashBuilder::command_resolver` installs a last-chance resolver, consulted only
+after every other dispatch route misses and immediately before the 127 path. It
+grants no new capability — a resolver is embedder-supplied host code exactly
+like a builtin passed to `BashBuilder::builtin`, which could already spawn
+processes. What it changes is narrower and worth stating plainly:
+
+- **The registry stops bounding the reachable name set.** "A command that does
+  not exist cannot run" holds only while every name that reaches host code is
+  registered. `Bash::builtin_names()` does not enumerate resolver-provided
+  names, so a gate built on that list is incomplete once a resolver exists.
+- **`before_tool` is unaffected.** Resolved commands dispatch through the same
+  builtin path as every other builtin, so the hook fires with the resolved name
+  and can cancel the call. The recommended pattern above holds unchanged.
+  `command_resolver_tests::before_tool_veto_blocks_a_resolved_command` pins this.
+
+A resolver that gates internally (returning `None` for names it will not run)
+restores a closed set; that is the recommended shape when the embedder has a
+policy to enforce.
 
 Recorded as TM-ESC-032 in [Threat Model](../security/threat-model.md).
 

--- a/knowledge/integrations/script-analysis.md
+++ b/knowledge/integrations/script-analysis.md
@@ -53,8 +53,14 @@ cannot see through:
 - shell functions and aliases that rebind a name
 - wrapper commands that run other commands named in their arguments —
   `xargs`, `env`, `timeout`, `find -exec`, `awk 'system(…)'`. These are **not**
-  flagged: they analyze as ordinary commands, so a host that allowlists one must
-  treat its arguments as commands itself
+  flagged opaque: they analyze as ordinary commands, so a host that allowlists
+  one must treat its arguments as commands itself. `ScriptAnalysis::command_wrappers()`
+  reports which prefix-style wrappers a script uses, and `analysis::COMMAND_WRAPPERS` /
+  `is_command_wrapper()` publish the list, so hosts do not hardcode a private
+  copy that drifts from ours. `find -exec` and language payloads
+  (`awk 'system(…)'`) are outside that list — they need per-tool argument
+  knowledge. `time` is absent by design: it is a keyword, so the timed command
+  is already the reported command name
 - arguments built from variables — `rm "$target"`
 
 The API reports these as *unknown*, never as *safe*: a command whose name is

--- a/knowledge/operations/testing.md
+++ b/knowledge/operations/testing.md
@@ -109,6 +109,49 @@ Uploaded to Codecov from three sources: Rust unit/integration coverage via
 `cargo tarpaulin`; Rust coverage exercised through Python and Node binding
 tests via `cargo llvm-cov`.
 
+## Third-Party Adoption Suite
+
+`crates/bashkit/tests/integration/thirdparty_adoption_tests.rs` covers the
+"agent bash tool" embedding shape end to end: a real workspace mounted
+read-write, a `CommandResolver` bridging unresolved names to host processes,
+and `HostMounts` mapping the VFS cwd back to a host directory.
+
+Decision: this shape was only ever validated downstream, and the first adopter
+(crabot) shipped two defects bashkit's own tests could not see — a harness that
+emptied `PATH`, and a stdin pipe to a host process that never reached EOF and
+hung the suite. Both are properties of the *composition*, not of any one API,
+so they need a test that composes.
+
+Rules for this file:
+
+- **The bridge in it is the reference.** If bridging a host command needs more
+  code than what is there, that is a gap in bashkit's API, not a reason to grow
+  the test.
+- **Use names bashkit does not implement** (`host-cat`, `host-echo`, …). The
+  resolver runs last, so a test using `cat` or `echo` silently asserts on
+  builtins and never reaches the bridge — verified by injecting a defect and
+  confirming the test fails.
+- **Never let a defect become a hang.** The bridge bounds its wait and drains
+  pipes only after a clean exit; after a timeout kill a grandchild can still
+  hold the write end, and reading would block forever. A hung job reports
+  nothing; a bounded one names the cause.
+
+`host_mounts_tests.rs` covers the mapping in isolation, including the
+sibling-prefix trap (`/workspace2` must not resolve inside `/workspace`).
+
+Both are `cfg(realfs)`, so the main `Run tests` step (which does not enable
+`realfs`) compiles them out. They run in the dedicated `Run realfs integration
+tests` step and in the `Test (Windows adoption shape)` job.
+
+## Windows CI
+
+`test-windows` is the only non-ubuntu job. It runs the adoption, host-mount,
+and command-resolver suites on `windows-latest` and gates `Check`.
+
+It is deliberately scoped rather than a full workspace port: the adoption shape
+exists to work on Windows without a real `bash`, and that claim needs a Windows
+runner to stay true. Everything else stays ubuntu-only.
+
 ## Third-Party API Steps in CI
 
 The `Examples` job runs a few steps that call third-party LLM APIs (Anthropic


### PR DESCRIPTION
## What changed

Four changes that make "embed bashkit as an agent's bash tool" a supported shape rather than one every adopter reinvents.

**`CommandResolver` — last-chance name resolution.** `BashBuilder::command_resolver` installs a resolver consulted only after every other dispatch route misses, immediately before the 127 path. Resolvers return a `Builtin`, so the resolved command runs through the normal builtin path: `before_tool` fires with the resolved name and can veto it, `catch_unwind` still contains panics, stdin/redirects are unchanged. It can never shadow a function, builtin, or `$PATH` script.

**`HostMounts` — VFS→host path mapping.** `Bash::host_mounts()` / `host_path_for()` report which real mounts actually applied and map a VFS path back to the host path behind it. Longest-component-prefix match, so a specific mount beats a root overlay and `/workspace2` never resolves inside `/workspace`. Mounts skipped at build time (allowlist rejection, canonicalize failure) are absent, so the table never reports a path that was never mounted.

**`analysis::COMMAND_WRAPPERS`** — publishes the wrapper list (`command`, `env`, `exec`, `xargs`, …) plus `is_command_wrapper()` and `ScriptAnalysis::command_wrappers()`. `is_opaque()` is deliberately unchanged.

**Adoption test suite + Windows CI.** An end-to-end test of the composition, and a `windows-latest` job that gates `Check`.

## Why

`everruns/bashkit` had no test for the composition adopters actually write, and no non-ubuntu CI. crabot — the first adopter of this shape — shipped two defects bashkit's own tests could not see: a test harness that emptied `PATH` on Linux, and a stdin pipe to a host process that never reached EOF and hung the suite.

Its `bash_kit.rs` also had to hand-roll four things bashkit could own: a static analysis pre-pass to collect external names (because builtins must be registered by name up front), a `bash -c` fallback for everything analysis can't see statically, VFS→host prefix matching, and a private `["command", "exec"]` list carrying the comment *"Re-verify when bumping the pinned bashkit version"*. The `bash -c` fallback is the costly one — it defeats the stated goal of running on Windows without a real bash.

`CommandResolver` removes the need for the pre-pass and the fallback; `HostMounts` removes the prefix matching; `COMMAND_WRAPPERS` removes the private list.

## Before / After

**Bridging a host command, before** — names must be enumerable before execution, so anything dynamic falls out of the interpreter entirely:

```rust
let names = collect_external_names(script)?;   // Err on eval / $TOOL / command / ./script.sh
for name in names { builder = builder.builtin(name, Box::new(HostCommandBuiltin { .. })); }
// on Err: spawn a real `bash -c` instead
```

**After** — one resolver, no pre-pass, no fallback:

```rust
let bash = Bash::builder()
    .mount_real_readwrite_at(&workspace, "/workspace")
    .command_resolver(Arc::new(HostBridge { mounts }))
    .build();
```

**The stdin defect, before this PR:** nothing upstream could catch it. **After:** injecting it (`std::mem::forget(pipe)` instead of `drop(pipe)`) produces one named failure in 20s:

```
test thirdparty_adoption_tests::pipeline_stdin_reaches_the_host_process_and_reaches_eof ... FAILED
assertion `left == right` failed: host command did not complete: ExecResult {
  stderr: "host-cat: host command exceeded 20s — did stdin reach EOF?", exit_code: 124, .. }
test result: FAILED. 7 passed; 1 failed
```

That took three iterations worth recording, because the first two versions of the test were wrong:

1. The defect **passed** — the test used `cat`, which is a bashkit builtin, so the bridge never ran. Fixed by using `host-`prefixed names bashkit does not implement.
2. The defect **hung past 180s** — `tokio::time::timeout` never fired because the blocked thread didn't yield. Fixed by bounding the bridge's own wait.
3. The defect **still hung** — killing `sh` left `cat` holding the stdout pipe, so draining blocked forever. Fixed by draining only after a clean exit.

A hung CI job reports nothing; a bounded one names the cause.

## Risk

- **Low.**
- `CommandResolver` is opt-in and runs last, so no existing dispatch changes. The `$PATH` search consumes pipeline stdin, so it is cloned for the resolver **only when one is installed** — the common path is untouched.
- `HostMounts` is `cfg(realfs)` and additive.
- `COMMAND_WRAPPERS` is additive; `is_opaque()` behavior is unchanged, so existing permission gates keep their current prompt rate.
- Security posture: a resolver grants no capability an embedder lacked — a `Builtin` could already spawn processes. It does mean the builtin registry stops bounding the reachable name set, so `Bash::builtin_names()` no longer enumerates it. `before_tool` remains the enforcement backstop and is pinned by test. `knowledge/integrations/script-analysis.md` is updated to say exactly this.
- New Windows job is scoped to the three new suites, not a full workspace port.

Verified locally: 3374 + 1645 lib/integration tests, 162 doc tests, 38 realfs tests, clippy clean (default, `realfs,http_client,ssh`, and `--no-default-features`). `ssh_supabase_tests` fails in my container only — outbound SSH is blocked (`ResourceLimit(Timeout(30s))`); it runs in CI's Examples job with network.

Not included: the `hostexec` builtin from the original proposal. Killing a process tree on timeout properly wants `libc`/`windows-sys`, and this crate deliberately keeps itself platform-clean; dropped by decision rather than deferred.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJhihi4WHXghsrPntctvXp)_