### PR TITLE
fix(compat): add competitor regression lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Run strict bash parity tests
         run: cargo test -p bashkit --test integration --features http_client,ssh -- spec_tests::bash_comparison_tests --ignored
 
+      - name: Run competitor regression corpus
+        run: cargo test -p bashkit --test integration --features http_client,jq -- competitor_regression_tests
+
       - name: Run doc tests
         run: cargo test --workspace --doc --features http_client,ssh,sqlite
 

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -275,6 +275,7 @@ Scripts may attempt to leak sensitive information.
 | JS `onOutput` errors expose host stack traces (TM-INF-028) | Callback throws, leaking `error.stack` | Propagate `error.message` only; strip absolute/`file://` paths | FIXED |
 | Raw callback errors leak host internals (TM-INF-030) | Tool callback throws API keys/connection strings/stack traces | `sanitize_errors` defaults on for `ScriptedTool`/`ToolImpl`/`ToolRegistry` across shell/Python/TypeScript | MITIGATED |
 | `final_env` capture bypasses filtering/caps (TM-INF-031) | `capture_final_env` leaks internal markers or exceeds caps | Visibility filter + output-byte cap applied when building `final_env` | MITIGATED |
+| Imported competitor fixture executes upstream code (TM-INF-032) | Automated import runs a compromised upstream script in CI | Fixtures are manually reviewed, checked-in JSON; CI never fetches upstream; host-Bash execution requires an explicit oracle | MITIGATED |
 | Stack backtrace disclosure (TM-INF-021) | Panics leak source paths, dep versions, function names via stderr | Custom panic hook suppresses backtraces in the CLI | MITIGATED |
 
 **Caller Responsibility (TM-INF-001):**

--- a/crates/bashkit/src/builtins/archive.rs
+++ b/crates/bashkit/src/builtins/archive.rs
@@ -5,6 +5,10 @@
 //! All decompression operations check output size against filesystem limits
 //! to prevent zip bomb attacks. Decompression is aborted early if the
 //! output would exceed limits.
+//!
+//! Design decision: tar's first bare argv is the historical option bundle;
+//! normalize it to the regular short-option path instead of maintaining a
+//! second parser.
 
 // Uses expect() for verified safe unwraps (e.g., strip_suffix after ends_with check)
 #![allow(clippy::unwrap_used)]
@@ -94,8 +98,25 @@ impl Builtin for Tar {
         let mut change_dir: Option<String> = None;
         let mut files: Vec<String> = Vec::new();
 
+        // GNU/bsdtar treat a bare first word as the historical option bundle.
+        // Normalize only that argv position so the regular short-option parser
+        // remains the single source of truth for flags and option arguments.
+        let normalized_args;
+        let args = if ctx
+            .args
+            .first()
+            .is_some_and(|arg| !arg.starts_with('-') && !arg.starts_with('+'))
+        {
+            normalized_args = std::iter::once(format!("-{}", ctx.args[0]))
+                .chain(ctx.args[1..].iter().cloned())
+                .collect::<Vec<_>>();
+            normalized_args.as_slice()
+        } else {
+            ctx.args
+        };
+
         // Parse arguments
-        let mut p = super::arg_parser::ArgParser::new(ctx.args);
+        let mut p = super::arg_parser::ArgParser::new(args);
         while !p.is_done() {
             if let Some(val) = p.flag_value_opt("-f") {
                 archive_file = Some(val.to_string());
@@ -1106,6 +1127,32 @@ mod tests {
         let result = Tar.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.contains("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_tar_rejects_unknown_old_style_option() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+        let args = vec!["qf".to_string(), "archive.tar".to_string()];
+        let ctx = Context {
+            args: &args,
+            env: &env,
+            variables: &mut variables,
+            cwd: &mut cwd,
+            fs,
+            stdin: None,
+            #[cfg(feature = "http_client")]
+            http_client: None,
+            #[cfg(feature = "git")]
+            git_client: None,
+            #[cfg(feature = "ssh")]
+            ssh_client: None,
+            shell: None,
+        };
+
+        let result = Tar.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 2);
+        assert_eq!(result.stderr, "tar: invalid option -- 'q'\n");
     }
 
     #[tokio::test]

--- a/crates/bashkit/tests/fixtures/competitor-regressions/just-bash-2026-08-05.json
+++ b/crates/bashkit/tests/fixtures/competitor-regressions/just-bash-2026-08-05.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "expected_case_count": 11,
+  "source": {
+    "repository": "https://github.com/vercel-labs/just-bash",
+    "window_start": "2026-05-05",
+    "window_end": "2026-08-05"
+  },
+  "cases": [
+    {
+      "id": "heredoc-body-in-command-substitution",
+      "upstream_commit": "4ece2580d8cb707e6c6b7fa22897ea3fdd21739a",
+      "upstream_date": "2026-06-03",
+      "classification": "pass",
+      "oracle": "real_bash",
+      "minimum_bash_major": 4,
+      "script": "OUT=$(cat <<'SCRIPT'\nJune's moon\nSCRIPT\n)\nprintf %s \"$OUT\"",
+      "expected": { "stdout": "June's moon", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "executable-script-exit-status",
+      "upstream_commit": "8edf226a0794b3d6101458aeb478819c84298839",
+      "upstream_date": "2026-07-21",
+      "classification": "pass",
+      "oracle": "real_bash",
+      "script": "printf 'exit 2\\n' > fail.sh\nchmod +x fail.sh\n./fail.sh; printf '%s\\n' \"$?\"",
+      "expected": { "stdout": "2\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "nested-jq-interpolation",
+      "upstream_commit": "7a5a0b9ae3bf0524722653cbf4b45e6bc176cf22",
+      "upstream_date": "2026-07-08",
+      "classification": "pass",
+      "oracle": "locked",
+      "required_features": ["jq"],
+      "script": "printf '%s\\n' '{\"m\":\"2026-06-05T10:00:00Z\"}' > payload.json\njq -r '\"\\(.m | sub(\"T.*\"; \"\"))\"' payload.json",
+      "expected": { "stdout": "2026-06-05\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "grep-double-dash-terminator",
+      "upstream_commit": "6df692f236ca108c888552a67557998156ac845b",
+      "upstream_date": "2026-07-24",
+      "classification": "pass",
+      "oracle": "real_bash",
+      "script": "printf 'match\\n-x\\n--help\\n' > patterns.txt\ngrep -- -x patterns.txt",
+      "expected": { "stdout": "-x\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "multiline-quoted-indentation",
+      "upstream_commit": "1ec5eec0aefd099d23ac9f056df1e6612c81d49b",
+      "upstream_date": "2026-06-29",
+      "classification": "pass",
+      "oracle": "real_bash",
+      "script": "printf '%s' 'first\n    second\n        third\n'",
+      "expected": { "stdout": "first\n    second\n        third\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "mixed-byte-text-flow",
+      "upstream_commit": "150a915a1d45a2cc7f2b6aec3268f27116c34916",
+      "upstream_date": "2026-06-18",
+      "classification": "pass",
+      "oracle": "real_bash",
+      "script": "printf 'Köpenicker\\n' > doc.txt\nsed -n 1p doc.txt; grep Köpenicker doc.txt | head -1",
+      "expected": { "stdout": "Köpenicker\nKöpenicker\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "repeated-curl-data",
+      "upstream_commit": "3d39a714b3751cedc173dffae27933dfe7b8b3b5",
+      "upstream_date": "2026-07-19",
+      "classification": "bug",
+      "resolution": "fixed",
+      "oracle": "locked",
+      "required_features": ["http_client"],
+      "transport": "echo_request_body",
+      "script": "curl -sS -d a=1 --data b=2 http://93.184.216.34/echo",
+      "expected": { "stdout": "a=1&b=2", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "rg-stdin-without-paths",
+      "upstream_commit": "ca1cf25c695ffe754bcdf7ab4bde0476073fe41a",
+      "upstream_date": "2026-07-08",
+      "classification": "pass",
+      "oracle": "locked",
+      "script": "printf 'hello world\\ngoodbye\\n' | rg hello",
+      "expected": { "stdout": "hello world\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "tar-old-style-option-bundle",
+      "upstream_commit": "efabdb7bab9c789057073d1dcad9f9df87eca173",
+      "upstream_date": "2026-06-18",
+      "classification": "bug",
+      "resolution": "fixed",
+      "oracle": "real_bash",
+      "script": "printf old-style > payload.txt\ntar cf archive.tar payload.txt\nrm payload.txt\ntar xf archive.tar\ncat payload.txt",
+      "expected": { "stdout": "old-style", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "cat-display-flags",
+      "upstream_commit": "6130334f0ed013771bbe39f32a249bdaf762c488",
+      "upstream_date": "2026-07-12",
+      "classification": "pass",
+      "oracle": "locked",
+      "script": "printf 'tab\\there\\nctrl\\a\\n' > display.txt\ncat -A display.txt",
+      "expected": { "stdout": "tab^Ihere$\nctrl^G$\n", "stderr": "", "exit_code": 0 }
+    },
+    {
+      "id": "set-euo-pipefail",
+      "upstream_commit": "c9904dea24ad2aa847749ee6289239c2a2c651fc",
+      "upstream_date": "2026-06-03",
+      "classification": "pass",
+      "oracle": "real_bash",
+      "script": "set -euo pipefail\nprintf ok",
+      "expected": { "stdout": "ok", "stderr": "", "exit_code": 0 }
+    }
+  ]
+}

--- a/crates/bashkit/tests/integration/competitor_regression_tests.rs
+++ b/crates/bashkit/tests/integration/competitor_regression_tests.rs
@@ -1,0 +1,340 @@
+//! Checked-in competitor regressions: no network fetches, one data row per case.
+//!
+//! Important decision: CI executes reviewed fixture scripts inside Bashkit. The
+//! separate host-oracle test only runs cases explicitly marked `real_bash`, in
+//! a temporary directory, and never imports or downloads code (TM-INF-032).
+
+use std::path::PathBuf;
+
+use bashkit::Bash;
+use serde::Deserialize;
+
+#[cfg(feature = "http_client")]
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+struct Corpus {
+    schema_version: u32,
+    expected_case_count: usize,
+    source: Source,
+    cases: Vec<Case>,
+}
+
+#[derive(Deserialize)]
+struct Source {
+    repository: String,
+    window_start: String,
+    window_end: String,
+}
+
+#[derive(Deserialize)]
+struct Case {
+    id: String,
+    upstream_commit: String,
+    upstream_date: String,
+    classification: String,
+    #[serde(default)]
+    resolution: Option<String>,
+    #[serde(default)]
+    limitation_id: Option<String>,
+    oracle: String,
+    #[serde(default)]
+    minimum_bash_major: Option<u32>,
+    #[serde(default)]
+    required_features: Vec<String>,
+    #[serde(default)]
+    transport: Option<String>,
+    script: String,
+    expected: Expected,
+}
+
+#[derive(Deserialize)]
+struct Expected {
+    stdout: String,
+    stderr: String,
+    exit_code: i32,
+}
+
+// THREAT[TM-INF-032]: Only load reviewed, checked-in JSON; this harness never
+// downloads upstream fixtures or generates executable source.
+fn load_corpora() -> Vec<(String, Corpus)> {
+    let dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/competitor-regressions");
+    let mut paths = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+        .map(|entry| entry.expect("read corpus directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    assert!(!paths.is_empty(), "competitor corpus must not be empty");
+    paths
+        .into_iter()
+        .map(|path| {
+            let bytes =
+                std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            let corpus = serde_json::from_slice(&bytes)
+                .unwrap_or_else(|e| panic!("parse {}: {e}", path.display()));
+            let name = path
+                .file_name()
+                .expect("corpus filename")
+                .to_string_lossy()
+                .into_owned();
+            (name, corpus)
+        })
+        .collect()
+}
+
+#[allow(clippy::match_like_matches_macro)] // Each arm has an independent compile-time feature gate.
+fn feature_available(name: &str) -> bool {
+    match name {
+        "http_client" => cfg!(feature = "http_client"),
+        "jq" => cfg!(feature = "jq"),
+        _ => false,
+    }
+}
+
+fn host_program(name: &str) -> PathBuf {
+    std::env::var_os("PATH")
+        .and_then(|path| {
+            std::env::split_paths(&path)
+                .map(|dir| dir.join(name))
+                .find(|candidate| candidate.is_file())
+        })
+        .unwrap_or_else(|| PathBuf::from(name))
+}
+
+fn bash_major(program: &std::path::Path) -> u32 {
+    let output = std::process::Command::new(program)
+        .arg("--version")
+        .output()
+        .expect("query real bash version");
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .find_map(|word| word.split('.').next()?.parse().ok())
+        .expect("parse real bash major version")
+}
+
+fn validate(case: &Case, source: &Source, limitations: &str) {
+    assert!(
+        case.id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+        "{}: id must be lowercase kebab-case",
+        case.id
+    );
+    assert!(
+        case.upstream_commit.len() == 40
+            && case
+                .upstream_commit
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+        "{}: upstream_commit must be a full Git object id",
+        case.id
+    );
+    assert!(
+        case.upstream_date.len() == 10
+            && case.upstream_date.as_str() >= source.window_start.as_str()
+            && case.upstream_date.as_str() <= source.window_end.as_str(),
+        "{}: date {} must remain in {}..{}",
+        case.id,
+        case.upstream_date,
+        source.window_start,
+        source.window_end
+    );
+    assert!(
+        matches!(
+            case.classification.as_str(),
+            "pass" | "bug" | "intentional_divergence"
+        ),
+        "{}: unknown classification {}",
+        case.id,
+        case.classification
+    );
+    match case.classification.as_str() {
+        "bug" => {
+            assert_eq!(case.resolution.as_deref(), Some("fixed"));
+            assert!(case.limitation_id.is_none());
+        }
+        "intentional_divergence" => {
+            let id = case
+                .limitation_id
+                .as_deref()
+                .unwrap_or_else(|| panic!("{}: divergence must name a limitation ID", case.id));
+            assert!(id.starts_with("L-"));
+            assert!(
+                limitations.contains(&format!("| {id} |")),
+                "{}: limitation {id} is not canonical",
+                case.id
+            );
+            assert!(case.resolution.is_none());
+        }
+        _ => {
+            assert!(case.resolution.is_none());
+            assert!(case.limitation_id.is_none());
+        }
+    }
+    assert!(matches!(case.oracle.as_str(), "real_bash" | "locked"));
+    if case.minimum_bash_major.is_some() {
+        assert_eq!(case.oracle, "real_bash");
+    }
+    for feature in &case.required_features {
+        assert!(matches!(feature.as_str(), "http_client" | "jq"));
+    }
+    assert!(
+        matches!(case.transport.as_deref(), None | Some("echo_request_body")),
+        "{}: unknown transport fixture",
+        case.id
+    );
+    if case.transport.is_some() {
+        assert!(
+            case.required_features.iter().any(|f| f == "http_client"),
+            "{}: transport fixture requires http_client",
+            case.id
+        );
+    }
+}
+
+#[cfg(feature = "http_client")]
+struct EchoRequestBody;
+
+#[cfg(feature = "http_client")]
+#[async_trait::async_trait]
+impl bashkit::HttpTransport for EchoRequestBody {
+    async fn execute(
+        &self,
+        request: bashkit::HttpTransportRequest,
+    ) -> Result<bashkit::HttpResponse, bashkit::HttpTransportError> {
+        Ok(bashkit::HttpResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "text/plain".into())],
+            body: request.body.unwrap_or_default(),
+        })
+    }
+}
+
+async fn run_bashkit(case: &Case) -> bashkit::ExecResult {
+    let builder = Bash::builder();
+    #[cfg(feature = "http_client")]
+    let builder = if case.transport.as_deref() == Some("echo_request_body") {
+        builder
+            .network(bashkit::NetworkAllowlist::allow_all())
+            .http_transport(Arc::new(EchoRequestBody))
+    } else {
+        builder
+    };
+    let mut bash = builder.build();
+    bash.exec(&case.script).await.expect("execute fixture")
+}
+
+#[test]
+fn competitor_corpus_has_complete_provenance_and_classification() {
+    let limitations = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../knowledge/operations/limitations.md"),
+    )
+    .expect("read canonical limitations");
+    let mut ids = std::collections::HashSet::new();
+    for (name, corpus) in load_corpora() {
+        assert_eq!(corpus.schema_version, 1, "{name}: unknown schema");
+        assert!(
+            corpus.source.repository.starts_with("https://"),
+            "{name}: source repository must be HTTPS"
+        );
+        assert!(
+            corpus.source.window_start.len() == 10
+                && corpus.source.window_end.len() == 10
+                && corpus.source.window_start <= corpus.source.window_end,
+            "{name}: invalid source window"
+        );
+        assert_eq!(
+            corpus.cases.len(),
+            corpus.expected_case_count,
+            "{name}: corpus selection is incomplete"
+        );
+        for case in &corpus.cases {
+            assert!(
+                ids.insert(case.id.clone()),
+                "duplicate case id: {}",
+                case.id
+            );
+            validate(case, &corpus.source, &limitations);
+        }
+    }
+}
+
+#[tokio::test]
+async fn competitor_regressions_stay_green_without_network() {
+    let mut failures = Vec::new();
+    for (_, corpus) in load_corpora() {
+        for case in corpus.cases {
+            if !case.required_features.iter().all(|f| feature_available(f)) {
+                continue;
+            }
+            let actual = run_bashkit(&case).await;
+            if actual.stdout != case.expected.stdout
+                || actual.stderr != case.expected.stderr
+                || actual.exit_code != case.expected.exit_code
+            {
+                failures.push(format!(
+                    "{}: expected ({:?}, {:?}, {}), got ({:?}, {:?}, {})",
+                    case.id,
+                    case.expected.stdout,
+                    case.expected.stderr,
+                    case.expected.exit_code,
+                    actual.stdout,
+                    actual.stderr,
+                    actual.exit_code
+                ));
+            }
+        }
+    }
+    assert!(failures.is_empty(), "\n{}", failures.join("\n"));
+}
+
+#[test]
+fn competitor_real_bash_oracles_match_locked_expectations() {
+    let bash = host_program("bash");
+    let bash_major = bash_major(&bash);
+    for (_, corpus) in load_corpora() {
+        for case in corpus.cases {
+            if case.oracle != "real_bash" {
+                continue;
+            }
+            if let Some(minimum) = case.minimum_bash_major
+                && bash_major < minimum
+            {
+                eprintln!(
+                    "skip {}: bash {} is older than required major {}",
+                    case.id, bash_major, minimum
+                );
+                continue;
+            }
+            let cwd = tempfile::tempdir().expect("oracle tempdir");
+            let output = std::process::Command::new(&bash)
+                .args(["--noprofile", "--norc", "-c", &case.script])
+                .current_dir(cwd.path())
+                .env_clear()
+                .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+                .env("LC_ALL", "C.UTF-8")
+                .output()
+                .expect("run real bash oracle");
+            assert_eq!(
+                output.stdout,
+                case.expected.stdout.as_bytes(),
+                "{} stdout",
+                case.id
+            );
+            assert_eq!(
+                output.stderr,
+                case.expected.stderr.as_bytes(),
+                "{} stderr",
+                case.id
+            );
+            assert_eq!(
+                output.status.code(),
+                Some(case.expected.exit_code),
+                "{} exit",
+                case.id
+            );
+        }
+    }
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -29,6 +29,7 @@ pub mod builtin_registry_tests;
 pub mod byte_range_panic_tests;
 pub mod cancellation_tests;
 pub mod cmdsub_quote_test;
+pub mod competitor_regression_tests;
 pub mod compgen_tests;
 pub mod coproc_tests;
 pub mod coreutils_differential_tests;

--- a/justfile
+++ b/justfile
@@ -103,6 +103,11 @@ check-bash-compat:
 check-bash-compat-verbose:
     ./scripts/update-spec-expected.sh --verbose
 
+# Run the checked-in quarterly competitor regression corpus. Hermetic: the
+# HTTP case uses an injected transport and no fixture is fetched at test time.
+competitor-regressions:
+    cargo test -p bashkit --test integration --features http_client,jq competitor_regression_tests
+
 # Generate comprehensive compatibility report
 compat-report:
     cargo test --test integration -- spec_tests::bash_comparison_tests --ignored --nocapture

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -4,6 +4,8 @@
 
 * **Contract**: Added a canonical, generated [Public Capability Parity](status/capability-parity.md) matrix across Rust `BashBuilder`/`BashTool`/`ScriptedTool`, CLI, Python, NAPI JavaScript, browser WASM, and C ABI. Every supported cell names executable evidence; every intentional exclusion states why. The central drift check rejects missing cells and stale test selectors.
 * **Security**: Added TM-ISO-025 for wrapper rebuilds silently dropping host configuration. The first audit finding was NAPI `reset()` losing constructor-seeded VFS files; shared state now retains and restores them, with a regression test.
+* **Testing**: Added a quarterly competitor-regression corpus contract: immutable upstream provenance, explicit pass/bug/intentional-divergence classification, real-Bash or locked oracles, and a feature-complete hermetic CI lane. The first import covers eleven behavior fixes from `vercel-labs/just-bash` between 2026-05-05 and 2026-08-05; it exposed and fixes tar old-style option bundles, while the ordered curl-data fix is supplied by its dedicated PR.
+* **Threat**: Registered TM-INF-032 for executing imported third-party behavior fixtures. Imports remain manually reviewed checked-in JSON, CI never fetches upstream content, and only explicitly marked portable cases reach the host-Bash oracle.
 
 ## 2026-08-01
 

--- a/knowledge/operations/testing.md
+++ b/knowledge/operations/testing.md
@@ -155,6 +155,40 @@ explicitly as a strict parity gate. Tests marked with `### bash_diff` are
 excluded from comparison. Tests marked with `### skip` are excluded from both
 spec tests and comparison.
 
+## Quarterly Competitor Regressions
+
+Behavior fixes imported from peer shell interpreters live as checked-in JSON
+under `crates/bashkit/tests/fixtures/competitor-regressions/`. Each quarterly
+corpus records its source repository, inclusive review window, and expected
+case count. Every case must include a stable kebab-case ID, full upstream
+commit hash, commit date, script, locked stdout/stderr/status, oracle, optional
+required Cargo features, and one classification:
+
+- `pass`: Bashkit already matched the behavior when imported.
+- `bug`: the import exposed a Bashkit defect; `resolution` must be `fixed` and
+  the same corpus remains the regression test.
+- `intentional_divergence`: `limitation_id` must resolve to a canonical `L-*`
+  row in [Known Limitations](limitations.md).
+
+Use `oracle: real_bash` only for portable shell behavior. The runner executes
+those cases with the first `bash` on `PATH`, a cleared environment, and a fresh
+temporary working directory. A case whose syntax requires a newer shell may
+set `minimum_bash_major`; older host oracles skip only that comparison. Use
+`locked` for platform-specific utilities, embedded runtimes, or HTTP; the
+expected value must be established during review. HTTP fixtures use an injected
+`HttpTransport`, never the network.
+
+Quarterly import process:
+
+1. Review upstream fixes since the prior corpus window; copy the smallest
+   behavior reproducer and pin the full commit hash.
+2. Add a new dated JSON corpus. Do not add a fetch step or generated executable
+   source: fixture review is the trust boundary (TM-INF-032).
+3. Run `just competitor-regressions`. Confirm every `real_bash` oracle and the
+   Bashkit lane; fix tight regressions or classify a canonical limitation.
+4. CI runs the same feature-complete, network-free lane. Schema, provenance,
+   unique IDs, classifications, and limitation references are test-enforced.
+
 ## Differential Fuzzing
 
 Grammar-based property testing using proptest generates random valid bash

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -413,6 +413,7 @@ execute permission (mode & 0o111); exit 127 missing / 126 non-executable; sheban
 | TM-INF-028 | JS `onOutput` callback errors expose host stack traces | When a caller-supplied `onOutput` callback throws, `toNativeOnOutput` in `wrapper.ts` propagated `error.stack` (host file paths, internal function names) across the sandbox boundary; script output is attacker-controlled and drives the callback, so an attacker could trigger a throw and read host deployment paths | Propagate `error.message` only; regex-strip absolute-path and `file://` segments (guards attacker-controlled message injection); cap at 256 chars. Regression test `onOutput error does not leak stack trace or host paths` in `__test__/streaming-output.spec.ts`; mitigation annotated `// THREAT[TM-INF-028]` in `wrapper.ts` | **FIXED** |
 | TM-INF-030 | Raw callback errors leak host internals through ScriptedTool/ToolImpl/ToolRegistry | Tool callbacks may throw errors containing API keys, connection strings, or stack traces; output is attacker-influenced and agent-visible | `sanitize_errors` defaults to true on `ScriptedTool`, `ToolImpl`, and the cross-runtime `ToolRegistry`; every shell/Python/TypeScript registry surface returns the same generic message (`scripted_tool/mod.rs`, `tool_def.rs`, `tool_registry.rs`) | **MITIGATED** |
 | TM-INF-031 | `final_env` capture bypasses output filtering and size caps | When `capture_final_env` is enabled, env contents are a user-visible output channel that could leak internal markers or exceed output limits | Visibility filtering + output-byte cap applied when building `final_env` (`interpreter/mod.rs`) | **MITIGATED** |
+| TM-INF-032 | Competitor fixture import executes untrusted upstream code in CI | Automatically downloading or mechanically copying third-party regression scripts into a host-shell oracle would let a compromised upstream run arbitrary commands with CI permissions; a source commit hash proves provenance, not trust | Competitor corpora are manually reviewed, data-only JSON checked into the repository with full commit provenance; CI performs no fetch; Bashkit cases run in the VFS with normal resource limits; only cases explicitly marked `real_bash` run under the host oracle, with a cleared environment and temporary cwd. The schema/classification gate is `competitor_corpus_has_complete_provenance_and_classification`; process contract is [Testing Strategy](../operations/testing.md) | **MITIGATED** |
 
 **TM-INF-022**: Generalizes TM-INF-016 to the whole builtin surface. Originating bug:
 `builtins/jq/` formatted jaq compile/parse errors with `{:?}`, leaking the jaq `File`
@@ -1251,6 +1252,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | SQLite opt-in and limits | TM-SQL-001 to TM-SQL-011 | `builtins/sqlite/` | Yes |
 | Path char validation (bidi) | TM-DOS-015, TM-UNI-003, TM-UNI-011 | `fs/limits.rs` | Partial (bidi yes, zero-width/tags no) |
 | Builtin panic catching | TM-INT-001, TM-UNI-001, TM-UNI-002, TM-UNI-015, TM-UNI-016, TM-UNI-017 | `interpreter/mod.rs` | Yes (catch_unwind) |
+| Reviewed competitor fixtures | TM-INF-032 | `tests/fixtures/competitor-regressions/`, `competitor_regression_tests.rs` | Yes |
 
 ### Open Controls (From 2026-03 Security Audit)
 
@@ -1375,6 +1377,7 @@ FsLimits::new()
 - `tests/builtin_error_security_tests.rs` - Custom builtin error handling tests (39 tests)
 - `tests/network_security_tests.rs` - HTTP security tests (53 tests: allowlist, size limits, timeouts)
 - `tests/logging_security_tests.rs` - Logging security tests (redaction, injection)
+- `tests/integration/competitor_regression_tests.rs` - third-party fixture provenance and execution boundary (TM-INF-032)
 
 **Recommendations**:
 - Add cargo-fuzz for parser and input handling


### PR DESCRIPTION
## What changed
- Adds an auto-discovered, checked-in quarterly competitor regression corpus with 11 behavior cases from vercel-labs/just-bash fixes dated 2026-05-05 through 2026-08-05.
- Enforces immutable provenance, explicit pass/bug/intentional-divergence classification, canonical limitation IDs, feature requirements, and expected case counts.
- Runs portable cases against real Bash and uses locked or injected oracles for jq, coreutils, and HTTP. CI performs no network access.
- Fixes tar historical option bundles such as tar cf and tar xf by normalizing the first bare option word through the existing short-option parser.
- Documents the quarterly import process and TM-INF-032 trust boundary.

## Why
Peer-interpreter fixes were useful compatibility signals but had no durable import process or CI enforcement. The lane makes future quarterly imports cheap while keeping third-party scripts reviewed, provenance-backed, and hermetic.

## Before / After
Before:
- No maintained competitor regression lane.
- tar cf archive.tar payload.txt exited 2 because cf was treated as a filename.
- Repeated curl data originally kept only the last value.

After:
- just competitor-regressions reports 3/3 harness tests green across all 11 classified cases.
- The tar cf / tar xf round trip returns old-style with exit 0.
- Repeated curl data returns a=1&b=2 through an injected echo transport after #2242.
- just pre-pr passes.

## Risk
- Low
- The runtime behavior change is limited to the first bare tar argument, matching GNU/bsd historical option-bundle behavior. Unknown bundles remain errors.
- Host-Bash comparisons run only explicitly marked portable cases in a temporary directory with a cleared environment. Imported fixtures remain a manual-review trust boundary.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered