### PR TITLE
fix(jq): accept literal controls in input strings

### DIFF
--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -157,6 +157,7 @@ let bash = Bash::builder()
 | Contradictory execution-profile limits (TM-DOS-097) | Host config silently requests ineffective or impossible limits | Validate profile cross-field invariants before `BashBuilder` accepts it | MITIGATED |
 | Suspended host-call retention (TM-DOS-098) | Script repeats event-backed calls or host never resumes one | Capacity-one channel, normal execution limits, and handle-owned session released on drop | MITIGATED |
 | `time` report amplification (TM-DOS-099) | Attacker-controlled `-f` format expands repeatedly or targets the VFS with `-o` | Incremental rendering is capped by the stderr limit before emission or file replacement | MITIGATED |
+| jq control normalization amplification (TM-DOS-100) | Literal controls expand sixfold as `\u00XX` | Charge single-pass work and lease live bytes before allocation growth | MITIGATED |
 
 ### Sandbox Escape (TM-ESC-*)
 

--- a/crates/bashkit/src/builtins/jq/input.rs
+++ b/crates/bashkit/src/builtins/jq/input.rs
@@ -1,0 +1,176 @@
+//! jq-only JSON input compatibility normalization.
+//!
+//! Real jq deployments accept literal U+0000..U+001F controls inside JSON
+//! strings. Keep that exception at this builtin boundary: the shared JSON
+//! parser and every other JSON contract remain strict.
+
+use std::borrow::Cow;
+
+use crate::limits::{ExecutionBudget, ExecutionBudgetLease};
+
+#[derive(Debug)]
+pub(super) struct NormalizedInput<'a> {
+    text: Cow<'a, str>,
+    _lease: Option<ExecutionBudgetLease>,
+}
+
+impl<'a> NormalizedInput<'a> {
+    pub(super) fn as_str(&self) -> &str {
+        &self.text
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum NormalizeError {
+    InvalidJson(String),
+    Resource(crate::error::Error),
+}
+
+impl From<crate::limits::LimitExceeded> for NormalizeError {
+    fn from(error: crate::limits::LimitExceeded) -> Self {
+        Self::Resource(error.into())
+    }
+}
+
+/// THREAT[TM-DOS-100]: Normalize in one bounded pass. Work is charged before
+/// scanning, and live bytes are reserved before allocating or growing output.
+pub(super) fn normalize<'a>(
+    budget: Option<&ExecutionBudget>,
+    input: &'a str,
+) -> std::result::Result<NormalizedInput<'a>, NormalizeError> {
+    if let Some(budget) = budget {
+        budget.consume_work(u64::try_from(input.len()).unwrap_or(u64::MAX))?;
+    }
+
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut output: Option<String> = None;
+    let mut lease = None;
+    let mut copied_through = 0usize;
+
+    for (offset, byte) in input.bytes().enumerate() {
+        if !in_string {
+            if byte == b'"' {
+                in_string = true;
+            }
+            continue;
+        }
+
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match byte {
+            b'\\' => escaped = true,
+            b'"' => in_string = false,
+            0x00..=0x1f => {
+                if output.is_none() {
+                    let Some(capacity) = input.len().checked_add(5) else {
+                        return Err(NormalizeError::InvalidJson(
+                            "jq: normalized input too large".into(),
+                        ));
+                    };
+                    lease = budget
+                        .map(|budget| budget.lease_bytes(capacity))
+                        .transpose()?;
+                    output = Some(String::with_capacity(capacity));
+                } else if let Some(reservation) = &mut lease {
+                    reservation.grow(5)?;
+                }
+
+                let normalized = output.as_mut().expect("output initialized above");
+                normalized.reserve_exact(5);
+                normalized.push_str(&input[copied_through..offset]);
+                use std::fmt::Write;
+                write!(normalized, "\\u{byte:04x}").expect("writing to String cannot fail");
+                copied_through = offset + 1;
+            }
+            _ => {}
+        }
+    }
+
+    if in_string {
+        return Err(NormalizeError::InvalidJson(
+            "jq: invalid JSON: unterminated string at end of input".into(),
+        ));
+    }
+
+    let text = match output {
+        Some(mut normalized) => {
+            normalized.push_str(&input[copied_through..]);
+            Cow::Owned(normalized)
+        }
+        None => Cow::Borrowed(input),
+    };
+    Ok(NormalizedInput {
+        text,
+        _lease: lease,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    use super::*;
+    use crate::limits::{ExecutionBudgetExceeded, ExecutionLimits, LimitExceeded};
+
+    fn budget(work: u64, live: u64) -> ExecutionBudget {
+        let limits = ExecutionLimits::new()
+            .max_work_units(work)
+            .max_live_intermediate_bytes(live);
+        ExecutionBudget::new(&limits, Arc::new(AtomicBool::new(false)))
+    }
+
+    #[test]
+    fn scan_charges_work_before_processing() {
+        let budget = budget(3, 100);
+        let NormalizeError::Resource(error) = normalize(Some(&budget), "\"a\n\"").unwrap_err()
+        else {
+            panic!("expected resource limit");
+        };
+        assert!(matches!(
+            error,
+            crate::error::Error::ResourceLimit(LimitExceeded::ExecutionBudget(
+                ExecutionBudgetExceeded::WorkUnits { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn allocation_is_leased_at_exact_boundary() {
+        let input = "\"a\n\"";
+        let exact = u64::try_from(input.len() + 5).unwrap();
+        assert!(normalize(Some(&budget(100, exact)), input).is_ok());
+
+        let NormalizeError::Resource(error) =
+            normalize(Some(&budget(100, exact - 1)), input).unwrap_err()
+        else {
+            panic!("expected resource limit");
+        };
+        assert!(matches!(
+            error,
+            crate::error::Error::ResourceLimit(LimitExceeded::ExecutionBudget(
+                ExecutionBudgetExceeded::LiveBytes { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn each_control_growth_is_leased_before_append() {
+        let input = "\"\n\t\"";
+        let one_control = u64::try_from(input.len() + 5).unwrap();
+        let NormalizeError::Resource(error) =
+            normalize(Some(&budget(100, one_control)), input).unwrap_err()
+        else {
+            panic!("expected resource limit");
+        };
+        assert!(matches!(
+            error,
+            crate::error::Error::ResourceLimit(LimitExceeded::ExecutionBudget(
+                ExecutionBudgetExceeded::LiveBytes { .. }
+            ))
+        ));
+    }
+}

--- a/crates/bashkit/src/builtins/jq/mod.rs
+++ b/crates/bashkit/src/builtins/jq/mod.rs
@@ -34,6 +34,7 @@ mod compat;
 mod convert;
 mod errors;
 mod format;
+mod input;
 mod regex_compat;
 
 #[cfg(test)]
@@ -128,7 +129,7 @@ async fn run_jq(ctx: Context<'_>, parsed: JqArgs<'_>) -> Result<ExecResult> {
         }
         let value = match req.kind {
             FileVarKind::Raw => serde_json::Value::String(text),
-            FileVarKind::Slurp => match parse_json_stream(&text) {
+            FileVarKind::Slurp => match parse_jq_json_stream(&ctx, &text)? {
                 Ok(vals) => {
                     // Inner values are already depth-checked by parse_json_stream;
                     // the wrapping array adds one level which the recursive
@@ -305,7 +306,7 @@ async fn run_jq(ctx: Context<'_>, parsed: JqArgs<'_>) -> Result<ExecResult> {
             })
             .collect()
     } else if parsed.slurp {
-        match parse_json_stream(input) {
+        match parse_jq_json_stream(&ctx, input)? {
             Ok(vals) => {
                 let arr: JqJson = JqJson::Array(vals);
                 vec![FilterInput {
@@ -317,7 +318,7 @@ async fn run_jq(ctx: Context<'_>, parsed: JqArgs<'_>) -> Result<ExecResult> {
             Err(e) => return Ok(ExecResult::err(format!("{e}\n"), 5)),
         }
     } else {
-        match parse_json_stream(input) {
+        match parse_jq_json_stream(&ctx, input)? {
             Ok(jq_vals) => jq_vals
                 .iter()
                 .enumerate()
@@ -457,6 +458,18 @@ async fn run_jq(ctx: Context<'_>, parsed: JqArgs<'_>) -> Result<ExecResult> {
     }
 
     Ok(ExecResult::ok(output))
+}
+
+fn parse_jq_json_stream(
+    ctx: &Context<'_>,
+    input: &str,
+) -> Result<std::result::Result<Vec<JqJson>, String>> {
+    let normalized = match input::normalize(ctx.execution_budget(), input) {
+        Ok(normalized) => normalized,
+        Err(input::NormalizeError::InvalidJson(message)) => return Ok(Err(message)),
+        Err(input::NormalizeError::Resource(error)) => return Err(error),
+    };
+    Ok(parse_json_stream(normalized.as_str()))
 }
 
 fn file_binding_exceeds_limit(used: usize, next: u64) -> bool {

--- a/crates/bashkit/src/builtins/jq/tests.rs
+++ b/crates/bashkit/src/builtins/jq/tests.rs
@@ -126,6 +126,106 @@ async fn keys_pretty_prints_array() {
     assert_eq!(result.trim(), "[\n  \"a\",\n  \"b\"\n]");
 }
 
+// jq deliberately accepts literal U+0000..U+001F bytes inside input strings.
+// This compatibility exception belongs only to jq's input boundary; output is
+// always valid JSON with the controls escaped.
+#[tokio::test]
+async fn literal_controls_inside_strings_are_escaped() {
+    let controls: String = (0u8..=0x1f).map(char::from).collect();
+    let input = format!("\"before{controls}after\"");
+    let result = run_jq_with_args(&["-c", "."], &input).await.unwrap();
+    assert_eq!(
+        result,
+        format!(
+            "{}\n",
+            serde_json::to_string(&format!("before{controls}after")).unwrap()
+        )
+    );
+}
+
+#[tokio::test]
+async fn literal_controls_preserve_adjacent_existing_escapes() {
+    let input = "\"left\\n\t\\t\rright\"";
+    let result = run_jq_with_args(&["-c", "explode"], input).await.unwrap();
+    assert_eq!(result, "[108,101,102,116,10,9,9,13,114,105,103,104,116]\n");
+}
+
+#[tokio::test]
+async fn literal_controls_work_across_concatenated_values() {
+    let result = run_jq_with_args(&["-c", "."], "\"a\nb\"{\"c\":\"d\te\"}")
+        .await
+        .unwrap();
+    assert_eq!(result, "\"a\\nb\"\n{\"c\":\"d\\te\"}\n");
+}
+
+#[tokio::test]
+async fn literal_controls_work_in_ndjson_after_escaped_quote() {
+    let result = run_jq_with_args(&["-c", "."], "\"a\\\"\tb\"\n\"c\rd\"\n")
+        .await
+        .unwrap();
+    assert_eq!(result, "\"a\\\"\\tb\"\n\"c\\rd\"\n");
+}
+
+#[tokio::test]
+async fn structural_whitespace_remains_structural() {
+    let result = run_jq_with_args(&["-c", "."], "\t1\r\n 2\n").await.unwrap();
+    assert_eq!(result, "1\n2\n");
+}
+
+#[tokio::test]
+async fn non_whitespace_control_outside_string_is_rejected() {
+    let result = run_jq_result(".", "1\u{0000}2").await.unwrap();
+    assert_eq!(result.exit_code, 5);
+    assert!(
+        result.stderr.contains("invalid JSON"),
+        "stderr={}",
+        result.stderr
+    );
+}
+
+#[tokio::test]
+async fn unterminated_string_with_control_is_rejected_deterministically() {
+    let first = run_jq_result(".", "\"unterminated\n").await.unwrap();
+    let second = run_jq_result(".", "\"unterminated\n").await.unwrap();
+    assert_eq!(first.exit_code, 5);
+    assert_eq!(first.stderr, second.stderr);
+    assert!(first.stderr.contains("unterminated string"));
+    crate::builtins::debug_leak_check::assert_no_leak(
+        &first,
+        "unterminated jq input string",
+        JQ_BANNED,
+    );
+}
+
+#[tokio::test]
+async fn literal_controls_work_for_file_and_slurpfile_inputs() {
+    let direct = run_jq_with_files(&["-c", ".", "/input.json"], &[("/input.json", "\"a\nb\"")])
+        .await
+        .unwrap();
+    assert_eq!(direct.stdout, "\"a\\nb\"\n");
+
+    let slurped = run_jq_with_files(
+        &["-nc", "--slurpfile", "data", "/input.json", "$data"],
+        &[("/input.json", "\"a\nb\"\"c\td\"")],
+    )
+    .await
+    .unwrap();
+    assert_eq!(slurped.stdout, "[\"a\\nb\",\"c\\td\"]\n");
+}
+
+#[tokio::test]
+async fn jq_argument_json_boundaries_remain_strict() {
+    let argjson = run_jq_result_with_args(&["--argjson", "x", "\"a\nb\"", "-n", "$x"], "")
+        .await
+        .unwrap();
+    assert_eq!(argjson.exit_code, 2);
+
+    let jsonargs = run_jq_result_with_args(&["-n", ".", "--jsonargs", "\"a\nb\""], "")
+        .await
+        .unwrap();
+    assert_eq!(jsonargs.exit_code, 2);
+}
+
 /// TM-DOS-093: an unbounded generator must not grow output without limit or
 /// hang the host. jaq's iterator is synchronous so the execution timeout
 /// cannot preempt it; the output-byte cap (here the 1 MB default, since the
@@ -1409,6 +1509,68 @@ mod differential {
             "exit-code mismatch for {args_label}: bashkit={}, real={}",
             bashkit.exit_code, real_code
         );
+    }
+
+    /// Prefer a direct raw-input comparison. Older jq builds reject controls
+    /// at the lexer, so fall back to equivalent escaped JSON on those versions
+    /// while retaining real jq as the filter/output oracle.
+    async fn assert_control_matches(args: &[&str], raw_input: &str, escaped_input: &str) {
+        if !real_jq_available() {
+            eprintln!("real jq not present; skipping differential test");
+            return;
+        }
+        let direct = run_real_jq(args, raw_input).unwrap();
+        let (real_out, real_code) = if direct.1 == 0 {
+            direct
+        } else {
+            run_real_jq(args, escaped_input).unwrap()
+        };
+        let bashkit = run_jq_result_with_args(args, raw_input).await.unwrap();
+        assert_eq!(bashkit.stdout, real_out);
+        assert_eq!(bashkit.exit_code, real_code);
+    }
+
+    #[tokio::test]
+    async fn diff_literal_newline_tab_and_cr() {
+        for (raw, escaped) in [
+            ("\"a\nb\"", "\"a\\nb\""),
+            ("\"a\tb\"", "\"a\\tb\""),
+            ("\"a\rb\"", "\"a\\rb\""),
+        ] {
+            assert_control_matches(&["-c", "."], raw, escaped).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn diff_all_literal_controls() {
+        let controls: String = (0u8..=0x1f).map(char::from).collect();
+        let raw = format!("\"{controls}\"");
+        let escaped = serde_json::to_string(&controls).unwrap();
+        assert_control_matches(&["-c", "."], &raw, &escaped).await;
+    }
+
+    #[tokio::test]
+    async fn diff_controls_adjacent_to_escapes_and_concatenated_values() {
+        assert_control_matches(
+            &["-c", "."],
+            "\"a\\n\tb\"\"c\r\\td\"",
+            "\"a\\n\\tb\"\"c\\r\\td\"",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn diff_control_normalization_boundary_size() {
+        let content = "x".repeat(16 * 1024);
+        let raw = format!("\"{content}\n\"");
+        let escaped = format!("\"{content}\\n\"");
+        assert_control_matches(&["-c", "length"], &raw, &escaped).await;
+    }
+
+    #[tokio::test]
+    async fn diff_malformed_quote_and_control_outside_string() {
+        assert_matches(&["-c", "."], "\"unterminated\n").await;
+        assert_matches(&["-c", "."], "1\u{0001}2").await;
     }
 
     #[tokio::test]

--- a/crates/bashkit/src/builtins/json.rs
+++ b/crates/bashkit/src/builtins/json.rs
@@ -456,6 +456,13 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn literal_control_in_string_remains_invalid_json() {
+        let r = run(&["type"], Some("\"line\nbreak\""), None).await;
+        assert_eq!(r.exit_code, 1);
+        assert!(r.stderr.contains("invalid JSON"));
+    }
+
+    #[tokio::test]
     async fn test_unknown_subcommand() {
         let r = run(&["nope"], Some("{}"), None).await;
         assert_eq!(r.exit_code, 1);

--- a/crates/bashkit/src/limits.rs
+++ b/crates/bashkit/src/limits.rs
@@ -956,6 +956,33 @@ pub struct ExecutionBudgetLease {
     bytes: u64,
 }
 
+impl ExecutionBudgetLease {
+    /// Increase this live-storage reservation before growing its buffer.
+    #[cfg(feature = "jq")]
+    pub(crate) fn grow(&mut self, additional: usize) -> Result<(), LimitExceeded> {
+        self.budget.check()?;
+        let additional = u64::try_from(additional).unwrap_or(u64::MAX);
+        let previous = self
+            .budget
+            .inner
+            .live_bytes
+            .fetch_add(additional, Ordering::Relaxed);
+        let used = previous.saturating_add(additional);
+        if used > self.budget.inner.max_live_bytes || previous.checked_add(additional).is_none() {
+            self.budget
+                .inner
+                .live_bytes
+                .fetch_sub(additional, Ordering::Relaxed);
+            return Err(self.budget.poison(ExecutionBudgetExceeded::LiveBytes {
+                used,
+                limit: self.budget.inner.max_live_bytes,
+            }));
+        }
+        self.bytes = self.bytes.saturating_add(additional);
+        Ok(())
+    }
+}
+
 /// RAII request terminator. Its drop path is intentionally infallible.
 pub(crate) struct ExecutionBudgetCompletionGuard {
     budget: ExecutionBudget,

--- a/crates/bashkit/tests/integration/execution_budget_tests.rs
+++ b/crates/bashkit/tests/integration/execution_budget_tests.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "jq")]
+use bashkit::ExecOptions;
 use bashkit::{
     Bash, Builtin, BuiltinContext, Error, ExecResult, ExecutionBudget, ExecutionLimits,
     LimitExceeded, async_trait,
@@ -144,6 +146,22 @@ async fn jq_generator_consumes_shared_work_budget() {
     let mut bash = Bash::builder().limits(limits).build();
 
     assert_budget_exhausted(bash.exec("jq -n 'range(0; 10000)'").await);
+}
+
+#[cfg(feature = "jq")]
+#[tokio::test]
+/// TM-DOS-100: jq must reserve normalized input before control expansion.
+async fn jq_control_normalization_respects_live_memory_budget() {
+    let limits = ExecutionLimits::new()
+        .max_work_units(10_000)
+        .max_aggregate_input_bytes(10_000)
+        .max_live_intermediate_bytes(8);
+    let mut bash = Bash::builder().limits(limits).build();
+
+    assert_budget_exhausted(
+        bash.exec_with_options("jq -c .", ExecOptions::new().stdin("\"a\n\""))
+            .await,
+    );
 }
 
 #[cfg(feature = "python")]

--- a/knowledge/foundations/index.md
+++ b/knowledge/foundations/index.md
@@ -4,6 +4,7 @@
 * [Parser](parser.md) - Bash syntax parser and lexer architecture and compatibility decisions.
 * [Virtual Filesystem](vfs.md) - Filesystem abstraction, path safety, implementations, and sandbox invariants.
 * [Builtin Commands](builtins.md) - Builtin command trait, execution planning, registration, and implementation conventions.
+* [jq Input Compatibility](jq.md) - jq JSON input normalization, strict-boundary scope, and resource-accounting rules.
 * [Parallel Execution](parallel-execution.md) - Threading model, shared ownership, and concurrency safety requirements.
 * [Snapshot History and Deltas](snapshot-history.md) - Content-addressed snapshot objects, commit DAG with forks, chunked binary content, and the version and capability compatibility rules for restore.
 * [Execution Profiles](execution-profiles.md) - Typed policy bundles across execution, memory, filesystem, network, and embedded runtimes.

--- a/knowledge/foundations/jq.md
+++ b/knowledge/foundations/jq.md
@@ -1,0 +1,57 @@
+---
+type: Subsystem Design
+title: jq Input Compatibility
+description: jq JSON input normalization, strict-boundary scope, and resource-accounting rules.
+tags:
+  - bashkit
+  - jq
+  - json
+---
+
+# jq Input Compatibility
+
+## Status
+
+Implemented.
+
+## Decision
+
+The `jq` builtin accepts literal U+0000 through U+001F controls inside JSON
+strings. A jq-only input-boundary pass rewrites each such byte to its `\u00XX`
+form before the strict serde stream parser sees it. The pass tracks JSON string
+and escape state, preserves existing escapes and structural whitespace, and
+handles NDJSON and concatenated JSON values without splitting the stream.
+
+This is intentionally not a general JSON policy. The `json` builtin,
+`serde_json` defaults, tool request/response contracts, `--argjson`, and
+`--jsonargs` remain strict. jq raw-input modes do not parse JSON and therefore
+do not normalize their bytes. Main jq input from stdin or files and
+`--slurpfile` use the compatibility boundary; `--rawfile` remains raw.
+
+Malformed quoting is rejected by the boundary with a stable jq-shaped error.
+Controls outside strings remain untouched, so only JSON whitespace is accepted
+there by the strict parser.
+
+## Resource accounting
+
+Normalization is a bounded single pass. It charges input length to the shared
+request work budget before scanning. Inputs without affected controls remain
+borrowed and allocate nothing. On the first rewrite it reserves the exact
+current normalized size from the live-intermediate budget before allocation;
+each later five-byte expansion grows that lease before the buffer grows. The
+lease remains live until strict parsing finishes (TM-DOS-100).
+
+## Verification
+
+`builtins::jq::tests` covers all 32 controls, newline/tab/CR, adjacent existing
+escapes, structural controls, NDJSON/concatenated values, malformed quoting,
+stdin/file/slurpfile paths, exact work/live-memory boundaries, debug-leak
+invariants, and differential filter/output semantics against real jq.
+`builtins::json::tests::literal_control_in_string_remains_invalid_json` proves
+the exception does not cross into the strict `json` builtin.
+
+## See also
+
+- [Builtin Commands](builtins.md) — builtin execution and request-budget context
+- [Known Limitations](../operations/limitations.md) — jq divergences and strict-boundary stance
+- [Threat Model](../security/threat-model.md) — TM-DOS-100 resource-exhaustion mitigation

--- a/knowledge/operations/limitations.md
+++ b/knowledge/operations/limitations.md
@@ -132,6 +132,10 @@ sanitization, redirect handling hardened against credential leaks, and curl's
 aggregate data/multipart request body capped at 10 MB. Repeated mixed curl
 `-d`/`--data`, `--data-raw`, `--data-binary`, and `--data-urlencode` parts retain
 command-line order; `-G`/`--get` moves their joined payload to the query string.
+The jq input boundary alone accepts literal U+0000..U+001F controls inside JSON
+strings; controls outside strings and malformed quoting remain invalid. The
+`json` builtin, serde defaults, tool JSON contracts, `--argjson`, and
+`--jsonargs` stay strict. See [jq Input Compatibility](../foundations/jq.md).
 
 ## CLI
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -1209,6 +1209,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-DOS-097 | Contradictory execution-profile limits | A host supplies a profile whose single-file quota exceeds its total VFS quota, requests an AST depth above the parser hard cap, or configures a zero runtime budget and assumes the ineffective value is enforced | `ExecutionProfileBuilder::build()` validates cross-field invariants and compiled-feature support before a profile can reach `BashBuilder`; typed named profiles are valid by construction — **MITIGATED** |
 | TM-DOS-098 | Suspended host-call retention or request accumulation | An untrusted script repeatedly invokes an event-backed builtin, or the host never resumes a yielded request, retaining interpreter and request data indefinitely | The sequential interpreter can reach only one call at a time; a capacity-one channel adds backpressure; the existing command, aggregate-budget, output, and wall-clock limits remain in force; `ExecutionHandle` exclusively owns the session so dropping it releases all retained state rather than exposing a partially unwound interpreter — **MITIGATED** |
 | TM-DOS-099 | `time -f/-o` report amplification bypasses output limits | A large attacker-controlled format repeats expanding fields and writes the result to the VFS instead of stderr | Report rendering is capped by `ExecutionLimits::max_stderr_bytes` before either stderr emission or VFS write; invalid/over-limit reports do not replace an existing `-o` target — **MITIGATED** |
+| TM-DOS-100 | jq control-character normalization amplification | A jq JSON string consisting of literal controls expands sixfold when each byte becomes `\u00XX`; an unmetered compatibility copy can exhaust memory or CPU before strict parsing | The jq-only normalizer charges input-length work before its single pass, borrows unchanged input, and acquires/grows a shared live-intermediate lease before every allocation growth (`builtins/jq/input.rs`) — **MITIGATED** |
 
 ### Accepted (Low Priority)
 
@@ -1323,6 +1324,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Session-level cumulative counters | TM-ISO-005 | `SessionLimits` caps cumulative commands and `exec()` calls across the lifetime of a `Bash` instance | **MITIGATED** |
 | Per-instance memory budget | TM-ISO-006 | `MemoryLimits` capping variable count, total bytes, array entries, function count, function body bytes | **MITIGATED** |
 | jq file binding amplification | TM-DOS-062 | `MAX_FILE_VAR_REQUESTS` and `MAX_FILE_VAR_BYTES` bound `--rawfile` / `--slurpfile` globals | **MITIGATED** |
+| jq control normalization amplification | TM-DOS-100 | Single-pass work charge plus live-intermediate lease grown before allocation | **MITIGATED** |
 | Heredoc suffix re-injection CPU amplification | TM-DOS-064 | Charge re-injected heredoc rest-of-line suffix length to parser fuel | **MITIGATED** |
 
 ---


### PR DESCRIPTION
## What changed
jq now accepts literal U+0000 through U+001F controls inside JSON strings across stdin, file, slurp, NDJSON, and concatenated-value paths. The jq-only normalization preserves escapes and structural whitespace, rejects malformed quoting, and meters work plus live allocation growth. All other JSON boundaries remain strict.

## Why
jq-compatible callers can produce JSON strings containing literal control bytes. serde rejects those before jaq can process them, creating a compatibility gap. Normalizing only at the jq input boundary closes that gap without weakening shared JSON contracts.

## Before / After
Before:
```console
$ printf '"a\nb"' | bashkit -c 'jq -c .'
jq: invalid JSON: control character (...) found while parsing a string
```

After:
```console
$ printf '"a\nb"' | bashkit -c 'jq -c .'
"a\\nb"
```

Proof: 31 real-jq differential tests, all-control/NDJSON/file/slurp/budget/security regressions, end-to-end CLI smoke, parallel-execution benchmark, and `just pre-pr` pass.

## Risk
- Low
- Scope is isolated to parsed jq input and `--slurpfile`; raw jq modes, jq argument JSON, the `json` builtin, serde defaults, and tool JSON contracts remain unchanged.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered