### PR TITLE
feat(streams): preserve byte-native shell transport

### DIFF
--- a/crates/bashkit-bench/src/runners.rs
+++ b/crates/bashkit-bench/src/runners.rs
@@ -75,7 +75,11 @@ impl BashkitRunner {
 async fn run_bashkit(script: &str) -> Result<(String, String, i32)> {
     let mut bash = Bash::builder().build();
     let result = bash.exec(script).await?;
-    Ok((result.stdout, result.stderr, result.exit_code))
+    Ok((
+        result.stdout.to_string(),
+        result.stderr.to_string(),
+        result.exit_code,
+    ))
 }
 
 // === Out-of-process bashkit CLI ===

--- a/crates/bashkit-capi/src/lib.rs
+++ b/crates/bashkit-capi/src/lib.rs
@@ -429,9 +429,7 @@ pub unsafe extern "C" fn bashkit_execute(
             let result = runtime
                 .block_on(bash.exec(script))
                 .map_err(ApiFailure::from_bash)?;
-            let stdout = result
-                .stdout_bytes
-                .unwrap_or_else(|| result.stdout.into_bytes());
+            let stdout = result.stdout.into_bytes();
             let mut flags = 0;
             if result.stdout_truncated {
                 flags |= BASHKIT_RESULT_STDOUT_TRUNCATED;

--- a/crates/bashkit-capi/tests/abi.rs
+++ b/crates/bashkit-capi/tests/abi.rs
@@ -56,6 +56,34 @@ fn creates_executes_and_preserves_shell_exit_status() {
 }
 
 #[test]
+fn execute_returns_exact_binary_stdout() {
+    unsafe {
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_default(&mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+        let mut result = ptr::null_mut();
+        assert_eq!(
+            bashkit_execute(
+                bash,
+                bytes(b"printf 'AAH//g==' | base64 -d | cat"),
+                &mut result,
+                &mut error,
+            ),
+            BashkitStatus::Ok
+        );
+        assert_eq!(
+            borrowed(bashkit_result_stdout(result)),
+            [0x00, 0x01, 0xff, 0xfe]
+        );
+        bashkit_result_free(result);
+        bashkit_free(bash);
+    }
+}
+
+#[test]
 fn configures_environment_files_limits_and_final_environment() {
     unsafe {
         let config = br#"{

--- a/crates/bashkit-cli/src/main.rs
+++ b/crates/bashkit-cli/src/main.rs
@@ -339,12 +339,9 @@ fn run_interactive(args: Args, mode: CliMode) -> Result<i32> {
 /// front, so this reads to EOF before execution starts (L-CLI-002).
 /// `--no-stdin` opts out for callers that inherit a pipe nobody will close.
 ///
-/// Non-UTF-8 input is replaced, not rejected — the interpreter's stdin is a
-/// `String`, and failing the run would be worse than lossy bytes for the
-/// text-processing pipelines this feeds.
 // THREAT[TM-DOS-095]: bounded read; an unbounded producer cannot grow the
 // buffer past MAX_STDIN_BYTES.
-fn read_host_stdin() -> Result<String> {
+fn read_host_stdin() -> Result<Vec<u8>> {
     use std::io::Read;
 
     let mut buf = Vec::new();
@@ -359,7 +356,7 @@ fn read_host_stdin() -> Result<String> {
             MAX_STDIN_BYTES / (1024 * 1024)
         );
     }
-    Ok(String::from_utf8_lossy(&buf).into_owned())
+    Ok(buf)
 }
 
 /// Split the parsed arguments into `$0` and the positional parameters.

--- a/crates/bashkit-eval/src/agent.rs
+++ b/crates/bashkit-eval/src/agent.rs
@@ -141,7 +141,7 @@ pub async fn run_agent_loop(
                 .unwrap_or("");
 
             let (stdout, stderr, exit_code) = match bash.exec(commands).await {
-                Ok(r) => (r.stdout, r.stderr, r.exit_code),
+                Ok(r) => (r.stdout.to_string(), r.stderr.to_string(), r.exit_code),
                 Err(e) => (String::new(), e.to_string(), 1),
             };
 

--- a/crates/bashkit-js/__test__/builtins.spec.ts
+++ b/crates/bashkit-js/__test__/builtins.spec.ts
@@ -259,6 +259,11 @@ test("base64 encode and decode", (t) => {
   );
 });
 
+test("binary stdout bytes are exact", (t) => {
+  const result = new Bash().executeSync("printf 'AAH//g==' | base64 -d | cat");
+  t.deepEqual(Array.from(result.stdoutBytes), [0x00, 0x01, 0xff, 0xfe]);
+});
+
 // ============================================================================
 // seq
 // ============================================================================

--- a/crates/bashkit-js/__test__/runtime-compat/builtins.test.mjs
+++ b/crates/bashkit-js/__test__/runtime-compat/builtins.test.mjs
@@ -77,6 +77,11 @@ describe("builtins", () => {
     assert.equal(bash.executeSync(`echo -n '${encoded}' | base64 -d`).stdout, "hello");
   });
 
+  it("returns exact binary stdout bytes", () => {
+    const result = new Bash().executeSync("printf 'AAH//g==' | base64 -d | cat");
+    assert.deepEqual(Array.from(result.stdoutBytes), [0x00, 0x01, 0xff, 0xfe]);
+  });
+
   it("jq JSON processing", () => {
     const bash = new Bash();
     assert.equal(

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -728,7 +728,9 @@ pub fn file_system_copy(
 #[derive(Clone)]
 pub struct ExecResult {
     pub stdout: String,
+    pub stdout_bytes: Vec<u8>,
     pub stderr: String,
+    pub stderr_bytes: Vec<u8>,
     pub exit_code: i32,
     pub error: Option<String>,
     pub stdout_truncated: bool,
@@ -802,9 +804,13 @@ type OutputTsfn = napi::threadsafe_function::ThreadsafeFunction<
 >;
 
 fn js_exec_result_from_rust(result: RustExecResult) -> ExecResult {
+    let stdout_bytes = result.stdout.as_bytes().to_vec();
+    let stderr_bytes = result.stderr.as_bytes().to_vec();
     ExecResult {
-        stdout: result.stdout,
-        stderr: result.stderr,
+        stdout: result.stdout.to_string(),
+        stdout_bytes,
+        stderr: result.stderr.to_string(),
+        stderr_bytes,
         exit_code: result.exit_code,
         error: None,
         stdout_truncated: result.stdout_truncated,
@@ -818,7 +824,9 @@ fn js_exec_result_from_error(err: impl ToString) -> ExecResult {
     let msg = err.to_string();
     ExecResult {
         stdout: String::new(),
+        stdout_bytes: Vec::new(),
         stderr: msg.clone(),
+        stderr_bytes: msg.as_bytes().to_vec(),
         exit_code: 1,
         error: Some(msg),
         stdout_truncated: false,
@@ -3209,9 +3217,13 @@ impl ScriptedTool {
             })
             .await
         });
+        let stdout_bytes = resp.stdout.as_bytes().to_vec();
+        let stderr_bytes = resp.stderr.as_bytes().to_vec();
         Ok(ExecResult {
             stdout: resp.stdout,
+            stdout_bytes,
             stderr: resp.stderr,
+            stderr_bytes,
             exit_code: resp.exit_code,
             error: resp.error,
             stdout_truncated: resp.stdout_truncated,
@@ -3231,9 +3243,13 @@ impl ScriptedTool {
                 timeout_ms: None,
             })
             .await;
+        let stdout_bytes = resp.stdout.as_bytes().to_vec();
+        let stderr_bytes = resp.stderr.as_bytes().to_vec();
         Ok(ExecResult {
             stdout: resp.stdout,
+            stdout_bytes,
             stderr: resp.stderr,
+            stderr_bytes,
             exit_code: resp.exit_code,
             error: resp.error,
             stdout_truncated: resp.stdout_truncated,

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -392,7 +392,9 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
 function errorExecResult(error: string): ExecResult {
   return {
     stdout: "",
+    stdoutBytes: [],
     stderr: error,
+    stderrBytes: Array.from(Buffer.from(error, "utf8")),
     exitCode: 1,
     error,
     stdoutTruncated: false,
@@ -406,7 +408,9 @@ function cancelledExecResult(): ExecResult {
   // Preserve prior behavior: cancellation does not populate stderr.
   return {
     stdout: "",
+    stdoutBytes: [],
     stderr: "",
+    stderrBytes: [],
     exitCode: 1,
     error: "execution cancelled",
     stdoutTruncated: false,

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -2473,7 +2473,11 @@ pub struct ExecResult {
     #[pyo3(get)]
     pub stdout: String,
     #[pyo3(get)]
+    pub stdout_bytes: Vec<u8>,
+    #[pyo3(get)]
     pub stderr: String,
+    #[pyo3(get)]
+    pub stderr_bytes: Vec<u8>,
     #[pyo3(get)]
     pub exit_code: i32,
     #[pyo3(get)]
@@ -2796,9 +2800,13 @@ impl BuiltinResult {
 // ============================================================================
 
 fn py_exec_result_from_rust(result: RustExecResult) -> ExecResult {
+    let stdout_bytes = result.stdout.as_bytes().to_vec();
+    let stderr_bytes = result.stderr.as_bytes().to_vec();
     ExecResult {
-        stdout: result.stdout,
-        stderr: result.stderr,
+        stdout: result.stdout.to_string(),
+        stdout_bytes,
+        stderr: result.stderr.to_string(),
+        stderr_bytes,
         exit_code: result.exit_code,
         error: None,
         stdout_truncated: result.stdout_truncated,
@@ -2811,7 +2819,9 @@ fn py_exec_result_from_error(err: impl ToString) -> ExecResult {
     let msg = err.to_string();
     ExecResult {
         stdout: String::new(),
+        stdout_bytes: Vec::new(),
         stderr: msg.clone(),
+        stderr_bytes: msg.as_bytes().to_vec(),
         exit_code: 1,
         error: Some(msg),
         stdout_truncated: false,
@@ -2952,7 +2962,7 @@ fn make_py_builtin_context(
         PyBuiltinContext {
             name: name.to_string(),
             argv: ctx.args.to_vec(),
-            stdin: ctx.stdin.map(str::to_owned),
+            stdin: ctx.stdin.map(ToString::to_string),
             env: ctx.env.clone(),
             cwd: ctx.cwd.to_string_lossy().into_owned(),
             fs,
@@ -3873,8 +3883,8 @@ fn extract_custom_builtin_callback_result(
 
     if let Ok(shell_result) = result.extract::<PyRef<'_, BuiltinResult>>() {
         return Ok(RustExecResult {
-            stdout: shell_result.stdout.clone(),
-            stderr: shell_result.stderr.clone(),
+            stdout: shell_result.stdout.clone().into(),
+            stderr: shell_result.stderr.clone().into(),
             exit_code: shell_result.exit_code,
             ..Default::default()
         });
@@ -4088,7 +4098,11 @@ fn build_python_output_callback(
             // Re-enter the caller's copied ContextVar snapshot for each chunk.
             let result = on_output.context.bind(py).call_method1(
                 "run",
-                (on_output.callback.bind(py), stdout_chunk, stderr_chunk),
+                (
+                    on_output.callback.bind(py),
+                    stdout_chunk.to_string(),
+                    stderr_chunk.to_string(),
+                ),
             )?;
             let is_awaitable = on_output
                 .is_awaitable
@@ -6362,9 +6376,13 @@ impl ScriptedTool {
                     timeout_ms: None,
                 })
                 .await;
+            let stdout_bytes = resp.stdout.as_bytes().to_vec();
+            let stderr_bytes = resp.stderr.as_bytes().to_vec();
             Ok(ExecResult {
                 stdout: resp.stdout,
+                stdout_bytes,
                 stderr: resp.stderr,
+                stderr_bytes,
                 exit_code: resp.exit_code,
                 error: resp.error,
                 stdout_truncated: resp.stdout_truncated,
@@ -6397,9 +6415,13 @@ impl ScriptedTool {
                 .await
             })
         });
+        let stdout_bytes = resp.stdout.as_bytes().to_vec();
+        let stderr_bytes = resp.stderr.as_bytes().to_vec();
         Ok(ExecResult {
             stdout: resp.stdout,
+            stdout_bytes,
             stderr: resp.stderr,
+            stderr_bytes,
             exit_code: resp.exit_code,
             error: resp.error,
             stdout_truncated: resp.stdout_truncated,

--- a/crates/bashkit-python/tests/test_builtins.py
+++ b/crates/bashkit-python/tests/test_builtins.py
@@ -293,6 +293,11 @@ def test_builtin_base64_encodes_and_decodes():
     assert decoded.stdout == "hello"
 
 
+def test_binary_stdout_bytes_are_exact():
+    result = Bash().execute_sync("printf 'AAH//g==' | base64 -d | cat")
+    assert bytes(result.stdout_bytes) == b"\x00\x01\xff\xfe"
+
+
 def test_builtin_seq_generates_range():
     bash = Bash()
     result = bash.execute_sync("seq 3 5")

--- a/crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
+++ b/crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs
@@ -61,6 +61,12 @@ test("sync: stderr is captured", () => {
   assert.equal(r.stderr, "oops\n");
 });
 
+test("sync: binary stdout bytes are exact", () => {
+  const bash = new Bash();
+  const r = bash.executeSync("printf 'AAH//g==' | base64 -d | cat");
+  assert.deepEqual(Array.from(r.stdoutBytes), [0x00, 0x01, 0xff, 0xfe]);
+});
+
 // --- Child shell (bash / sh builtin) ---------------------------------------
 // Regression: the bash/sh builtin re-parses its child script. On
 // wasm32-unknown-unknown that parse must run inline — the native path wraps it
@@ -178,7 +184,10 @@ test("output is capped and reports truncation", () => {
 
 test("options: seeded files", () => {
   const bash = new Bash({ files: { "/config.json": '{"debug":true}' } });
-  assert.equal(bash.executeSync("jq -c .debug /config.json").stdout.trim(), "true");
+  assert.equal(
+    bash.executeSync("jq -c .debug /config.json").stdout.trim(),
+    "true",
+  );
 });
 
 // --- Virtual filesystem (Bash helpers) -------------------------------------
@@ -278,7 +287,9 @@ test("async builtin under executeSync fails fast without invoking callback", () 
 
 test("sync builtin works under executeSync", () => {
   const bash = new Bash({
-    customBuiltins: { shout: (ctx) => (ctx.argv[0] ?? "").toUpperCase() + "\n" },
+    customBuiltins: {
+      shout: (ctx) => (ctx.argv[0] ?? "").toUpperCase() + "\n",
+    },
   });
   assert.equal(bash.executeSync("shout hello").stdout, "HELLO\n");
 });

--- a/crates/bashkit-wasm/js/index.d.ts
+++ b/crates/bashkit-wasm/js/index.d.ts
@@ -59,7 +59,11 @@ export interface BashOptions {
 /** Result of a bash execution. */
 export interface ExecResult {
   readonly stdout: string;
+  /** Exact stdout bytes. Use this for binary output. */
+  readonly stdoutBytes: Uint8Array;
   readonly stderr: string;
+  /** Exact stderr bytes. Use this for binary output. */
+  readonly stderrBytes: Uint8Array;
   readonly exitCode: number;
   readonly success: boolean;
   readonly stdoutTruncated: boolean;

--- a/crates/bashkit-wasm/src/lib.rs
+++ b/crates/bashkit-wasm/src/lib.rs
@@ -50,7 +50,11 @@ pub fn __start() {
 #[wasm_bindgen(getter_with_clone)]
 pub struct ExecResult {
     pub stdout: String,
+    #[wasm_bindgen(js_name = stdoutBytes)]
+    pub stdout_bytes: Vec<u8>,
     pub stderr: String,
+    #[wasm_bindgen(js_name = stderrBytes)]
+    pub stderr_bytes: Vec<u8>,
     #[wasm_bindgen(js_name = exitCode)]
     pub exit_code: i32,
     pub success: bool,
@@ -64,8 +68,10 @@ impl From<CoreExecResult> for ExecResult {
     fn from(r: CoreExecResult) -> Self {
         ExecResult {
             success: r.exit_code == 0,
-            stdout: r.stdout,
-            stderr: r.stderr,
+            stdout: r.stdout.to_string(),
+            stdout_bytes: r.stdout.as_bytes().to_vec(),
+            stderr: r.stderr.to_string(),
+            stderr_bytes: r.stderr.as_bytes().to_vec(),
             exit_code: r.exit_code,
             stdout_truncated: r.stdout_truncated,
             stderr_truncated: r.stderr_truncated,
@@ -184,7 +190,7 @@ impl Builtin for JsBuiltin {
         let request = BuiltinRequest {
             name: &self.name,
             argv: ctx.args,
-            stdin: ctx.stdin,
+            stdin: ctx.stdin.map(|stdin| &**stdin),
             env: ctx.env,
             cwd: ctx.cwd.to_string_lossy().into_owned(),
         };

--- a/crates/bashkit/docs/custom_builtins.md
+++ b/crates/bashkit/docs/custom_builtins.md
@@ -253,8 +253,9 @@ previous command:
 
 ```rust,ignore
 // echo "hello" | mycommand
-let input = ctx.stdin.unwrap_or("");
-let processed = input.to_uppercase();
+let input = ctx.stdin.expect("pipeline input");
+let exact_bytes = input.as_bytes();
+let processed = input.text_lossy().to_uppercase(); // explicit text boundary
 ```
 
 ## Return Values
@@ -263,11 +264,16 @@ Builtins return `Result<ExecResult>`:
 
 ```rust,ignore
 pub struct ExecResult {
-    pub stdout: String,
-    pub stderr: String,
+    pub stdout: StreamData,
+    pub stderr: StreamData,
     pub exit_code: i32,
 }
 ```
+
+`StreamData` preserves exact bytes. Use `ExecResult::ok_bytes` for binary
+output, `as_bytes()`/`into_bytes()` for byte consumers, and `text()` or
+`text_lossy()` only for text-oriented consumers. Shell variables and command
+substitution are text-only; command substitution removes NUL bytes.
 
 Helper constructors:
 

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -538,6 +538,7 @@ All unexpected errors are caught and converted to safe, human-readable messages.
 | Stack trace exposure (TM-INT-006) | Panic unwinds show call stack | `catch_unwind` prevents propagation | MITIGATED |
 | /dev/urandom empty with head -c (TM-INT-007) | `head -c 16 /dev/urandom` returns empty | Fix virtual device pipe handling | **MITIGATED** |
 | C ABI unwind (TM-INT-008) | Rust panic enters a foreign runtime or leaks details | Catch every exported operation and return a generic error | **MITIGATED** |
+| Binary output bypasses resource limits (TM-INT-009) | Invalid UTF-8 exceeds configured caps when counted as text | Byte-native accumulation and callbacks truncate by exact byte length | **MITIGATED** |
 
 **Panic Recovery:**
 

--- a/crates/bashkit/examples/custom_builtins.rs
+++ b/crates/bashkit/examples/custom_builtins.rs
@@ -34,7 +34,10 @@ struct Upper;
 #[async_trait]
 impl Builtin for Upper {
     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx
+            .stdin
+            .map(|stdin| stdin.text_lossy())
+            .unwrap_or_default();
         Ok(ExecResult::ok(input.to_uppercase()))
     }
 }

--- a/crates/bashkit/src/builtins/alias.rs
+++ b/crates/bashkit/src/builtins/alias.rs
@@ -56,8 +56,8 @@ impl Builtin for Alias {
         }
 
         Ok(ExecResult {
-            stdout: output,
-            stderr,
+            stdout: output.into(),
+            stderr: stderr.into(),
             exit_code,
             ..Default::default()
         })
@@ -101,7 +101,7 @@ impl Builtin for Unalias {
         }
 
         Ok(ExecResult {
-            stderr,
+            stderr: stderr.into(),
             exit_code,
             ..Default::default()
         })

--- a/crates/bashkit/src/builtins/archive.rs
+++ b/crates/bashkit/src/builtins/archive.rs
@@ -291,10 +291,9 @@ async fn create_tar(
 
     // Write to file or stdout
     if archive_name == "-" {
-        // Convert to lossy string for stdout
         return Ok(ExecResult {
-            stdout: String::from_utf8_lossy(&final_data).to_string(),
-            stderr: verbose_output,
+            stdout: final_data.into(),
+            stderr: verbose_output.into(),
             exit_code: 0,
             control_flow: crate::interpreter::ControlFlow::None,
             ..Default::default()
@@ -305,8 +304,8 @@ async fn create_tar(
     ctx.fs.write_file(&archive_path, &final_data).await?;
 
     Ok(ExecResult {
-        stdout: String::new(),
-        stderr: verbose_output,
+        stdout: crate::StreamData::new(),
+        stderr: verbose_output.into(),
         exit_code: 0,
         control_flow: crate::interpreter::ControlFlow::None,
         ..Default::default()
@@ -683,8 +682,8 @@ async fn extract_tar(
     }
 
     Ok(ExecResult {
-        stdout: stdout_output,
-        stderr: verbose_output,
+        stdout: stdout_output.into(),
+        stderr: verbose_output.into(),
         exit_code: 0,
         control_flow: crate::interpreter::ControlFlow::None,
         ..Default::default()

--- a/crates/bashkit/src/builtins/awk/mod.rs
+++ b/crates/bashkit/src/builtins/awk/mod.rs
@@ -597,14 +597,14 @@ impl Builtin for Awk {
                 }
                 Self::flush_file_outputs(&interp, &ctx).await?;
                 let mut result = ExecResult::with_code(interp.output, exit_code.unwrap_or(0));
-                result.stderr = interp.stderr_output;
+                result.stderr = interp.stderr_output.into();
                 return Ok(result);
             }
         }
 
         // Process input
         let inputs: Vec<String> = if files.is_empty() {
-            vec![ctx.stdin.unwrap_or("").to_string()]
+            vec![ctx.stdin.map(ToString::to_string).unwrap_or_default()]
         } else {
             let mut inputs = Vec::new();
             for file in &files {
@@ -689,7 +689,7 @@ impl Builtin for Awk {
 
         Self::flush_file_outputs(&interp, &ctx).await?;
         let mut result = ExecResult::with_code(interp.output, exit_code.unwrap_or(0));
-        result.stderr = interp.stderr_output;
+        result.stderr = interp.stderr_output.into();
         Ok(result)
     }
 }

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -33,7 +33,7 @@ async fn run_awk(args: &[&str], stdin: Option<&str>) -> Result<ExecResult> {
         variables: &mut vars,
         cwd: &mut cwd,
         fs,
-        stdin,
+        stdin: crate::builtins::test_stream_opt(stdin),
         #[cfg(feature = "http_client")]
         http_client: None,
         #[cfg(feature = "git")]
@@ -648,7 +648,7 @@ async fn run_awk_with_fs(
         variables: &mut vars,
         cwd: &mut cwd,
         fs: fs.clone(),
-        stdin,
+        stdin: crate::builtins::test_stream_opt(stdin),
         #[cfg(feature = "http_client")]
         http_client: None,
         #[cfg(feature = "git")]
@@ -877,7 +877,7 @@ async fn run_awk_with_file(
         variables: &mut vars,
         cwd: &mut cwd,
         fs,
-        stdin,
+        stdin: crate::builtins::test_stream_opt(stdin),
         #[cfg(feature = "http_client")]
         http_client: None,
         #[cfg(feature = "git")]
@@ -1119,7 +1119,7 @@ async fn run_awk_with_custom_fs(
         variables: &mut vars,
         cwd: &mut cwd,
         fs,
-        stdin,
+        stdin: crate::builtins::test_stream_opt(stdin),
         #[cfg(feature = "http_client")]
         http_client: None,
         #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/base64.rs
+++ b/crates/bashkit/src/builtins/base64.rs
@@ -17,20 +17,6 @@ use crate::interpreter::ExecResult;
 ///   -w COLS         Wrap encoded lines after COLS characters (default: 76, 0 = no wrap)
 pub struct Base64;
 
-fn stdin_to_bytes(input: &str) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(input.len());
-    for ch in input.chars() {
-        let code = ch as u32;
-        if code <= u8::MAX as u32 {
-            bytes.push(code as u8);
-        } else {
-            let mut buf = [0; 4];
-            bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
-        }
-    }
-    bytes
-}
-
 impl BuiltinHelper for Base64 {
     const NAME: &'static str = "base64";
 }
@@ -72,11 +58,10 @@ impl Builtin for Base64 {
             }
         }
 
-        // Get input bytes: file reads must be byte-exact; stdin may contain the
-        // interpreter's Latin-1 byte-preserving surrogate string.
+        // Byte streams and files share the same exact representation.
         let input = if let Some(ref path) = file {
             if path == "-" {
-                stdin_to_bytes(ctx.stdin.unwrap_or(""))
+                ctx.stdin_bytes().unwrap_or_default().to_vec()
             } else {
                 let resolved = super::resolve_path(ctx.cwd, path);
                 match ctx.fs.read_file(&resolved).await {
@@ -87,7 +72,7 @@ impl Builtin for Base64 {
                 }
             }
         } else {
-            stdin_to_bytes(ctx.stdin.unwrap_or(""))
+            ctx.stdin_bytes().unwrap_or_default().to_vec()
         };
 
         if decode {
@@ -197,8 +182,8 @@ mod tests {
     async fn test_decode_binary_preserves_stdout_bytes() {
         let result = run_base64(&["-d"], Some("AAH//kIAfw==")).await;
         assert_eq!(
-            result.stdout_bytes.as_deref(),
-            Some(&[0x00, 0x01, 0xff, 0xfe, b'B', 0x00, 0x7f][..])
+            result.stdout.as_bytes(),
+            &[0x00, 0x01, 0xff, 0xfe, b'B', 0x00, 0x7f]
         );
     }
 

--- a/crates/bashkit/src/builtins/cat.rs
+++ b/crates/bashkit/src/builtins/cat.rs
@@ -10,7 +10,7 @@ use std::ffi::OsString;
 use std::path::Path;
 
 use super::generated::cat_args::cat_command;
-use super::{Builtin, Context, read_text_file};
+use super::{Builtin, Context};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
@@ -63,11 +63,11 @@ impl Builtin for Cat {
             .map(|vs| vs.map(|v| v.to_string_lossy().into_owned()).collect())
             .unwrap_or_default();
 
-        let mut raw = String::new();
+        let mut raw = Vec::new();
         for file in &files {
             if file == "-" {
                 if let Some(stdin) = ctx.stdin {
-                    raw.push_str(stdin);
+                    raw.extend_from_slice(stdin.as_bytes());
                 }
             } else {
                 let path = if Path::new(file).is_absolute() {
@@ -75,11 +75,16 @@ impl Builtin for Cat {
                 } else {
                     ctx.cwd.join(file).to_string_lossy().into_owned()
                 };
-                match read_text_file(&*ctx.fs, Path::new(&path), "cat").await {
-                    Ok(t) => raw.push_str(&t),
-                    Err(e) => return Ok(e),
+                match ctx.fs.read_file(Path::new(&path)).await {
+                    Ok(bytes) => raw.extend_from_slice(&bytes),
+                    Err(e) => return Ok(ExecResult::err(format!("cat: {file}: {e}\n"), 1)),
                 }
             }
+        }
+
+        if !(show_ends || show_tabs || show_nonprinting || number_all || number_nonblank || squeeze)
+        {
+            return Ok(ExecResult::ok_bytes(raw));
         }
 
         let output = render(
@@ -100,29 +105,27 @@ impl Builtin for Cat {
 /// One pass because numbering interacts with squeezing — squeezed blank
 /// lines must not be numbered. Two passes mis-number `cat -ns`.
 fn render(
-    raw: &str,
+    raw: &[u8],
     show_ends: bool,
     show_tabs: bool,
     show_nonprinting: bool,
     number_all: bool,
     number_nonblank: bool,
     squeeze: bool,
-) -> String {
-    use std::fmt::Write;
-
-    let mut out = String::with_capacity(raw.len());
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(raw.len());
     let mut counter: u64 = 0;
     let mut prev_blank = false;
 
-    let mut iter = raw.split_inclusive('\n').peekable();
+    let mut iter = raw.split_inclusive(|byte| *byte == b'\n').peekable();
     if iter.peek().is_none() {
         return out;
     }
 
     for chunk in iter {
-        let (body, sep): (&str, &str) = match chunk.strip_suffix('\n') {
-            Some(b) => (b, "\n"),
-            None => (chunk, ""),
+        let (body, has_newline): (&[u8], bool) = match chunk.strip_suffix(b"\n") {
+            Some(body) => (body, true),
+            None => (chunk, false),
         };
         let is_blank = body.is_empty();
 
@@ -133,21 +136,23 @@ fn render(
 
         if number_all || (number_nonblank && !is_blank) {
             counter += 1;
-            let _ = write!(out, "{counter:>6}\t");
+            out.extend_from_slice(format!("{counter:>6}\t").as_bytes());
         }
 
         if show_nonprinting || show_tabs {
-            for b in body.bytes() {
+            for &b in body {
                 emit_byte(&mut out, b, show_tabs, show_nonprinting);
             }
         } else {
-            out.push_str(body);
+            out.extend_from_slice(body);
         }
 
-        if show_ends && !sep.is_empty() {
-            out.push('$');
+        if show_ends && has_newline {
+            out.push(b'$');
         }
-        out.push_str(sep);
+        if has_newline {
+            out.push(b'\n');
+        }
     }
     out
 }
@@ -159,35 +164,32 @@ fn render(
 ///   show_nonprinting; passed through otherwise.
 /// - 0x7F (DEL): `^?`.
 /// - 0x80..=0xFF (high bit set): `M-` prefix + low-7-bit rendered same way.
-fn emit_byte(out: &mut String, b: u8, show_tabs: bool, show_nonprinting: bool) {
+fn emit_byte(out: &mut Vec<u8>, b: u8, show_tabs: bool, show_nonprinting: bool) {
     match b {
         b'\t' if show_tabs => {
-            out.push('^');
-            out.push('I');
+            out.extend_from_slice(b"^I");
         }
-        b'\t' => out.push('\t'),
-        b'\n' => out.push('\n'),
+        b'\t' => out.push(b'\t'),
+        b'\n' => out.push(b'\n'),
         0..=31 if show_nonprinting => {
-            out.push('^');
-            out.push((b + 64) as char);
+            out.push(b'^');
+            out.push(b + 64);
         }
         0x7f if show_nonprinting => {
-            out.push('^');
-            out.push('?');
+            out.extend_from_slice(b"^?");
         }
         128..=255 if show_nonprinting => {
-            out.push_str("M-");
+            out.extend_from_slice(b"M-");
             let low = b & 0x7f;
             if (0..32).contains(&low) {
-                out.push('^');
-                out.push((low + 64) as char);
+                out.push(b'^');
+                out.push(low + 64);
             } else if low == 0x7f {
-                out.push('^');
-                out.push('?');
+                out.extend_from_slice(b"^?");
             } else {
-                out.push(low as char);
+                out.push(low);
             }
         }
-        _ => out.push(b as char),
+        _ => out.push(b),
     }
 }

--- a/crates/bashkit/src/builtins/checksum.rs
+++ b/crates/bashkit/src/builtins/checksum.rs
@@ -121,9 +121,9 @@ async fn checksum_execute<D: Digest>(ctx: &Context<'_>, cmd: &str) -> Result<Exe
     Ok(ExecResult::ok(output))
 }
 
-fn write_stdin_digest<D: Digest>(stdin: Option<&str>, output: &mut String) {
-    let input = stdin.unwrap_or("");
-    let hash = hex_digest::<D>(input.as_bytes());
+fn write_stdin_digest<D: Digest>(stdin: Option<&crate::StreamData>, output: &mut String) {
+    let input = stdin.map(crate::StreamData::as_bytes).unwrap_or_default();
+    let hash = hex_digest::<D>(input);
     output.push_str(&hash);
     output.push_str("  -\n");
 }
@@ -159,7 +159,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/column.rs
+++ b/crates/bashkit/src/builtins/column.rs
@@ -226,7 +226,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/comm.rs
+++ b/crates/bashkit/src/builtins/comm.rs
@@ -208,7 +208,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/csv.rs
+++ b/crates/bashkit/src/builtins/csv.rs
@@ -397,7 +397,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/curl.rs
+++ b/crates/bashkit/src/builtins/curl.rs
@@ -432,7 +432,7 @@ fn curl_body_too_large_error() -> ExecResult {
 async fn resolve_data_body(
     parts: &[CurlDataPart],
     get_mode: bool,
-    stdin: Option<&str>,
+    stdin: Option<&crate::StreamData>,
     cwd: &std::path::Path,
     fs: &dyn crate::fs::FileSystem,
 ) -> std::result::Result<Option<Vec<u8>>, Box<ExecResult>> {
@@ -467,7 +467,7 @@ async fn resolve_data_body(
 async fn resolve_curl_data_part(
     part: &CurlDataPart,
     get_mode: bool,
-    stdin: Option<&str>,
+    stdin: Option<&crate::StreamData>,
     stdin_available: &mut bool,
     cwd: &std::path::Path,
     fs: &dyn crate::fs::FileSystem,
@@ -484,7 +484,10 @@ async fn resolve_curl_data_part(
     let bytes = if let Some((path, name)) = file {
         let contents = if path == "-" {
             let contents = if *stdin_available {
-                stdin.unwrap_or("").as_bytes().to_vec()
+                stdin
+                    .map(crate::StreamData::as_bytes)
+                    .unwrap_or_default()
+                    .to_vec()
             } else {
                 Vec::new()
             };
@@ -1007,11 +1010,12 @@ async fn execute_curl_request(
                 // Check for HTTP errors if -f flag is set
                 if fail_on_error && response.status >= 400 {
                     return Ok(ExecResult {
-                        stdout: String::new(),
+                        stdout: crate::StreamData::new(),
                         stderr: format!(
                             "curl: (22) The requested URL returned error: {}\n",
                             response.status
-                        ),
+                        )
+                        .into(),
                         exit_code: 22,
                         control_flow: crate::interpreter::ControlFlow::None,
                         ..Default::default()
@@ -1528,8 +1532,8 @@ async fn execute_wget_request(
             }
 
             Ok(ExecResult {
-                stdout: String::new(),
-                stderr: stderr_msg,
+                stdout: crate::StreamData::new(),
+                stderr: stderr_msg.into(),
                 exit_code: 0,
                 control_flow: crate::interpreter::ControlFlow::None,
                 ..Default::default()
@@ -1688,7 +1692,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -1766,7 +1770,7 @@ mod tests {
         #[tokio::test]
         async fn test_curl_data_at_stdin_body_too_large() {
             let fs = InMemoryFs::new();
-            let large_body = "x".repeat(CURL_MAX_REQUEST_BODY_BYTES + 1);
+            let large_body = crate::StreamData::from("x".repeat(CURL_MAX_REQUEST_BODY_BYTES + 1));
             let parts = [CurlDataPart {
                 kind: CurlDataKind::Data,
                 value: "@-".to_string(),

--- a/crates/bashkit/src/builtins/cuttr.rs
+++ b/crates/bashkit/src/builtins/cuttr.rs
@@ -347,6 +347,36 @@ impl Builtin for Tr {
             Ok(set) => set,
             Err(msg) => return Ok(Self::err(&msg, 1)),
         };
+        if !delete && !squeeze && non_flag_args.len() < 2 {
+            return Ok(Self::err("missing operand after SET1", 1));
+        }
+        let stdin = ctx.stdin.cloned().unwrap_or_default();
+        let byte_mode =
+            ctx.env.get("LC_ALL").is_some_and(|locale| locale == "C") || stdin.text().is_err();
+        if byte_mode && set1.iter().all(|c| (*c as u32) <= u8::MAX as u32) {
+            let set2 = if non_flag_args.len() >= 2 {
+                match expand_char_set(&non_flag_args[1]) {
+                    Ok(set) => Some(set),
+                    Err(msg) => return Ok(Self::err(&msg, 1)),
+                }
+            } else {
+                None
+            };
+            if set2
+                .as_ref()
+                .is_none_or(|set| set.iter().all(|c| (*c as u32) <= u8::MAX as u32))
+            {
+                let output = translate_bytes(
+                    stdin.as_bytes(),
+                    &set1,
+                    set2.as_deref(),
+                    delete,
+                    squeeze,
+                    complement,
+                );
+                return Ok(ExecResult::ok_bytes(output));
+            }
+        }
         if complement {
             // Complement: use all byte-range chars (0-255) NOT in set1.
             // Covers full Latin-1 range so binary data from /dev/urandom
@@ -358,7 +388,7 @@ impl Builtin for Tr {
                 .collect();
         }
 
-        let stdin = ctx.stdin.unwrap_or("");
+        let stdin = &*stdin;
 
         let result = if delete && squeeze {
             // -ds: delete SET1 chars, then squeeze SET2 chars
@@ -410,6 +440,56 @@ impl Builtin for Tr {
 
         Ok(ExecResult::ok(result))
     }
+}
+
+fn translate_bytes(
+    stdin: &[u8],
+    set1: &[char],
+    set2: Option<&[char]>,
+    delete: bool,
+    squeeze: bool,
+    complement: bool,
+) -> Vec<u8> {
+    let original: Vec<u8> = set1.iter().map(|c| *c as u8).collect();
+    let effective: Vec<u8> = if complement {
+        (u8::MIN..=u8::MAX)
+            .filter(|byte| !original.contains(byte))
+            .collect()
+    } else {
+        original
+    };
+    let translated: Vec<u8> = set2
+        .map(|set| set.iter().map(|c| *c as u8).collect())
+        .unwrap_or_default();
+
+    let mut output = Vec::with_capacity(stdin.len());
+    for &byte in stdin {
+        if delete && effective.contains(&byte) {
+            continue;
+        }
+        let mapped = if !delete {
+            effective
+                .iter()
+                .position(|candidate| *candidate == byte)
+                .and_then(|position| translated.get(position).or(translated.last()))
+                .copied()
+                .unwrap_or(byte)
+        } else {
+            byte
+        };
+        let squeeze_set = if delete {
+            &translated
+        } else if translated.is_empty() {
+            &effective
+        } else {
+            &translated
+        };
+        if squeeze && output.last() == Some(&mapped) && squeeze_set.contains(&mapped) {
+            continue;
+        }
+        output.push(mapped);
+    }
+    output
 }
 
 /// Squeeze repeated consecutive characters that are in the given set
@@ -606,7 +686,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -632,7 +712,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/date.rs
+++ b/crates/bashkit/src/builtins/date.rs
@@ -512,8 +512,8 @@ impl Builtin for Date {
         // THREAT[TM-INT-003]: Invalid format strings could cause chrono to panic
         if let Err(e) = validate_format(&format) {
             return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: format!("date: {}\n", e),
+                stdout: crate::StreamData::new(),
+                stderr: format!("date: {}\n", e).into(),
                 exit_code: 1,
                 control_flow: crate::interpreter::ControlFlow::None,
                 ..Default::default()

--- a/crates/bashkit/src/builtins/diff.rs
+++ b/crates/bashkit/src/builtins/diff.rs
@@ -424,7 +424,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/environ.rs
+++ b/crates/bashkit/src/builtins/environ.rs
@@ -123,8 +123,8 @@ impl Builtin for Printenv {
         }
 
         Ok(ExecResult {
-            stdout: output,
-            stderr: String::new(),
+            stdout: output.into(),
+            stderr: crate::StreamData::new(),
             exit_code,
             control_flow: crate::interpreter::ControlFlow::None,
             ..Default::default()

--- a/crates/bashkit/src/builtins/envsubst.rs
+++ b/crates/bashkit/src/builtins/envsubst.rs
@@ -48,7 +48,7 @@ impl Builtin for Envsubst {
             }
         }
 
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
 
         if list_vars {
             // List variables found in input
@@ -196,7 +196,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/expand.rs
+++ b/crates/bashkit/src/builtins/expand.rs
@@ -68,7 +68,7 @@ impl Builtin for Expand {
         }
 
         let input = if files.is_empty() {
-            ctx.stdin.unwrap_or("").to_string()
+            ctx.stdin.map(ToString::to_string).unwrap_or_default()
         } else {
             let mut buf = String::new();
             for file in &files {
@@ -198,7 +198,7 @@ impl Builtin for Unexpand {
         }
 
         let input = if files.is_empty() {
-            ctx.stdin.unwrap_or("").to_string()
+            ctx.stdin.map(ToString::to_string).unwrap_or_default()
         } else {
             let mut buf = String::new();
             for file in &files {
@@ -340,7 +340,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -364,7 +364,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/export.rs
+++ b/crates/bashkit/src/builtins/export.rs
@@ -65,7 +65,7 @@ impl Builtin for Export {
         }
 
         Ok(ExecResult {
-            stderr,
+            stderr: stderr.into(),
             exit_code,
             ..Default::default()
         })

--- a/crates/bashkit/src/builtins/fold.rs
+++ b/crates/bashkit/src/builtins/fold.rs
@@ -63,7 +63,7 @@ impl Builtin for Fold {
         }
 
         let input = if files.is_empty() {
-            ctx.stdin.unwrap_or("").to_string()
+            ctx.stdin.map(ToString::to_string).unwrap_or_default()
         } else {
             let mut buf = String::new();
             for file in &files {
@@ -163,7 +163,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/glob_cmd.rs
+++ b/crates/bashkit/src/builtins/glob_cmd.rs
@@ -170,7 +170,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/grep.rs
+++ b/crates/bashkit/src/builtins/grep.rs
@@ -600,7 +600,7 @@ impl Builtin for Grep {
         };
         let inputs: Vec<(String, String)> = if opts.files.is_empty() {
             // Read from stdin
-            let mut stdin_content = ctx.stdin.unwrap_or("").to_string();
+            let mut stdin_content = ctx.stdin.map(ToString::to_string).unwrap_or_default();
             if opts.binary_as_text {
                 // Filter null bytes for -a flag
                 stdin_content = stdin_content.replace('\0', "");
@@ -1107,7 +1107,7 @@ mod tests {
             variables: &mut vars,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/headtail.rs
+++ b/crates/bashkit/src/builtins/headtail.rs
@@ -40,9 +40,11 @@ impl Builtin for Head {
             // Read from stdin
             if let Some(stdin) = ctx.stdin {
                 if byte_mode {
-                    output = take_first_bytes(stdin, count);
+                    return Ok(ExecResult::ok_bytes(
+                        stdin.as_bytes()[..stdin.len().min(count)].to_vec(),
+                    ));
                 } else {
-                    output = take_first_lines(stdin, count);
+                    output = take_first_lines(&stdin.text_lossy(), count);
                 }
             }
         } else {
@@ -65,14 +67,14 @@ impl Builtin for Head {
                 match ctx.fs.read_file(&path).await {
                     Ok(content) => {
                         if byte_mode {
-                            // String-backed stdout cannot carry arbitrary raw bytes. Decode
-                            // valid UTF-8 normally, and use the Latin-1 fallback only for
-                            // non-UTF-8 device/binary data such as /dev/urandom.
                             let bytes = &content[..content.len().min(count)];
-                            output.push_str(&decode_file_bytes_for_path(&path, bytes));
+                            if files.len() == 1 {
+                                return Ok(ExecResult::ok_bytes(bytes.to_vec()));
+                            }
+                            output.push_str(&String::from_utf8_lossy(bytes));
                         } else {
                             output.push_str(&take_first_lines(
-                                &decode_file_bytes_for_path(&path, &content),
+                                &String::from_utf8_lossy(&content),
                                 count,
                             ));
                         }
@@ -118,10 +120,11 @@ impl Builtin for Tail {
         if files.is_empty() {
             // Read from stdin
             if let Some(stdin) = ctx.stdin {
+                let stdin = stdin.text_lossy();
                 output = if from_start {
-                    take_from_line(stdin, num_lines)
+                    take_from_line(&stdin, num_lines)
                 } else {
-                    take_last_lines(stdin, num_lines)
+                    take_last_lines(&stdin, num_lines)
                 };
             }
         } else {
@@ -197,61 +200,6 @@ fn parse_head_args(
     }
 
     Ok((count, byte_mode, files))
-}
-
-fn normalize_vfs_path(path: &std::path::Path) -> std::path::PathBuf {
-    path.components()
-        .fold(std::path::PathBuf::new(), |mut acc, c| match c {
-            std::path::Component::ParentDir => {
-                acc.pop();
-                acc
-            }
-            std::path::Component::CurDir => acc,
-            c => {
-                acc.push(c);
-                acc
-            }
-        })
-}
-
-fn decode_file_bytes_for_path(path: &std::path::Path, bytes: &[u8]) -> String {
-    let normalized = normalize_vfs_path(path);
-    if normalized == std::path::Path::new("/dev/urandom")
-        || normalized == std::path::Path::new("/dev/random")
-    {
-        latin1_bytes_to_string(bytes)
-    } else {
-        std::str::from_utf8(bytes)
-            .map(str::to_owned)
-            .unwrap_or_else(|_| latin1_bytes_to_string(bytes))
-    }
-}
-
-fn latin1_bytes_to_string(bytes: &[u8]) -> String {
-    bytes.iter().map(|&b| b as char).collect()
-}
-
-/// Take the first N bytes from text.
-///
-/// Bashkit keeps ordinary command output as UTF-8 strings, but binary device
-/// input is represented as Latin-1 chars so `/dev/urandom` pipelines keep one
-/// char per original byte. Treat only binary-looking Latin-1 as char-counted;
-/// normal UTF-8 stdin must never emit more than `head -c N` bytes.
-fn take_first_bytes(text: &str, n: usize) -> String {
-    if looks_like_latin1_binary(text) {
-        return text.chars().take(n).collect();
-    }
-
-    let mut end = text.len().min(n);
-    while end > 0 && !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    text[..end].to_string()
-}
-
-fn looks_like_latin1_binary(text: &str) -> bool {
-    text.chars()
-        .any(|c| matches!(c, '\0'..='\x08' | '\x0b'..='\x0c' | '\x0e'..='\x1f' | '\x7f'..='\u{9f}'))
 }
 
 /// Parse arguments for tail command, including +N "from start" syntax.
@@ -369,7 +317,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -395,7 +343,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -452,14 +400,6 @@ mod tests {
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout, "é");
         assert_eq!(result.stdout.len(), 2);
-    }
-
-    #[test]
-    fn test_head_c_preserves_latin1_binary_byte_model() {
-        let input = "A\0éZ";
-        let output = take_first_bytes(input, 3);
-        assert_eq!(output.chars().count(), 3);
-        assert_eq!(output, "A\0é");
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/hextools.rs
+++ b/crates/bashkit/src/builtins/hextools.rs
@@ -627,7 +627,7 @@ impl Builtin for Hexdump {
 // --- Shared helpers ---
 
 async fn collect_input(
-    stdin: Option<&str>,
+    stdin: Option<&crate::StreamData>,
     files: &[String],
     cwd: &std::path::Path,
     fs: &std::sync::Arc<dyn crate::fs::FileSystem>,
@@ -685,7 +685,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -711,7 +711,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -737,7 +737,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/iconv.rs
+++ b/crates/bashkit/src/builtins/iconv.rs
@@ -367,7 +367,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs_dyn,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/inspect.rs
+++ b/crates/bashkit/src/builtins/inspect.rs
@@ -502,7 +502,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("stdin content"),
+            stdin: Some(crate::builtins::test_stream("stdin content")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/introspect.rs
+++ b/crates/bashkit/src/builtins/introspect.rs
@@ -115,7 +115,7 @@ impl Builtin for Type {
 
         let exit_code = if all_found { 0 } else { 1 };
         Ok(ExecResult {
-            stdout: output,
+            stdout: output.into(),
             exit_code,
             ..Default::default()
         })
@@ -152,7 +152,7 @@ impl Builtin for Which {
 
         let exit_code = if all_found { 0 } else { 1 };
         Ok(ExecResult {
-            stdout: output,
+            stdout: output.into(),
             exit_code,
             ..Default::default()
         })

--- a/crates/bashkit/src/builtins/join.rs
+++ b/crates/bashkit/src/builtins/join.rs
@@ -77,7 +77,13 @@ impl Builtin for Join {
             return Ok(ExecResult::err("join: missing operand\n".to_string(), 1));
         }
 
-        let content1 = read_input(ctx.fs.as_ref(), ctx.cwd, files[0], ctx.stdin).await?;
+        let content1 = read_input(
+            ctx.fs.as_ref(),
+            ctx.cwd,
+            files[0],
+            ctx.stdin.map(|stdin| &**stdin),
+        )
+        .await?;
         let content2 = read_input(ctx.fs.as_ref(), ctx.cwd, files[1], None).await?;
 
         let lines1: Vec<&str> = content1.lines().collect();

--- a/crates/bashkit/src/builtins/jq/mod.rs
+++ b/crates/bashkit/src/builtins/jq/mod.rs
@@ -163,7 +163,7 @@ async fn run_jq(ctx: Context<'_>, parsed: JqArgs<'_>) -> Result<ExecResult> {
         file_content = combined;
         file_content.as_str()
     } else {
-        ctx.stdin.unwrap_or("")
+        ctx.stdin.map(|stdin| &**stdin).unwrap_or("")
     };
 
     // Empty stdin without -n yields empty output (matches real jq for files

--- a/crates/bashkit/src/builtins/jq/tests.rs
+++ b/crates/bashkit/src/builtins/jq/tests.rs
@@ -5,7 +5,7 @@
 //! through `Jq::execute` — covering positive, negative, and security cases.
 
 use super::*;
-use crate::builtins::Context;
+use crate::builtins::{Context, test_stream};
 use crate::error::Error;
 use crate::fs::{FileSystem, InMemoryFs};
 use crate::interpreter::ExecResult;
@@ -19,7 +19,7 @@ async fn run_jq(filter: &str, input: &str) -> Result<String> {
 
 async fn run_jq_with_args(args: &[&str], input: &str) -> Result<String> {
     let result = run_jq_result_with_args(args, input).await?;
-    Ok(result.stdout)
+    Ok(result.stdout.to_string())
 }
 
 async fn run_jq_result(filter: &str, input: &str) -> Result<ExecResult> {
@@ -39,7 +39,7 @@ async fn run_jq_result_with_args(args: &[&str], input: &str) -> Result<ExecResul
         variables: &mut vars,
         cwd: &mut cwd,
         fs,
-        stdin: Some(input),
+        stdin: Some(test_stream(input)),
         #[cfg(feature = "http_client")]
         http_client: None,
         #[cfg(feature = "git")]
@@ -964,7 +964,7 @@ async fn dollar_env_returns_shell_env() {
         variables: &mut vars,
         cwd: &mut cwd,
         fs,
-        stdin: Some("null"),
+        stdin: Some(test_stream("null")),
         #[cfg(feature = "http_client")]
         http_client: None,
         #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/json.rs
+++ b/crates/bashkit/src/builtins/json.rs
@@ -322,7 +322,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs_dyn,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/ls/find.rs
+++ b/crates/bashkit/src/builtins/ls/find.rs
@@ -406,8 +406,8 @@ impl Builtin for Find {
         }
 
         Ok(ExecResult {
-            stdout: output,
-            stderr: errors,
+            stdout: output.into(),
+            stderr: errors.into(),
             exit_code: if had_error { 1 } else { 0 },
             control_flow: ControlFlow::None,
             ..Default::default()

--- a/crates/bashkit/src/builtins/ls/tests.rs
+++ b/crates/bashkit/src/builtins/ls/tests.rs
@@ -2879,7 +2879,7 @@ async fn ls_long_date_for(mtime_secs: u64) -> String {
 
     let result = Ls.execute(ctx).await.unwrap();
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
-    result.stdout
+    result.stdout.to_string()
 }
 
 #[tokio::test]

--- a/crates/bashkit/src/builtins/mapfile.rs
+++ b/crates/bashkit/src/builtins/mapfile.rs
@@ -35,7 +35,7 @@ impl Builtin for Mapfile {
             array_name = name.clone();
         }
 
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
 
         let mut result = ExecResult::ok(String::new());
 

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -263,19 +263,20 @@ pub(crate) async fn read_text_file(
     path: &Path,
     cmd_name: &str,
 ) -> std::result::Result<String, ExecResult> {
-    let content = fs
-        .read_file(path)
+    let content = read_stream_file(fs, path, cmd_name).await?;
+
+    Ok(content.to_string())
+}
+
+pub(crate) async fn read_stream_file(
+    fs: &dyn FileSystem,
+    path: &Path,
+    cmd_name: &str,
+) -> std::result::Result<crate::StreamData, ExecResult> {
+    fs.read_file(path)
         .await
-        .map_err(|e| ExecResult::err(format!("{cmd_name}: {}: {e}\n", path.display()), 1))?;
-
-    // Binary device files (/dev/urandom, /dev/random): preserve raw bytes as
-    // Latin-1 (ISO 8859-1) so each byte 0x00-0xFF maps 1:1 to a char.
-    // This lets `tr -dc 'a-z0-9' < /dev/urandom | head -c N` work correctly.
-    if path == Path::new("/dev/urandom") || path == Path::new("/dev/random") {
-        return Ok(content.iter().map(|&b| b as char).collect());
-    }
-
-    Ok(String::from_utf8_lossy(&content).into_owned())
+        .map(crate::StreamData::from)
+        .map_err(|e| ExecResult::err(format!("{cmd_name}: {}: {e}\n", path.display()), 1))
 }
 
 /// Check args for `--help` and optionally `--version`.
@@ -485,7 +486,7 @@ pub struct SubCommand {
     /// Command arguments.
     pub args: Vec<String>,
     /// Optional stdin to pipe into the command.
-    pub stdin: Option<String>,
+    pub stdin: Option<crate::StreamData>,
     /// Command-scoped environment assignments (`VAR=value cmd ...`), applied
     /// only to this command's environment. Used by `xargs --process-slot-var`
     /// to expose a per-invocation parallel-slot index.
@@ -617,7 +618,7 @@ pub struct Context<'a> {
     ///
     /// Contains output from the previous command in a pipeline.
     /// For `echo hello | mycommand`, stdin will be `Some("hello\n")`.
-    pub stdin: Option<&'a str>,
+    pub stdin: Option<&'a crate::StreamData>,
 
     /// HTTP client for network operations (curl, wget).
     ///
@@ -659,6 +660,16 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
+    /// Exact pipeline stdin bytes.
+    pub fn stdin_bytes(&self) -> Option<&[u8]> {
+        self.stdin.map(crate::StreamData::as_bytes)
+    }
+
+    /// Pipeline stdin decoded for a text-only builtin.
+    pub fn stdin_text_lossy(&self) -> Option<std::borrow::Cow<'_, str>> {
+        self.stdin.map(crate::StreamData::text_lossy)
+    }
+
     /// Look up a typed per-execution extension, if present.
     pub fn execution_extension<T>(&self) -> Option<&T>
     where
@@ -681,6 +692,11 @@ impl<'a> Context<'a> {
         fs: std::sync::Arc<dyn crate::fs::FileSystem>,
         stdin: Option<&'a str>,
     ) -> Self {
+        let stdin = stdin.map(|text| {
+            let stream: &'static crate::StreamData =
+                Box::leak(Box::new(crate::StreamData::from(text)));
+            stream as &'a crate::StreamData
+        });
         Self {
             args,
             env,
@@ -697,6 +713,16 @@ impl<'a> Context<'a> {
             shell: None,
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) fn test_stream(text: &str) -> &'static crate::StreamData {
+    Box::leak(Box::new(crate::StreamData::from(text)))
+}
+
+#[cfg(test)]
+pub(crate) fn test_stream_opt(text: Option<&str>) -> Option<&'static crate::StreamData> {
+    text.map(test_stream)
 }
 
 /// Trait for implementing builtin commands.
@@ -887,9 +913,8 @@ impl<'a> BashkitContext<'a> {
 
     fn into_exec_result(self) -> ExecResult {
         ExecResult {
-            stdout: self.stdout,
-            stdout_bytes: None,
-            stderr: self.stderr,
+            stdout: self.stdout.into(),
+            stderr: self.stderr.into(),
             exit_code: self.exit_code,
             ..Default::default()
         }
@@ -927,7 +952,7 @@ impl<'a> BashkitContext<'a> {
 
     /// Pipeline stdin, if the builtin is invoked after a pipe.
     pub fn stdin(&self) -> Option<&str> {
-        self.inner.stdin
+        self.inner.stdin.and_then(|stdin| stdin.text().ok())
     }
 
     /// Look up a typed per-execution extension, if present.

--- a/crates/bashkit/src/builtins/nl.rs
+++ b/crates/bashkit/src/builtins/nl.rs
@@ -227,7 +227,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -262,7 +262,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/paste.rs
+++ b/crates/bashkit/src/builtins/paste.rs
@@ -239,7 +239,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -274,7 +274,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/patch.rs
+++ b/crates/bashkit/src/builtins/patch.rs
@@ -430,7 +430,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs_dyn,
-            stdin: Some(stdin),
+            stdin: Some(crate::builtins::test_stream(stdin)),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/pipeline.rs
+++ b/crates/bashkit/src/builtins/pipeline.rs
@@ -217,7 +217,7 @@ impl Builtin for Xargs {
             Err(e) => return Ok(e),
         };
 
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
         if input.is_empty() {
             return Ok(ExecResult::ok(String::new()));
         }
@@ -254,7 +254,7 @@ impl Builtin for Xargs {
             Err(_) => return Ok(None), // Let execute() handle the error
         };
 
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
         if input.is_empty() {
             return Ok(None); // Let execute() handle empty input
         }
@@ -324,7 +324,7 @@ impl Builtin for Tee {
             .map(|vs| vs.map(|v| v.to_string_lossy().into_owned()).collect())
             .unwrap_or_default();
 
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
 
         for file in &files {
             // tee(1): "If a FILE is -, it refers to a file named - ."
@@ -453,7 +453,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("foo bar baz"),
+            stdin: Some(crate::builtins::test_stream("foo bar baz")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -480,7 +480,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("file1 file2"),
+            stdin: Some(crate::builtins::test_stream("file1 file2")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -507,7 +507,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b c"),
+            stdin: Some(crate::builtins::test_stream("a b c")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -544,7 +544,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("file1\nfile2"),
+            stdin: Some(crate::builtins::test_stream("file1\nfile2")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -572,7 +572,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a:b:c"),
+            stdin: Some(crate::builtins::test_stream("a:b:c")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -599,7 +599,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some(""),
+            stdin: Some(crate::builtins::test_stream("")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -626,7 +626,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("test"),
+            stdin: Some(crate::builtins::test_stream("test")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -653,7 +653,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("file1 file2"),
+            stdin: Some(crate::builtins::test_stream("file1 file2")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -686,7 +686,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b c"),
+            stdin: Some(crate::builtins::test_stream("a b c")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -722,7 +722,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b c"),
+            stdin: Some(crate::builtins::test_stream("a b c")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -749,7 +749,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a"),
+            stdin: Some(crate::builtins::test_stream("a")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -785,7 +785,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b c d"),
+            stdin: Some(crate::builtins::test_stream("a b c d")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -828,7 +828,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b"),
+            stdin: Some(crate::builtins::test_stream("a b")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -865,7 +865,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b c"),
+            stdin: Some(crate::builtins::test_stream("a b c")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -914,7 +914,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("a b c d"),
+            stdin: Some(crate::builtins::test_stream("a b c d")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -947,7 +947,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("Hello, world!"),
+            stdin: Some(crate::builtins::test_stream("Hello, world!")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -977,7 +977,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("content"),
+            stdin: Some(crate::builtins::test_stream("content")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -1013,7 +1013,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("appended"),
+            stdin: Some(crate::builtins::test_stream("appended")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -1042,7 +1042,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("pass through"),
+            stdin: Some(crate::builtins::test_stream("pass through")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -1069,7 +1069,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs.clone(),
-            stdin: Some("test"),
+            stdin: Some(crate::builtins::test_stream("test")),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/python.rs
+++ b/crates/bashkit/src/builtins/python.rs
@@ -1127,7 +1127,7 @@ fn format_exception_with_output(e: MontyException, printed: &str) -> ExecResult 
     let stderr = format!("{e}\n");
     let mut result = ExecResult::err(stderr, 1);
     if !printed.is_empty() {
-        result.stdout = printed.to_string();
+        result.stdout = printed.to_string().into();
     }
     result
 }

--- a/crates/bashkit/src/builtins/rg/mod.rs
+++ b/crates/bashkit/src/builtins/rg/mod.rs
@@ -4987,8 +4987,8 @@ fn rg_quiet_result(
         *any_match = true;
         if !opts.stats {
             return Some(ExecResult {
-                stdout: String::new(),
-                stderr: stderr.to_string(),
+                stdout: crate::StreamData::new(),
+                stderr: stderr.to_string().into(),
                 exit_code: 0,
                 ..Default::default()
             });
@@ -5284,12 +5284,19 @@ impl Builtin for Rg {
                 output
             };
             return Ok(ExecResult {
-                stdout: output,
+                stdout: output.into(),
                 exit_code: if found_files { 0 } else { 1 },
                 ..Default::default()
             });
         }
-        if let Err(result) = load_rg_pattern_files(&*ctx.fs, ctx.cwd, ctx.stdin, &mut opts).await {
+        if let Err(result) = load_rg_pattern_files(
+            &*ctx.fs,
+            ctx.cwd,
+            ctx.stdin.map(|stdin| &**stdin),
+            &mut opts,
+        )
+        .await
+        {
             return Ok(result);
         }
         if opts.patterns.is_empty() {
@@ -6879,8 +6886,8 @@ impl Builtin for Rg {
             1
         };
         Ok(ExecResult {
-            stdout: output,
-            stderr: collected_inputs.stderr,
+            stdout: output.into(),
+            stderr: collected_inputs.stderr.into(),
             exit_code,
             ..Default::default()
         })
@@ -7191,7 +7198,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs: fs_dyn,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/sed.rs
+++ b/crates/bashkit/src/builtins/sed.rs
@@ -954,7 +954,7 @@ impl Builtin for Sed {
 
         // Determine input
         let inputs: Vec<(Option<String>, String)> = if opts.files.is_empty() {
-            vec![(None, ctx.stdin.unwrap_or("").to_string())]
+            vec![(None, ctx.stdin.map(ToString::to_string).unwrap_or_default())]
         } else {
             let mut inputs = Vec::new();
             for file in &opts.files {
@@ -1144,8 +1144,8 @@ impl Builtin for Sed {
             Ok(ExecResult::ok(output))
         } else {
             Ok(ExecResult {
-                stdout: output,
-                stderr: warnings,
+                stdout: output.into(),
+                stderr: warnings.into(),
                 exit_code: 0,
                 ..Default::default()
             })
@@ -1186,7 +1186,7 @@ mod tests {
             variables: &mut vars,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/semver.rs
+++ b/crates/bashkit/src/builtins/semver.rs
@@ -181,7 +181,7 @@ impl Builtin for Semver {
                 }
             }
             "sort" => {
-                let input = ctx.stdin.unwrap_or("");
+                let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
                 let mut versions: Vec<&str> =
                     input.lines().filter(|l| !l.trim().is_empty()).collect();
                 versions.sort_by(|a, b| {
@@ -229,7 +229,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/shuf.rs
+++ b/crates/bashkit/src/builtins/shuf.rs
@@ -84,8 +84,8 @@ impl Builtin for Shuf {
         } else {
             // Reading lines: positional file path, "-", or absent (stdin).
             let raw = match positionals.first() {
-                None => ctx.stdin.unwrap_or("").to_string(),
-                Some(s) if s == "-" => ctx.stdin.unwrap_or("").to_string(),
+                None => ctx.stdin.map(ToString::to_string).unwrap_or_default(),
+                Some(s) if s == "-" => ctx.stdin.map(ToString::to_string).unwrap_or_default(),
                 Some(file) => {
                     let path = if Path::new(file).is_absolute() {
                         file.clone()

--- a/crates/bashkit/src/builtins/sortuniq.rs
+++ b/crates/bashkit/src/builtins/sortuniq.rs
@@ -801,7 +801,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]
@@ -827,7 +827,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/split.rs
+++ b/crates/bashkit/src/builtins/split.rs
@@ -81,7 +81,7 @@ impl Builtin for Split {
         let prefix = positional.get(1).copied().unwrap_or("x");
 
         let input = if file == "-" {
-            ctx.stdin.unwrap_or("").to_string()
+            ctx.stdin.map(ToString::to_string).unwrap_or_default()
         } else {
             let path = resolve_path(ctx.cwd, file);
             match read_text_file(ctx.fs.as_ref(), &path, "split").await {
@@ -199,7 +199,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/sqlite/mod.rs
+++ b/crates/bashkit/src/builtins/sqlite/mod.rs
@@ -373,7 +373,7 @@ impl Builtin for Sqlite {
             ));
         }
 
-        let parsed = match parse_args(&invocation_args, ctx.stdin) {
+        let parsed = match parse_args(&invocation_args, ctx.stdin.map(|stdin| &**stdin)) {
             Ok(p) => p,
             Err(e) => {
                 return Ok(ExecResult::err(format!("sqlite: {e}\n"), 2));
@@ -540,8 +540,8 @@ impl Builtin for Sqlite {
             exit_code,
             ..Default::default()
         };
-        result.stdout = stdout;
-        result.stderr = stderr;
+        result.stdout = stdout.into();
+        result.stderr = stderr.into();
         Ok(result)
     }
 }

--- a/crates/bashkit/src/builtins/ssh/cmd.rs
+++ b/crates/bashkit/src/builtins/ssh/cmd.rs
@@ -648,13 +648,13 @@ fn build_result(output: super::SshOutput, _quiet: bool) -> ExecResult {
     if output.exit_code == 0 {
         let mut result = ExecResult::ok(output.stdout);
         if !output.stderr.is_empty() {
-            result.stderr = output.stderr;
+            result.stderr = output.stderr.into();
         }
         result
     } else {
         let mut result = ExecResult::err(output.stdout, output.exit_code);
         if !output.stderr.is_empty() {
-            result.stderr = output.stderr;
+            result.stderr = output.stderr.into();
         }
         result
     }

--- a/crates/bashkit/src/builtins/strings.rs
+++ b/crates/bashkit/src/builtins/strings.rs
@@ -225,7 +225,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/template.rs
+++ b/crates/bashkit/src/builtins/template.rs
@@ -364,7 +364,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/textrev.rs
+++ b/crates/bashkit/src/builtins/textrev.rs
@@ -226,7 +226,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/timeout.rs
+++ b/crates/bashkit/src/builtins/timeout.rs
@@ -184,7 +184,7 @@ impl Builtin for Timeout {
                     command: SubCommand {
                         name: cmd_name,
                         args: cmd_args,
-                        stdin: ctx.stdin.map(|s| s.to_string()),
+                        stdin: ctx.stdin.cloned(),
                         assignments: Vec::new(),
                     },
                 }))
@@ -241,7 +241,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/tomlq.rs
+++ b/crates/bashkit/src/builtins/tomlq.rs
@@ -355,7 +355,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/typescript.rs
+++ b/crates/bashkit/src/builtins/typescript.rs
@@ -1095,7 +1095,7 @@ async fn handle_stat(args: &[Value], fs: &Arc<dyn FileSystem>, cwd: &Path) -> Va
 /// Format a ZapCode error with any stdout already produced.
 fn format_error_with_output(e: zapcode_core::ZapcodeError, stdout: &str) -> ExecResult {
     let mut result = ExecResult::err(format!("{e}\n"), 1);
-    result.stdout = stdout.to_string();
+    result.stdout = stdout.to_string().into();
     result
 }
 

--- a/crates/bashkit/src/builtins/vars.rs
+++ b/crates/bashkit/src/builtins/vars.rs
@@ -50,7 +50,7 @@ impl Builtin for Unset {
             // are inherited and can't be unset by the shell
         }
         Ok(ExecResult {
-            stderr,
+            stderr: stderr.into(),
             exit_code,
             ..Default::default()
         })
@@ -540,8 +540,8 @@ impl Builtin for Shopt {
                     ctx.variables.get(&key).map(|v| v == "1").unwrap_or(false)
                 });
                 Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: String::new(),
+                    stdout: crate::StreamData::new(),
+                    stderr: crate::StreamData::new(),
                     exit_code: if all_on { 0 } else { 1 },
                     control_flow: crate::interpreter::ControlFlow::None,
                     ..Default::default()
@@ -594,8 +594,8 @@ impl Builtin for Shopt {
                 }
                 if any_invalid {
                     Ok(ExecResult {
-                        stdout: String::new(),
-                        stderr: output,
+                        stdout: crate::StreamData::new(),
+                        stderr: output.into(),
                         exit_code: 1,
                         control_flow: crate::interpreter::ControlFlow::None,
                         ..Default::default()

--- a/crates/bashkit/src/builtins/wait.rs
+++ b/crates/bashkit/src/builtins/wait.rs
@@ -52,8 +52,8 @@ impl Builtin for Wait {
         }
 
         let mut result = ExecResult {
-            stdout,
-            stderr,
+            stdout: stdout.into(),
+            stderr: stderr.into(),
             exit_code: last_exit_code,
             ..Default::default()
         };

--- a/crates/bashkit/src/builtins/wc.rs
+++ b/crates/bashkit/src/builtins/wc.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 
-use super::{Builtin, Context, read_text_file};
+use super::{Builtin, Context, read_stream_file};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
@@ -131,7 +131,7 @@ impl Builtin for Wc {
         if files.is_empty() {
             // Read from stdin
             if let Some(stdin) = ctx.stdin {
-                let counts = count_text(stdin);
+                let counts = count_data(stdin.as_bytes());
                 // Real bash: no padding for single-value stdin, padded for multiple values
                 let padded = flags.active_count() > 1;
                 output.push_str(&format_counts(&counts, &flags, None, padded));
@@ -146,9 +146,9 @@ impl Builtin for Wc {
                     ctx.cwd.join(file)
                 };
 
-                match read_text_file(&*ctx.fs, &path, "wc").await {
-                    Ok(text) => {
-                        let counts = count_text(&text);
+                match read_stream_file(&*ctx.fs, &path, "wc").await {
+                    Ok(data) => {
+                        let counts = count_data(data.as_bytes());
 
                         total_lines += counts.lines;
                         total_words += counts.words;
@@ -196,18 +196,22 @@ struct TextCounts {
     max_line_length: usize,
 }
 
-/// Count lines, words, bytes, characters, and max line length in text
-fn count_text(text: &str) -> TextCounts {
+/// Count stream data. Invalid UTF-8 is one character per byte, matching the
+/// byte-oriented C locale instead of inventing Unicode replacement characters.
+fn count_data(bytes: &[u8]) -> TextCounts {
+    let text = String::from_utf8_lossy(bytes);
     // wc -l counts newline characters, not logical lines
-    let lines = text.chars().filter(|&c| c == '\n').count();
+    let lines = bytes.iter().filter(|&&byte| byte == b'\n').count();
     let words = text.split_whitespace().count();
-    let bytes = text.len();
-    let chars = text.chars().count();
+    let byte_count = bytes.len();
+    let chars = std::str::from_utf8(bytes)
+        .map(|valid| valid.chars().count())
+        .unwrap_or(byte_count);
     let max_line_length = text.lines().map(|l| l.chars().count()).max().unwrap_or(0);
     TextCounts {
         lines,
         words,
-        bytes,
+        bytes: byte_count,
         chars,
         max_line_length,
     }
@@ -278,7 +282,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/builtins/yaml.rs
+++ b/crates/bashkit/src/builtins/yaml.rs
@@ -529,7 +529,7 @@ mod tests {
             variables: &mut variables,
             cwd: &mut cwd,
             fs,
-            stdin,
+            stdin: crate::builtins::test_stream_opt(stdin),
             #[cfg(feature = "http_client")]
             http_client: None,
             #[cfg(feature = "git")]

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -238,7 +238,7 @@ fn compat_bash_versinfo_array() -> HashMap<usize, String> {
 ///
 /// Requires `Send + Sync` because the interpreter holds this across `.await` points.
 /// Closures capturing `Arc<Mutex<_>>` satisfy both bounds automatically.
-pub type OutputCallback = Box<dyn FnMut(&str, &str) + Send + Sync>;
+pub type OutputCallback = Box<dyn FnMut(&crate::StreamData, &crate::StreamData) + Send + Sync>;
 use crate::parser::{
     ArithmeticForCommand, Assignment, AssignmentValue, CaseCommand, Command, CommandList,
     CompoundCommand, CoprocCommand, ForCommand, FunctionDef, IfCommand, ListOperator, ParameterOp,
@@ -273,16 +273,6 @@ fn subcommand_env_assignments(pairs: &[(String, String)]) -> Vec<Assignment> {
 /// redirect and command-scoped `VAR=value` assignments. Shared by the `Timeout`,
 /// `Batch`, and `BatchWithStatus` plan arms.
 fn subcommand_to_command(cmd: &builtins::SubCommand) -> Command {
-    let redirects = if let Some(ref stdin_data) = cmd.stdin {
-        vec![Redirect {
-            fd: None,
-            fd_var: None,
-            kind: RedirectKind::HereString,
-            target: Word::literal(stdin_data.trim_end_matches('\n').to_string()),
-        }]
-    } else {
-        Vec::new()
-    };
     Command::Simple(SimpleCommand {
         name: Word::quoted_literal(cmd.name.clone()),
         args: cmd
@@ -290,7 +280,7 @@ fn subcommand_to_command(cmd: &builtins::SubCommand) -> Command {
             .iter()
             .map(|s| Word::quoted_literal(s.clone()))
             .collect(),
-        redirects,
+        redirects: Vec::new(),
         assignments: subcommand_env_assignments(&cmd.assignments),
         span: Span::new(),
     })
@@ -580,42 +570,9 @@ fn command_not_found_message(name: &str, known_commands: &[&str]) -> String {
     msg
 }
 
-/// Decode file bytes for String-backed interpreter paths. Prefer valid UTF-8
-/// so scripts and text files keep Unicode intact; force the existing Latin-1
-/// byte model for random devices, and use it as a fallback for other non-UTF-8
-/// data that cannot be represented as text without replacement.
-fn decode_file_bytes(bytes: &[u8]) -> String {
-    std::str::from_utf8(bytes)
-        .map(str::to_owned)
-        .unwrap_or_else(|_| latin1_bytes_to_string(bytes))
-}
-
-fn normalize_vfs_path(path: &Path) -> std::path::PathBuf {
-    path.components()
-        .fold(std::path::PathBuf::new(), |mut acc, c| match c {
-            std::path::Component::ParentDir => {
-                acc.pop();
-                acc
-            }
-            std::path::Component::CurDir => acc,
-            c => {
-                acc.push(c);
-                acc
-            }
-        })
-}
-
-fn decode_file_bytes_for_path(path: &Path, bytes: &[u8]) -> String {
-    let normalized = normalize_vfs_path(path);
-    if normalized == Path::new("/dev/urandom") || normalized == Path::new("/dev/random") {
-        latin1_bytes_to_string(bytes)
-    } else {
-        decode_file_bytes(bytes)
-    }
-}
-
-fn latin1_bytes_to_string(bytes: &[u8]) -> String {
-    bytes.iter().map(|&b| b as char).collect()
+/// Decode a script/source file at the shell's unavoidable text boundary.
+fn decode_file_bytes_for_path(_path: &Path, bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
 }
 
 /// Check if a path refers to /dev/null after normalization.
@@ -1136,7 +1093,7 @@ pub struct Interpreter {
     ssh_client: Option<crate::builtins::ssh::SshClient>,
     /// Stdin inherited from pipeline for compound commands (while read, etc.)
     /// Each read operation consumes one line, advancing through the data.
-    pipeline_stdin: Option<String>,
+    pipeline_stdin: Option<crate::StreamData>,
     /// Position within the current argument while `getopts` walks a clustered
     /// short-option group (e.g. `-abc`). Interpreter-internal working state for
     /// `execute_getopts`; `0` means "at the start of the next option group".
@@ -1198,7 +1155,7 @@ pub struct Interpreter {
     /// Temporary buffer for fd3+ output during compound body execution.
     /// Populated by `1>&N` (N>=3) in apply_redirections, consumed by
     /// apply_redirections_fd_table for compound redirect routing.
-    pending_fd_output: HashMap<i32, String>,
+    pending_fd_output: HashMap<i32, crate::StreamData>,
     /// Fd3+ targets from compound redirect processing (e.g. `3>&1` maps fd3→Stdout).
     /// Populated during apply_redirections_fd_table redirect loop, consumed during routing.
     pending_fd_targets: Vec<(i32, FdTarget)>,
@@ -1270,17 +1227,6 @@ impl ArithmeticExpansionState {
 }
 
 impl Interpreter {
-    fn utf8_prefix_at_most(s: &str, max_bytes: usize) -> &str {
-        if s.len() <= max_bytes {
-            return s;
-        }
-        let mut end = max_bytes;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        &s[..end]
-    }
-
     // Decision: restored `$!` must match Bashkit-produced virtual numeric job ids.
     const MAX_RESTORED_LAST_BG_PID_LEN: usize = 20;
     const MAX_GLOB_DEPTH: usize = 50;
@@ -1930,17 +1876,21 @@ impl Interpreter {
         self.pending_fd_capture_depth = 0;
     }
 
-    fn append_pending_fd_output(&mut self, fd: i32, data: &str) {
+    fn append_pending_fd_output(&mut self, fd: i32, data: &crate::StreamData) {
         if data.is_empty() {
             return;
         }
-        let used: usize = self.pending_fd_output.values().map(String::len).sum();
+        let used: usize = self
+            .pending_fd_output
+            .values()
+            .map(crate::StreamData::len)
+            .sum();
         let remaining = self.limits.max_stdout_bytes.saturating_sub(used);
         if remaining == 0 {
             return;
         }
         let entry = self.pending_fd_output.entry(fd).or_default();
-        entry.push_str(Self::utf8_prefix_at_most(data, remaining));
+        entry.append(&data.prefix(remaining));
     }
 
     /// Name `$0` expands to when no real script or function frame is active.
@@ -1984,7 +1934,7 @@ impl Interpreter {
     /// Seed the stdin a top-level command reads when it is not fed by a pipe
     /// or redirect. Must be called after `reset_transient_state`, which clears
     /// it between executions.
-    pub(crate) fn set_pipeline_stdin(&mut self, stdin: String) {
+    pub(crate) fn set_pipeline_stdin(&mut self, stdin: crate::StreamData) {
         self.pipeline_stdin = Some(stdin);
     }
 
@@ -2484,7 +2434,12 @@ impl Interpreter {
     /// `emit_count_before` is the value of `output_emit_count` before the sub-call
     /// that produced this output. If the count advanced, sub-calls already emitted
     /// and we skip to avoid duplicates.
-    fn maybe_emit_output(&mut self, stdout: &str, stderr: &str, emit_count_before: u64) -> bool {
+    fn maybe_emit_output(
+        &mut self,
+        stdout: &crate::StreamData,
+        stderr: &crate::StreamData,
+        emit_count_before: u64,
+    ) -> bool {
         if self.output_callback.is_none() {
             return false;
         }
@@ -2501,14 +2456,14 @@ impl Interpreter {
             .limits
             .max_stderr_bytes
             .saturating_sub(self.output_stream_stderr_bytes);
-        let stdout_chunk = Self::utf8_prefix_at_most(stdout, stdout_remaining);
-        let stderr_chunk = Self::utf8_prefix_at_most(stderr, stderr_remaining);
+        let stdout_chunk = stdout.prefix(stdout_remaining);
+        let stderr_chunk = stderr.prefix(stderr_remaining);
         if stdout_chunk.is_empty() && stderr_chunk.is_empty() {
             return false;
         }
 
         if let Some(ref mut cb) = self.output_callback {
-            cb(stdout_chunk, stderr_chunk);
+            cb(&stdout_chunk, &stderr_chunk);
             self.output_emit_count += 1;
             self.output_stream_stdout_bytes += stdout_chunk.len();
             self.output_stream_stderr_bytes += stderr_chunk.len();
@@ -2591,8 +2546,8 @@ impl Interpreter {
         run_exit_trap: bool,
         fire_exit_hook: bool,
     ) -> Result<ExecResult> {
-        let mut stdout = String::new();
-        let mut stderr = String::new();
+        let mut stdout = crate::StreamData::new();
+        let mut stderr = crate::StreamData::new();
         let mut exit_code = 0;
         let mut stdout_truncated = false;
         let mut stderr_truncated = false;
@@ -2613,9 +2568,9 @@ impl Interpreter {
                         stdout_truncated = true;
                     }
                 } else if result.stdout.len() <= remaining {
-                    stdout.push_str(&result.stdout);
+                    stdout.append(&result.stdout);
                 } else {
-                    stdout.push_str(Self::utf8_prefix_at_most(&result.stdout, remaining));
+                    stdout.append(&result.stdout.prefix(remaining));
                     stdout_truncated = true;
                 }
             }
@@ -2628,9 +2583,9 @@ impl Interpreter {
                         stderr_truncated = true;
                     }
                 } else if result.stderr.len() <= remaining {
-                    stderr.push_str(&result.stderr);
+                    stderr.append(&result.stderr);
                 } else {
-                    stderr.push_str(Self::utf8_prefix_at_most(&result.stderr, remaining));
+                    stderr.append(&result.stderr.prefix(remaining));
                     stderr_truncated = true;
                 }
             }
@@ -2705,8 +2660,8 @@ impl Interpreter {
                             &trap_result.stderr,
                             emit_before,
                         );
-                        stdout.push_str(&trap_result.stdout);
-                        stderr.push_str(&trap_result.stderr);
+                        stdout.append(&trap_result.stdout);
+                        stderr.append(&trap_result.stderr);
                     }
                 }
             }
@@ -2803,8 +2758,8 @@ impl Interpreter {
                     Some("exit_nonzero") => {
                         // Return non-zero exit code without error
                         return Ok(ExecResult {
-                            stdout: String::new(),
-                            stderr: "injected failure".to_string(),
+                            stdout: crate::StreamData::new(),
+                            stderr: "injected failure".into(),
                             exit_code: 127,
                             control_flow: ControlFlow::None,
                             ..Default::default()
@@ -2988,8 +2943,8 @@ impl Interpreter {
                                     &trap_result.stderr,
                                     emit_before,
                                 );
-                                res.stdout.push_str(&trap_result.stdout);
-                                res.stderr.push_str(&trap_result.stderr);
+                                res.stdout.append(&trap_result.stdout);
+                                res.stderr.append(&trap_result.stderr);
                             }
                         }
                     }
@@ -3033,13 +2988,13 @@ impl Interpreter {
     /// Execute an if statement
     async fn execute_if(&mut self, if_cmd: &IfCommand) -> Result<ExecResult> {
         // Accumulate stdout/stderr from all condition evaluations
-        let mut cond_stdout = String::new();
-        let mut cond_stderr = String::new();
+        let mut cond_stdout = crate::StreamData::new();
+        let mut cond_stderr = crate::StreamData::new();
 
         // Execute condition (no errexit checking - conditions are expected to fail)
         let condition_result = self.execute_condition_sequence(&if_cmd.condition).await?;
-        cond_stdout.push_str(&condition_result.stdout);
-        cond_stderr.push_str(&condition_result.stderr);
+        cond_stdout.append(&condition_result.stdout);
+        cond_stderr.append(&condition_result.stderr);
 
         if condition_result.exit_code == 0 {
             // Condition succeeded, execute then branch
@@ -3052,8 +3007,8 @@ impl Interpreter {
         // Check elif branches
         for (elif_condition, elif_body) in &if_cmd.elif_branches {
             let elif_result = self.execute_condition_sequence(elif_condition).await?;
-            cond_stdout.push_str(&elif_result.stdout);
-            cond_stderr.push_str(&elif_result.stderr);
+            cond_stdout.append(&elif_result.stdout);
+            cond_stderr.append(&elif_result.stderr);
 
             if elif_result.exit_code == 0 {
                 let mut result = self.execute_command_sequence(elif_body).await?;
@@ -3157,7 +3112,7 @@ impl Interpreter {
                     }
                     state::LoopAction::Break => break,
                     state::LoopAction::Continue => continue,
-                    state::LoopAction::Exit(r) => return Ok(r),
+                    state::LoopAction::Exit(r) => return Ok(*r),
                 }
             }
 
@@ -3175,8 +3130,8 @@ impl Interpreter {
     /// the corresponding item; otherwise it is set to empty. REPLY is always
     /// set to the raw input. EOF ends the loop.
     async fn execute_select(&mut self, select_cmd: &SelectCommand) -> Result<ExecResult> {
-        let mut stdout = String::new();
-        let mut stderr = String::new();
+        let mut stdout = crate::StreamData::new();
+        let mut stderr = crate::StreamData::new();
         let mut exit_code = 0;
 
         // Expand word list
@@ -3236,29 +3191,29 @@ impl Interpreter {
 
                 // Output menu to stderr
                 stderr.push_str(&menu);
-                stderr.push('\n');
+                stderr.push_byte(b'\n');
                 stderr.push_str(&ps3);
 
                 // Read a line from pipeline_stdin
                 let line = if let Some(ref ps) = self.pipeline_stdin {
                     if ps.is_empty() {
                         // EOF: bash prints newline and exits with code 1
-                        stdout.push('\n');
+                        stdout.push_byte(b'\n');
                         exit_code = 1;
                         break;
                     }
                     let data = ps.clone();
                     if let Some(newline_pos) = data.find('\n') {
                         let line = data[..newline_pos].to_string();
-                        self.pipeline_stdin = Some(data[newline_pos + 1..].to_string());
+                        self.pipeline_stdin = Some(data.as_bytes()[newline_pos + 1..].into());
                         line
                     } else {
-                        self.pipeline_stdin = Some(String::new());
-                        data
+                        self.pipeline_stdin = Some(crate::StreamData::new());
+                        data.text_lossy().into_owned()
                     }
                 } else {
                     // No stdin: bash prints newline and exits with code 1
-                    stdout.push('\n');
+                    stdout.push_byte(b'\n');
                     exit_code = 1;
                     break;
                 };
@@ -3286,8 +3241,8 @@ impl Interpreter {
                 let emit_before = self.output_emit_count;
                 let result = self.execute_command_sequence(&select_cmd.body).await?;
                 self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-                stdout.push_str(&result.stdout);
-                stderr.push_str(&result.stderr);
+                stdout.append(&result.stdout);
+                stderr.append(&result.stderr);
                 exit_code = result.exit_code;
 
                 // Check for break/continue
@@ -3394,7 +3349,7 @@ impl Interpreter {
                         }
                     }
                     state::LoopAction::Break => break,
-                    state::LoopAction::Exit(r) => return Ok(r),
+                    state::LoopAction::Exit(r) => return Ok(*r),
                 }
 
                 // Execute step
@@ -3422,7 +3377,7 @@ impl Interpreter {
         if let Some(err_msg) = self.nounset_error.take() {
             self.last_exit_code = 1;
             return Ok(ExecResult {
-                stderr: err_msg,
+                stderr: err_msg.into(),
                 exit_code: 1,
                 control_flow: ControlFlow::Return(1),
                 ..Default::default()
@@ -3432,8 +3387,8 @@ impl Interpreter {
         self.last_exit_code = exit_code;
 
         Ok(ExecResult {
-            stdout: String::new(),
-            stderr: String::new(),
+            stdout: crate::StreamData::new(),
+            stderr: crate::StreamData::new(),
             exit_code,
             control_flow: ControlFlow::None,
             ..Default::default()
@@ -3757,8 +3712,8 @@ impl Interpreter {
         let exit_code = if result != 0 { 0 } else { 1 };
 
         Ok(ExecResult {
-            stdout: String::new(),
-            stderr: String::new(),
+            stdout: crate::StreamData::new(),
+            stderr: crate::StreamData::new(),
             exit_code,
             control_flow: ControlFlow::None,
             ..Default::default()
@@ -3942,8 +3897,8 @@ impl Interpreter {
                     &condition_result.stderr,
                     emit_before_cond,
                 );
-                acc.stdout.push_str(&condition_result.stdout);
-                acc.stderr.push_str(&condition_result.stderr);
+                acc.stdout.append(&condition_result.stdout);
+                acc.stderr.append(&condition_result.stderr);
                 let should_break = if break_on_zero {
                     condition_result.exit_code == 0
                 } else {
@@ -3969,7 +3924,7 @@ impl Interpreter {
                     }
                     state::LoopAction::Break => break,
                     state::LoopAction::Continue => continue,
-                    state::LoopAction::Exit(r) => return Ok(r),
+                    state::LoopAction::Exit(r) => return Ok(*r),
                 }
             }
 
@@ -3985,8 +3940,8 @@ impl Interpreter {
         use crate::parser::CaseTerminator;
         let word_value = self.expand_word(&case_cmd.word).await?;
 
-        let mut stdout = String::new();
-        let mut stderr = String::new();
+        let mut stdout = crate::StreamData::new();
+        let mut stderr = crate::StreamData::new();
         let mut exit_code = 0;
         let mut fallthrough = false;
 
@@ -4007,8 +3962,8 @@ impl Interpreter {
 
             if matched {
                 let r = self.execute_command_sequence(&case_item.commands).await?;
-                stdout.push_str(&r.stdout);
-                stderr.push_str(&r.stderr);
+                stdout.append(&r.stdout);
+                stderr.append(&r.stderr);
                 exit_code = r.exit_code;
                 if r.control_flow != ControlFlow::None {
                     return Ok(ExecResult {
@@ -4443,7 +4398,7 @@ impl Interpreter {
         &mut self,
         shell_name: &str,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         // Parse arguments — Err means early-return result (--version, --help, errors)
@@ -4469,7 +4424,7 @@ impl Interpreter {
                 }
             }
         } else if let Some(ref stdin_content) = stdin {
-            stdin_content.clone()
+            stdin_content.text_lossy().into_owned()
         } else {
             return Ok(ExecResult::ok(String::new()));
         };
@@ -4725,52 +4680,52 @@ enum FdTarget {
 /// `apply_redirections_fd_table` to keep these locals out of the async state machine.
 #[inline(never)]
 fn route_fd_table_content(
-    orig_stdout: &str,
-    orig_stderr: &str,
+    orig_stdout: &crate::StreamData,
+    orig_stderr: &crate::StreamData,
     fd1: &FdTarget,
     fd2: &FdTarget,
     extra_fd_targets: &[(i32, FdTarget)],
-    pending: &HashMap<i32, String>,
+    pending: &HashMap<i32, crate::StreamData>,
 ) -> (
-    String,
-    String,
-    std::collections::HashMap<PathBuf, (String, bool, String)>,
+    crate::StreamData,
+    crate::StreamData,
+    std::collections::HashMap<PathBuf, (crate::StreamData, bool, String)>,
 ) {
-    let mut new_stdout = String::new();
-    let mut new_stderr = String::new();
-    let mut file_writes: std::collections::HashMap<PathBuf, (String, bool, String)> =
+    let mut new_stdout = crate::StreamData::new();
+    let mut new_stderr = crate::StreamData::new();
+    let mut file_writes: std::collections::HashMap<PathBuf, (crate::StreamData, bool, String)> =
         std::collections::HashMap::new();
 
-    let route = |data: &str,
+    let route = |data: &crate::StreamData,
                  target: &FdTarget,
-                 fw: &mut std::collections::HashMap<PathBuf, (String, bool, String)>,
-                 out: &mut String,
-                 err: &mut String| match target {
+                 fw: &mut std::collections::HashMap<PathBuf, (crate::StreamData, bool, String)>,
+                 out: &mut crate::StreamData,
+                 err: &mut crate::StreamData| match target {
         FdTarget::Stdout => {
             if !data.is_empty() {
-                out.push_str(data);
+                out.append(data);
             }
         }
         FdTarget::Stderr => {
             if !data.is_empty() {
-                err.push_str(data);
+                err.append(data);
             }
         }
         FdTarget::DevNull => {}
         FdTarget::WriteFile(p, d) => {
             let entry = fw
                 .entry(p.clone())
-                .or_insert_with(|| (String::new(), false, d.clone()));
+                .or_insert_with(|| (crate::StreamData::new(), false, d.clone()));
             if !data.is_empty() {
-                entry.0.push_str(data);
+                entry.0.append(data);
             }
         }
         FdTarget::AppendFile(p, d) => {
             let entry = fw
                 .entry(p.clone())
-                .or_insert_with(|| (String::new(), true, d.clone()));
+                .or_insert_with(|| (crate::StreamData::new(), true, d.clone()));
             if !data.is_empty() {
-                entry.0.push_str(data);
+                entry.0.append(data);
             }
         }
     };
@@ -4845,8 +4800,8 @@ impl Interpreter {
         commands: &[Command],
         check_errexit: bool,
     ) -> Result<ExecResult> {
-        let mut stdout = String::new();
-        let mut stderr = String::new();
+        let mut stdout = crate::StreamData::new();
+        let mut stderr = crate::StreamData::new();
         let mut exit_code = 0;
         let mut last_errexit_suppressed = false;
 
@@ -4854,8 +4809,8 @@ impl Interpreter {
             let emit_before = self.output_emit_count;
             let result = self.execute_command(command).await?;
             self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-            stdout.push_str(&result.stdout);
-            stderr.push_str(&result.stderr);
+            stdout.append(&result.stdout);
+            stderr.append(&result.stderr);
             exit_code = result.exit_code;
             self.last_exit_code = exit_code;
 
@@ -4898,7 +4853,7 @@ impl Interpreter {
 
     /// Execute a pipeline (cmd1 | cmd2 | cmd3)
     async fn execute_pipeline(&mut self, pipeline: &Pipeline) -> Result<ExecResult> {
-        let mut stdin_data: Option<String> = None;
+        let mut stdin_data: Option<crate::StreamData> = None;
         let mut last_result = ExecResult::ok(String::new());
         let mut pipe_statuses = Vec::new();
 
@@ -4976,8 +4931,8 @@ impl Interpreter {
     async fn spawn_in_background(
         &mut self,
         cmd: &Command,
-        parent_stdout: &mut String,
-        parent_stderr: &mut String,
+        parent_stdout: &mut crate::StreamData,
+        parent_stderr: &mut crate::StreamData,
     ) -> Result<()> {
         // Execute the command synchronously
         let emit_before = self.output_emit_count;
@@ -4985,8 +4940,8 @@ impl Interpreter {
         self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
 
         // Emit output immediately (background output goes to terminal in real bash)
-        parent_stdout.push_str(&result.stdout);
-        parent_stderr.push_str(&result.stderr);
+        parent_stdout.append(&result.stdout);
+        parent_stderr.append(&result.stderr);
 
         // Store only the exit code in the job table (output already emitted).
         // The command already ran to completion synchronously, so the result is
@@ -5006,8 +4961,8 @@ impl Interpreter {
     /// Execute a command list (cmd1 && cmd2 || cmd3)
     #[allow(unused_assignments)] // control_flow may be set but overwritten
     async fn execute_list(&mut self, list: &CommandList) -> Result<ExecResult> {
-        let mut stdout = String::new();
-        let mut stderr = String::new();
+        let mut stdout = crate::StreamData::new();
+        let mut stderr = crate::StreamData::new();
         let mut exit_code;
         let mut control_flow;
         let mut exit_code_from_conditional_context = false;
@@ -5026,8 +4981,8 @@ impl Interpreter {
             let emit_before = self.output_emit_count;
             let result = self.execute_command(&list.first).await?;
             self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-            stdout.push_str(&result.stdout);
-            stderr.push_str(&result.stderr);
+            stdout.append(&result.stdout);
+            stderr.append(&result.stderr);
             exit_code = result.exit_code;
             self.last_exit_code = exit_code;
             control_flow = result.control_flow;
@@ -5114,8 +5069,8 @@ impl Interpreter {
                     let emit_before = self.output_emit_count;
                     let result = self.execute_command(cmd).await?;
                     self.maybe_emit_output(&result.stdout, &result.stderr, emit_before);
-                    stdout.push_str(&result.stdout);
-                    stderr.push_str(&result.stderr);
+                    stdout.append(&result.stdout);
+                    stderr.append(&result.stderr);
                     exit_code = result.exit_code;
                     self.last_exit_code = exit_code;
                     control_flow = result.control_flow;
@@ -5343,7 +5298,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         command: &SimpleCommand,
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         var_saves: Vec<(String, Option<String>)>,
     ) -> Option<Result<ExecResult>> {
         let is_plain_literal = !command.name.quoted
@@ -5453,8 +5408,11 @@ impl Interpreter {
         for (path_str, commands) in deferred {
             let path = Path::new(&path_str);
             let stdin_data = if let Ok(bytes) = self.fs.read_file(path).await {
-                let s = decode_file_bytes_for_path(path, &bytes);
-                if s.is_empty() { None } else { Some(s) }
+                if bytes.is_empty() {
+                    None
+                } else {
+                    Some(bytes.into())
+                }
             } else {
                 None
             };
@@ -5464,8 +5422,8 @@ impl Interpreter {
                 let cmd_result = self.execute_command(cmd).await?;
                 self.pipeline_stdin = prev_stdin;
                 if let Ok(r) = result {
-                    r.stdout.push_str(&cmd_result.stdout);
-                    r.stderr.push_str(&cmd_result.stderr);
+                    r.stdout.append(&cmd_result.stdout);
+                    r.stderr.append(&cmd_result.stderr);
                 }
             }
         }
@@ -5520,7 +5478,7 @@ impl Interpreter {
     fn execute_simple_command<'a>(
         &'a mut self,
         command: &'a SimpleCommand,
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         Box::pin(async move {
             let deferred_proc_sub_start = self.deferred_proc_subs.len();
@@ -5538,8 +5496,8 @@ impl Interpreter {
                 self.last_exit_code = 1;
                 self.discard_deferred_proc_subs_from(deferred_proc_sub_start);
                 return Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: err_msg,
+                    stdout: crate::StreamData::new(),
+                    stderr: err_msg.into(),
                     exit_code: 1,
                     control_flow: ControlFlow::Return(1),
                     ..Default::default()
@@ -5600,8 +5558,8 @@ impl Interpreter {
                 self.last_exit_code = exit_code;
                 self.discard_deferred_proc_subs_from(deferred_proc_sub_start);
                 return Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: String::new(),
+                    stdout: crate::StreamData::new(),
+                    stderr: crate::StreamData::new(),
                     exit_code,
                     control_flow: crate::interpreter::ControlFlow::None,
                     ..Default::default()
@@ -5661,7 +5619,9 @@ impl Interpreter {
             // Prepend xtrace to stderr
             let mut result = if let Some(trace) = xtrace_line {
                 result.map(|mut r| {
-                    r.stderr = trace + &r.stderr;
+                    let mut stderr: crate::StreamData = trace.into();
+                    stderr.append(&r.stderr);
+                    r.stderr = stderr;
                     r
                 })
             } else {
@@ -5731,7 +5691,7 @@ impl Interpreter {
         name: &'a str,
         args: Vec<String>,
         command: &'a SimpleCommand,
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         Box::pin(async move {
             // Track $_ (last argument of previous command, from already-expanded args)
@@ -5745,8 +5705,8 @@ impl Interpreter {
             if let Some(err_msg) = self.nounset_error.take() {
                 self.last_exit_code = 1;
                 return Ok(ExecResult {
-                    stdout: String::new(),
-                    stderr: err_msg,
+                    stdout: crate::StreamData::new(),
+                    stderr: err_msg.into(),
                     exit_code: 1,
                     control_flow: ControlFlow::Return(1),
                     ..Default::default()
@@ -5771,7 +5731,7 @@ impl Interpreter {
 
             // For `read -u FD`, check if FD is a coproc read FD and inject data as stdin
             let stdin = if name == "read" && stdin.is_none() {
-                self.try_coproc_read_stdin(&args).or(stdin)
+                self.try_coproc_read_stdin(&args).map(Into::into).or(stdin)
             } else {
                 stdin
             };
@@ -5787,11 +5747,11 @@ impl Interpreter {
                         let data = ps.clone();
                         if let Some(newline_pos) = data.find('\n') {
                             let line = data[..=newline_pos].to_string();
-                            self.pipeline_stdin = Some(data[newline_pos + 1..].to_string());
-                            Some(line)
+                            self.pipeline_stdin = Some(data.as_bytes()[newline_pos + 1..].into());
+                            Some(line.into())
                         } else {
                             // Last line without trailing newline
-                            self.pipeline_stdin = Some(String::new());
+                            self.pipeline_stdin = Some(crate::StreamData::new());
                             Some(data)
                         }
                     } else {
@@ -5882,7 +5842,7 @@ impl Interpreter {
                         self.coproc_buffers.insert(fd, lines);
                     } else {
                         // exec < file: redirect stdin for subsequent commands
-                        self.pipeline_stdin = Some(text);
+                        self.pipeline_stdin = Some(text.into());
                     }
                 }
                 RedirectKind::DupInput => {
@@ -5988,7 +5948,7 @@ impl Interpreter {
         &'a mut self,
         name: &'a str,
         args: &'a [String],
-        stdin: Option<&'a str>,
+        stdin: Option<&'a crate::StreamData>,
         redirects: &'a [Redirect],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         // Clone the Arc out of the map so the call doesn't hold a borrow on
@@ -6003,7 +5963,7 @@ impl Interpreter {
         name: &'a str,
         builtin: Arc<dyn Builtin>,
         args: &'a [String],
-        stdin: Option<&'a str>,
+        stdin: Option<&'a crate::StreamData>,
         redirects: &'a [Redirect],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         self.execute_builtin_arc(name, builtin, args, stdin, redirects)
@@ -6016,7 +5976,7 @@ impl Interpreter {
         name: &'a str,
         builtin: Arc<dyn Builtin>,
         args: &'a [String],
-        stdin: Option<&'a str>,
+        stdin: Option<&'a crate::StreamData>,
         redirects: &'a [Redirect],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         Box::pin(async move {
@@ -6173,12 +6133,12 @@ impl Interpreter {
         }
         let event = crate::hooks::ToolResult {
             name: name.to_string(),
-            stdout: result.stdout.clone(),
+            stdout: result.stdout.text_lossy().into_owned(),
             exit_code: result.exit_code,
         };
         match self.hooks.fire_after_tool(event) {
             Some(event) => ExecResult {
-                stdout: event.stdout,
+                stdout: event.stdout.into(),
                 exit_code: event.exit_code,
                 ..result
             },
@@ -6194,7 +6154,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         let args = if !self.hooks.before_tool.is_empty() {
@@ -6229,7 +6189,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Option<Result<ExecResult>> {
         if self.shell_profile.is_logic_only()
@@ -6277,7 +6237,7 @@ impl Interpreter {
         name: &'a str,
         command: &'a SimpleCommand,
         args: Vec<String>,
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<ExecResult>> + Send + 'a>> {
         Box::pin(async move {
             // Check for functions first
@@ -6302,20 +6262,14 @@ impl Interpreter {
             // Host-registered builtins (mutable, may override baked-in builtins).
             if let Some(builtin) = self.host_builtins.as_ref().and_then(|reg| reg.lookup(name)) {
                 return self
-                    .execute_host_builtin(
-                        name,
-                        builtin,
-                        &args,
-                        stdin.as_deref(),
-                        &command.redirects,
-                    )
+                    .execute_host_builtin(name, builtin, &args, stdin.as_ref(), &command.redirects)
                     .await;
             }
 
             // Registered builtins
             if self.builtins.contains_key(name) {
                 return self
-                    .execute_registered_builtin(name, &args, stdin.as_deref(), &command.redirects)
+                    .execute_registered_builtin(name, &args, stdin.as_ref(), &command.redirects)
                     .await;
             }
 
@@ -6372,7 +6326,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         let path = self.resolve_path(name);
@@ -6459,7 +6413,7 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<Option<ExecResult>> {
         let path_var = self
@@ -6505,7 +6459,7 @@ impl Interpreter {
         name: &str,
         content: &str,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         // Strip shebang line if present
@@ -6774,7 +6728,7 @@ impl Interpreter {
     async fn execute_eval(
         &mut self,
         args: &[String],
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         if args.is_empty() {
@@ -7102,7 +7056,7 @@ impl Interpreter {
         name: &str,
         func_def: &FunctionDef,
         args: Vec<String>,
-        stdin: Option<String>,
+        stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         // Check function depth limit
@@ -7414,8 +7368,8 @@ impl Interpreter {
         }
         let exit_code = if last_val == 0 { 1 } else { 0 };
         let result = ExecResult {
-            stdout: String::new(),
-            stderr: String::new(),
+            stdout: crate::StreamData::new(),
+            stderr: crate::StreamData::new(),
             exit_code,
             control_flow: ControlFlow::None,
             ..Default::default()
@@ -7501,7 +7455,7 @@ impl Interpreter {
             }
         }
         let result = ExecResult {
-            stderr,
+            stderr: stderr.into(),
             exit_code,
             ..Default::default()
         };
@@ -7551,8 +7505,8 @@ impl Interpreter {
         if optind < 1 || optind > parse_args.len() {
             self.insert_variable_checked(varname.clone(), "?".to_string());
             return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: String::new(),
+                stdout: crate::StreamData::new(),
+                stderr: crate::StreamData::new(),
                 exit_code: 1,
                 control_flow: crate::interpreter::ControlFlow::None,
                 ..Default::default()
@@ -7569,8 +7523,8 @@ impl Interpreter {
                     .insert("OPTIND".to_string(), (optind + 1).to_string());
             }
             return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: String::new(),
+                stdout: crate::StreamData::new(),
+                stderr: crate::StreamData::new(),
                 exit_code: 1,
                 control_flow: crate::interpreter::ControlFlow::None,
                 ..Default::default()
@@ -7591,8 +7545,8 @@ impl Interpreter {
             self.getopts_char_idx = 0;
             self.insert_variable_checked(varname.clone(), "?".to_string());
             return Ok(ExecResult {
-                stdout: String::new(),
-                stderr: String::new(),
+                stdout: crate::StreamData::new(),
+                stderr: crate::StreamData::new(),
                 exit_code: 1,
                 control_flow: crate::interpreter::ControlFlow::None,
                 ..Default::default()
@@ -7640,7 +7594,8 @@ impl Interpreter {
                         result.stderr = format!(
                             "bash: getopts: option requires an argument -- '{}'\n",
                             opt_char
-                        );
+                        )
+                        .into();
                         result = self.apply_redirections(result, redirects).await?;
                         return Ok(result);
                     }
@@ -7676,7 +7631,7 @@ impl Interpreter {
             } else {
                 self.insert_variable_checked(varname.clone(), "?".to_string());
                 let mut result = ExecResult::ok(String::new());
-                result.stderr = format!("bash: getopts: illegal option -- '{}'\n", opt_char);
+                result.stderr = format!("bash: getopts: illegal option -- '{}'\n", opt_char).into();
                 result = self.apply_redirections(result, redirects).await?;
                 return Ok(result);
             }
@@ -7695,7 +7650,7 @@ impl Interpreter {
     async fn execute_command_builtin(
         &mut self,
         args: &[String],
-        _stdin: Option<String>,
+        _stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         if args.is_empty() {
@@ -7746,8 +7701,8 @@ impl Interpreter {
                     ExecResult::ok(format!("{}\n", name))
                 } else {
                     ExecResult {
-                        stdout: String::new(),
-                        stderr: String::new(),
+                        stdout: crate::StreamData::new(),
+                        stderr: crate::StreamData::new(),
                         exit_code: 1,
                         control_flow: crate::interpreter::ControlFlow::None,
                         ..Default::default()
@@ -7812,7 +7767,7 @@ impl Interpreter {
                             target,
                             builtin,
                             builtin_args,
-                            _stdin.as_deref(),
+                            _stdin.as_ref(),
                             redirects,
                         )
                         .await;
@@ -7823,7 +7778,7 @@ impl Interpreter {
                             target,
                             builtin,
                             builtin_args,
-                            _stdin.as_deref(),
+                            _stdin.as_ref(),
                             redirects,
                         )
                         .await;
@@ -8153,7 +8108,7 @@ impl Interpreter {
         }
 
         let mut result = ExecResult {
-            stderr: declare_stderr,
+            stderr: declare_stderr.into(),
             exit_code: declare_exit_code,
             ..Default::default()
         };
@@ -8211,10 +8166,17 @@ impl Interpreter {
                     let baseline_bash_source_len = self.bash_source_stack.len();
                     let baseline_function_depth = self.counters.function_depth;
                     let baseline_pipeline_stdin = self.pipeline_stdin.clone();
+                    self.pipeline_stdin = command.stdin.clone();
                     let exec_future = self.execute_command(&inner_cmd);
                     match timeout(duration, exec_future).await {
-                        Ok(Ok(result)) => result,
-                        Ok(Err(e)) => return Err(e),
+                        Ok(Ok(result)) => {
+                            self.pipeline_stdin = baseline_pipeline_stdin;
+                            result
+                        }
+                        Ok(Err(e)) => {
+                            self.pipeline_stdin = baseline_pipeline_stdin;
+                            return Err(e);
+                        }
                         Err(_) => {
                             self.reconcile_cancelled_execution_state(
                                 baseline_call_stack_len,
@@ -8236,16 +8198,19 @@ impl Interpreter {
                 outcome
             }
             builtins::ExecutionPlan::Batch { commands } => {
-                let mut combined_stdout = String::new();
-                let mut combined_stderr = String::new();
+                let mut combined_stdout = crate::StreamData::new();
+                let mut combined_stderr = crate::StreamData::new();
                 let mut last_exit_code = 0;
 
                 for cmd in commands {
                     let inner_cmd = subcommand_to_command(&cmd);
-
-                    let result = self.execute_command(&inner_cmd).await?;
-                    combined_stdout.push_str(&result.stdout);
-                    combined_stderr.push_str(&result.stderr);
+                    let saved_stdin = self.pipeline_stdin.take();
+                    self.pipeline_stdin = cmd.stdin;
+                    let result = self.execute_command(&inner_cmd).await;
+                    self.pipeline_stdin = saved_stdin;
+                    let result = result?;
+                    combined_stdout.append(&result.stdout);
+                    combined_stderr.append(&result.stderr);
                     last_exit_code = result.exit_code;
                 }
 
@@ -8262,16 +8227,19 @@ impl Interpreter {
                 stderr_prefix,
                 force_error_exit,
             } => {
-                let mut combined_stdout = String::new();
-                let mut combined_stderr = stderr_prefix;
+                let mut combined_stdout = crate::StreamData::new();
+                let mut combined_stderr: crate::StreamData = stderr_prefix.into();
                 let mut last_exit_code = 0;
 
                 for cmd in commands {
                     let inner_cmd = subcommand_to_command(&cmd);
-
-                    let result = self.execute_command(&inner_cmd).await?;
-                    combined_stdout.push_str(&result.stdout);
-                    combined_stderr.push_str(&result.stderr);
+                    let saved_stdin = self.pipeline_stdin.take();
+                    self.pipeline_stdin = cmd.stdin;
+                    let result = self.execute_command(&inner_cmd).await;
+                    self.pipeline_stdin = saved_stdin;
+                    let result = result?;
+                    combined_stdout.append(&result.stdout);
+                    combined_stderr.append(&result.stderr);
                     last_exit_code = result.exit_code;
                 }
 
@@ -8305,7 +8273,7 @@ impl Interpreter {
         baseline_call_stack_len: usize,
         baseline_bash_source_len: usize,
         baseline_function_depth: usize,
-        baseline_pipeline_stdin: Option<String>,
+        baseline_pipeline_stdin: Option<crate::StreamData>,
     ) {
         let leaked_call_frames = self
             .call_stack
@@ -8446,7 +8414,7 @@ impl Interpreter {
             let mut stdout = String::new();
             for cmd in commands {
                 let cmd_result = self.execute_command(cmd).await?;
-                stdout.push_str(&cmd_result.stdout);
+                stdout.push_str(&cmd_result.stdout.command_substitution_text());
             }
             if self.fs.write_file(path, stdout.as_bytes()).await.is_err() {
                 Ok(stdout)
@@ -8508,7 +8476,7 @@ impl Interpreter {
             let mut stdout = String::new();
             for cmd in commands {
                 let cmd_result = self.execute_command(cmd).await?;
-                stdout.push_str(&cmd_result.stdout);
+                stdout.push_str(&cmd_result.stdout.command_substitution_text());
                 self.last_exit_code = cmd_result.exit_code;
                 if matches!(cmd_result.control_flow, ControlFlow::Exit(_)) {
                     break;
@@ -8527,7 +8495,7 @@ impl Interpreter {
                     .execute_capture_only_sequence(&trap_script.commands)
                     .await
             {
-                stdout.push_str(&trap_result.stdout);
+                stdout.push_str(&trap_result.stdout.command_substitution_text());
             }
             self.restore_subshell_state(snapshot);
             self.counters.pop_subst();
@@ -9079,7 +9047,8 @@ impl Interpreter {
                                 self.execute_command_sequence(&script.commands).await?;
                             self.restore_subshell_state(snapshot);
                             self.counters.pop_subst();
-                            let trimmed = cmd_result.stdout.trim_end_matches('\n');
+                            let command_output = cmd_result.stdout.command_substitution_text();
+                            let trimmed = command_output.trim_end_matches('\n');
                             if trimmed.is_empty() {
                                 result.push('0');
                             } else {
@@ -9329,11 +9298,11 @@ impl Interpreter {
     /// Run ERR trap if registered. Appends trap output to stdout/stderr.
     /// Run the DEBUG trap handler (fires before each simple command).
     /// Returns (stdout, stderr) from the trap handler.
-    async fn run_debug_trap(&mut self) -> (String, String) {
+    async fn run_debug_trap(&mut self) -> (crate::StreamData, crate::StreamData) {
         // THREAT[TM-DOS-035]: Suppress DEBUG trap inside trap handlers to prevent
         // recursive amplification (each trapped command firing more DEBUG traps).
         if self.in_trap {
-            return (String::new(), String::new());
+            return (crate::StreamData::new(), crate::StreamData::new());
         }
         if let Some(trap_cmd) = self.scoped.traps.get("DEBUG").cloned() {
             // THREAT[TM-DOS-030]: Propagate interpreter parser limits
@@ -9354,10 +9323,14 @@ impl Interpreter {
                 }
             }
         }
-        (String::new(), String::new())
+        (crate::StreamData::new(), crate::StreamData::new())
     }
 
-    async fn run_err_trap(&mut self, stdout: &mut String, stderr: &mut String) {
+    async fn run_err_trap(
+        &mut self,
+        stdout: &mut crate::StreamData,
+        stderr: &mut crate::StreamData,
+    ) {
         // THREAT[TM-DOS-035]: Suppress ERR trap re-entrancy while executing trap
         // handlers to prevent recursive ERR -> ERR amplification.
         if self.in_trap {
@@ -9378,8 +9351,8 @@ impl Interpreter {
                 self.in_trap = false;
                 if let Ok(trap_result) = result {
                     self.maybe_emit_output(&trap_result.stdout, &trap_result.stderr, emit_before);
-                    stdout.push_str(&trap_result.stdout);
-                    stderr.push_str(&trap_result.stderr);
+                    stdout.append(&trap_result.stdout);
+                    stderr.append(&trap_result.stderr);
                 }
             }
         }

--- a/crates/bashkit/src/interpreter/redirection.rs
+++ b/crates/bashkit/src/interpreter/redirection.rs
@@ -11,9 +11,9 @@ impl Interpreter {
     /// Process input redirections (< file, <<< string)
     pub(super) async fn process_input_redirections(
         &mut self,
-        existing_stdin: Option<String>,
+        existing_stdin: Option<crate::StreamData>,
         redirects: &[Redirect],
-    ) -> Result<Option<String>> {
+    ) -> Result<Option<crate::StreamData>> {
         let mut stdin = existing_stdin;
 
         for redirect in redirects {
@@ -31,7 +31,7 @@ impl Interpreter {
                     let path = self.resolve_path(&target_path);
                     // Handle /dev/null at interpreter level - cannot be bypassed
                     if is_dev_null(&path) {
-                        stdin = Some(String::new()); // EOF
+                        stdin = Some(crate::StreamData::new()); // EOF
                     } else if self.shell_profile.is_logic_only() {
                         return Err(crate::error::Error::Execution(format!(
                             "bash: {}: filesystem redirection disabled",
@@ -40,7 +40,7 @@ impl Interpreter {
                     } else {
                         match self.fs.read_file(&path).await {
                             Ok(content) => {
-                                stdin = Some(decode_file_bytes_for_path(&path, &content));
+                                stdin = Some(content.into());
                             }
                             Err(e) => {
                                 return Err(crate::error::Error::CommandFailure(format!(
@@ -53,12 +53,12 @@ impl Interpreter {
                 RedirectKind::HereString => {
                     // <<< string - use the target as stdin content
                     let content = self.expand_word(&redirect.target).await?;
-                    stdin = Some(format!("{}\n", content));
+                    stdin = Some(format!("{}\n", content).into());
                 }
                 RedirectKind::HereDoc | RedirectKind::HereDocStrip => {
                     // << EOF / <<- EOF - use the heredoc content as stdin
                     let content = self.expand_word(&redirect.target).await?;
-                    stdin = Some(content);
+                    stdin = Some(content.into());
                 }
                 RedirectKind::DupInput => {
                     // <&FD - if FD is a coproc read FD, consume next line
@@ -67,9 +67,9 @@ impl Interpreter {
                         && let Some(buf) = self.coproc_buffers.get_mut(&fd)
                     {
                         if let Some(line) = buf.pop() {
-                            stdin = Some(format!("{}\n", line));
+                            stdin = Some(format!("{}\n", line).into());
                         } else {
-                            stdin = Some(String::new()); // EOF
+                            stdin = Some(crate::StreamData::new()); // EOF
                         }
                     }
                 }
@@ -89,8 +89,8 @@ impl Interpreter {
         redirects: &[Redirect],
     ) -> Result<ExecResult> {
         if let Some(stderr) = self.logic_only_redirect_error(redirects) {
-            result.stdout = String::new();
-            result.stderr = stderr;
+            result.stdout = crate::StreamData::new();
+            result.stderr = stderr.into();
             result.exit_code = 1;
             return Ok(result);
         }
@@ -121,20 +121,18 @@ impl Interpreter {
                     let path = self.resolve_path(&target_path);
                     if is_dev_null(&path) {
                         match redirect.fd {
-                            Some(2) => result.stderr = String::new(),
-                            _ => {
-                                result.stdout = String::new();
-                                result.stdout_bytes = None;
-                            }
+                            Some(2) => result.stderr = crate::StreamData::new(),
+                            _ => result.stdout = crate::StreamData::new(),
                         }
                     } else {
                         if redirect.kind == RedirectKind::Output
                             && self.scoped.variables.get("SHOPT_C").map(|v| v.as_str()) == Some("1")
                             && self.fs.stat(&path).await.is_ok()
                         {
-                            result.stdout = String::new();
+                            result.stdout = crate::StreamData::new();
                             result.stderr =
-                                format!("bash: {}: cannot overwrite existing file\n", target_path);
+                                format!("bash: {}: cannot overwrite existing file\n", target_path)
+                                    .into();
                             result.exit_code = 1;
                             return Ok(result);
                         }
@@ -143,26 +141,24 @@ impl Interpreter {
                                 if let Err(e) =
                                     self.fs.write_file(&path, result.stderr.as_bytes()).await
                                 {
-                                    result.stderr = format!("bash: {}: {}\n", target_path, e);
+                                    result.stderr =
+                                        format!("bash: {}: {}\n", target_path, e).into();
                                     result.exit_code = 1;
                                     return Ok(result);
                                 }
-                                result.stderr = String::new();
+                                result.stderr = crate::StreamData::new();
                             }
                             _ => {
-                                let stdout = result
-                                    .stdout_bytes
-                                    .as_deref()
-                                    .unwrap_or(result.stdout.as_bytes());
-                                if let Err(e) = self.fs.write_file(&path, stdout).await {
-                                    result.stdout = String::new();
-                                    result.stdout_bytes = None;
-                                    result.stderr = format!("bash: {}: {}\n", target_path, e);
+                                if let Err(e) =
+                                    self.fs.write_file(&path, result.stdout.as_bytes()).await
+                                {
+                                    result.stdout = crate::StreamData::new();
+                                    result.stderr =
+                                        format!("bash: {}: {}\n", target_path, e).into();
                                     result.exit_code = 1;
                                     return Ok(result);
                                 }
-                                result.stdout = String::new();
-                                result.stdout_bytes = None;
+                                result.stdout = crate::StreamData::new();
                             }
                         }
                     }
@@ -172,11 +168,8 @@ impl Interpreter {
                     let path = self.resolve_path(&target_path);
                     if is_dev_null(&path) {
                         match redirect.fd {
-                            Some(2) => result.stderr = String::new(),
-                            _ => {
-                                result.stdout = String::new();
-                                result.stdout_bytes = None;
-                            }
+                            Some(2) => result.stderr = crate::StreamData::new(),
+                            _ => result.stdout = crate::StreamData::new(),
                         }
                     } else {
                         match redirect.fd {
@@ -184,26 +177,24 @@ impl Interpreter {
                                 if let Err(e) =
                                     self.fs.append_file(&path, result.stderr.as_bytes()).await
                                 {
-                                    result.stderr = format!("bash: {}: {}\n", target_path, e);
+                                    result.stderr =
+                                        format!("bash: {}: {}\n", target_path, e).into();
                                     result.exit_code = 1;
                                     return Ok(result);
                                 }
-                                result.stderr = String::new();
+                                result.stderr = crate::StreamData::new();
                             }
                             _ => {
-                                let stdout = result
-                                    .stdout_bytes
-                                    .as_deref()
-                                    .unwrap_or(result.stdout.as_bytes());
-                                if let Err(e) = self.fs.append_file(&path, stdout).await {
-                                    result.stdout = String::new();
-                                    result.stdout_bytes = None;
-                                    result.stderr = format!("bash: {}: {}\n", target_path, e);
+                                if let Err(e) =
+                                    self.fs.append_file(&path, result.stdout.as_bytes()).await
+                                {
+                                    result.stdout = crate::StreamData::new();
+                                    result.stderr =
+                                        format!("bash: {}: {}\n", target_path, e).into();
                                     result.exit_code = 1;
                                     return Ok(result);
                                 }
-                                result.stdout = String::new();
-                                result.stdout_bytes = None;
+                                result.stdout = crate::StreamData::new();
                             }
                         }
                     }
@@ -212,23 +203,18 @@ impl Interpreter {
                     let target_path = self.expand_word(&redirect.target).await?;
                     let path = self.resolve_path(&target_path);
                     if is_dev_null(&path) {
-                        result.stdout = String::new();
-                        result.stdout_bytes = None;
-                        result.stderr = String::new();
+                        result.stdout = crate::StreamData::new();
+                        result.stderr = crate::StreamData::new();
                     } else {
-                        let mut combined = result
-                            .stdout_bytes
-                            .clone()
-                            .unwrap_or_else(|| result.stdout.as_bytes().to_vec());
+                        let mut combined = result.stdout.as_bytes().to_vec();
                         combined.extend_from_slice(result.stderr.as_bytes());
                         if let Err(e) = self.fs.write_file(&path, &combined).await {
-                            result.stderr = format!("bash: {}: {}\n", target_path, e);
+                            result.stderr = format!("bash: {}: {}\n", target_path, e).into();
                             result.exit_code = 1;
                             return Ok(result);
                         }
-                        result.stdout = String::new();
-                        result.stdout_bytes = None;
-                        result.stderr = String::new();
+                        result.stdout = crate::StreamData::new();
+                        result.stderr = crate::StreamData::new();
                     }
                 }
                 RedirectKind::DupOutput => {
@@ -244,8 +230,8 @@ impl Interpreter {
                             std::mem::take(&mut result.stdout)
                         };
                         match &fd_target {
-                            FdTarget::Stdout => result.stdout.push_str(&data),
-                            FdTarget::Stderr => result.stderr.push_str(&data),
+                            FdTarget::Stdout => result.stdout.append(&data),
+                            FdTarget::Stderr => result.stderr.append(&data),
                             FdTarget::DevNull => {}
                             FdTarget::WriteFile(path, _) | FdTarget::AppendFile(path, _) => {
                                 self.fs.append_file(path, data.as_bytes()).await?;
@@ -254,12 +240,12 @@ impl Interpreter {
                     } else {
                         match (src_fd, target_fd) {
                             (2, 1) => {
-                                result.stdout.push_str(&result.stderr);
-                                result.stderr = String::new();
+                                result.stdout.append(&result.stderr);
+                                result.stderr = crate::StreamData::new();
                             }
                             (1, 2) => {
-                                result.stderr.push_str(&result.stdout);
-                                result.stdout = String::new();
+                                result.stderr.append(&result.stdout);
+                                result.stdout = crate::StreamData::new();
                             }
                             (src, dst) if dst >= 3 => {
                                 let data = if src == 2 {
@@ -340,9 +326,10 @@ impl Interpreter {
                         && !is_dev_null(&path)
                         && self.fs.stat(&path).await.is_ok()
                     {
-                        result.stdout = String::new();
+                        result.stdout = crate::StreamData::new();
                         result.stderr =
-                            format!("bash: {}: cannot overwrite existing file\n", target_path);
+                            format!("bash: {}: cannot overwrite existing file\n", target_path)
+                                .into();
                         result.exit_code = 1;
                         self.clear_pending_fd_redirect_state();
                         return Ok(result);
@@ -442,7 +429,7 @@ impl Interpreter {
                 self.fs.write_file(path, content.as_bytes()).await
             };
             if let Err(e) = write_result {
-                new_stderr = format!("bash: {}: {}\n", display_path, e);
+                new_stderr = format!("bash: {}: {}\n", display_path, e).into();
                 result.exit_code = 1;
                 result.stdout = new_stdout;
                 result.stderr = new_stderr;

--- a/crates/bashkit/src/interpreter/state.rs
+++ b/crates/bashkit/src/interpreter/state.rs
@@ -52,11 +52,9 @@ pub enum BuiltinSideEffect {
 #[derive(Debug, Clone, Default)]
 pub struct ExecResult {
     /// Standard output
-    pub stdout: String,
-    /// Exact stdout bytes when a builtin produces binary data.
-    pub stdout_bytes: Option<Vec<u8>>,
+    pub stdout: crate::StreamData,
     /// Standard error
-    pub stderr: String,
+    pub stderr: crate::StreamData,
     /// Exit code
     pub exit_code: i32,
     /// Control flow signal (break, continue, return)
@@ -80,10 +78,10 @@ pub struct ExecResult {
 
 impl ExecResult {
     /// Create a successful result with the given stdout.
-    pub fn ok(stdout: impl Into<String>) -> Self {
+    pub fn ok(stdout: impl Into<crate::StreamData>) -> Self {
         Self {
             stdout: stdout.into(),
-            stderr: String::new(),
+            stderr: crate::StreamData::new(),
             exit_code: 0,
             ..Default::default()
         }
@@ -91,20 +89,18 @@ impl ExecResult {
 
     /// Create a successful result with exact stdout bytes.
     pub fn ok_bytes(bytes: Vec<u8>) -> Self {
-        let stdout = bytes.iter().map(|&byte| byte as char).collect();
         Self {
-            stdout,
-            stdout_bytes: Some(bytes),
-            stderr: String::new(),
+            stdout: bytes.into(),
+            stderr: crate::StreamData::new(),
             exit_code: 0,
             ..Default::default()
         }
     }
 
     /// Create a failed result with the given stderr.
-    pub fn err(stderr: impl Into<String>, exit_code: i32) -> Self {
+    pub fn err(stderr: impl Into<crate::StreamData>, exit_code: i32) -> Self {
         Self {
-            stdout: String::new(),
+            stdout: crate::StreamData::new(),
             stderr: stderr.into(),
             exit_code,
             ..Default::default()
@@ -112,10 +108,10 @@ impl ExecResult {
     }
 
     /// Create a result with stdout and custom exit code.
-    pub fn with_code(stdout: impl Into<String>, exit_code: i32) -> Self {
+    pub fn with_code(stdout: impl Into<crate::StreamData>, exit_code: i32) -> Self {
         Self {
             stdout: stdout.into(),
-            stderr: String::new(),
+            stderr: crate::StreamData::new(),
             exit_code,
             ..Default::default()
         }
@@ -145,7 +141,7 @@ pub(crate) enum LoopAction {
     Continue,
     /// Exit the loop immediately and return this result to the caller.
     /// Used for multi-level break/continue propagation and return.
-    Exit(ExecResult),
+    Exit(Box<ExecResult>),
 }
 
 /// Accumulates stdout/stderr/exit_code/errexit_suppressed across loop
@@ -153,8 +149,8 @@ pub(crate) enum LoopAction {
 ///
 /// Eliminates duplicated tracking in for, arithmetic-for, and while/until loops.
 pub(crate) struct LoopAccumulator {
-    pub stdout: String,
-    pub stderr: String,
+    pub stdout: crate::StreamData,
+    pub stderr: crate::StreamData,
     pub exit_code: i32,
     pub errexit_suppressed: bool,
 }
@@ -162,8 +158,8 @@ pub(crate) struct LoopAccumulator {
 impl LoopAccumulator {
     pub fn new() -> Self {
         Self {
-            stdout: String::new(),
-            stderr: String::new(),
+            stdout: crate::StreamData::new(),
+            stderr: crate::StreamData::new(),
             exit_code: 0,
             errexit_suppressed: false,
         }
@@ -175,22 +171,26 @@ impl LoopAccumulator {
     /// For multi-level break/continue or return, builds a propagation
     /// `ExecResult` and returns `LoopAction::Exit`.
     pub fn accumulate(&mut self, result: ExecResult) -> LoopAction {
-        self.stdout.push_str(&result.stdout);
-        self.stderr.push_str(&result.stderr);
+        self.stdout.append(&result.stdout);
+        self.stderr.append(&result.stderr);
         self.exit_code = result.exit_code;
         self.errexit_suppressed = result.errexit_suppressed;
 
         match result.control_flow {
             ControlFlow::Break(n) if n <= 1 => LoopAction::Break,
-            ControlFlow::Break(n) => LoopAction::Exit(self.build_exit(ControlFlow::Break(n - 1))),
+            ControlFlow::Break(n) => {
+                LoopAction::Exit(Box::new(self.build_exit(ControlFlow::Break(n - 1))))
+            }
             ControlFlow::Continue(n) if n <= 1 => LoopAction::Continue,
             ControlFlow::Continue(n) => {
-                LoopAction::Exit(self.build_exit(ControlFlow::Continue(n - 1)))
+                LoopAction::Exit(Box::new(self.build_exit(ControlFlow::Continue(n - 1))))
             }
             ControlFlow::Return(code) => {
-                LoopAction::Exit(self.build_exit(ControlFlow::Return(code)))
+                LoopAction::Exit(Box::new(self.build_exit(ControlFlow::Return(code))))
             }
-            ControlFlow::Exit(code) => LoopAction::Exit(self.build_exit(ControlFlow::Exit(code))),
+            ControlFlow::Exit(code) => {
+                LoopAction::Exit(Box::new(self.build_exit(ControlFlow::Exit(code))))
+            }
             ControlFlow::None => LoopAction::None,
         }
     }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -440,6 +440,7 @@ pub mod parser;
 #[cfg(feature = "scripted_tool")]
 pub mod scripted_tool;
 mod snapshot;
+mod stream;
 /// Test-only helpers shared between internal `#[cfg(test)]` modules,
 /// integration tests in `tests/*.rs`, and cargo-fuzz targets in
 /// `fuzz/fuzz_targets/*.rs`. See `knowledge/security/threat-model.md` for the
@@ -458,6 +459,7 @@ pub(crate) mod tool_def;
 mod tool_registry;
 /// Structured execution trace events.
 pub mod trace;
+pub use stream::StreamData;
 
 pub use analysis::{
     AnalyzedCommand, AnalyzedRedirect, CommandContext, RedirectMode, ScriptAnalysis,
@@ -661,7 +663,7 @@ pub struct ExecOptions {
     output_callback: Option<OutputCallback>,
     arg0: Option<String>,
     positional: Option<Vec<String>>,
-    stdin: Option<String>,
+    stdin: Option<StreamData>,
 }
 
 impl ExecOptions {
@@ -737,7 +739,7 @@ impl ExecOptions {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn stdin(mut self, stdin: impl Into<String>) -> Self {
+    pub fn stdin(mut self, stdin: impl Into<StreamData>) -> Self {
         self.stdin = Some(stdin.into());
         self
     }
@@ -754,7 +756,7 @@ impl ExecOptions {
 struct Invocation {
     arg0: Option<String>,
     positional: Option<Vec<String>>,
-    stdin: Option<String>,
+    stdin: Option<StreamData>,
 }
 
 impl Invocation {
@@ -1180,14 +1182,14 @@ impl Bash {
             if !self.interpreter.hooks().after_exec.is_empty() {
                 let output = hooks::ExecOutput {
                     script: script.to_string(),
-                    stdout: exec_result.stdout.clone(),
-                    stderr: exec_result.stderr.clone(),
+                    stdout: exec_result.stdout.text_lossy().into_owned(),
+                    stderr: exec_result.stderr.text_lossy().into_owned(),
                     exit_code: exec_result.exit_code,
                 };
                 match self.interpreter.hooks().fire_after_exec(output) {
                     Some(output) => Ok(ExecResult {
-                        stdout: output.stdout,
-                        stderr: output.stderr,
+                        stdout: output.stdout.into(),
+                        stderr: output.stderr.into(),
                         exit_code: output.exit_code,
                         ..exec_result
                     }),
@@ -5164,7 +5166,7 @@ fn
         #[async_trait]
         impl Builtin for Upper {
             async fn execute(&self, ctx: Context<'_>) -> crate::Result<ExecResult> {
-                let input = ctx.stdin.unwrap_or("");
+                let input = ctx.stdin.map(|stdin| &**stdin).unwrap_or("");
                 Ok(ExecResult::ok(input.to_uppercase()))
             }
         }

--- a/crates/bashkit/src/scripted_tool/execute.rs
+++ b/crates/bashkit/src/scripted_tool/execute.rs
@@ -128,20 +128,22 @@ impl ScriptedTool {
 
         let fut = async {
             let result = if let Some(sender) = stream_sender {
-                let output_cb = Box::new(move |stdout_chunk: &str, stderr_chunk: &str| {
-                    if !stdout_chunk.is_empty() {
-                        let _ = sender.send(ToolOutputChunk {
-                            data: serde_json::json!(stdout_chunk),
-                            kind: "stdout".to_string(),
-                        });
-                    }
-                    if !stderr_chunk.is_empty() {
-                        let _ = sender.send(ToolOutputChunk {
-                            data: serde_json::json!(stderr_chunk),
-                            kind: "stderr".to_string(),
-                        });
-                    }
-                });
+                let output_cb = Box::new(
+                    move |stdout_chunk: &crate::StreamData, stderr_chunk: &crate::StreamData| {
+                        if !stdout_chunk.is_empty() {
+                            let _ = sender.send(ToolOutputChunk {
+                                data: serde_json::json!(stdout_chunk),
+                                kind: "stdout".to_string(),
+                            });
+                        }
+                        if !stderr_chunk.is_empty() {
+                            let _ = sender.send(ToolOutputChunk {
+                                data: serde_json::json!(stderr_chunk),
+                                kind: "stderr".to_string(),
+                            });
+                        }
+                    },
+                );
                 bash.exec_streaming(&commands, output_cb).await
             } else {
                 bash.exec(&commands).await

--- a/crates/bashkit/src/scripted_tool/extension.rs
+++ b/crates/bashkit/src/scripted_tool/extension.rs
@@ -435,14 +435,14 @@ impl Builtin for ToolBuiltinAdapter {
                     .invoke_from_context(
                         &self.name,
                         params,
-                        ctx.stdin.map(String::from),
+                        ctx.stdin.map(|stdin| stdin.text_lossy().into_owned()),
                         ToolCallSurface::Shell,
                         &ctx,
                     )
                     .await;
                 ExecResult {
-                    stdout: output.stdout,
-                    stderr: output.stderr,
+                    stdout: output.stdout.into(),
+                    stderr: output.stderr.into(),
                     exit_code: output.exit_code,
                     ..Default::default()
                 }

--- a/crates/bashkit/src/stream.rs
+++ b/crates/bashkit/src/stream.rs
@@ -1,0 +1,189 @@
+//! Byte-native shell stream values.
+//!
+//! Important decision: bytes are canonical. Text decoding only happens at an
+//! explicit consumer boundary; invalid UTF-8 is never rewritten in transport.
+
+use std::borrow::Cow;
+use std::fmt;
+
+/// Owned data carried by a shell byte stream.
+#[derive(Clone, Default, Eq, PartialEq)]
+pub struct StreamData {
+    bytes: Vec<u8>,
+    text: String,
+}
+
+impl StreamData {
+    pub const fn new() -> Self {
+        Self {
+            bytes: Vec::new(),
+            text: String::new(),
+        }
+    }
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+    pub fn text(&self) -> Result<&str, std::str::Utf8Error> {
+        std::str::from_utf8(&self.bytes)
+    }
+    pub fn text_lossy(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.text)
+    }
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+    pub(crate) fn append(&mut self, other: &Self) {
+        let boundary = self.bytes.len();
+        self.bytes.extend_from_slice(&other.bytes);
+        if lossy_decode_changes_at_boundary(&self.bytes, boundary) {
+            self.refresh_text();
+        } else {
+            self.text.push_str(&other.text);
+        }
+    }
+    pub(crate) fn append_text(&mut self, text: &str) {
+        self.append(&Self::from(text));
+    }
+    pub(crate) fn push_str(&mut self, text: &str) {
+        self.append_text(text);
+    }
+    pub(crate) fn push_byte(&mut self, byte: u8) {
+        self.append(&Self::from(vec![byte]));
+    }
+    pub(crate) fn prefix(&self, limit: usize) -> Self {
+        Self::from(self.bytes[..self.bytes.len().min(limit)].to_vec())
+    }
+    /// Shell variables cannot contain NUL. This is the command-substitution text boundary.
+    pub(crate) fn command_substitution_text(&self) -> String {
+        let bytes: Vec<u8> = self
+            .bytes
+            .iter()
+            .copied()
+            .filter(|byte| *byte != 0)
+            .collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+    fn refresh_text(&mut self) {
+        self.text = String::from_utf8_lossy(&self.bytes).into_owned();
+    }
+}
+
+fn lossy_decode_changes_at_boundary(bytes: &[u8], boundary: usize) -> bool {
+    let start = boundary.saturating_sub(3);
+    let end = bytes.len().min(boundary.saturating_add(3));
+    let mut split = String::from_utf8_lossy(&bytes[start..boundary]).into_owned();
+    split.push_str(&String::from_utf8_lossy(&bytes[boundary..end]));
+    split != String::from_utf8_lossy(&bytes[start..end])
+}
+
+impl fmt::Debug for StreamData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StreamData")
+            .field("bytes", &self.bytes)
+            .field("text", &self.text)
+            .finish()
+    }
+}
+impl fmt::Display for StreamData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.text_lossy())
+    }
+}
+impl From<Vec<u8>> for StreamData {
+    fn from(bytes: Vec<u8>) -> Self {
+        let text = String::from_utf8_lossy(&bytes).into_owned();
+        Self { bytes, text }
+    }
+}
+impl From<String> for StreamData {
+    fn from(text: String) -> Self {
+        Self {
+            bytes: text.as_bytes().to_vec(),
+            text,
+        }
+    }
+}
+impl From<&str> for StreamData {
+    fn from(value: &str) -> Self {
+        value.to_owned().into()
+    }
+}
+impl From<&[u8]> for StreamData {
+    fn from(value: &[u8]) -> Self {
+        value.to_vec().into()
+    }
+}
+impl From<&StreamData> for String {
+    fn from(value: &StreamData) -> Self {
+        value.text.clone()
+    }
+}
+impl PartialEq<str> for StreamData {
+    fn eq(&self, other: &str) -> bool {
+        self.bytes == other.as_bytes()
+    }
+}
+impl PartialEq<&str> for StreamData {
+    fn eq(&self, other: &&str) -> bool {
+        self.bytes == other.as_bytes()
+    }
+}
+impl PartialEq<String> for StreamData {
+    fn eq(&self, other: &String) -> bool {
+        self.bytes == other.as_bytes()
+    }
+}
+impl PartialEq<StreamData> for String {
+    fn eq(&self, other: &StreamData) -> bool {
+        self.as_bytes() == other.bytes
+    }
+}
+impl PartialEq<StreamData> for str {
+    fn eq(&self, other: &StreamData) -> bool {
+        self.as_bytes() == other.bytes
+    }
+}
+
+impl std::ops::Deref for StreamData {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.text
+    }
+}
+
+impl std::ops::Add<&StreamData> for StreamData {
+    type Output = StreamData;
+    fn add(mut self, rhs: &StreamData) -> Self::Output {
+        self.append(rhs);
+        self
+    }
+}
+
+impl serde::Serialize for StreamData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StreamData;
+
+    #[test]
+    fn append_redecodes_utf8_split_across_chunks() {
+        let mut stream = StreamData::from(vec![0xc3]);
+        stream.append(&StreamData::from(vec![0xa9]));
+
+        assert_eq!(stream.as_bytes(), "é".as_bytes());
+        assert_eq!(stream.text_lossy(), "é");
+    }
+}

--- a/crates/bashkit/src/testing.rs
+++ b/crates/bashkit/src/testing.rs
@@ -78,8 +78,8 @@ pub fn fuzz_init() {
 pub async fn run(script: &str) -> ExecResult {
     let mut bash = Bash::new();
     bash.exec(script).await.unwrap_or_else(|e| ExecResult {
-        stdout: String::new(),
-        stderr: e.to_string(),
+        stdout: crate::StreamData::new(),
+        stderr: e.to_string().into(),
         exit_code: 1,
         control_flow: ControlFlow::None,
         ..Default::default()
@@ -95,8 +95,8 @@ pub async fn run(script: &str) -> ExecResult {
 /// to inspect.
 pub async fn fuzz_exec(bash: &mut Bash, script: &str, ctx: &str, tool_banned: &[&str]) {
     let result = bash.exec(script).await.unwrap_or_else(|e| ExecResult {
-        stdout: String::new(),
-        stderr: e.to_string(),
+        stdout: crate::StreamData::new(),
+        stderr: e.to_string().into(),
         exit_code: 1,
         control_flow: ControlFlow::None,
         ..Default::default()

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -329,8 +329,8 @@ pub struct ToolResponse {
 impl From<ExecResult> for ToolResponse {
     fn from(result: ExecResult) -> Self {
         Self {
-            stdout: result.stdout,
-            stderr: result.stderr,
+            stdout: result.stdout.text_lossy().into_owned(),
+            stderr: result.stderr.text_lossy().into_owned(),
             exit_code: result.exit_code,
             error: None,
             stdout_truncated: result.stdout_truncated,
@@ -1117,10 +1117,10 @@ impl Tool for BashTool {
         let output_cb: OutputCallback = Box::new(move |stdout_chunk, stderr_chunk| {
             if let Ok(mut cb) = status_cb_output.lock() {
                 if !stdout_chunk.is_empty() {
-                    cb(ToolStatus::stdout(stdout_chunk));
+                    cb(ToolStatus::stdout(stdout_chunk.text_lossy()));
                 }
                 if !stderr_chunk.is_empty() {
-                    cb(ToolStatus::stderr(stderr_chunk));
+                    cb(ToolStatus::stderr(stderr_chunk.text_lossy()));
                 }
             }
         });

--- a/crates/bashkit/tests/integration/builtin_error_security_tests.rs
+++ b/crates/bashkit/tests/integration/builtin_error_security_tests.rs
@@ -829,7 +829,7 @@ async fn builtin_error_panic_no_stack_trace() {
 
     let error_text = match &result {
         Ok(r) => r.stderr.clone(),
-        Err(e) => e.to_string(),
+        Err(e) => e.to_string().into(),
     };
 
     // Should not contain stack trace indicators

--- a/crates/bashkit/tests/integration/builtin_registry_tests.rs
+++ b/crates/bashkit/tests/integration/builtin_registry_tests.rs
@@ -152,7 +152,9 @@ async fn registry_pipe_chain() {
     #[async_trait]
     impl Builtin for Upper {
         async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
-            Ok(ExecResult::ok(ctx.stdin.unwrap_or("").to_uppercase()))
+            Ok(ExecResult::ok(
+                ctx.stdin.map_or("", |stdin| &**stdin).to_uppercase(),
+            ))
         }
     }
     registry.insert("upper", Arc::new(Upper));

--- a/crates/bashkit/tests/integration/byte_stream_tests.rs
+++ b/crates/bashkit/tests/integration/byte_stream_tests.rs
@@ -1,0 +1,130 @@
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+use bashkit::{Bash, Builtin, BuiltinContext, ExecOptions, ExecResult, StreamData, async_trait};
+
+#[tokio::test]
+async fn binary_base64_head_cat_pipeline_preserves_exact_bytes() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("printf 'AAH//kIAfw==' | base64 -d | head -c 7 | cat")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.stdout.as_bytes(),
+        &[0x00, 0x01, 0xff, 0xfe, b'B', 0x00, 0x7f]
+    );
+}
+
+#[tokio::test]
+async fn mixed_utf8_and_invalid_bytes_survive_stdin_pipeline_and_redirect() {
+    let input = StreamData::from(vec![b'h', 0xc3, 0xa9, 0xff, 0x00, b'\n']);
+    let mut bash = Bash::new();
+    let result = bash
+        .exec_with_options(
+            "cat > /blob; cat /blob | base64 -w 0",
+            ExecOptions::new().stdin(input),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout.text().unwrap(), "aMOp/wAK\n");
+    assert_eq!(
+        bash.fs()
+            .read_file(std::path::Path::new("/blob"))
+            .await
+            .unwrap(),
+        [b'h', 0xc3, 0xa9, 0xff, 0x00, b'\n']
+    );
+}
+
+#[tokio::test]
+async fn byte_output_limit_and_streaming_callback_split_without_utf8_rewrite() {
+    let chunks = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let callback_chunks = Arc::clone(&chunks);
+    let mut bash = Bash::builder()
+        .limits(bashkit::ExecutionLimits::new().max_stdout_bytes(4))
+        .build();
+    let result = bash
+        .exec_with_options(
+            "printf '/wABAg==' | base64 -d",
+            ExecOptions::new().streaming(Box::new(move |stdout, _stderr| {
+                callback_chunks
+                    .lock()
+                    .unwrap()
+                    .extend_from_slice(stdout.as_bytes());
+            })),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout.as_bytes(), &[0xff, 0x00, 0x01, 0x02]);
+    assert_eq!(*chunks.lock().unwrap(), [0xff, 0x00, 0x01, 0x02]);
+}
+
+struct CopyBytes;
+
+#[async_trait]
+impl Builtin for CopyBytes {
+    async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
+        Ok(ExecResult::ok(ctx.stdin.cloned().unwrap_or_default()))
+    }
+}
+
+#[tokio::test]
+async fn custom_builtin_receives_byte_native_stdin() {
+    let mut bash = Bash::builder()
+        .builtin("copy-bytes", Box::new(CopyBytes))
+        .build();
+    let result = bash
+        .exec("printf '/wD+' | base64 -d | copy-bytes")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.as_bytes(), &[0xff, 0x00, 0xfe]);
+}
+
+#[tokio::test]
+async fn execution_plan_preserves_binary_stdin() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("printf '/wD+' | base64 -d | timeout 1 cat")
+        .await
+        .unwrap();
+    assert_eq!(result.stdout.as_bytes(), &[0xff, 0x00, 0xfe]);
+}
+
+#[tokio::test]
+async fn c_locale_tr_filters_invalid_bytes_without_replacement_text() {
+    let input = StreamData::from(vec![0xff, b'a', 0x80, b'7', 0x00, b'Z']);
+    let mut bash = Bash::new();
+    let result = bash
+        .exec_with_options("LC_ALL=C tr -dc 'a-z0-9'", ExecOptions::new().stdin(input))
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout.as_bytes(), b"a7");
+}
+
+#[tokio::test]
+async fn command_substitution_drops_nuls_at_text_boundary() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec("x=$(printf 'QQBCAA==' | base64 -d); printf '%s' \"$x\"")
+        .await
+        .unwrap();
+
+    assert_eq!(result.stdout.as_bytes(), b"AB");
+}
+
+#[tokio::test]
+async fn binary_pipeline_matches_real_bash_byte_for_byte() {
+    let script = "printf 'AAHDqf/+QgB/' | base64 -d | head -c 8 | cat";
+    let expected = Command::new("bash").args(["-c", script]).output().unwrap();
+    assert!(expected.status.success());
+
+    let mut bash = Bash::new();
+    let actual = bash.exec(script).await.unwrap();
+    assert_eq!(actual.stdout.as_bytes(), expected.stdout);
+    assert_eq!(actual.exit_code, expected.status.code().unwrap());
+}

--- a/crates/bashkit/tests/integration/coreutils_differential_tests.rs
+++ b/crates/bashkit/tests/integration/coreutils_differential_tests.rs
@@ -213,7 +213,7 @@ async fn run_bashkit(fx: &DiffFixture) -> (String, String, i32) {
     };
 
     let r = bash.exec(&cmd).await.expect("bashkit exec");
-    (r.stdout, r.stderr, r.exit_code)
+    (r.stdout.to_string(), r.stderr.to_string(), r.exit_code)
 }
 
 fn shell_quote(s: &str) -> String {

--- a/crates/bashkit/tests/integration/custom_builtins_tests.rs
+++ b/crates/bashkit/tests/integration/custom_builtins_tests.rs
@@ -32,7 +32,7 @@ struct Transform {
 #[async_trait]
 impl Builtin for Transform {
     async fn execute(&self, ctx: BuiltinContext<'_>) -> bashkit::Result<ExecResult> {
-        let input = ctx.stdin.unwrap_or("");
+        let input = ctx.stdin.map_or("", |stdin| &**stdin);
         Ok(ExecResult::ok((self.transform_fn)(input)))
     }
 }

--- a/crates/bashkit/tests/integration/issue_275_279_282_test.rs
+++ b/crates/bashkit/tests/integration/issue_275_279_282_test.rs
@@ -12,7 +12,7 @@ use bashkit::Bash;
 async fn run(script: &str) -> String {
     let mut bash = Bash::builder().build();
     let result = bash.exec(script).await.expect("exec failed");
-    result.stdout
+    result.stdout.to_string()
 }
 
 /// Issue #275: Parser corrupts \( in single-quoted strings

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -27,6 +27,7 @@ pub mod blackbox_security_tests;
 pub mod builtin_error_security_tests;
 pub mod builtin_registry_tests;
 pub mod byte_range_panic_tests;
+pub mod byte_stream_tests;
 pub mod cancellation_tests;
 pub mod cmdsub_quote_test;
 pub mod competitor_regression_tests;

--- a/crates/bashkit/tests/integration/network_security_tests.rs
+++ b/crates/bashkit/tests/integration/network_security_tests.rs
@@ -1069,7 +1069,7 @@ mod custom_transport {
             .exec("curl -s http://93.184.216.34 2>&1")
             .await
             .unwrap();
-        (result.stdout, result.exit_code)
+        (result.stdout.to_string(), result.exit_code)
     }
 
     // Host-boundary errors must surface as the curl exit codes scripts (and

--- a/crates/bashkit/tests/integration/output_truncation_tests.rs
+++ b/crates/bashkit/tests/integration/output_truncation_tests.rs
@@ -66,9 +66,9 @@ async fn stdout_one_byte_over_limit_truncated() {
 }
 
 #[tokio::test]
-async fn stdout_truncation_preserves_utf8_boundaries() {
+async fn stdout_truncation_applies_to_exact_bytes() {
     let result = run_with_limits("echo é", 1, 1_048_576).await;
-    assert_eq!(result.stdout, "");
+    assert_eq!(result.stdout.as_bytes(), &[0xc3]);
     assert!(result.stdout_truncated);
 }
 
@@ -88,9 +88,9 @@ async fn stderr_not_truncated_when_within_limit() {
 }
 
 #[tokio::test]
-async fn stderr_truncation_preserves_utf8_boundaries() {
+async fn stderr_truncation_applies_to_exact_bytes() {
     let result = run_with_limits("echo é >&2", 1_048_576, 1).await;
-    assert_eq!(result.stderr, "");
+    assert_eq!(result.stderr.as_bytes(), &[0xc3]);
     assert!(result.stderr_truncated);
 }
 

--- a/crates/bashkit/tests/integration/proptest_differential.rs
+++ b/crates/bashkit/tests/integration/proptest_differential.rs
@@ -28,7 +28,7 @@ fn run_real_bash(script: &str) -> (String, i32) {
 async fn run_bashkit(script: &str) -> (String, i32) {
     let mut bash = Bash::new();
     match bash.exec(script).await {
-        Ok(result) => (result.stdout, result.exit_code),
+        Ok(result) => (result.stdout.to_string(), result.exit_code),
         Err(e) => {
             // Parse errors should return exit code 2 (like bash)
             let exit_code = if matches!(e, bashkit::Error::Parse { .. }) {

--- a/crates/bashkit/tests/integration/snapshot_history_tests.rs
+++ b/crates/bashkit/tests/integration/snapshot_history_tests.rs
@@ -25,7 +25,11 @@ fn commit_into(bash: &Bash, store: &mut Store, parents: &[CommitId]) -> CommitId
 }
 
 async fn read_file(bash: &mut Bash, path: &str) -> String {
-    bash.exec(&format!("cat {path}")).await.unwrap().stdout
+    bash.exec(&format!("cat {path}"))
+        .await
+        .unwrap()
+        .stdout
+        .to_string()
 }
 
 // ==================== Round-trip fidelity ====================
@@ -108,6 +112,7 @@ async fn read_via_od(bash: &mut Bash, path: &str) -> String {
         .await
         .unwrap()
         .stdout
+        .to_string()
 }
 
 #[tokio::test]

--- a/crates/bashkit/tests/integration/spec_runner.rs
+++ b/crates/bashkit/tests/integration/spec_runner.rs
@@ -189,7 +189,7 @@ pub async fn run_spec_test_with(
     let mut bash = make_bash();
 
     let (bashkit_stdout, bashkit_exit_code, error) = match bash.exec(&test.script).await {
-        Ok(result) => (result.stdout, result.exit_code, None),
+        Ok(result) => (result.stdout.to_string(), result.exit_code, None),
         Err(e) => (String::new(), 1, Some(e.to_string())),
     };
 
@@ -234,7 +234,7 @@ async fn run_spec_test_paused_time(test: &SpecTest) -> TestResult {
         rt.block_on(async {
             let mut bash = Bash::new();
             match bash.exec(&script).await {
-                Ok(result) => (result.stdout, result.exit_code, None),
+                Ok(result) => (result.stdout.to_string(), result.exit_code, None),
                 Err(e) => (String::new(), 1, Some(e.to_string())),
             }
         })

--- a/crates/bashkit/tests/integration/sqlite_differential_tests.rs
+++ b/crates/bashkit/tests/integration/sqlite_differential_tests.rs
@@ -103,7 +103,7 @@ async fn run_bashkit_sqlite(flags: &[&str], sql: &str) -> String {
         "bashkit sqlite failed: stderr={:?}",
         r.stderr
     );
-    r.stdout
+    r.stdout.to_string()
 }
 
 /// Drive both engines with the same input and assert byte-equal output.

--- a/crates/bashkit/tests/integration/threat_model_tests.rs
+++ b/crates/bashkit/tests/integration/threat_model_tests.rs
@@ -4827,7 +4827,7 @@ echo ${#arr[@]}
         let result = bash.exec(script).await;
         let err_msg = match &result {
             Err(e) => e.to_string(),
-            Ok(r) => r.stderr.clone(),
+            Ok(r) => r.stderr.to_string(),
         };
         assert!(
             result.is_err(),

--- a/crates/bashkit/tests/integration/tool_registry_tests.rs
+++ b/crates/bashkit/tests/integration/tool_registry_tests.rs
@@ -199,7 +199,10 @@ async fn registry_deadline_cancels_callback_and_tenants_do_not_share_context_or_
         )
         .await
         .unwrap();
-    assert_eq!((first.stdout.as_str(), second.stdout.as_str()), ("a", "b"));
+    assert_eq!(
+        (first.stdout.text().unwrap(), second.stdout.text().unwrap()),
+        ("a", "b")
+    );
     assert_eq!(&*seen.lock().unwrap(), &["a", "b"]);
     assert_eq!(a_trace.take_invocations().len(), 1);
     assert_eq!(b_trace.take_invocations().len(), 1);

--- a/crates/bashkit/tests/integration/urandom_tests.rs
+++ b/crates/bashkit/tests/integration/urandom_tests.rs
@@ -20,20 +20,21 @@ async fn urandom_no_replacement_chars() {
     );
 }
 
-/// Issue #811: head -c N /dev/urandom should return exactly N chars
-/// (each original byte maps to one char in the Latin-1 model)
+/// Issue #811: head -c N /dev/urandom should return exactly N bytes.
+/// Binary streams no longer use a Latin-1 text surrogate, so `wc -c` is the
+/// byte-native assertion; `wc -m` is intentionally a text boundary.
 #[tokio::test]
-async fn urandom_head_char_count() {
+async fn urandom_head_byte_count() {
     let mut bash = Bash::new();
     for n in [1, 4, 8, 16, 32] {
         let result = bash
-            .exec(&format!("head -c {n} /dev/urandom | wc -m"))
+            .exec(&format!("head -c {n} /dev/urandom | wc -c"))
             .await
             .unwrap();
         let count: usize = result.stdout.trim().parse().unwrap_or(0);
         assert_eq!(
             count, n,
-            "head -c {n} /dev/urandom | wc -m should produce exactly {n} chars"
+            "head -c {n} /dev/urandom | wc -c should produce exactly {n} bytes"
         );
     }
 }

--- a/crates/bashkit/tests/security_failpoint_tests.rs
+++ b/crates/bashkit/tests/security_failpoint_tests.rs
@@ -18,8 +18,8 @@ use std::time::Duration;
 async fn run_script(script: &str) -> ExecResult {
     let mut bash = Bash::new();
     bash.exec(script).await.unwrap_or_else(|e| ExecResult {
-        stdout: String::new(),
-        stderr: e.to_string(),
+        stdout: Default::default(),
+        stderr: e.to_string().into(),
         exit_code: 1,
         control_flow: ControlFlow::None,
         ..Default::default()
@@ -30,8 +30,8 @@ async fn run_script(script: &str) -> ExecResult {
 async fn run_script_with_limits(script: &str, limits: ExecutionLimits) -> ExecResult {
     let mut bash = Bash::builder().limits(limits).build();
     bash.exec(script).await.unwrap_or_else(|e| ExecResult {
-        stdout: String::new(),
-        stderr: e.to_string(),
+        stdout: Default::default(),
+        stderr: e.to_string().into(),
         exit_code: 1,
         control_flow: ControlFlow::None,
         ..Default::default()

--- a/crates/bashkit/tests/ssh_supabase_tests.rs
+++ b/crates/bashkit/tests/ssh_supabase_tests.rs
@@ -32,7 +32,7 @@ mod ssh_supabase {
                 return;
             }
 
-            last_stderr = result.stderr;
+            last_stderr = result.stderr.to_string();
             if attempt < 3 {
                 tokio::time::sleep(std::time::Duration::from_secs(10)).await;
             }

--- a/knowledge/foundations/architecture.md
+++ b/knowledge/foundations/architecture.md
@@ -54,6 +54,21 @@ call: streaming callback, builtin extensions, `arg0`, `positional`, and
   immediately before execution. A pipe or redirect inside the script
   still wins for the command it applies to.
 
+### Byte-native streams
+
+`StreamData` is the canonical stdin/stdout/stderr transport value. Its byte
+buffer is authoritative through `ExecOptions`, interpreter pipeline state,
+redirections, `BuiltinContext`, `ExecResult`, and streaming callbacks. Output
+limits truncate by bytes, including in live callbacks. Byte-oriented builtins
+and bindings use `as_bytes()`/`into_bytes()`; text-oriented consumers cross an
+explicit UTF-8 boundary with `text()` or `text_lossy()`.
+
+Shell words and variables remain text. Command substitution therefore removes
+NUL bytes, as Bash does because variables cannot contain NUL, then decodes the
+remaining bytes for expansion and strips trailing newlines. JSON tool results
+are also text-only; native Rust, C, Python, Node, and browser results expose raw
+stdout/stderr bytes alongside their display strings.
+
 Both are installed late (just before `execute`) so the size, hook, and
 parse checks that can return early cannot leave state behind.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -6,6 +6,8 @@
 * **Security**: Added TM-ISO-025 for wrapper rebuilds silently dropping host configuration. The first audit finding was NAPI `reset()` losing constructor-seeded VFS files; shared state now retains and restores them, with a regression test.
 * **Testing**: Added a quarterly competitor-regression corpus contract: immutable upstream provenance, explicit pass/bug/intentional-divergence classification, real-Bash or locked oracles, and a feature-complete hermetic CI lane. The first import covers eleven behavior fixes from `vercel-labs/just-bash` between 2026-05-05 and 2026-08-05; it exposed and fixes tar old-style option bundles, while the ordered curl-data fix is supplied by its dedicated PR.
 * **Threat**: Registered TM-INF-032 for executing imported third-party behavior fixtures. Imports remain manually reviewed checked-in JSON, CI never fetches upstream content, and only explicitly marked portable cases reach the host-Bash oracle.
+* **Decision**: Made `StreamData` the authoritative byte transport for execution stdin, pipelines, redirects, results, callbacks, and native bindings. Text decoding is confined to shell/parser/text-builtin/JSON boundaries; command substitution removes NUL because Bash variables cannot contain it. Updated [Architecture](foundations/architecture.md), [Known Limitations](operations/limitations.md), and [Threat Model](security/threat-model.md).
+* **Testing**: Added byte-for-byte Bash differential and regressions for binary base64/head/cat pipelines, mixed UTF-8 and invalid bytes, redirects, output caps, callbacks, custom builtins, command substitution, and C/Python/Node binding results.
 
 ## 2026-08-01
 

--- a/knowledge/operations/limitations.md
+++ b/knowledge/operations/limitations.md
@@ -54,6 +54,7 @@ execution model. Evidence is a threat-model ID, a test, or `stance`
 | L-WASM-002 | Browser build: `executeSync()` cannot run async custom builtins (fails with a clear message); use `execute()` | Single-threaded event loop can't settle a JS `Promise` without yielding | `crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs` |
 | L-WASM-003 | Browser build: background jobs (`cmd &`) run synchronously and `awk` file redirects drive the VFS inline; no work runs on a separate thread | `wasm32-unknown-unknown` is single-threaded — `std::thread::spawn`/`tokio::spawn` are unavailable; safe because the in-memory VFS never suspends | `crates/bashkit-wasm/__test__/bashkit-wasm.test.mjs` |
 | L-CAPI-001 | C ABI v1 excludes callbacks, custom builtins, streaming, async cancellation, host mounts, transport hooks, snapshots, scripted tools, and external filesystem providers | These require explicit reentrancy, callback lifetime, and dynamic-library unload contracts | [C API](../runtimes/c-api.md), stance |
+| L-STREAM-001 | Shell words, variables, command substitution, script source, text-oriented builtins, and JSON tool responses cannot represent arbitrary bytes. Command substitution removes NUL; other text boundaries decode invalid UTF-8 with replacement. Use `StreamData`, binding byte fields, redirects, or byte-oriented builtins for exact data | Bash variables and the parser are text domains; JSON strings are Unicode | `byte_stream_tests`, [Architecture](../foundations/architecture.md) |
 
 ### Design Rationale
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -825,8 +825,9 @@ session's isolated VFS.
 | TM-INT-001 | Builtin panic crash | Invalid input triggers panic in builtin | `catch_unwind` wrapper on all builtins | **MITIGATED** |
 | TM-INT-002 | Panic info leak | Panic message reveals sensitive data | Sanitized error messages (no panic details) | **MITIGATED** |
 | TM-INT-003 | Date format panic | Invalid strftime format causes chrono panic | Pre-validation with `StrftimeItems` | **MITIGATED** |
-| TM-INT-007 | `/dev/urandom` empty with `head -c` | `head -c 16 /dev/urandom` returns empty output; pipe from virtual device to builtin loses data | `read_file_for_builtin` (`builtins/mod.rs`) reads `/dev/urandom`/`/dev/random` as Latin-1 chars (each byte 0x00-0xFF maps 1:1 to a char) so `head -c N` returns N bytes of randomness in both the path-argument form and the `cat /dev/urandom \| head -c N` pipe form | **MITIGATED** |
+| TM-INT-007 | Binary stream corruption | String-first pipelines rewrote non-UTF-8 bytes through a Latin-1 surrogate and could lose NUL/high bytes across builtins, redirects, callbacks, or bindings | `StreamData` keeps bytes authoritative through stdin, pipelines, redirects, results, callbacks, and native bindings; binary differential/regression tests cover `base64 -d \| head -c \| cat`, mixed UTF-8/bytes, limits, and redirects | **MITIGATED** |
 | TM-INT-008 | Panic crosses the C ABI boundary | Rust unwind enters a foreign runtime or exposes panic details | Every exported C operation uses `catch_unwind`; fallible calls return a generic, capped `BASHKIT_INTERNAL_ERROR` | **MITIGATED** |
+| TM-INT-009 | Binary output bypasses resource limits | Byte-native output or callbacks count characters instead of bytes, allowing invalid UTF-8 to exceed configured caps | Accumulation and streaming callbacks truncate `StreamData` by exact byte length before delivery; regression tests assert binary output-limit behavior | **MITIGATED** |
 
 **Current Risk**: LOW. Implementation: `interpreter/mod.rs` wraps every builtin call in
 `AssertUnwindSafe(..).catch_unwind()` (TM-INT-001) and converts panics to the sanitized
@@ -1179,7 +1180,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | ~~TM-ISO-022~~ | ~~`$?` leaks across `exec()` calls~~ | ~~Exit code from previous exec visible to next~~ | `reset_transient_state()` zeroes `last_exit_code` (**FIXED**) |
 | TM-ISO-023 | `set -e` leaks across `exec()` calls | Unexpected abort — `set` options from previous exec affect next exec | `SET_OPTION_VARS` cleared in `reset_transient_state()` (**FIXED**) |
 | ~~TM-ISO-024~~ | ~~`$?` leaks into VFS subprocess~~ | ~~False `set -e` failures in VFS script subprocess~~ | `execute_script_content` resets `last_exit_code` / `nounset_error` (**FIXED**) |
-| ~~TM-INT-007~~ | ~~`/dev/urandom` empty with `head -c`~~ | ~~Weak randomness (empty output)~~ | `read_file_for_builtin` reads virtual devices as Latin-1 (**FIXED**) |
+| ~~TM-INT-007~~ | ~~Binary stream corruption~~ | ~~NUL/high bytes lost across pipelines and redirects~~ | Byte-native `StreamData` transport (**FIXED**) |
 | ~~TM-DOS-044~~ | ~~Nested `$()` stack overflow (regression)~~ | ~~SIGABRT at depth ~50 despite #492 fix~~ | Depth-50 nested-subst test (`finding_nested_cmd_subst_stack_overflow::depth_50_is_bounded`) passes (**FIXED**) |
 | TM-DOS-088 | Command substitution OOM via state cloning | OOM at depth N (memory ≈ N × state_size) | Dedicated `max_subst_depth` limit (default 32), separate from `max_function_depth` — **FIXED** via #1088 |
 | TM-DOS-089 | Command substitution stack overflow via inlined futures | SIGABRT at ~20-30 nested $() levels | Box::pin `expand_word` and `execute_cmd_subst` to cap per-level stack — **FIXED** via #1089 |


### PR DESCRIPTION
## What changed

Introduces `StreamData` as the authoritative byte-native transport for stdin, pipelines, redirects, command results, streaming callbacks, custom builtins, and supported native/browser bindings. Byte-oriented builtins now preserve NUL, invalid UTF-8, and high bytes end to end; output limits count exact bytes. Text conversion is explicit at parser, variable, text-builtin, scripted-tool, and JSON boundaries.

Rust, C, Python, Node, and browser WASM results expose exact stdout/stderr bytes. Command substitution follows Bash's text-variable constraint by removing NUL before lossy UTF-8 conversion and trailing-newline stripping. In-repo callers, examples, architecture, limitations, and threat models are updated.

## Why

The previous string-first stream model rewrote arbitrary process data through lossy Unicode/Latin-1 surrogates. Binary pipelines and bindings could corrupt bytes, and character-based output accounting could diverge from configured byte limits.

## Before / After

Before: binary `base64 -d | head | cat` pipelines could replace `0xff`/`0xfe`, and public results exposed only lossy strings.

After, CLI pipeline proof:

```text
$ bashkit -c "printf 'AAH//kIAfw==' | base64 -d | head -c 7 | cat" | xxd -p
0001fffe42007f
```

Host stdin proof:

```text
$ printf '\377\000' | bashkit -c base64
/wA=
```

C, Python, Node, and browser WASM byte-result regressions assert exact `00 01 ff fe` output.

## Risk

- High
- This intentionally changes public/internal Rust stream fields from `String` to `StreamData` and adds raw-byte result fields to bindings. Text-only consumers continue to see documented lossy display strings; callers constructing results/options may require source updates.
- Shell words and variables remain text-only. Command substitution cannot preserve NUL because Bash variables cannot contain it.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (intentional breaking API change; no compatibility shim required)

Validation:

- `just pre-pr`
- C ABI exact-binary regression
- Node NAPI release build, TypeScript check, exact-binary AVA regression
- Python ABI3 local build and exact-binary smoke
- browser WASM release build and 33 tests
- CLI byte-pipeline and host-stdin smokes
