### PR TITLE
perf(regex): cache runtime regex compilation

### DIFF
--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -207,6 +207,10 @@ name = "file_ops"
 harness = false
 
 [[bench]]
+name = "awk_regex"
+harness = false
+
+[[bench]]
 name = "snapshot_history"
 harness = false
 

--- a/crates/bashkit/benches/awk_regex.rs
+++ b/crates/bashkit/benches/awk_regex.rs
@@ -1,0 +1,121 @@
+//! AWK runtime-regex benchmarks.
+//!
+//! Guards the distinction between parser-compiled top-level patterns and
+//! expression/function operands compiled during evaluation. The input mirrors
+//! a 50k-line access-log scan where field expressions run 300k times.
+//!
+//! Run with: `cargo bench --bench awk_regex`
+
+use std::hint::black_box;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use tokio::runtime::Runtime;
+
+const LINES: usize = 50_000;
+const FIELD_EVALUATIONS: u64 = (LINES * 6) as u64;
+
+const EXPRESSION_ANCHORED: &str =
+    r#"awk '{for(i=1;i<=NF;i++) if ($i ~ /^bytes=/) n++} END {print n}' /access.log"#;
+const EXPRESSION_UNANCHORED: &str =
+    r#"awk '{for(i=1;i<=NF;i++) if ($i ~ /bytes=1/) n++} END {print n}' /access.log"#;
+const INDEX_PREFIX: &str =
+    r#"awk '{for(i=1;i<=NF;i++) if (index($i,"bytes=")==1) n++} END {print n}' /access.log"#;
+const TOP_LEVEL_PATTERN: &str = r#"awk '/bytes=1/ {n++} END {print n}' /access.log"#;
+
+fn seed_access_log(rt: &Runtime) -> Arc<InMemoryFs> {
+    let fs = Arc::new(InMemoryFs::new());
+    let mut input = String::with_capacity(LINES * 48);
+    for i in 0..LINES {
+        use std::fmt::Write;
+        writeln!(
+            input,
+            "2026-08-05 host{} method=GET code=200 bytes={} p/{}",
+            i % 7,
+            i % 1000,
+            i % 50
+        )
+        .unwrap();
+    }
+    rt.block_on(async {
+        let fs_dyn: Arc<dyn FileSystem> = fs.clone();
+        fs_dyn
+            .write_file(Path::new("/access.log"), input.as_bytes())
+            .await
+            .expect("write access log");
+    });
+    fs
+}
+
+fn bash_with(fs: &Arc<InMemoryFs>) -> Bash {
+    let fs_dyn: Arc<dyn FileSystem> = fs.clone();
+    Bash::builder().fs(fs_dyn).build()
+}
+
+fn bench_awk_regex(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_access_log(&rt);
+    let mut group = c.benchmark_group("awk_regex");
+
+    for (name, script, evaluations) in [
+        (
+            "expression_anchored",
+            EXPRESSION_ANCHORED,
+            FIELD_EVALUATIONS,
+        ),
+        (
+            "expression_unanchored",
+            EXPRESSION_UNANCHORED,
+            FIELD_EVALUATIONS,
+        ),
+        ("index_prefix", INDEX_PREFIX, FIELD_EVALUATIONS),
+        ("top_level_pattern", TOP_LEVEL_PATTERN, LINES as u64),
+    ] {
+        group.throughput(Throughput::Elements(evaluations));
+        group.bench_function(name, |b| {
+            b.to_async(&rt).iter(|| {
+                let fs = fs.clone();
+                async move {
+                    let mut bash = bash_with(&fs);
+                    black_box(bash.exec(script).await.expect("awk benchmark"));
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(5))
+}
+
+#[test]
+fn verify_workloads() {
+    let rt = Runtime::new().unwrap();
+    let fs = seed_access_log(&rt);
+    rt.block_on(async {
+        for (script, expected) in [
+            (EXPRESSION_ANCHORED, "50000"),
+            (EXPRESSION_UNANCHORED, "5550"),
+            (INDEX_PREFIX, "50000"),
+            (TOP_LEVEL_PATTERN, "5550"),
+        ] {
+            let mut bash = bash_with(&fs);
+            let result = bash.exec(script).await.expect("execute workload");
+            assert_eq!(result.stdout.trim(), expected);
+        }
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets = bench_awk_regex
+}
+criterion_main!(benches);

--- a/crates/bashkit/benches/results/criterion-awk-regex-mykhailos-mini-darwin-arm64-1785952907.md
+++ b/crates/bashkit/benches/results/criterion-awk-regex-mykhailos-mini-darwin-arm64-1785952907.md
@@ -1,0 +1,30 @@
+# Criterion AWK Runtime Regex Benchmark
+
+## System Information
+
+- **Moniker**: `Mykhailos-Mini.lan-darwin-arm64`
+- **Hostname**: Mykhailos-Mini.lan
+- **OS**: Darwin
+- **Architecture**: arm64
+- **CPUs**: 12
+- **Timestamp**: 1785952907
+- **Profile**: release (`opt-level=3`, fat LTO, one codegen unit)
+
+## Workload
+
+50,000 generated access-log lines. Field-expression cases scan six fields per
+line (300,000 expression evaluations); the top-level pattern runs once per line.
+
+| Benchmark | Time | 95% confidence interval | Throughput |
+|-----------|-------:|------------------------:|-----------:|
+| `expression_anchored` (`$i ~ /^bytes=/`) | 392.37 ms | 281.97–448.22 ms | 0.76 M eval/s |
+| `expression_unanchored` (`$i ~ /bytes=1/`) | 153.91 ms | 145.66–473.49 ms | 1.95 M eval/s |
+| `index_prefix` (`index($i,"bytes=")==1`) | 117.55 ms | 109.27–166.90 ms | 2.55 M eval/s |
+| `top_level_pattern` (`/bytes=1/`) | 39.01 ms | 30.17–62.97 ms | 1.28 M lines/s |
+
+## Notes
+
+- `expression_anchored` is the regression workload: runtime compilation is
+  cached, so its remaining cost is expression evaluation and regex matching.
+- `top_level_pattern` remains the parser-compiled control path.
+- Run with `cargo bench -p bashkit --bench awk_regex`.

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -69,7 +69,7 @@ through configurable limits.
 | For loop (TM-DOS-017) | `for i in $(seq 1 inf)` | Loop limit | MITIGATED |
 | Nested loops (TM-DOS-018) | Double for loop | `max_total_loop_iterations` (1M) | MITIGATED |
 | Command flood (TM-DOS-019) | 100K sequential commands | Command limit (10K) | MITIGATED |
-| Long computation (TM-DOS-023) | Complex awk/sed regex | Timeout (30s) | MITIGATED |
+| Long computation (TM-DOS-023) | Complex awk/sed regex, including repeated awk and `[[ =~ ]]` operands | Linear-time engine; bounded runtime regex caches; timeout (30s) | MITIGATED |
 | Regex backtrack (TM-DOS-025) | `grep "a](*b)*c" file` | Regex crate limits | PARTIAL |
 | AWK unbounded loops (TM-DOS-033) | `BEGIN { while(1){} }` | Timeout (30s) backstop | PARTIAL |
 

--- a/crates/bashkit/src/builtins/awk/interpreter.rs
+++ b/crates/bashkit/src/builtins/awk/interpreter.rs
@@ -13,7 +13,7 @@ use crate::builtins::limits::{
     AWK_MAX_GETLINE_FILE_BYTES as MAX_GETLINE_FILE_BYTES,
     AWK_MAX_OUTPUT_BYTES as MAX_AWK_OUTPUT_BYTES, AWK_MAX_OUTPUT_TARGETS as MAX_AWK_OUTPUT_TARGETS,
 };
-use crate::builtins::search_common::build_regex;
+use crate::builtins::search_common::RuntimeRegexCache;
 use crate::fs::{FileSystem, normalize_path};
 use crate::limits::ExecutionLimits;
 // On wasm32 there is no OS thread to bridge the sync AWK evaluator to the async
@@ -38,6 +38,9 @@ pub(super) enum AwkFlow {
 // - AWK_MAX_OUTPUT_TARGETS (distinct redirected output files).
 // - AWK_MAX_GETLINE_CACHED_FILES (distinct files held open by `getline`).
 // - AWK_MAX_GETLINE_FILE_BYTES / AWK_MAX_GETLINE_CACHE_BYTES (retained input bytes).
+// THREAT[TM-DOS-023]: Runtime regex operands share one bounded cache. Invalid
+// patterns are cached too, preventing repeated compilation failures from
+// becoming a CPU sink.
 
 /// One redirected VFS write, dispatched to the [`VfsWriter`] thread.
 #[cfg(not(target_family = "wasm"))]
@@ -194,6 +197,7 @@ pub(super) struct AwkInterpreter {
     range_active: HashMap<usize, bool>,
     /// Max iterations for a single loop, inherited from execution limits.
     pub(super) max_loop_iterations: usize,
+    regex_cache: RuntimeRegexCache,
 }
 
 impl AwkInterpreter {
@@ -215,7 +219,12 @@ impl AwkInterpreter {
             cwd: PathBuf::from("/"),
             range_active: HashMap::new(),
             max_loop_iterations: ExecutionLimits::default().max_loop_iterations,
+            regex_cache: RuntimeRegexCache::default(),
         }
+    }
+
+    fn runtime_regex(&mut self, pattern: &str) -> Option<regex::Regex> {
+        self.regex_cache.get_or_compile(pattern)
     }
 
     fn resolve_getline_path(&self, path_str: &str) -> String {
@@ -303,7 +312,7 @@ impl AwkInterpreter {
     fn eval_expr_as_bool(&mut self, expr: &AwkExpr) -> bool {
         if let AwkExpr::Regex(pattern) = expr {
             let line = self.state.get_field(0).as_string();
-            if let Ok(re) = build_regex(pattern) {
+            if let Some(re) = self.runtime_regex(pattern) {
                 return re.is_match(&line);
             }
             return false;
@@ -384,7 +393,7 @@ impl AwkInterpreter {
                         0.0
                     }),
                     "~" => {
-                        if let Ok(re) = build_regex(&r.as_string()) {
+                        if let Some(re) = self.runtime_regex(&r.as_string()) {
                             AwkValue::Number(if re.is_match(&l.as_string()) {
                                 1.0
                             } else {
@@ -395,7 +404,7 @@ impl AwkInterpreter {
                         }
                     }
                     "!~" => {
-                        if let Ok(re) = build_regex(&r.as_string()) {
+                        if let Some(re) = self.runtime_regex(&r.as_string()) {
                             AwkValue::Number(if !re.is_match(&l.as_string()) {
                                 1.0
                             } else {
@@ -511,7 +520,7 @@ impl AwkInterpreter {
             }
             AwkExpr::Match(expr, pattern) => {
                 let s = self.eval_expr(expr).as_string();
-                if let Ok(re) = build_regex(pattern) {
+                if let Some(re) = self.runtime_regex(pattern) {
                     AwkValue::Number(if re.is_match(&s) { 1.0 } else { 0.0 })
                 } else {
                     AwkValue::Number(0.0)
@@ -665,7 +674,7 @@ impl AwkInterpreter {
 
                 let target = self.eval_expr(&target_expr).as_string();
 
-                if let Ok(re) = build_regex(&pattern) {
+                if let Some(re) = self.runtime_regex(&pattern) {
                     let (result, count) = if name == "gsub" {
                         let count = re.find_iter(&target).count();
                         (
@@ -751,7 +760,7 @@ impl AwkInterpreter {
                 } else {
                     None
                 };
-                if let Ok(re) = build_regex(&pattern) {
+                if let Some(re) = self.runtime_regex(&pattern) {
                     if let Some(caps) = re.captures(&s) {
                         let m = caps.get(0).unwrap();
                         let rstart = m.start() + 1; // awk is 1-indexed
@@ -799,7 +808,7 @@ impl AwkInterpreter {
                 } else {
                     self.state.get_field(0).as_string()
                 };
-                if let Ok(re) = build_regex(&pattern) {
+                if let Some(re) = self.runtime_regex(&pattern) {
                     if how == "g" || how == "G" {
                         AwkValue::String(re.replace_all(&target, replacement.as_str()).to_string())
                     } else {
@@ -1534,5 +1543,38 @@ impl AwkInterpreter {
             }
             other => self.matches_pattern(other),
         }
+    }
+}
+
+#[cfg(test)]
+mod regex_cache_tests {
+    use super::*;
+
+    #[test]
+    fn repeated_match_expression_compiles_regex_once() {
+        let mut interp = AwkInterpreter::new();
+        interp.state.set_line("bytes=123");
+        let expr = AwkExpr::BinOp(
+            Box::new(AwkExpr::Field(Box::new(AwkExpr::Number(0.0)))),
+            "~".to_string(),
+            Box::new(AwkExpr::Regex("^bytes=".to_string())),
+        );
+
+        for _ in 0..300_000 {
+            assert!(interp.eval_expr(&expr).as_bool());
+        }
+
+        assert_eq!(interp.regex_cache.compile_count(), 1);
+    }
+
+    #[test]
+    fn repeated_invalid_regex_compiles_once() {
+        let mut interp = AwkInterpreter::new();
+
+        for _ in 0..100 {
+            assert!(interp.runtime_regex("[").is_none());
+        }
+
+        assert_eq!(interp.regex_cache.compile_count(), 1);
     }
 }

--- a/crates/bashkit/src/builtins/limits.rs
+++ b/crates/bashkit/src/builtins/limits.rs
@@ -33,6 +33,8 @@ pub(crate) const AWK_MAX_GETLINE_CACHED_FILES: usize = 100;
 pub(crate) const AWK_MAX_GETLINE_FILE_BYTES: usize = 10_000_000;
 /// awk: max total bytes retained by all `getline < file` inputs.
 pub(crate) const AWK_MAX_GETLINE_CACHE_BYTES: usize = 10_000_000;
+/// Max compiled runtime regexes retained by one evaluator.
+pub(crate) const RUNTIME_REGEX_CACHE_ENTRIES: usize = 64;
 
 /// curl: max number of HTTP redirects to follow.
 #[cfg(feature = "http_client")]

--- a/crates/bashkit/src/builtins/search_common.rs
+++ b/crates/bashkit/src/builtins/search_common.rs
@@ -3,8 +3,12 @@
 //! Extracted from duplicated code in grep.rs and rg.rs to provide a single
 //! canonical implementation of common search operations.
 
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
 use regex::{Regex, RegexBuilder};
 
+use crate::builtins::limits::RUNTIME_REGEX_CACHE_ENTRIES;
 use crate::error::{Error, Result};
 
 /// Default compiled-regex size limit (1 MB).
@@ -17,6 +21,56 @@ pub(crate) const REGEX_DFA_SIZE_LIMIT: usize = 1_000_000;
 /// Bounds worst-case backtracking so a pathological pattern can't hang the
 /// sandbox (mirrors `sed.rs`'s fallback limit; see TM-INF threat model).
 pub(crate) const FANCY_BACKTRACK_LIMIT: usize = 1_000_000;
+
+/// THREAT[TM-DOS-023]: Per-evaluator cache for regex operands compiled during
+/// execution, preventing repeated compilation from consuming the CPU budget.
+///
+/// Both successful and failed compilations are retained. Entry count bounds
+/// compiled programs; retained pattern text shares [`REGEX_SIZE_LIMIT`].
+#[derive(Default)]
+pub(crate) struct RuntimeRegexCache {
+    entries: HashMap<Arc<str>, Option<Regex>>,
+    insertion_order: VecDeque<Arc<str>>,
+    pattern_bytes: usize,
+    #[cfg(test)]
+    compile_count: usize,
+}
+
+impl RuntimeRegexCache {
+    pub(crate) fn get_or_compile(&mut self, pattern: &str) -> Option<Regex> {
+        if let Some(regex) = self.entries.get(pattern) {
+            return regex.clone();
+        }
+        if pattern.len() > REGEX_SIZE_LIMIT {
+            return None;
+        }
+
+        #[cfg(test)]
+        {
+            self.compile_count += 1;
+        }
+        let regex = build_regex(pattern).ok();
+        while self.entries.len() >= RUNTIME_REGEX_CACHE_ENTRIES
+            || self.pattern_bytes + pattern.len() > REGEX_SIZE_LIMIT
+        {
+            let Some(oldest) = self.insertion_order.pop_front() else {
+                break;
+            };
+            self.pattern_bytes -= oldest.len();
+            self.entries.remove(oldest.as_ref());
+        }
+        let key: Arc<str> = Arc::from(pattern);
+        self.pattern_bytes += key.len();
+        self.insertion_order.push_back(Arc::clone(&key));
+        self.entries.insert(key, regex.clone());
+        regex
+    }
+
+    #[cfg(test)]
+    pub(crate) fn compile_count(&self) -> usize {
+        self.compile_count
+    }
+}
 
 /// Build a regex with enforced size limits.
 pub(crate) fn build_regex(pattern: &str) -> std::result::Result<Regex, regex::Error> {
@@ -159,5 +213,26 @@ mod tests {
         });
 
         assert_eq!(visited, 1);
+    }
+
+    #[test]
+    fn runtime_regex_cache_retains_failures_and_bounds_entries() {
+        let mut cache = RuntimeRegexCache::default();
+        assert!(cache.get_or_compile("[").is_none());
+        assert!(cache.get_or_compile("[").is_none());
+
+        for i in 0..=RUNTIME_REGEX_CACHE_ENTRIES {
+            assert!(cache.get_or_compile(&format!("^value{i}$")).is_some());
+        }
+
+        assert_eq!(cache.compile_count(), RUNTIME_REGEX_CACHE_ENTRIES + 2);
+        assert_eq!(cache.entries.len(), RUNTIME_REGEX_CACHE_ENTRIES);
+        assert!(cache.pattern_bytes <= REGEX_SIZE_LIMIT);
+        assert!(
+            cache
+                .get_or_compile(&"x".repeat(REGEX_SIZE_LIMIT + 1))
+                .is_none()
+        );
+        assert_eq!(cache.compile_count(), RUNTIME_REGEX_CACHE_ENTRIES + 2);
     }
 }

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -53,6 +53,7 @@ const OPERAND_QUOTE_MARK_CANDIDATES: &[char] = &[
 
 use futures_util::FutureExt;
 
+use crate::builtins::search_common::RuntimeRegexCache;
 use crate::builtins::{self, Builtin};
 #[cfg(feature = "failpoints")]
 use crate::error::Error;
@@ -1167,6 +1168,8 @@ pub struct Interpreter {
     /// Aliases currently being expanded (prevents infinite recursion).
     /// When alias `foo` expands to `foo bar`, the inner `foo` is not re-expanded.
     expanding_aliases: HashSet<String>,
+    /// THREAT[TM-DOS-023]: Bounded cache for repeated `[[ value =~ pattern ]]` evaluations.
+    regex_cache: RuntimeRegexCache,
     /// Command history entries for the current session.
     history: Vec<HistoryEntry>,
     /// Retained command/cwd bytes for bounded history accounting.
@@ -1614,6 +1617,7 @@ impl Interpreter {
             nounset_error: None,
             pipestatus: Vec::new(),
             expanding_aliases: HashSet::new(),
+            regex_cache: RuntimeRegexCache::default(),
             history: Vec::new(),
             history_bytes: 0,
             history_saved_entries: 0,
@@ -1907,6 +1911,7 @@ impl Interpreter {
         }
         self.getopts_char_idx = 0;
         self.pipeline_stdin = None;
+        self.regex_cache = RuntimeRegexCache::default();
         self.bash_source_stack.clear();
         self.arrays_mut().remove("BASH_SOURCE");
     }
@@ -3724,8 +3729,8 @@ impl Interpreter {
 
     /// Perform regex match and set BASH_REMATCH array.
     fn regex_match(&mut self, string: &str, pattern: &str) -> bool {
-        match regex::Regex::new(pattern) {
-            Ok(re) => {
+        match self.regex_cache.get_or_compile(pattern) {
+            Some(re) => {
                 if let Some(captures) = re.captures(string) {
                     // Set BASH_REMATCH array
                     let mut rematch = HashMap::new();
@@ -3740,7 +3745,7 @@ impl Interpreter {
                     false
                 }
             }
-            Err(_) => {
+            None => {
                 self.arrays_mut().remove("BASH_REMATCH");
                 false
             }
@@ -11380,6 +11385,18 @@ echo "count=$COUNT"
             .await
             .unwrap();
         assert_eq!(result.stdout.trim(), "match");
+    }
+
+    #[test]
+    fn repeated_conditional_regex_compiles_once() {
+        let fs: Arc<dyn FileSystem> = Arc::new(InMemoryFs::new());
+        let mut interp = Interpreter::new(fs);
+
+        for _ in 0..300_000 {
+            assert!(interp.regex_match("bytes=123", "^bytes="));
+        }
+
+        assert_eq!(interp.regex_cache.compile_count(), 1);
     }
 
     #[tokio::test]

--- a/knowledge/operations/limitations.md
+++ b/knowledge/operations/limitations.md
@@ -116,13 +116,15 @@ pass in CI); only divergences and boundaries are recorded here.
 |----|------|------------|----------|
 | L-AWK-001 | awk | Some complex regex patterns unsupported (engine shared with sed/grep, size-limited) | stance |
 | L-JQ-001 | jq | Alternative `//`: jaq errors on `.foo` applied to null instead of returning null (upstream jaq divergence) | 1 skipped spec test |
+| L-JQ-002 | jq | Regex natives compile the pattern per filter invocation; mapping `test`/`match`/`split` over many inputs can repeat compilation because jaq's native callback has no per-run cache state | `regex_compat.rs::re_native` |
 | L-GREP-001 | grep | `--color`/`--colour`, `--line-buffered` accepted as no-ops | `l_grep_001_noop_flags` |
 | L-CURL-001 | curl | Spec-test coverage for methods/headers/auth/redirects not ported (needs `http_client` + allowlist in harness); payload behavior has integration and real-curl differential coverage | stance |
 | L-CURL-002 | curl/wget | Unknown options are ignored for compatibility, not rejected (real curl/wget error); deliberate leniency | `curl.rs` |
 | L-STR-001 | strings | Accepts dash-prefixed filenames (e.g. `-data.bin`), so only a lone unknown short option (`-Q`) is rejected as invalid; GNU rejects `-data.bin` too | `strings.rs` |
 
 Safety boundaries (enforced, not bugs): printf width/precision caps,
-output buffer caps, getline file-cache cap, shared regex size limit,
+output buffer caps, getline file-cache cap, shared regex size limit, runtime regex
+cache cap (64 entries and 1 MB retained pattern text per evaluator),
 curl/wget timeouts clamped to [1, 600] s, multipart field-name
 sanitization, redirect handling hardened against credential leaks, and curl's
 aggregate data/multipart request body capped at 10 MB. Repeated mixed curl

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -246,7 +246,7 @@ runaway scripts without permanently breaking the session.
 
 | ID | Threat | Attack Vector | Mitigation | Status |
 |----|--------|--------------|------------|--------|
-| TM-DOS-023 | Long computation | Complex awk/sed regex | Timeout (30s) | **MITIGATED** |
+| TM-DOS-023 | Long computation | Complex awk/sed regex, including repeated evaluation of dynamic awk and `[[ =~ ]]` operands | Linear-time regex engine; runtime regex compilation cached per evaluator (64 entries / 1 MB retained pattern text, including invalid patterns); timeout (30s) | **MITIGATED** |
 | TM-DOS-024 | Parser hang | Malformed input | `parser_timeout` (5s) + `max_parser_operations` | **MITIGATED** |
 | TM-DOS-025 | Regex backtrack | `grep "a](*b)*c" file`; `grep -P '(a+)+$' file` | Default `regex` engine is linear-time; `grep -P`/`sed` fancy-regex paths capped by `FANCY_BACKTRACK_LIMIT` (1M steps) — exceeding it yields "no match", not a hang | **MITIGATED** |
 | TM-DOS-027 | Builtin parser recursion | Deeply nested awk/jq expressions | `MAX_AWK_PARSER_DEPTH` (100) + `MAX_JQ_JSON_DEPTH` (100) | **MITIGATED** |

--- a/site/src/data/performance-timeline.json
+++ b/site/src/data/performance-timeline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-22T22:43:59.000Z",
+  "generatedAt": "2026-08-05T18:01:47.000Z",
   "sources": {
     "bench": "crates/bashkit-bench/results/*.json",
     "criterion": "crates/bashkit/benches/results/*.md",
@@ -7,7 +7,7 @@
   },
   "summary": {
     "benchRuns": 6,
-    "criterionRuns": 7,
+    "criterionRuns": 9,
     "evalRuns": 38,
     "latestBench": {
       "id": "bench-vm-linux-x86_64-1779764460",
@@ -1206,6 +1206,48 @@
       "fastestCase": {
         "name": "single_bash_new",
         "us": 39.9
+      },
+      "bestImprovement": null
+    },
+    {
+      "id": "criterion-snapshot-history-baseline-linux-x86_64-1785444523",
+      "kind": "criterion",
+      "family": "snapshot",
+      "label": "criterion — snapshot_history — baseline",
+      "date": "2026-07-30",
+      "timestamp": "2026-07-30T20:48:43.000Z",
+      "source": "crates/bashkit/benches/results/criterion-snapshot-history-baseline-linux-x86_64-1785444523.md",
+      "reportSource": "crates/bashkit/benches/results/criterion-snapshot-history-baseline-linux-x86_64-1785444523.md",
+      "cases": 3,
+      "medianUs": 1260,
+      "p95Us": 1269,
+      "medianChangePct": null,
+      "meanChangePct": null,
+      "bestChangePct": null,
+      "fastestCase": {
+        "name": "case",
+        "us": 149
+      },
+      "bestImprovement": null
+    },
+    {
+      "id": "criterion-awk-regex-mykhailos-mini-darwin-arm64-1785952907",
+      "kind": "criterion",
+      "family": "awk",
+      "label": "Criterion AWK Runtime Regex Benchmark",
+      "date": "2026-08-05",
+      "timestamp": "2026-08-05T18:01:47.000Z",
+      "source": "crates/bashkit/benches/results/criterion-awk-regex-mykhailos-mini-darwin-arm64-1785952907.md",
+      "reportSource": "crates/bashkit/benches/results/criterion-awk-regex-mykhailos-mini-darwin-arm64-1785952907.md",
+      "cases": 4,
+      "medianUs": 135730,
+      "p95Us": 356601,
+      "medianChangePct": null,
+      "meanChangePct": null,
+      "bestChangePct": null,
+      "fastestCase": {
+        "name": "`top_level_pattern` (`/bytes=1/`)",
+        "us": 39010
       },
       "bestImprovement": null
     }
@@ -4909,6 +4951,24 @@
       "detail": "single_bash_new at 39.9 us median",
       "metric": 5296.8,
       "source": "crates/bashkit/benches/results/criterion-parallel-vm-linux-x86_64-1782168239.md"
+    },
+    {
+      "date": "2026-07-30",
+      "timestamp": "2026-07-30T20:48:43.000Z",
+      "kind": "Criterion",
+      "title": "snapshot",
+      "detail": "case at 149 us median",
+      "metric": 1260,
+      "source": "crates/bashkit/benches/results/criterion-snapshot-history-baseline-linux-x86_64-1785444523.md"
+    },
+    {
+      "date": "2026-08-05",
+      "timestamp": "2026-08-05T18:01:47.000Z",
+      "kind": "Criterion",
+      "title": "awk",
+      "detail": "`top_level_pattern` (`/bytes=1/`) at 39010 us median",
+      "metric": 135730,
+      "source": "crates/bashkit/benches/results/criterion-awk-regex-mykhailos-mini-darwin-arm64-1785952907.md"
     }
   ]
 }


### PR DESCRIPTION
## What changed
Cache runtime-compiled regexes per evaluator for AWK expression/function operands and Bash conditional regex matches. Successful and invalid patterns share bounded 64-entry / 1 MB caches and existing regex compilation limits.

Add and store a Criterion benchmark covering 300,000 anchored and unanchored AWK field evaluations, the index-prefix control, and the already-precompiled top-level pattern.

Audit adjacent paths: grep and sed already compile once per command. jq regex natives can still compile once per filter callback; that constraint is recorded as L-JQ-002 for focused follow-up.

## Why
AWK ~ and !~ compiled their operand on every evaluation. Compilation dominated runtime, especially for anchored patterns, and the same issue existed in repeated Bash conditional regex evaluation.

## Before / After
Before: the reported 50k-line anchored AWK expression took 8.58 s for 300k evaluations. A deterministic pre-fix test observed 10,000 compilations across 10,000 evaluations.

After: tests observe exactly one compilation across 300,000 repeated evaluations. The stored release benchmark on Darwin arm64 measures:
- anchored expression: 392.37 ms / 300k evaluations
- unanchored expression: 153.91 ms / 300k evaluations
- index-prefix control: 117.55 ms / 300k evaluations
- parser-compiled top-level pattern: 39.01 ms / 50k lines

CLI smoke output:
- AWK anchored scan: 50000
- repeated Bash conditional regex: shell-regex-ok

## Risk
- Low
- Cache eviction could affect performance only; regex semantics remain unchanged.
- Cache lifetime is one evaluator/top-level execution and retained data is bounded.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] just test
- [x] just pre-pr
- [x] just check-okf
- [x] just check-doc-links
- [x] Criterion benchmark stored