### PR TITLE
test(adoption): cover the agent-bash-tool embedding shape, on Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,11 @@ jobs:
       - name: Run realfs tests
         run: cargo test --features realfs -p bashkit --test realfs_tests -p bashkit-cli
 
+      # The third-party adoption and host-mount suites are `cfg(realfs)`, so
+      # the main "Run tests" step (no realfs) compiles them out entirely.
+      - name: Run realfs integration tests
+        run: cargo test -p bashkit --test integration --features realfs -- host_mounts_tests thirdparty_adoption_tests
+
       - name: Run fail-point tests (single-threaded)
         run: cargo test --features failpoints --test security_failpoint_tests -- --test-threads=1
 
@@ -246,6 +251,33 @@ jobs:
 
       - name: Test RealFS and overlay containment
         run: cargo test -p bashkit --test realfs_tests --features realfs windows_containment
+
+  # The adoption shape this covers — bashkit as an agent's shell, with commands
+  # bridged to host processes — exists to work on Windows without a real bash.
+  # Kept separate from `windows-containment`: that job pins path-containment
+  # semantics (TM-ESC-033), this one pins the embedding contract. Scoped to the
+  # adoption suites rather than the whole workspace.
+  test-windows:
+    name: Test (Windows adoption shape)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: windows-adoption
+
+      - name: Run third-party adoption tests
+        run: cargo test -p bashkit --test integration --features realfs -- thirdparty_adoption_tests
+
+      - name: Run host mount mapping tests
+        run: cargo test -p bashkit --test integration --features realfs -- host_mounts_tests
+
+      - name: Run command resolver tests
+        run: cargo test -p bashkit --test integration -- command_resolver_tests
 
   examples:
     name: Examples
@@ -377,7 +409,7 @@ jobs:
   check:
     name: Check
     if: always()
-    needs: [lint, audit, test, examples, fuzz-check]
+    needs: [lint, audit, test, windows-containment, test-windows, examples, fuzz-check]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all jobs passed
@@ -385,6 +417,8 @@ jobs:
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.audit.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
+             [[ "${{ needs.windows-containment.result }}" != "success" ]] || \
+             [[ "${{ needs.test-windows.result }}" != "success" ]] || \
              [[ "${{ needs.examples.result }}" != "success" ]] || \
              [[ "${{ needs.fuzz-check.result }}" != "success" ]]; then
             echo "One or more required jobs failed"

--- a/crates/bashkit/tests/integration/harness_example_tests.rs
+++ b/crates/bashkit/tests/integration/harness_example_tests.rs
@@ -1,3 +1,8 @@
+//! Unix-only: uses `std::os::unix` (file modes, symlinks). The integration
+//! binary is built on Windows by the `Test (Windows adoption shape)` job, so
+//! this module must gate itself out rather than break that compile.
+#![cfg(unix)]
+
 use std::fs;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::Path;

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -105,6 +105,7 @@ pub mod sqlite_security_tests;
 pub mod stack_overflow_regression_tests;
 pub mod subst_depth_limit_tests;
 pub mod symlink_overlay_security_tests;
+pub mod thirdparty_adoption_tests;
 pub mod threat_model_doc_tests;
 pub mod threat_model_tests;
 pub mod time_compat_scan_tests;

--- a/crates/bashkit/tests/integration/thirdparty_adoption_tests.rs
+++ b/crates/bashkit/tests/integration/thirdparty_adoption_tests.rs
@@ -1,0 +1,365 @@
+//! End-to-end test of the "agent bash tool" adoption shape.
+//!
+//! This is the integration an embedder writes when it wants bashkit to *be*
+//! its shell — a real workspace mounted read-write, and commands bashkit does
+//! not implement bridged to host executables so the same code path works on
+//! Windows without a real `bash`.
+//!
+//! Decision: this exists because the shape was only ever validated downstream.
+//! The first adopter to write it (crabot) shipped two defects bashkit's own
+//! tests could not see: a harness that emptied `PATH`, and a stdin pipe to a
+//! host process that never reached EOF and hung the suite. Both are behaviors
+//! of *this* composition — `CommandResolver` + `HostMounts` + `realfs` — so
+//! they belong here, and this file runs on Windows in CI too.
+//!
+//! The bridge below is deliberately the whole thing: if bridging a host
+//! command needs more code than this, that is a gap in bashkit's API.
+
+#![cfg(feature = "realfs")]
+
+use async_trait::async_trait;
+use bashkit::{Bash, Builtin, BuiltinContext, CommandResolver, ExecResult, HostMount, HostMounts};
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Bound on a bridged host command.
+///
+/// A real bridge needs one regardless; here it also keeps a defect from
+/// turning into a hung CI job. A leaked stdin pipe means the child waits for
+/// EOF forever, and a test that hangs reports nothing — this turns it into a
+/// named failure.
+const HOST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Run a script through the host shell.
+///
+/// `sh`/`cmd` rather than a bare binary because the set of standalone
+/// executables shared by Linux, macOS, and Windows is effectively empty.
+fn shell_out(script: &str) -> (String, Vec<String>) {
+    if cfg!(windows) {
+        ("cmd".into(), vec!["/C".into(), script.into()])
+    } else {
+        ("sh".into(), vec!["-c".into(), script.into()])
+    }
+}
+
+/// Map a bridged name to the host program it runs.
+///
+/// The `host-` prefix matters: bashkit implements `cat`, `echo`, `pwd` and
+/// `false` itself, so a test using those names would never reach the bridge —
+/// it would silently assert on builtins instead. Returning `None` for
+/// unprefixed names also keeps the normal 127 path observable.
+fn host_program(name: &str) -> Option<&'static str> {
+    Some(match name.strip_prefix("host-")? {
+        // Reads stdin to EOF on every platform.
+        "cat" => {
+            if cfg!(windows) {
+                "sort"
+            } else {
+                "cat"
+            }
+        }
+        "pwd" => {
+            if cfg!(windows) {
+                "cd"
+            } else {
+                "pwd"
+            }
+        }
+        "false" => {
+            if cfg!(windows) {
+                "exit 1"
+            } else {
+                "false"
+            }
+        }
+        "echo" => "echo",
+        _ => return None,
+    })
+}
+
+/// Bridges one command name to a host process.
+///
+/// The interesting parts, all of which the first adopter got wrong at least
+/// once: the cwd comes from the mount table (never a default), stdin is fed
+/// through a pipe that must reach EOF, and the exit code is passed through.
+struct HostCommand {
+    name: String,
+    program: &'static str,
+    mounts: Arc<HostMounts>,
+}
+
+#[async_trait]
+impl Builtin for HostCommand {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        // A cwd on no mount is an error. Falling back to some default would
+        // run the command in the wrong directory.
+        let Some(dir) = self.mounts.resolve(ctx.cwd) else {
+            return Ok(ExecResult::err(
+                format!("{}: cwd is not on a host mount", self.name),
+                1,
+            ));
+        };
+
+        let script = std::iter::once(self.program.to_string())
+            .chain(ctx.args.iter().cloned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let (program, args) = shell_out(&script);
+
+        // Bytes, not text: a host command's stdin may not be valid UTF-8.
+        let stdin_data = ctx.stdin.map(|s| s.as_bytes().to_vec());
+        let output = tokio::task::spawn_blocking(move || {
+            let mut cmd = std::process::Command::new(program);
+            cmd.args(args)
+                .current_dir(dir)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .stdin(if stdin_data.is_some() {
+                    Stdio::piped()
+                } else {
+                    Stdio::null()
+                });
+
+            let mut child = cmd.spawn()?;
+            if let Some(data) = stdin_data {
+                use std::io::Write;
+                // Dropping the handle closes the pipe. Without that the child
+                // waits for EOF forever — the exact hang this file exists for.
+                let mut pipe = child.stdin.take().expect("stdin piped");
+                pipe.write_all(&data)?;
+                drop(pipe);
+            }
+
+            let deadline = Instant::now() + HOST_TIMEOUT;
+            let status = loop {
+                if let Some(status) = child.try_wait()? {
+                    break Some(status);
+                }
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            };
+
+            // Only drain on a clean exit. After a timeout kill, a grandchild
+            // the shell spawned can still hold the write end, and reading
+            // would block forever — turning the bounded wait back into a hang.
+            //
+            // Reading after exit is safe here because the outputs are small.
+            // A production bridge must drain concurrently with the wait, or a
+            // child that fills the pipe buffer blocks before it can exit.
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+            if status.is_some() {
+                if let Some(mut pipe) = child.stdout.take() {
+                    let _ = pipe.read_to_end(&mut stdout);
+                }
+                if let Some(mut pipe) = child.stderr.take() {
+                    let _ = pipe.read_to_end(&mut stderr);
+                }
+            }
+            Ok::<_, std::io::Error>((status, stdout, stderr))
+        })
+        .await
+        .expect("spawn_blocking");
+
+        Ok(match output {
+            Ok((Some(status), stdout, stderr)) => ExecResult {
+                stdout: stdout.into(),
+                stderr: stderr.into(),
+                exit_code: status.code().unwrap_or(1),
+                ..Default::default()
+            },
+            Ok((None, _, _)) => ExecResult::err(
+                format!(
+                    "{}: host command exceeded {}s — did stdin reach EOF?",
+                    self.name,
+                    HOST_TIMEOUT.as_secs()
+                ),
+                124,
+            ),
+            // Bash's convention for a command that could not be executed.
+            Err(e) => ExecResult::err(format!("{}: {e}", self.name), 127),
+        })
+    }
+}
+
+/// Bridges any name bashkit did not resolve, exactly as an agent tool would.
+struct HostBridge {
+    mounts: Arc<HostMounts>,
+}
+
+impl CommandResolver for HostBridge {
+    fn resolve(&self, name: &str) -> Option<Arc<dyn Builtin>> {
+        let program = host_program(name)?;
+        Some(Arc::new(HostCommand {
+            name: name.to_owned(),
+            program,
+            mounts: Arc::clone(&self.mounts),
+        }))
+    }
+}
+
+struct Fixture {
+    bash: Bash,
+    workspace: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = std::fs::canonicalize(dir.path()).unwrap();
+    std::fs::create_dir(workspace.join("sub")).unwrap();
+
+    // Built up front and shared: the resolver is passed *into* the builder, so
+    // it cannot ask the not-yet-existing instance where things are mounted.
+    let mounts = Arc::new(HostMounts::new([HostMount {
+        host_path: workspace.clone(),
+        vfs_path: PathBuf::from("/workspace"),
+    }]));
+
+    let bash = Bash::builder()
+        .allowed_mount_paths([workspace.clone()])
+        .mount_real_readwrite_at(workspace.clone(), "/workspace")
+        .cwd("/workspace")
+        .command_resolver(Arc::new(HostBridge {
+            mounts: Arc::clone(&mounts),
+        }))
+        .build();
+
+    // The bridge and the real mount must agree, or every cwd mapping is wrong.
+    assert_eq!(bash.host_path_for("/workspace"), Some(workspace.clone()));
+
+    Fixture {
+        bash,
+        workspace,
+        _dir: dir,
+    }
+}
+
+#[tokio::test]
+async fn bridged_host_command_runs_and_returns_output() {
+    let mut f = fixture();
+    let result = f.bash.exec("host-echo hello from host").await.unwrap();
+    assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
+    assert!(
+        result.stdout.contains("hello from host"),
+        "unexpected: {result:?}"
+    );
+}
+
+/// A builtin bashkit implements must win over the bridge — the resolver runs
+/// last, so it must never be consulted for `echo`.
+#[tokio::test]
+async fn builtins_win_over_the_bridge() {
+    let mut f = fixture();
+    let result = f.bash.exec("echo bridged").await.unwrap();
+    assert_eq!(result.stdout, "bridged\n");
+}
+
+/// A name the bridge declines still gets the normal `command not found`.
+#[tokio::test]
+async fn undeclined_names_keep_command_not_found() {
+    let mut f = fixture();
+    let result = f.bash.exec("definitely-not-a-command-xyz").await.unwrap();
+    assert_eq!(result.exit_code, 127, "unexpected: {result:?}");
+}
+
+/// Stdin must reach the host process *and* hit EOF. A bridge that leaks the
+/// write end hangs here instead of failing, so the timeout is the assertion.
+#[tokio::test]
+async fn pipeline_stdin_reaches_the_host_process_and_reaches_eof() {
+    let mut f = fixture();
+    let result = f.bash.exec("echo piped-payload | host-cat").await.unwrap();
+    assert_eq!(
+        result.exit_code, 0,
+        "host command did not complete: {result:?}"
+    );
+    assert!(
+        result.stdout.contains("piped-payload"),
+        "unexpected: {result:?}"
+    );
+}
+
+/// `cd` moves the VFS cwd; the bridge must map the *new* cwd to the host, not
+/// silently keep spawning in the workspace root.
+#[tokio::test]
+async fn cd_changes_the_host_spawn_directory() {
+    let mut f = fixture();
+    let result = f.bash.exec("cd sub && host-pwd").await.unwrap();
+    assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
+    let printed = result.stdout.trim().replace('\\', "/");
+    assert!(
+        printed.ends_with("/sub"),
+        "host command ran in the wrong directory: {printed}"
+    );
+}
+
+/// Writes through bashkit's own builtins must land on the real filesystem —
+/// the reason the workspace is mounted read-write rather than overlaid.
+#[tokio::test]
+async fn builtin_writes_reach_the_real_filesystem() {
+    let mut f = fixture();
+    let result = f
+        .bash
+        .exec("echo written > out.txt && mkdir -p sub2 && cp out.txt sub2/copy.txt")
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
+
+    assert_eq!(
+        std::fs::read_to_string(f.workspace.join("out.txt")).unwrap(),
+        "written\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(f.workspace.join("sub2/copy.txt")).unwrap(),
+        "written\n"
+    );
+}
+
+/// A non-zero host exit code behaves like any other command: it does not abort
+/// the script, and it drives `&&` / `||`.
+#[tokio::test]
+async fn host_exit_codes_drive_control_flow() {
+    let mut f = fixture();
+    let result = f.bash.exec("host-false || echo recovered").await.unwrap();
+    assert!(
+        result.stdout.contains("recovered"),
+        "unexpected: {result:?}"
+    );
+
+    let result = f.bash.exec("host-false; echo after").await.unwrap();
+    assert!(
+        result.stdout.contains("after"),
+        "script aborted: {result:?}"
+    );
+
+    let result = f.bash.exec("host-false").await.unwrap();
+    assert_ne!(result.exit_code, 0);
+}
+
+/// The whole point of the composition: syntax bashkit implements (heredocs,
+/// command substitution, pipelines) works with bridged commands mixed in,
+/// with no real `bash` process anywhere.
+#[tokio::test]
+async fn bashkit_syntax_composes_with_bridged_commands() {
+    let mut f = fixture();
+    let result = f
+        .bash
+        .exec("cat <<'EOF'\nheredoc line\nEOF\necho \"host says: $(host-echo ok)\"")
+        .await
+        .unwrap();
+    assert!(
+        result.stdout.contains("heredoc line"),
+        "unexpected: {result:?}"
+    );
+    assert!(
+        result.stdout.contains("host says: ok"),
+        "unexpected: {result:?}"
+    );
+}

--- a/knowledge/operations/testing.md
+++ b/knowledge/operations/testing.md
@@ -109,6 +109,49 @@ Uploaded to Codecov from three sources: Rust unit/integration coverage via
 `cargo tarpaulin`; Rust coverage exercised through Python and Node binding
 tests via `cargo llvm-cov`.
 
+## Third-Party Adoption Suite
+
+`crates/bashkit/tests/integration/thirdparty_adoption_tests.rs` covers the
+"agent bash tool" embedding shape end to end: a real workspace mounted
+read-write, a `CommandResolver` bridging unresolved names to host processes,
+and `HostMounts` mapping the VFS cwd back to a host directory.
+
+Decision: this shape was only ever validated downstream, and the first adopter
+(crabot) shipped two defects bashkit's own tests could not see — a harness that
+emptied `PATH`, and a stdin pipe to a host process that never reached EOF and
+hung the suite. Both are properties of the *composition*, not of any one API,
+so they need a test that composes.
+
+Rules for this file:
+
+- **The bridge in it is the reference.** If bridging a host command needs more
+  code than what is there, that is a gap in bashkit's API, not a reason to grow
+  the test.
+- **Use names bashkit does not implement** (`host-cat`, `host-echo`, …). The
+  resolver runs last, so a test using `cat` or `echo` silently asserts on
+  builtins and never reaches the bridge — verified by injecting a defect and
+  confirming the test fails.
+- **Never let a defect become a hang.** The bridge bounds its wait and drains
+  pipes only after a clean exit; after a timeout kill a grandchild can still
+  hold the write end, and reading would block forever. A hung job reports
+  nothing; a bounded one names the cause.
+
+`host_mounts_tests.rs` covers the mapping in isolation, including the
+sibling-prefix trap (`/workspace2` must not resolve inside `/workspace`).
+
+Both are `cfg(realfs)`, so the main `Run tests` step (which does not enable
+`realfs`) compiles them out. They run in the dedicated `Run realfs integration
+tests` step and in the `Test (Windows adoption shape)` job.
+
+## Windows CI
+
+`test-windows` is the only non-ubuntu job. It runs the adoption, host-mount,
+and command-resolver suites on `windows-latest` and gates `Check`.
+
+It is deliberately scoped rather than a full workspace port: the adoption shape
+exists to work on Windows without a real `bash`, and that claim needs a Windows
+runner to stay true. Everything else stays ubuntu-only.
+
 ## Third-Party API Steps in CI
 
 The `Examples` job runs a few steps that call third-party LLM APIs (Anthropic


### PR DESCRIPTION
Stack 3/3 — **merge #2247 and #2248 first.** Targets `main` rather than #2248's branch because CI only triggers on PRs targeting `main`; the diff will shrink to just this change once those merge. **Review the last two commits only** (`test(adoption): …` and `test(ci): gate the unix-only harness example module`).

## What changed

- `thirdparty_adoption_tests.rs` — the composition an embedder actually writes, end to end: a real workspace mounted read-write, a `CommandResolver` bridging unresolved names to host processes, `HostMounts` mapping the cwd back.
- A `windows-latest` job running the adoption, host-mount, and command-resolver suites, gating `Check`.
- `harness_example_tests.rs` gated `#[cfg(unix)]` — it uses `std::os::unix`, and the integration binary now has to compile on Windows.

## Why

This shape was only ever validated downstream, and bashkit had no non-ubuntu CI. crabot — the first adopter — shipped two defects nothing upstream could catch:

1. A test harness that emptied `PATH` on Linux (a Windows-only Git-Bash fixup that ran unconditionally), failing 13 of 24 tests.
2. A stdin pipe to a host process that never reached EOF, hanging the suite indefinitely.

Both are properties of the *composition*, not of any single API, so they need a test that composes.

## Before / After

**Before:** neither defect was detectable upstream.

**After:** injecting the EOF defect (`std::mem::forget(pipe)` for `drop(pipe)`) produces one named failure in 20s:

```
test thirdparty_adoption_tests::pipeline_stdin_reaches_the_host_process_and_reaches_eof ... FAILED
assertion `left == right` failed: host command did not complete: ExecResult {
  stderr: "host-cat: host command exceeded 20s — did stdin reach EOF?", exit_code: 124, .. }
test result: FAILED. 7 passed; 1 failed
```

Getting there took three iterations, all worth recording because each was a wrong test that looked right:

1. The injected defect **passed** — the test used `cat`, which is a bashkit builtin, so the resolver (which runs last) was never consulted and the bridge never ran. Fixed by using `host-`prefixed names bashkit does not implement.
2. It then **hung past 180s** — `tokio::time::timeout` never fired, because the blocked thread never yielded. Fixed by bounding the bridge's own wait.
3. It **still hung** — killing `sh` left `cat` holding the stdout pipe, so draining blocked forever. Fixed by draining only after a clean exit.

A hung CI job reports nothing; a bounded one names the cause. The rules that fell out of this are written down in `knowledge/operations/testing.md` so the next person does not rediscover them.

The Windows job also immediately earned its place: its first run failed, and not on the new tests — `harness_example_tests.rs` uses `std::os::unix` ungated, which had been invisible while every job was ubuntu-only.

## Scope note

The Windows job is deliberately scoped to the three adoption suites rather than porting the whole workspace. Its job is to keep the embedding contract honest — the shape exists to work on Windows without a real bash — not to make every test cross-platform.

The bridge in the test file is meant to be the reference implementation. If bridging a host command needs more code than that, it is a gap in bashkit's API rather than a reason to grow the test.

## Risk

- **Low.** Tests and CI only; no library code changes.
- New job adds a Windows runner to every PR (~2 min).

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered