### PR TITLE
feat(builtins): add CommandResolver for last-chance name resolution

### DIFF
--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -387,6 +387,63 @@ impl BuiltinRegistry {
     }
 }
 
+/// Resolve a command name to a builtin at dispatch time.
+///
+/// [`BuiltinRegistry`] answers "which names are registered" from a map fixed
+/// before the name is known. A resolver is asked *about a specific name*, after
+/// every other dispatch route has missed and immediately before the 127
+/// "command not found" path — so an embedder can decide at runtime, per name,
+/// without enumerating the set in advance.
+///
+/// Decision: resolvers return a [`Builtin`] rather than executing directly.
+/// The resolved builtin runs through the same dispatch path as every other
+/// builtin, so `before_tool` hooks fire with the resolved name and can veto it,
+/// `catch_unwind` still contains panics, and redirects and stdin behave
+/// identically. A bespoke execution path would have to re-earn all of that.
+///
+/// Returning `None` falls through to the normal `command not found` error.
+///
+/// # Security
+///
+/// A resolver is embedder-supplied host code, exactly like a builtin passed to
+/// [`BashBuilder::builtin`](crate::BashBuilder::builtin) — it grants no
+/// capability the embedder did not already have. What it *does* change is that
+/// the set of names reaching host code stops being enumerable in advance, so
+/// `Bash::builtin_names()` no longer bounds it. `before_tool` remains the
+/// enforcement backstop; see `knowledge/integrations/script-analysis.md`.
+///
+/// # Example
+///
+/// ```
+/// use bashkit::{Builtin, BuiltinContext, CommandResolver, ExecResult, async_trait};
+/// use std::sync::Arc;
+///
+/// struct Echoer(String);
+///
+/// #[async_trait]
+/// impl Builtin for Echoer {
+///     async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+///         Ok(ExecResult::ok(format!("ran {}\n", self.0)))
+///     }
+/// }
+///
+/// struct AnyToolResolver;
+///
+/// impl CommandResolver for AnyToolResolver {
+///     fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+///         name.starts_with("tool-").then(|| Arc::new(Echoer(name.into())) as Arc<dyn Builtin>)
+///     }
+/// }
+/// ```
+pub trait CommandResolver: Send + Sync {
+    /// Return a builtin to run for `name`, or `None` to fall through to
+    /// `command not found`.
+    ///
+    /// Called on every unresolved command, so keep it cheap — cache rather
+    /// than probing the filesystem on each call.
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>>;
+}
+
 /// Typed, per-execution data exposed to builtin implementations.
 ///
 /// This is intentionally separate from shell state: extensions live for one

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1062,6 +1062,10 @@ pub struct Interpreter {
     /// override baked-in commands. Survives `reset_transient_state` because
     /// it lives behind an `Arc<RwLock>` shared with the embedder.
     host_builtins: Option<crate::builtins::BuiltinRegistry>,
+    /// Optional last-chance name resolver. Consulted only after every other
+    /// dispatch route has missed, immediately before `command not found`, so
+    /// it can never shadow a function, builtin, or `$PATH` script.
+    command_resolver: Option<Arc<dyn crate::builtins::CommandResolver>>,
     /// Call stack for local variable scoping
     call_stack: Vec<CallFrame>,
     /// Source file stack for BASH_SOURCE array
@@ -1537,6 +1541,7 @@ impl Interpreter {
             last_exit_code: 0,
             builtins,
             host_builtins,
+            command_resolver: None,
             call_stack: Vec::new(),
             bash_source_stack: Vec::new(),
             limits: ExecutionLimits::default(),
@@ -1958,6 +1963,14 @@ impl Interpreter {
     /// Set an environment variable.
     pub fn set_env(&mut self, key: &str, value: &str) {
         self.env.insert(key.to_string(), value.to_string());
+    }
+
+    /// Install the last-chance command resolver (public API for builder).
+    pub(crate) fn set_command_resolver(
+        &mut self,
+        resolver: Arc<dyn crate::builtins::CommandResolver>,
+    ) {
+        self.command_resolver = Some(resolver);
     }
 
     /// Set a shell variable (public API for builder).
@@ -6360,6 +6373,15 @@ impl Interpreter {
                     .await;
             }
 
+            // The `$PATH` search consumes `stdin`, so keep a copy for the
+            // resolver — but only when one is installed, so the common path
+            // does not pay to clone piped input.
+            let resolver_stdin = self
+                .command_resolver
+                .is_some()
+                .then(|| stdin.clone())
+                .flatten();
+
             // $PATH search
             if !self.shell_profile.is_logic_only()
                 && let Some(result) = self
@@ -6367,6 +6389,25 @@ impl Interpreter {
                     .await?
             {
                 return Ok(result);
+            }
+
+            // Last-chance resolver. Dispatches through `execute_builtin_arc`
+            // like every other builtin, so `before_tool` fires with the
+            // resolved name and can veto it.
+            if let Some(builtin) = self
+                .command_resolver
+                .as_ref()
+                .and_then(|resolver| resolver.resolve(name))
+            {
+                return self
+                    .execute_builtin_arc(
+                        name,
+                        builtin,
+                        &args,
+                        resolver_stdin.as_ref(),
+                        &command.redirects,
+                    )
+                    .await;
             }
 
             // Command not found

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -469,8 +469,8 @@ pub use async_trait::async_trait;
 pub use builtins::git::GitConfig;
 pub use builtins::ssh::{SshAllowlist, SshConfig, TrustedHostKey};
 pub use builtins::{
-    BashkitContext, Builtin, BuiltinRegistry, ClapBuiltin, Context as BuiltinContext,
-    ExecutionExtensions, Extension,
+    BashkitContext, Builtin, BuiltinRegistry, ClapBuiltin, CommandResolver,
+    Context as BuiltinContext, ExecutionExtensions, Extension,
 };
 pub use clap;
 #[cfg(feature = "http_client")]
@@ -1659,6 +1659,8 @@ pub struct BashBuilder {
     /// Optional host-owned mutable registry. Entries here are consulted at
     /// dispatch time, so embedders can register/remove builtins after build.
     host_builtins: Option<BuiltinRegistry>,
+    /// Optional last-chance name resolver, consulted just before the 127 path.
+    command_resolver: Option<Arc<dyn CommandResolver>>,
     /// Files to mount in the virtual filesystem
     mounted_files: Vec<MountedFile>,
     /// Lazy files to mount (loaded on first read)
@@ -2472,6 +2474,50 @@ impl BashBuilder {
         self
     }
 
+    /// Install a last-chance [`CommandResolver`].
+    ///
+    /// [`BashBuilder::builtin`] and [`BashBuilder::builtin_registry`] both map
+    /// *known names* to builtins. A resolver is asked about a name the
+    /// interpreter could not otherwise resolve, so an embedder bridging an
+    /// open-ended command space (host executables, a remote tool catalog) does
+    /// not have to enumerate it before execution.
+    ///
+    /// Consulted last — after shell functions, special builtins, the host
+    /// registry, baked-in builtins, path-based scripts, and the `$PATH` search
+    /// — and only when all of those miss. It therefore cannot shadow an
+    /// existing command; use [`BashBuilder::builtin`] to override one.
+    ///
+    /// The resolved builtin runs through the normal builtin path, so
+    /// [`before_tool`](BashBuilder::before_tool) hooks fire with the resolved
+    /// name and can veto the call.
+    ///
+    /// Note that resolver-provided names are not enumerable, so they do not
+    /// appear in [`Bash::builtin_names`] or in `command not found` suggestions.
+    ///
+    /// ```
+    /// # use bashkit::{Bash, Builtin, BuiltinContext, CommandResolver, ExecResult, async_trait};
+    /// # use std::sync::Arc;
+    /// # struct Stub;
+    /// # #[async_trait]
+    /// # impl Builtin for Stub {
+    /// #     async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+    /// #         Ok(ExecResult::ok("stub\n".to_string()))
+    /// #     }
+    /// # }
+    /// struct Resolver;
+    /// impl CommandResolver for Resolver {
+    ///     fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+    ///         (name == "deploy").then(|| Arc::new(Stub) as Arc<dyn Builtin>)
+    ///     }
+    /// }
+    ///
+    /// let bash = Bash::builder().command_resolver(Arc::new(Resolver)).build();
+    /// ```
+    pub fn command_resolver(mut self, resolver: Arc<dyn CommandResolver>) -> Self {
+        self.command_resolver = Some(resolver);
+        self
+    }
+
     /// Register a capability extension.
     ///
     /// Extensions contribute a related set of builtins as one unit. Commands
@@ -3077,6 +3123,7 @@ impl BashBuilder {
             self.trace_callback,
             self.custom_builtins,
             self.host_builtins,
+            self.command_resolver,
             self.history_file,
             #[cfg(feature = "http_client")]
             self.network_allowlist,
@@ -3323,6 +3370,7 @@ impl BashBuilder {
         trace_callback: Option<TraceCallback>,
         custom_builtins: HashMap<String, Box<dyn Builtin>>,
         host_builtins: Option<BuiltinRegistry>,
+        command_resolver: Option<Arc<dyn CommandResolver>>,
         history_file: Option<PathBuf>,
         #[cfg(feature = "http_client")] network_allowlist: Option<NetworkAllowlist>,
         #[cfg(feature = "http_client")] http_limits: network::HttpLimits,
@@ -3354,6 +3402,10 @@ impl BashBuilder {
             host_builtins,
             shell_profile,
         );
+
+        if let Some(resolver) = command_resolver {
+            interpreter.set_command_resolver(resolver);
+        }
 
         // Set environment variables (also override shell variable defaults)
         for (key, value) in &env {

--- a/crates/bashkit/tests/integration/command_resolver_tests.rs
+++ b/crates/bashkit/tests/integration/command_resolver_tests.rs
@@ -1,0 +1,246 @@
+//! Integration tests for [`CommandResolver`] — the last-chance name resolver.
+//!
+//! The contract under test, in order of importance:
+//! 1. it runs only when every other dispatch route missed (never shadows),
+//! 2. resolved commands go through the normal builtin path, so `before_tool`
+//!    fires with the resolved name and can veto them,
+//! 3. returning `None` leaves the 127 behavior untouched.
+
+use async_trait::async_trait;
+use bashkit::hooks::HookAction;
+use bashkit::{Bash, Builtin, BuiltinContext, CommandResolver, ExecResult};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Echoes which name it was resolved under, plus any args and stdin.
+struct Resolved {
+    name: String,
+}
+
+#[async_trait]
+impl Builtin for Resolved {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        let mut out = format!("resolved:{}", self.name);
+        if !ctx.args.is_empty() {
+            out.push_str(&format!(" args:{}", ctx.args.join(",")));
+        }
+        if let Some(stdin) = ctx.stdin {
+            out.push_str(&format!(" stdin:{}", stdin.trim_end()));
+        }
+        out.push('\n');
+        Ok(ExecResult::ok(out))
+    }
+}
+
+/// Resolves every name, counting calls so tests can assert it was not consulted.
+struct ResolveAll {
+    calls: Arc<AtomicUsize>,
+}
+
+impl CommandResolver for ResolveAll {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Some(Arc::new(Resolved { name: name.into() }))
+    }
+}
+
+/// Resolves nothing — the fall-through case.
+struct ResolveNothing;
+
+impl CommandResolver for ResolveNothing {
+    fn resolve(&self, _name: &str) -> Option<Arc<dyn Builtin>> {
+        None
+    }
+}
+
+fn resolve_all() -> (Bash, Arc<AtomicUsize>) {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::clone(&calls),
+        }))
+        .build();
+    (bash, calls)
+}
+
+#[tokio::test]
+async fn resolver_handles_an_otherwise_unknown_command() {
+    let (mut bash, calls) = resolve_all();
+    let result = bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.stdout, "resolved:definitely-not-a-command-xyz\n");
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn resolver_receives_args_and_pipeline_stdin() {
+    let (mut bash, _) = resolve_all();
+    let result = bash
+        .exec("echo piped | some-host-tool --flag v")
+        .await
+        .unwrap();
+    assert_eq!(
+        result.stdout,
+        "resolved:some-host-tool args:--flag,v stdin:piped\n"
+    );
+}
+
+#[tokio::test]
+async fn resolver_never_shadows_a_baked_in_builtin() {
+    let (mut bash, calls) = resolve_all();
+    let result = bash.exec("echo hello").await.unwrap();
+    assert_eq!(result.stdout, "hello\n");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "resolver must not be consulted for a command that already resolves"
+    );
+}
+
+#[tokio::test]
+async fn resolver_never_shadows_a_shell_function() {
+    let (mut bash, calls) = resolve_all();
+    let result = bash
+        .exec("greet() { echo from-function; }; greet")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout, "from-function\n");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn resolver_never_shadows_a_builder_registered_builtin() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut bash = Bash::builder()
+        .builtin(
+            "deploy",
+            Box::new(Resolved {
+                name: "registered".into(),
+            }),
+        )
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::clone(&calls),
+        }))
+        .build();
+    let result = bash.exec("deploy").await.unwrap();
+    assert_eq!(result.stdout, "resolved:registered\n");
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn resolver_returning_none_keeps_command_not_found() {
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveNothing))
+        .build();
+    let result = bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.exit_code, 127);
+    assert!(
+        result.stderr.contains("command not found"),
+        "unexpected: {}",
+        result.stderr
+    );
+}
+
+#[tokio::test]
+async fn no_resolver_keeps_command_not_found() {
+    let mut bash = Bash::new();
+    let result = bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.exit_code, 127);
+}
+
+/// The security contract from `knowledge/integrations/script-analysis.md`:
+/// `before_tool` is the enforcement backstop, and it must keep working for
+/// names that only exist because a resolver produced them.
+#[tokio::test]
+async fn before_tool_veto_blocks_a_resolved_command() {
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }))
+        .before_tool(Box::new(|event| {
+            if event.name == "forbidden-tool" {
+                HookAction::Cancel("blocked by policy".into())
+            } else {
+                HookAction::Continue(event)
+            }
+        }))
+        .build();
+
+    let blocked = bash.exec("forbidden-tool").await.unwrap();
+    assert_ne!(blocked.exit_code, 0, "veto must not succeed");
+    assert!(
+        !blocked.stdout.contains("resolved:"),
+        "vetoed command still ran: {}",
+        blocked.stdout
+    );
+
+    let allowed = bash.exec("permitted-tool").await.unwrap();
+    assert_eq!(allowed.stdout, "resolved:permitted-tool\n");
+}
+
+/// `before_tool` sees the *resolved* name, so an allowlist keyed on names
+/// works the same for resolver-provided commands as for registered ones.
+#[tokio::test]
+async fn before_tool_observes_the_resolved_name() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let recorder = Arc::clone(&seen);
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(ResolveAll {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }))
+        .before_tool(Box::new(move |event| {
+            recorder.lock().unwrap().push(event.name.clone());
+            HookAction::Continue(event)
+        }))
+        .build();
+
+    bash.exec("host-tool --version").await.unwrap();
+    assert_eq!(seen.lock().unwrap().as_slice(), ["host-tool"]);
+}
+
+/// A resolved command is an ordinary command: its exit code drives `&&`/`||`
+/// and `if`, and a non-zero code does not abort the script.
+#[tokio::test]
+async fn resolved_exit_codes_drive_control_flow() {
+    struct Failing;
+    #[async_trait]
+    impl Builtin for Failing {
+        async fn execute(&self, _ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+            Ok(ExecResult::err("boom", 3))
+        }
+    }
+    struct FailResolver;
+    impl CommandResolver for FailResolver {
+        fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+            (name == "failing-tool").then(|| Arc::new(Failing) as Arc<dyn Builtin>)
+        }
+    }
+
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(FailResolver))
+        .build();
+
+    let result = bash.exec("failing-tool; echo after").await.unwrap();
+    assert!(
+        result.stdout.contains("after"),
+        "script aborted: {result:?}"
+    );
+
+    let result = bash.exec("failing-tool || echo recovered").await.unwrap();
+    assert!(result.stdout.contains("recovered"));
+
+    let result = bash.exec("failing-tool").await.unwrap();
+    assert_eq!(result.exit_code, 3);
+}
+
+/// Resolver names are not enumerable, so they must not appear in
+/// `builtin_names()` — an embedder gating on that list needs to know.
+#[tokio::test]
+async fn resolved_names_are_not_enumerable() {
+    let (bash, _) = resolve_all();
+    assert!(
+        !bash
+            .builtin_names()
+            .contains(&"anything-at-all".to_string())
+    );
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -30,6 +30,7 @@ pub mod byte_range_panic_tests;
 pub mod byte_stream_tests;
 pub mod cancellation_tests;
 pub mod cmdsub_quote_test;
+pub mod command_resolver_tests;
 pub mod competitor_regression_tests;
 pub mod compgen_tests;
 pub mod coproc_tests;

--- a/knowledge/foundations/builtins.md
+++ b/knowledge/foundations/builtins.md
@@ -27,7 +27,8 @@ genuinely mean help/version handle them directly in `execute()`.
 
 ### Command Dispatch Order
 
-functions → special commands → builtins → path execution → $PATH search → "command not found"
+functions → special commands → builtins → path execution → $PATH search →
+`CommandResolver` → "command not found"
 
 Scripts containing `/` are resolved against VFS. Commands without `/` are
 searched in `$PATH` directories. Shebang lines are stripped; content executed
@@ -94,6 +95,7 @@ Command-resolution order (see `Interpreter::dispatch_command`):
 3. **Host registry** (`BuiltinRegistry::lookup`)
 4. Baked-in + builder-registered builtins
 5. Script execution by path / `$PATH` search
+6. `CommandResolver::resolve` (last chance, see below)
 
 So registry entries can override baked-in commands (e.g. wrap `cat` with
 tracing) but shell functions still win — matching standard bash
@@ -112,6 +114,39 @@ Implementation notes:
   `reset_transient_state` leaves it untouched and snapshots do not
   serialize it. Restoring from a snapshot requires re-attaching the
   registry handle.
+
+### CommandResolver — Last-Chance Name Resolution
+
+`BuiltinRegistry` answers "which names are registered" from a map fixed before
+the name is known. `CommandResolver` is asked *about a specific name*, after
+every other route has missed and immediately before the 127 path, so an
+embedder bridging an open-ended command space (host executables, a remote tool
+catalog) does not have to enumerate it up front.
+
+```rust
+pub trait CommandResolver: Send + Sync {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>>;
+}
+```
+
+Decision: resolvers return a `Builtin` rather than executing directly. The
+resolved builtin runs through `execute_builtin_arc` — the same path as every
+other builtin — so `before_tool` fires with the resolved name and can veto it,
+`catch_unwind` still contains panics, and stdin/redirects behave identically. A
+bespoke execution path would have to re-earn all of that.
+
+Consequences to keep in mind:
+
+- Resolver-provided names are **not enumerable**: they do not appear in
+  `Bash::builtin_names()` or in `command not found` suggestions. Security
+  implications are in `../integrations/script-analysis.md`.
+- Being last, a resolver can never shadow a function, builtin, or `$PATH`
+  script. Use `BashBuilder::builtin` to override one.
+- `resolve` is called for every unresolved command, so it must be cheap;
+  cache rather than probing the filesystem per call.
+- The `$PATH` search consumes the pipeline stdin, so the interpreter clones it
+  for the resolver **only when a resolver is installed** — the common path does
+  not pay for the clone.
 
 ### Execution Extensions
 

--- a/knowledge/integrations/script-analysis.md
+++ b/knowledge/integrations/script-analysis.md
@@ -64,10 +64,32 @@ recognized dangerous command" as "safe" without checking those flags builds a
 bypassable gate.
 
 Enforcement primitives remain: the builtin registry (a command that does not
-exist cannot run), `NetworkAllowlist`, the filesystem mount policy, and the
-`before_tool` hook, which fires with the **resolved** command name at
-execution time. Recommended pattern: `analyze()` for the pre-execution UX
-decision, `before_tool` for the enforcement backstop.
+exist cannot run — unless a `CommandResolver` is installed, see below),
+`NetworkAllowlist`, the filesystem mount policy, and the `before_tool` hook,
+which fires with the **resolved** command name at execution time. Recommended
+pattern: `analyze()` for the pre-execution UX decision, `before_tool` for the
+enforcement backstop.
+
+### `CommandResolver` and the enumerable-name assumption
+
+`BashBuilder::command_resolver` installs a last-chance resolver, consulted only
+after every other dispatch route misses and immediately before the 127 path. It
+grants no new capability — a resolver is embedder-supplied host code exactly
+like a builtin passed to `BashBuilder::builtin`, which could already spawn
+processes. What it changes is narrower and worth stating plainly:
+
+- **The registry stops bounding the reachable name set.** "A command that does
+  not exist cannot run" holds only while every name that reaches host code is
+  registered. `Bash::builtin_names()` does not enumerate resolver-provided
+  names, so a gate built on that list is incomplete once a resolver exists.
+- **`before_tool` is unaffected.** Resolved commands dispatch through the same
+  builtin path as every other builtin, so the hook fires with the resolved name
+  and can cancel the call. The recommended pattern above holds unchanged.
+  `command_resolver_tests::before_tool_veto_blocks_a_resolved_command` pins this.
+
+A resolver that gates internally (returning `None` for names it will not run)
+restores a closed set; that is the recommended shape when the embedder has a
+policy to enforce.
 
 Recorded as TM-ESC-032 in [Threat Model](../security/threat-model.md).
 


### PR DESCRIPTION
Stack 1/3 — base of the adoption stack (#2248 builds on this, #2249 on that). Independent of #2245.

## What changed

`BashBuilder::command_resolver(Arc<dyn CommandResolver>)` installs a resolver consulted for a command name the interpreter could not otherwise resolve:

```rust
pub trait CommandResolver: Send + Sync {
    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>>;
}
```

It runs **last** — after shell functions, special builtins, the host registry, baked-in builtins, path-based scripts, and the `$PATH` search — so it can never shadow an existing command. Returning `None` leaves the 127 path untouched.

## Why

`BuiltinRegistry` maps *known names* to builtins from a map fixed before the name is known. An embedder bridging an open-ended command space — host executables, a remote tool catalog — must therefore enumerate that space up front.

crabot does exactly this, and pays for it twice: a static analysis pre-pass collects external names, and everything the pre-pass cannot see statically (`eval`, `$TOOL`, `command foo`, `./script.sh`) falls back to spawning a **real `bash -c`**. That fallback defeats the stated reason they embedded an in-process interpreter — running on Windows without a real bash.

A runtime hook resolves all of those at dispatch time, so neither the pre-pass nor the fallback is needed.

## Before / After

**Before** — names must be known before execution:
```rust
let names = collect_external_names(script)?;  // Err on eval / $TOOL / command / ./x.sh
for name in names { builder = builder.builtin(name, Box::new(HostCommandBuiltin { .. })); }
// on Err: give up and spawn `bash -c` instead
```

**After:**
```rust
let bash = Bash::builder().command_resolver(Arc::new(HostBridge)).build();
```

## Design note

Resolvers return a `Builtin` rather than executing directly, so the resolved command runs through `execute_builtin_arc` — the same path as every other builtin. That is what keeps `before_tool` firing with the resolved name, `catch_unwind` containing panics, and stdin/redirects behaving identically. A bespoke execution path would have had to re-earn all of it.

## Risk

- **Low.** Opt-in, and it runs last, so no existing dispatch changes.
- The `$PATH` search consumes pipeline stdin, so it is cloned for the resolver **only when a resolver is installed** — the common path does not pay for it.
- **Security:** a resolver grants no capability an embedder lacked — a `Builtin` passed to `BashBuilder::builtin` could already spawn processes. What changes is that the builtin registry stops bounding the reachable name set, so `Bash::builtin_names()` no longer enumerates it. `before_tool` remains the enforcement backstop and is pinned by `before_tool_veto_blocks_a_resolved_command`. `knowledge/integrations/script-analysis.md` states exactly this and no more.

11 tests cover: never shadowing builtins/functions/registered builtins, args and pipeline stdin, exit codes driving `&&`/`||`, `None` preserving 127, the veto path, and non-enumerability.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered