### PR TITLE
feat(fs): publish host mount table for VFS-to-host path mapping

### DIFF
--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -802,6 +802,9 @@ pub struct Bash {
     /// Operator-approved in-process SQLite opt-in captured at build time.
     #[cfg(feature = "sqlite")]
     sqlite_inprocess_opt_in: bool,
+    /// Real host directories mounted into the VFS, for host-path resolution.
+    #[cfg(feature = "realfs")]
+    host_mounts: HostMounts,
 }
 
 impl Default for Bash {
@@ -1525,6 +1528,30 @@ impl Bash {
         self.interpreter.restore_shell_state(state);
     }
 
+    /// Real host directories mounted into this instance's VFS.
+    ///
+    /// Empty unless a `mount_real_*` builder method was used. Mounts that were
+    /// skipped at build time (allowlist rejection, canonicalize failure) are
+    /// absent, so what this reports is what is actually reachable.
+    #[cfg(feature = "realfs")]
+    pub fn host_mounts(&self) -> &HostMounts {
+        &self.host_mounts
+    }
+
+    /// Map a VFS path to the host path backing it.
+    ///
+    /// Shorthand for [`host_mounts().resolve()`](HostMounts::resolve). Returns
+    /// `None` for a relative path or one no mount covers — treat that as an
+    /// error, not a cue to fall back to a default directory.
+    ///
+    /// The typical use is an embedder bridging commands to host processes:
+    /// a builtin receives the VFS cwd in [`BuiltinContext::cwd`] and needs the
+    /// host directory to spawn in.
+    #[cfg(feature = "realfs")]
+    pub fn host_path_for(&self, vfs_path: impl AsRef<Path>) -> Option<PathBuf> {
+        self.host_mounts.resolve(vfs_path.as_ref())
+    }
+
     /// Names of all builtins dispatchable in this instance, sorted.
     ///
     /// Reflects what this build + configuration actually dispatches:
@@ -1641,6 +1668,93 @@ struct MountedLazyFile {
     size_hint: u64,
     mode: u32,
     loader: LazyLoader,
+}
+
+/// Where a real host directory ended up in the VFS.
+///
+/// Produced by the `mount_real_*` builder methods; `host_path` is the
+/// canonicalized host directory actually mounted, which may differ from the
+/// path passed in (symlinks, `/tmp` → `/private/tmp` on macOS).
+#[cfg(feature = "realfs")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostMount {
+    /// Canonicalized host directory.
+    pub host_path: PathBuf,
+    /// VFS path it is reachable at. `/` for a root overlay mount.
+    pub vfs_path: PathBuf,
+}
+
+/// The real host directories mounted into a [`Bash`] instance.
+///
+/// Decision: published because embedders bridging commands to host processes
+/// must map a VFS cwd back to a host directory, and hand-rolling that mapping
+/// is a trap — a naive string prefix match puts `/home/u/proj2` inside
+/// `/home/u/proj`. [`resolve`](Self::resolve) matches whole path components and
+/// prefers the longest match, so a specific mount always beats a root overlay.
+#[cfg(feature = "realfs")]
+#[derive(Debug, Clone, Default)]
+pub struct HostMounts {
+    mounts: Vec<HostMount>,
+}
+
+#[cfg(feature = "realfs")]
+impl HostMounts {
+    /// Build a table from mounts the caller already knows.
+    ///
+    /// Useful for the chicken-and-egg case: a [`CommandResolver`] is passed
+    /// *into* the builder, so the builtins it produces cannot call
+    /// [`Bash::host_mounts`] on an instance that does not exist yet. Construct
+    /// the table first, share one `Arc` between the resolver and the
+    /// `mount_real_*` calls, and both agree by construction.
+    ///
+    /// `host_path` should be canonicalized if the VFS mount was; compare
+    /// against [`Bash::host_mounts`] after building to confirm what actually
+    /// mounted.
+    pub fn new(mounts: impl IntoIterator<Item = HostMount>) -> Self {
+        Self {
+            mounts: mounts.into_iter().collect(),
+        }
+    }
+
+    /// Every mount, in the order the builder applied them.
+    pub fn all(&self) -> &[HostMount] {
+        &self.mounts
+    }
+
+    /// True when no real host directory is mounted.
+    pub fn is_empty(&self) -> bool {
+        self.mounts.is_empty()
+    }
+
+    /// Map a VFS path to the host path backing it.
+    ///
+    /// Returns `None` for a relative path, or when no mount covers it. Callers
+    /// must treat `None` as an error rather than falling back to a default
+    /// directory — running a host command in the wrong directory is worse than
+    /// refusing to run it.
+    ///
+    /// When mounts overlap (a workspace mounted inside a root overlay), the
+    /// longest matching VFS prefix wins.
+    pub fn resolve(&self, vfs_path: &Path) -> Option<PathBuf> {
+        // VFS paths are POSIX-style on every host, so root-ness is `has_root`,
+        // not `is_absolute`: on Windows `Path::new("/workspace")` is *not*
+        // absolute (that needs a drive prefix), and an `is_absolute` check
+        // there silently returns `None` for every VFS path.
+        if !vfs_path.has_root() {
+            return None;
+        }
+        self.mounts
+            .iter()
+            .filter_map(|mount| {
+                let rest = vfs_path.strip_prefix(&mount.vfs_path).ok()?;
+                Some((
+                    mount.vfs_path.components().count(),
+                    mount.host_path.join(rest),
+                ))
+            })
+            .max_by_key(|(depth, _)| *depth)
+            .map(|(_, host)| host)
+    }
 }
 
 /// A real host directory to mount in the VFS during builder construction.
@@ -3105,7 +3219,7 @@ impl BashBuilder {
 
         // Layer 1: Apply real filesystem mounts (if any)
         #[cfg(feature = "realfs")]
-        let base_fs = Self::apply_real_mounts(
+        let (base_fs, host_mounts) = Self::apply_real_mounts(
             &self.real_mounts,
             self.mount_path_allowlist.as_deref(),
             base_fs,
@@ -3176,6 +3290,12 @@ impl BashBuilder {
             #[cfg(feature = "ssh")]
             self.ssh_handler,
         );
+
+        // Set after build — avoids adding another arg to build_with_fs.
+        #[cfg(feature = "realfs")]
+        {
+            result.host_mounts = host_mounts;
+        }
 
         // Set hooks after build — avoids adding another arg to build_with_fs.
         let hooks = hooks::Hooks {
@@ -3271,13 +3391,16 @@ impl BashBuilder {
         real_mounts: &[MountedRealDir],
         mount_allowlist: Option<&[PathBuf]>,
         base_fs: Arc<dyn FileSystem>,
-    ) -> Arc<dyn FileSystem> {
+    ) -> (Arc<dyn FileSystem>, HostMounts) {
         if real_mounts.is_empty() {
-            return base_fs;
+            return (base_fs, HostMounts::default());
         }
 
         let mut current_fs = base_fs;
         let mut mount_points: Vec<(PathBuf, Arc<dyn FileSystem>)> = Vec::new();
+        // Only mounts that actually applied are recorded: a path skipped by the
+        // allowlist or a failed canonicalize must not look resolvable.
+        let mut host_mounts = HostMounts::default();
         let canonical_allowlist: Option<Vec<PathBuf>> = mount_allowlist.map(|allowlist| {
             allowlist
                 .iter()
@@ -3359,9 +3482,17 @@ impl BashBuilder {
                     // Overlay at root: real fs becomes the lower layer,
                     // existing VFS content overlaid on top
                     current_fs = Arc::new(OverlayFs::new(real_fs));
+                    host_mounts.mounts.push(HostMount {
+                        host_path: canonical_host,
+                        vfs_path: PathBuf::from("/"),
+                    });
                 }
                 Some(mount_point) => {
                     mount_points.push((mount_point.clone(), real_fs));
+                    host_mounts.mounts.push(HostMount {
+                        host_path: canonical_host,
+                        vfs_path: mount_point.clone(),
+                    });
                 }
             }
         }
@@ -3378,9 +3509,9 @@ impl BashBuilder {
                     );
                 }
             }
-            Arc::new(mountable)
+            (Arc::new(mountable), host_mounts)
         } else {
-            current_fs
+            (current_fs, host_mounts)
         }
     }
 
@@ -3527,6 +3658,8 @@ impl BashBuilder {
             python_inprocess_opt_in,
             #[cfg(feature = "sqlite")]
             sqlite_inprocess_opt_in,
+            #[cfg(feature = "realfs")]
+            host_mounts: HostMounts::default(),
         }
     }
 }

--- a/crates/bashkit/tests/integration/host_mounts_tests.rs
+++ b/crates/bashkit/tests/integration/host_mounts_tests.rs
@@ -1,0 +1,154 @@
+//! Tests for [`HostMounts`] — mapping a VFS path back to the host path.
+//!
+//! The traps being pinned here are the ones an embedder hits when hand-rolling
+//! this mapping: string-prefix matching that swallows sibling directories, and
+//! overlapping mounts where the wrong one wins.
+
+#![cfg(feature = "realfs")]
+
+use bashkit::{Bash, HostMount, HostMounts};
+use std::path::{Path, PathBuf};
+
+fn mounts() -> HostMounts {
+    HostMounts::new([
+        HostMount {
+            host_path: PathBuf::from("/srv/root"),
+            vfs_path: PathBuf::from("/"),
+        },
+        HostMount {
+            host_path: PathBuf::from("/home/user/proj"),
+            vfs_path: PathBuf::from("/workspace"),
+        },
+    ])
+}
+
+#[test]
+fn resolves_a_path_under_a_mount() {
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace/src/main.rs")),
+        Some(PathBuf::from("/home/user/proj/src/main.rs"))
+    );
+}
+
+#[test]
+fn resolves_the_mount_point_itself() {
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace")),
+        Some(PathBuf::from("/home/user/proj"))
+    );
+}
+
+/// The trap: a plain string prefix match puts `/workspace2` inside
+/// `/workspace`. Matching whole components sends it to the root mount instead.
+#[test]
+fn sibling_of_a_mount_does_not_land_inside_it() {
+    let resolved = mounts().resolve(Path::new("/workspace2/src")).unwrap();
+    assert_ne!(resolved, PathBuf::from("/home/user/proj2/src"));
+    assert_ne!(resolved, PathBuf::from("/home/user/proj/src"));
+    assert_eq!(resolved, PathBuf::from("/srv/root/workspace2/src"));
+}
+
+/// A specific mount nested inside a root overlay must win over the overlay.
+#[test]
+fn longest_matching_mount_wins() {
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace/deep/file")),
+        Some(PathBuf::from("/home/user/proj/deep/file"))
+    );
+    // …and a path the specific mount does not cover still falls to the root.
+    assert_eq!(
+        mounts().resolve(Path::new("/tmp/scratch")),
+        Some(PathBuf::from("/srv/root/tmp/scratch"))
+    );
+}
+
+/// VFS paths are POSIX-style on every host. On Windows a leading `/` is not
+/// "absolute" — that needs a drive prefix — so a root check written as
+/// `is_absolute` resolves nothing at all there, and every host-bridged command
+/// loses its working directory.
+#[test]
+fn posix_vfs_paths_resolve_regardless_of_host_platform() {
+    assert!(
+        Path::new("/workspace").has_root(),
+        "a VFS path is root-ed on every platform"
+    );
+    assert_eq!(
+        mounts().resolve(Path::new("/workspace/src")),
+        Some(PathBuf::from("/home/user/proj").join("src")),
+    );
+}
+
+#[test]
+fn relative_paths_do_not_resolve() {
+    assert_eq!(mounts().resolve(Path::new("src")), None);
+    assert_eq!(mounts().resolve(Path::new("../escape")), None);
+}
+
+#[test]
+fn unmapped_path_is_none_when_nothing_is_mounted() {
+    let empty = HostMounts::default();
+    assert!(empty.is_empty());
+    assert_eq!(empty.resolve(Path::new("/anywhere")), None);
+}
+
+/// Without a root overlay there is no catch-all, so an uncovered path must
+/// report `None` rather than silently landing in some other mount.
+#[test]
+fn uncovered_path_without_a_root_mount_is_none() {
+    let only_workspace = HostMounts::new([HostMount {
+        host_path: PathBuf::from("/home/user/proj"),
+        vfs_path: PathBuf::from("/workspace"),
+    }]);
+    assert_eq!(only_workspace.resolve(Path::new("/etc/passwd")), None);
+}
+
+#[test]
+fn a_plain_instance_reports_no_host_mounts() {
+    let bash = Bash::new();
+    assert!(bash.host_mounts().is_empty());
+    assert_eq!(bash.host_path_for("/anything"), None);
+}
+
+/// The table reflects what actually mounted, resolving through the real
+/// builder path (including canonicalization).
+#[test]
+fn builder_records_real_mounts() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("hello.txt"), "hi\n").unwrap();
+    let host = std::fs::canonicalize(dir.path()).unwrap();
+
+    let bash = Bash::builder()
+        .allowed_mount_paths([host.clone()])
+        .mount_real_readwrite_at(host.clone(), "/workspace")
+        .build();
+
+    assert_eq!(bash.host_mounts().all().len(), 1);
+    assert_eq!(
+        bash.host_path_for("/workspace/hello.txt"),
+        Some(host.join("hello.txt"))
+    );
+}
+
+/// A mount rejected by the allowlist must not appear resolvable — reporting a
+/// host path for a directory that was never mounted is worse than reporting
+/// nothing.
+#[test]
+fn skipped_mounts_are_not_recorded() {
+    let allowed = tempfile::tempdir().unwrap();
+    let rejected = tempfile::tempdir().unwrap();
+    let allowed_host = std::fs::canonicalize(allowed.path()).unwrap();
+    let rejected_host = std::fs::canonicalize(rejected.path()).unwrap();
+
+    let bash = Bash::builder()
+        .allowed_mount_paths([allowed_host.clone()])
+        .mount_real_readwrite_at(allowed_host.clone(), "/allowed")
+        .mount_real_readwrite_at(rejected_host, "/rejected")
+        .build();
+
+    assert_eq!(bash.host_mounts().all().len(), 1);
+    assert_eq!(bash.host_path_for("/rejected/x"), None);
+    assert_eq!(
+        bash.host_path_for("/allowed/x"),
+        Some(allowed_host.join("x"))
+    );
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -55,6 +55,7 @@ pub mod glob_intermediate_component_tests;
 pub mod harness_example_tests;
 pub mod history_tests;
 pub mod host_call_execution_tests;
+pub mod host_mounts_tests;
 pub mod issue_1175_test;
 pub mod issue_1776_test;
 pub mod issue_1777_test;

--- a/knowledge/foundations/vfs.md
+++ b/knowledge/foundations/vfs.md
@@ -193,6 +193,39 @@ Symlinks are stored but intentionally not followed for security:
 - Prevents symlink escape attacks (TM-ESC-002)
 - Prevents symlink loop DoS (TM-DOS-011)
 
+## Host Mount Table (`HostMounts`)
+
+`realfs` mounts are recorded as a `HostMounts` table on the `Bash` instance:
+`Bash::host_mounts()` lists them, `Bash::host_path_for(vfs)` maps a VFS path
+back to the host path backing it.
+
+Decision: published because embedders that bridge commands to host processes
+must map a VFS cwd to a host directory to spawn in, and hand-rolling it is a
+trap — a naive string prefix match puts `/workspace2` inside `/workspace`.
+`HostMounts::resolve` matches whole path components and prefers the longest
+match, so a specific mount beats a root overlay.
+
+Rules:
+
+- Only mounts that actually applied are recorded. A path skipped by the
+  allowlist or a failed `canonicalize` is absent, so the table never reports a
+  host path for something that was never mounted.
+- `host_path` is the canonicalized host directory, which may differ from the
+  path passed to the builder (symlinks, `/tmp` → `/private/tmp` on macOS).
+- A root overlay mount (`mount_real_readonly` with no VFS path) is recorded at
+  `/`, so it acts as the catch-all. Without one, an uncovered path resolves to
+  `None`.
+- `None` means "no mount covers this". Callers must treat it as an error rather
+  than falling back to a default directory: spawning a host process in the
+  wrong directory is worse than refusing to spawn it.
+- `HostMounts::new` lets an embedder build the table up front. A
+  `CommandResolver` is passed *into* the builder, so builtins it produces
+  cannot call `Bash::host_mounts()` on an instance that does not exist yet;
+  sharing one `Arc` between the resolver and the `mount_real_*` calls makes
+  both agree by construction.
+
+Tests: `crates/bashkit/tests/integration/host_mounts_tests.rs`.
+
 ## Binding API Parity
 
 All language bindings must expose the same filesystem concepts:


### PR DESCRIPTION
Stack 2/3 — **merge #2247 first.** Targets `main` rather than #2247's branch because CI only triggers on PRs targeting `main`; the diff will shrink to just this change once #2247 merges. **Review the last commit only** (`feat(fs): publish host mount table…`).

## What changed

`realfs` mounts are now recorded and exposed:

- `Bash::host_mounts()` — which real mounts actually applied
- `Bash::host_path_for(vfs)` / `HostMounts::resolve(vfs)` — map a VFS path back to the host path behind it
- `HostMounts::new(..)` — build the table up front

## Why

An embedder bridging commands to host processes gets the VFS cwd from `BuiltinContext::cwd` and needs a host directory to spawn in. Nothing exposed that, so crabot hand-rolled `vfs_cwd_to_host` + `match_mount` — and had to write a dedicated test for the trap it contains, because a string prefix match puts `/workspace2` inside `/workspace`.

We own the mount table. Hosts should not be reimplementing prefix matching against it.

## Before / After

**Before:** ~50 lines of component-walking in the embedder, plus a regression test for a trap we handed them.

**After:**
```rust
bash.host_path_for("/workspace/src/main.rs");  // Some("/home/u/proj/src/main.rs")
bash.host_path_for("/workspace2/src");         // -> root mount, NOT inside /workspace
bash.host_path_for("/etc/passwd");             // None when no mount covers it
```

Three behaviors worth calling out, each pinned by a test:

- **Longest matching VFS prefix wins**, matched by whole path components — so a specific mount beats a root overlay, and `/workspace2` never lands inside `/workspace`.
- **`None` means "no mount covers this"**, and callers must treat it as an error. Falling back to a default directory would run a host command somewhere the script never asked for — worse than refusing.
- **Only mounts that actually applied are recorded.** A path rejected by the allowlist or a failed `canonicalize` is absent, so the table never reports a host path for something that was never mounted.

`HostMounts::new` exists for a real ordering problem: a `CommandResolver` is passed *into* the builder, so the builtins it produces cannot call `Bash::host_mounts()` on an instance that does not exist yet. Build the table first, share one `Arc` with both, and they agree by construction.

## Design note

An earlier draft put this on `BuiltinContext` as `ctx.host_path(..)`. Adding a required field to `Context` broke ~50 internal construction sites for modest gain, so it was dropped in favor of the shared-`Arc` shape above.

## Risk

- **Low.** `cfg(realfs)` and additive; no existing behavior changes.
- `apply_real_mounts` gained a return value; no caller-visible effect.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered