### PR TITLE
fix(fs): harden Windows path containment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,27 @@ jobs:
         env:
           PROPTEST_CASES: 50
 
+  windows-containment:
+    # THREAT[TM-ESC-033]: Windows path parsing has drive, UNC, device, and
+    # reparse-point semantics that cannot be exercised on a Unix runner.
+    name: Windows filesystem containment
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: windows-containment
+
+      - name: Test VFS path normalization
+        run: cargo test -p bashkit --lib --features realfs windows_containment
+
+      - name: Test RealFS and overlay containment
+        run: cargo test -p bashkit --test realfs_tests --features realfs windows_containment
+
   examples:
     name: Examples
     runs-on: ubuntu-latest

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -173,6 +173,7 @@ Scripts may attempt to break out of the sandbox to access the host system.
 | Custom builtins lost (TM-ESC-014) | `std::mem::take` empties builtins | Arc-cloned builtins | **FIXED** |
 | Symlink overlay rename (TM-ESC-016) | `ln -s /etc/passwd x; mv x y` | Overlay rename/copy preserve symlinks | **FIXED** |
 | Namespace source-root or policy escape (TM-ESC-031) | `..` escapes a rebased or nested mount | Normalize before longest-prefix selection; join only the stripped suffix; enforce both mutation endpoints | MITIGATED |
+| Windows host-path namespace escape (TM-ESC-033) | Drive/UNC/device path or reparse point discards the RealFS root | Normalize into the POSIX VFS root; canonicalize existing ancestors; component-aware root check; Windows CI | MITIGATED |
 
 **Process Escape:**
 

--- a/crates/bashkit/src/fs/mod.rs
+++ b/crates/bashkit/src/fs/mod.rs
@@ -510,6 +510,9 @@ impl FileSystem for DisabledFs {
 /// `/../..`), returns `/`.
 pub fn normalize_path(path: &Path) -> PathBuf {
     use std::path::Component;
+    // THREAT[TM-ESC-033]: Discard host namespace prefixes before any backend
+    // join. On Windows this contains drive-relative, drive-absolute, UNC, and
+    // device paths inside the POSIX VFS root instead of preserving host syntax.
     // Build path as String with forward slashes to ensure Unix-style paths
     // on all platforms (the VFS is always Unix-style, even on Windows).
     let mut segments: Vec<&str> = Vec::new();
@@ -533,6 +536,35 @@ pub fn normalize_path(path: &Path) -> PathBuf {
         PathBuf::from("/")
     } else {
         PathBuf::from(format!("/{}", segments.join("/")))
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_containment_tests {
+    use super::*;
+
+    #[test]
+    fn windows_containment_normalizes_host_path_syntax_into_vfs_root() {
+        assert_eq!(
+            normalize_path(Path::new(r"\tmp\..\safe")),
+            Path::new("/safe")
+        );
+        assert_eq!(
+            normalize_path(Path::new(r"C:relative\file.txt")),
+            Path::new("/relative/file.txt")
+        );
+        assert_eq!(
+            normalize_path(Path::new(r"C:\absolute\file.txt")),
+            Path::new("/absolute/file.txt")
+        );
+        assert_eq!(
+            normalize_path(Path::new(r"\\server\share\file.txt")),
+            Path::new("/file.txt")
+        );
+        assert_eq!(
+            normalize_path(Path::new(r"\\?\C:\device\file.txt")),
+            Path::new("/device/file.txt")
+        );
     }
 }
 

--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -165,7 +165,10 @@ impl RealFs {
     /// prevent traversal and symlink escapes before attaching the missing
     /// suffix.
     async fn resolve(&self, vpath: &Path) -> std::io::Result<PathBuf> {
-        let normalized = normalize_vpath(vpath);
+        // THREAT[TM-ESC-033]: Use the shared POSIX VFS normalizer. A
+        // platform-aware normalization here would preserve Windows prefixes,
+        // and joining a drive/UNC/device absolute path would discard `root`.
+        let normalized = super::normalize_path(vpath);
         // Strip leading "/" to make it relative
         let relative = normalized.strip_prefix("/").unwrap_or(&normalized);
 
@@ -236,7 +239,7 @@ impl RealFs {
     /// root, then append the basename verbatim. The caller must then use
     /// `symlink_metadata`/`read_link`/`remove_file` on the result.
     async fn resolve_no_follow(&self, vpath: &Path) -> std::io::Result<PathBuf> {
-        let normalized = normalize_vpath(vpath);
+        let normalized = super::normalize_path(vpath);
         let relative = normalized.strip_prefix("/").unwrap_or(&normalized);
 
         if relative == Path::new("") {
@@ -272,7 +275,7 @@ impl RealFs {
     /// a host path whose leaf is still a symlink to outside the root.
     /// `symlink_metadata` describes the link itself, catching that case.
     async fn resolve_for_create(&self, vpath: &Path) -> std::io::Result<PathBuf> {
-        let normalized = normalize_vpath(vpath);
+        let normalized = super::normalize_path(vpath);
         let relative = normalized.strip_prefix("/").unwrap_or(&normalized);
 
         if relative != Path::new("") {
@@ -371,31 +374,6 @@ fn normalize_host_path(path: &Path) -> PathBuf {
                 }
             }
             std::path::Component::CurDir => {}
-            c => components.push(c),
-        }
-    }
-    if components.is_empty() {
-        PathBuf::from("/")
-    } else {
-        components.iter().collect()
-    }
-}
-
-/// Normalize a virtual path: collapse `.` and `..`, ensure absolute.
-fn normalize_vpath(path: &Path) -> PathBuf {
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::RootDir => {
-                components.clear();
-                components.push(std::path::Component::RootDir);
-            }
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if components.len() > 1 {
-                    components.pop();
-                }
-            }
             c => components.push(c),
         }
     }
@@ -534,10 +512,16 @@ impl FsBackend for RealFs {
         let real_link = self.resolve(link).await?;
 
         // Absolute targets always escape the mount root on disk
-        if target.is_absolute() {
+        // THREAT[TM-ESC-033]: `C:target` is drive-relative, not absolute, but
+        // still carries host namespace semantics and cannot be a VFS target.
+        if target.is_absolute()
+            || target
+                .components()
+                .any(|component| matches!(component, std::path::Component::Prefix(_)))
+        {
             return Err(IoError::new(
                 ErrorKind::PermissionDenied,
-                "symlink with absolute target not allowed in RealFs (sandbox security)",
+                "symlink with absolute or drive-relative target not allowed in RealFs (sandbox security)",
             )
             .into());
         }

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -3165,9 +3165,9 @@ impl BashBuilder {
     /// directory component.
     #[cfg(feature = "realfs")]
     fn is_sensitive_mount_path(host_path: &Path) -> bool {
-        // Refuse mounting the host root outright. `starts_with("/")` matches
-        // everything so the prefix check below cannot express this.
-        if host_path == Path::new("/") {
+        // THREAT[TM-FS-013]: A canonical host root has no parent. This covers
+        // `/` plus Windows drive, UNC-share, and device-namespace roots.
+        if host_path.parent().is_none() {
             return true;
         }
         if Self::SENSITIVE_MOUNT_PATHS

--- a/crates/bashkit/tests/realfs_tests.rs
+++ b/crates/bashkit/tests/realfs_tests.rs
@@ -32,6 +32,7 @@ mod windows_containment {
     #[tokio::test]
     async fn windows_containment_vfs_and_overlay_are_rooted_and_case_sensitive() {
         let lower = Arc::new(InMemoryFs::new());
+        lower.mkdir(Path::new("/Case"), false).await.unwrap();
         lower
             .write_file(Path::new("/Case/file.txt"), b"lower")
             .await

--- a/crates/bashkit/tests/realfs_tests.rs
+++ b/crates/bashkit/tests/realfs_tests.rs
@@ -7,6 +7,178 @@
 use bashkit::{Bash, BashBuilder};
 use std::path::Path;
 
+#[cfg(windows)]
+mod windows_containment {
+    use super::*;
+    use bashkit::{FileSystem, FsBackend, InMemoryFs, OverlayFs, RealFs, RealFsMode};
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::Arc;
+
+    fn device_path(path: &Path) -> PathBuf {
+        PathBuf::from(format!(r"\\?\{}", path.display()))
+    }
+
+    fn create_junction(link: &Path, target: &Path) {
+        let status = Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(link)
+            .arg(target)
+            .status()
+            .unwrap();
+        assert!(status.success(), "failed to create test junction");
+    }
+
+    #[tokio::test]
+    async fn windows_containment_vfs_and_overlay_are_rooted_and_case_sensitive() {
+        let lower = Arc::new(InMemoryFs::new());
+        lower
+            .write_file(Path::new("/Case/file.txt"), b"lower")
+            .await
+            .unwrap();
+        let overlay = OverlayFs::new(lower);
+
+        assert_eq!(
+            overlay
+                .read_file(Path::new(r"\Case\file.txt"))
+                .await
+                .unwrap(),
+            b"lower"
+        );
+        assert!(!overlay.exists(Path::new("/case/file.txt")).await.unwrap());
+
+        overlay
+            .write_file(Path::new(r"C:\Case\upper.txt"), b"upper")
+            .await
+            .unwrap();
+        assert_eq!(
+            overlay
+                .read_file(Path::new("/Case/upper.txt"))
+                .await
+                .unwrap(),
+            b"upper"
+        );
+    }
+
+    #[tokio::test]
+    async fn windows_containment_realfs_rejects_drive_and_device_absolute_escape() {
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let outside = sandbox.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let secret = outside.join("secret.txt");
+        std::fs::write(&secret, b"outside-secret").unwrap();
+
+        let fs = RealFs::open(&root, RealFsMode::ReadOnly).await.unwrap();
+        for hostile in [secret.clone(), device_path(&secret)] {
+            let result = fs.read(&hostile).await;
+            assert!(
+                !matches!(result, Ok(ref bytes) if bytes == b"outside-secret"),
+                "host path escaped RealFs root: {}",
+                hostile.display()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn windows_containment_realfs_keeps_missing_descendants_under_root() {
+        let root = tempfile::tempdir().unwrap();
+        let fs = RealFs::open(root.path(), RealFsMode::ReadWrite)
+            .await
+            .unwrap();
+
+        fs.write(Path::new(r"\missing\deep\file.txt"), b"inside")
+            .await
+            .unwrap();
+        assert_eq!(
+            std::fs::read(root.path().join("missing/deep/file.txt")).unwrap(),
+            b"inside"
+        );
+    }
+
+    #[tokio::test]
+    async fn windows_containment_realfs_rejects_drive_relative_symlink_target() {
+        let root = tempfile::tempdir().unwrap();
+        let fs = RealFs::open(root.path(), RealFsMode::ReadWrite)
+            .await
+            .unwrap();
+
+        assert!(
+            fs.symlink(Path::new(r"C:target.txt"), Path::new("/link"))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn windows_containment_realfs_handles_case_and_alternate_separators_inside_root() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("MixedCase.TXT"), b"inside").unwrap();
+        let fs = RealFs::open(root.path(), RealFsMode::ReadOnly)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fs.read(Path::new(r"\mixedcase.txt")).await.unwrap(),
+            b"inside"
+        );
+    }
+
+    #[tokio::test]
+    async fn windows_containment_builder_refuses_drive_root_without_allowlist() {
+        let sandbox = tempfile::tempdir().unwrap();
+        let probe = sandbox.path().join("drive-root-probe.txt");
+        std::fs::write(&probe, b"host-secret").unwrap();
+        let drive_root = sandbox.path().ancestors().last().unwrap();
+        let relative_probe = probe
+            .strip_prefix(drive_root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        let bash = Bash::builder()
+            .mount_real_readonly_at(drive_root, "/host")
+            .build();
+        let result = bash
+            .fs()
+            .read_file(Path::new(&format!("/host/{relative_probe}")))
+            .await;
+        assert!(!matches!(result, Ok(ref bytes) if bytes == b"host-secret"));
+    }
+
+    #[tokio::test]
+    async fn windows_containment_realfs_blocks_symlink_and_junction_targets() {
+        let sandbox = tempfile::tempdir().unwrap();
+        let root = sandbox.path().join("root");
+        let root_prefix_sibling = sandbox.path().join("root-evil");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&root_prefix_sibling).unwrap();
+        std::fs::write(root_prefix_sibling.join("secret.txt"), b"outside-secret").unwrap();
+
+        std::os::windows::fs::symlink_file(
+            root_prefix_sibling.join("secret.txt"),
+            root.join("file-link"),
+        )
+        .unwrap();
+        create_junction(&root.join("junction"), &root_prefix_sibling);
+
+        let fs = RealFs::open(&root, RealFsMode::ReadOnly).await.unwrap();
+        for hostile in [
+            Path::new("/file-link"),
+            Path::new("/junction/secret.txt"),
+            Path::new("/junction/missing/descendant.txt"),
+        ] {
+            let result = fs.read(hostile).await;
+            assert!(
+                !matches!(result, Ok(ref bytes) if bytes == b"outside-secret"),
+                "reparse target escaped RealFs root: {}",
+                hostile.display()
+            );
+        }
+    }
+}
+
 // macOS temp dirs canonicalize under /private, which RealFs treats as
 // sensitive. Tests allowlist only the temp fixtures they mount.
 fn builder_allowing_host_paths(paths: &[&Path]) -> BashBuilder {

--- a/knowledge/foundations/vfs.md
+++ b/knowledge/foundations/vfs.md
@@ -59,6 +59,9 @@ Do you need a custom filesystem?
 #### OverlayFs
 - Copy-on-write layer over another FileSystem, whiteout tracking for deletes
 - Useful for: temp modifications, testing, isolation
+- Uses the same POSIX-rooted path normalization as `InMemoryFs` on every host.
+  On Windows, `\` is accepted as an alternate separator, host drive/UNC/device
+  prefixes are discarded, and VFS lookup remains case-sensitive.
 
 #### MountableFs
 - Mount multiple filesystems at different paths
@@ -97,6 +100,14 @@ Do you need a custom filesystem?
 - Path traversal prevented via canonicalization + root prefix check
 - New-path writes canonicalize the nearest existing ancestor before attaching a
   missing suffix, blocking symlink escapes through non-existent subpaths
+- Windows drive-relative, drive-absolute, UNC, and device-style virtual paths
+  are normalized into the POSIX VFS root before host joining. Existing-path and
+  missing-descendant checks follow symlinks, junctions, and other reparse points
+  before applying component-aware root containment; host lookup itself retains
+  Windows case-insensitive behavior.
+- Windows `RealFs::symlink()` does not create a host reparse point; it creates an
+  empty file after applying target-containment validation. Pre-existing host
+  symlinks and junctions are supported and containment-checked.
 - Builder: `mount_real_readonly[_at]()`, `mount_real_readwrite()`; CLI:
   `--mount-ro` / `--mount-rw` (`host:vfs` syntax for mount point)
 

--- a/knowledge/operations/limitations.md
+++ b/knowledge/operations/limitations.md
@@ -47,6 +47,7 @@ execution model. Evidence is a threat-model ID, a test, or `stance`
 | L-PROC-003 | No process spawning; external commands run as builtins | Core sandbox model: no fork/exec escape surface | `l_proc_003_no_process_spawning` |
 | L-FS-001 | Symlinks stored but never followed in path resolution (`ln -s` works, `read_link()` returns targets, traversal blocked) | Prevents symlink loops and link-based sandbox escapes | TM-DOS-011 |
 | L-FS-002 | No file permission enforcement in the VFS | Single-tenant virtual FS; permissions would be theater | `l_fs_002_no_permission_enforcement` |
+| L-FS-003 | On Windows, `RealFs::symlink()` validates the target but creates an empty host file rather than a symlink/reparse point; pre-existing host symlinks and junctions remain readable subject to containment checks | Windows requires choosing file-vs-directory link semantics and may require link privileges; the portable VFS symlink contract does not carry that host metadata | TM-ESC-033 |
 | L-NET-001 | No raw network sockets; HTTP only via `curl`/`wget`/`http` builtins | Allowlist-mediated egress is the only network surface | `l_net_001_no_raw_sockets` |
 | L-NET-002 | No DNS resolution; hosts must appear in the allowlist | Resolution would bypass allowlist intent | `l_net_002_default_deny_no_resolution` |
 | L-SIG-001 | `trap` stores INT/TERM handlers but no signal delivery in virtual mode (EXIT, ERR fire) | No host signals exist inside the sandbox | `l_sig_001_signal_traps_not_delivered` |

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -314,6 +314,7 @@ panicked. Resolved with `wrapping_*` ops, masked shift amounts, clamped exponent
 | TM-ESC-004 | Mount escape | Mount real paths | MountableFs controlled | **MITIGATED** |
 | TM-ESC-016 | Symlink escape via overlay rename | `ln -s /etc/passwd x; mv x y` | Overlay rename/copy preserve symlinks as symlinks | **FIXED** |
 | TM-ESC-031 | Namespace source-root or policy escape | `..` selects a shorter mount, escapes a rebased source root, or bypasses a nested read-only mount | Normalize before longest-prefix selection; join only the stripped suffix; independently enforce both mutation endpoints | **MITIGATED** |
+| TM-ESC-033 | Windows host-path namespace escape | A direct VFS/RealFs path preserves a drive-relative, drive-absolute, UNC, or device prefix; `root.join(path)` discards the configured root, or a symlink/junction redirects an existing prefix | Shared POSIX VFS normalization discards host prefixes before backend joins; RealFs canonicalizes existing paths or the nearest existing ancestor and performs component-aware root checks; drive-relative symlink targets are rejected; Windows CI exercises alternate separators, case behavior, root-prefix siblings, reparse points, and missing descendants | **MITIGATED** |
 | TM-FS-013 | Permissive RealFs mount default | `mount_real_readonly_at("/", …)` exposes whole host without `allowed_mount_paths` | Allowlist-first: `/`, `/etc`, `/root`, `/Users`, `/home`, `/dev`, `/proc`, `/sys`, `/run`, `/var/run`, `/boot`, `/private`, and any path component matching `.ssh`, `.aws`, `.kube`, `.docker`, `.gnupg`, `.gcloud` are refused unless explicitly allowlisted | **MITIGATED** |
 
 **Current Risk**: MEDIUM - Two open escape vectors (TM-ESC-012, TM-ESC-013) need remediation
@@ -347,6 +348,13 @@ each mutating endpoint is checked independently. Regression tests:
 `tm_esc_031_namespace_normalizes_without_source_or_nested_mount_escape`,
 `tm_esc_031_namespace_readonly_mount_denies_every_mutation_without_bypass`, and
 `tm_esc_031_namespace_rejects_invalid_paths_and_protects_namespace_nodes`.
+
+**TM-ESC-033**: The VFS is POSIX-rooted even on Windows. The shared normalizer
+removes Windows host namespace prefixes before `RealFs` joins a virtual path to
+its canonical root. Existing entries and nearest existing ancestors are then
+canonicalized, so symlink/junction targets, root-prefix siblings, and missing
+suffixes cannot escape. `windows_containment_*` tests run continuously on a
+Windows runner; drive roots are also sensitive mounts under TM-FS-013.
 
 #### 2.2 Process Escape
 
@@ -1230,14 +1238,14 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Shared request execution budget | TM-DOS-096 | `limits.rs`, `parser/mod.rs`, `interpreter/mod.rs`, high-risk builtins/runtimes | Yes |
 | Persistent custom fd cap | TM-DOS-063 | `limits.rs`, `interpreter/mod.rs` | Yes |
 | Command history caps | TM-DOS-094 | `limits.rs`, `interpreter/mod.rs`, `builtins/environ.rs` | Yes |
-| Virtual filesystem | TM-ESC-001, TM-ESC-003 | `fs/memory.rs` | Yes |
+| Virtual filesystem | TM-ESC-001, TM-ESC-003, TM-ESC-033 | `fs/memory.rs`, `fs/overlay.rs`, `fs/realfs.rs` | Yes |
 | Filesystem limits | TM-DOS-005 to TM-DOS-010, TM-DOS-014 | `fs/limits.rs` | Yes |
 | Path depth limit (100) | TM-DOS-012 | `fs/limits.rs` | Yes |
 | Filename length limit (255) | TM-DOS-013 | `fs/limits.rs` | Yes |
 | Path length limit (4096) | TM-DOS-013 | `fs/limits.rs` | Yes |
 | Path char validation | TM-DOS-015 | `fs/limits.rs` | Yes |
 | Zip bomb protection | TM-DOS-007, TM-NET-013 | `builtins/archive.rs` | Yes |
-| Path normalization | TM-ESC-001, TM-INJ-005 | `fs/memory.rs` | Yes |
+| Path normalization | TM-ESC-001, TM-ESC-033, TM-INJ-005 | `fs/mod.rs`, `fs/realfs.rs` | Yes |
 | No symlink following | TM-ESC-002, TM-DOS-011 | `fs/memory.rs` | Yes |
 | Network allowlist | TM-INF-010, TM-NET-001 to TM-NET-007 | `network/allowlist.rs` | Yes |
 | Domain allowlist | TM-NET-015, TM-NET-016, TM-NET-017 | `network/allowlist.rs` | Planned |


### PR DESCRIPTION
## What changed
Windows host path syntax is now contained by the same POSIX-rooted normalization used across Bashkit VFS layers. RealFS rejects drive-relative symlink targets, treats Windows drive/UNC/device roots as sensitive mounts, and continuously tests host reparse-point containment on a native Windows runner.

The Windows suite covers alternate separators, drive-relative and drive-absolute paths, UNC/device prefixes, VFS-vs-host case behavior, component-aware root-prefix checks, symlink/junction targets, and canonicalization through missing descendants. The RealFS Windows symlink-creation limitation is now explicit.

## Why
RealFS had a private platform-aware virtual-path normalizer. On Windows it could preserve a drive, UNC, or device prefix; joining an absolute host path could discard the configured RealFS root. Existing Unix CI could not exercise that namespace behavior.

## Before / After
Before: a direct RealFS call with a Windows absolute/device path could preserve host namespace semantics, and no native Windows containment suite guarded VFS/overlay/RealFS behavior.

After: host prefixes are discarded before backend joins, canonical existing ancestors enforce component-aware containment across symlinks/junctions and missing suffixes, drive roots require explicit allowlisting, and `Windows filesystem containment` runs on every PR.

Proof:
- `cargo test -p bashkit --lib --features realfs fs::realfs::tests`
- `cargo test -p bashkit --test realfs_tests --features realfs`
- `cargo test -p bashkit --test integration -- limitations_doc_tests threat_model_doc_tests`
- `just pre-pr`
- `cargo test -p bashkit --test realfs_tests --features realfs readwrite_mount_modifies_host -- --exact`

## Risk
- Medium
- Windows direct RealFS callers that supplied host-style prefixed paths now resolve inside the VFS root instead of retaining host namespace semantics. This is the intended security boundary.
- Native Windows symlink creation can depend on runner privileges; junction coverage exercises the same reparse-point canonicalization path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered