### PR TITLE
feat(archives): add bzip2 interoperability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "base64 0.23.0",
  "bigdecimal",
  "bitflags 2.13.1",
+ "bzip2",
  "chrono",
  "clap",
  "criterion",
@@ -717,6 +718,15 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
 
 [[package]]
 name = "cast"
@@ -2631,6 +2641,12 @@ name = "lexical-util"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ chrono = "0.4"
 
 # Compression
 flate2 = "1"
+bzip2 = { version = "0.6.1", default-features = true }
 
 # Base64 encoding
 base64 = "0.23"

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -64,8 +64,9 @@ jaq-core = { workspace = true, optional = true }
 jaq-std = { workspace = true, optional = true }
 jaq-json = { workspace = true, optional = true }
 
-# Compression (for gzip/gunzip)
+# Compression (for gzip/gunzip and bzip2/bunzip2)
 flate2 = { workspace = true }
+bzip2 = { workspace = true }
 
 # Base64 encoding (for base64 builtin and HTTP basic auth)
 base64 = { workspace = true }

--- a/crates/bashkit/docs/compatibility.md
+++ b/crates/bashkit/docs/compatibility.md
@@ -106,9 +106,12 @@ for sandbox security reasons. See the compliance spec for details.
 | `file` | (none) | Detect file type via magic bytes |
 | `less` | (none) | View file (behaves like cat in virtual mode) |
 | `stat` | `-c FORMAT` | Display file metadata |
-| `tar` | `-c`, `-x`, `-t`, `-v`, `-f`, `-z` | Archive operations |
+| `tar` | `-c`, `-x`, `-t`, `-v`, `-f`, `-z`/`--gzip`, `-j`/`--bzip2` | Archive operations; auto-detects gzip/bzip2 while reading |
 | `gzip` | `-d`, `-k`, `-f` | Compress files |
 | `gunzip` | `-k`, `-f` | Decompress files |
+| `bzip2` | `-c`, `-d`, `-z`, `-k`, `-f` | Compress or decompress bzip2 streams/files |
+| `bunzip2` | `-c`, `-k`, `-f` | Decompress bzip2 streams/files |
+| `bzcat` | | Decompress bzip2 streams/files to stdout |
 | `env` | `[VAR=val]` | Print/modify environment |
 | `printenv` | `[VAR]` | Print environment variables |
 | `history` | (none) | Command history (limited in virtual mode) |

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -41,6 +41,7 @@ through configurable limits.
 | Large file (TM-DOS-005) | `dd if=/dev/zero bs=1G count=100` | `max_file_size` limit | MITIGATED |
 | Many files (TM-DOS-006) | Create 1M files | `max_file_count` | MITIGATED |
 | Zip bomb (TM-DOS-007) | `gunzip bomb.gz` | Decompression limit | MITIGATED |
+| Archive allocation-before-check (TM-DOS-102) | Tiny gzip/bzip2 input expands before quota accounting | Check size/ratio and lease live bytes before output-buffer growth | MITIGATED |
 | Tar bomb (TM-DOS-008) | `tar -xf bomb.tar` | FS limits | MITIGATED |
 | Recursive copy (TM-DOS-009) | `cp -r /tmp /tmp/copy` | FS limits | MITIGATED |
 | Append flood (TM-DOS-010) | `while true; do echo x >> f; done` | FS + loop limits | MITIGATED |
@@ -159,6 +160,7 @@ let bash = Bash::builder()
 | `time` report amplification (TM-DOS-099) | Attacker-controlled `-f` format expands repeatedly or targets the VFS with `-o` | Incremental rendering is capped by the stderr limit before emission or file replacement | MITIGATED |
 | jq control normalization amplification (TM-DOS-100) | Literal controls expand sixfold as `\u00XX` | Charge single-pass work and lease live bytes before allocation growth | MITIGATED |
 | yq structured-data amplification (TM-DOS-101) | Deep/multi-document YAML or JSON, runaway filters, expanded output | Parser depth and 4096-document caps, aggregate budgets, shared jaq work/deadline/output limits, final render cap | MITIGATED |
+| Archive decoder pre-allocation (TM-DOS-102) | Compressed output grows before memory checks | Validate and charge each decoder chunk before reserve/copy | MITIGATED |
 
 ### Sandbox Escape (TM-ESC-*)
 

--- a/crates/bashkit/src/builtins/archive.rs
+++ b/crates/bashkit/src/builtins/archive.rs
@@ -1,4 +1,4 @@
-//! Archive builtins - tar, gzip, gunzip
+//! Archive builtins - tar, gzip, gunzip, bzip2, bunzip2, bzcat
 //!
 //! # Zip Bomb Protection
 //!
@@ -9,11 +9,18 @@
 //! Design decision: tar's first bare argv is the historical option bundle;
 //! normalize it to the regular short-option path instead of maintaining a
 //! second parser.
+//!
+//! bzip2 0.6 uses the maintained pure-Rust libbz2-rs backend by default. Its
+//! fixed codec state plus bounded, pre-charged output avoids native-library
+//! deployment differences while retaining standard bzip2 CRC validation.
 
 // Uses expect() for verified safe unwraps (e.g., strip_suffix after ends_with check)
 #![allow(clippy::unwrap_used)]
 
 use async_trait::async_trait;
+use bzip2::Compression as BzCompression;
+use bzip2::read::BzDecoder;
+use bzip2::write::BzEncoder;
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -26,6 +33,26 @@ use super::{Builtin, Context, resolve_path};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum ArchiveCompression {
+    #[default]
+    None,
+    Gzip,
+    Bzip2,
+}
+
+impl ArchiveCompression {
+    fn detect(data: &[u8]) -> Self {
+        if data.starts_with(b"BZh") {
+            Self::Bzip2
+        } else if data.starts_with(&[0x1f, 0x8b]) {
+            Self::Gzip
+        } else {
+            Self::None
+        }
+    }
+}
+
 /// Read from a decoder with size limits to prevent zip bombs.
 ///
 /// Returns an error if the decompressed size exceeds the limit or
@@ -35,8 +62,18 @@ fn read_with_limit<R: Read>(
     compressed_size: usize,
     max_size: u64,
 ) -> std::io::Result<Vec<u8>> {
+    read_with_limit_budgeted(&mut reader, compressed_size, max_size, None)
+}
+
+fn read_with_limit_budgeted<R: Read>(
+    mut reader: R,
+    compressed_size: usize,
+    max_size: u64,
+    budget: Option<&crate::limits::ExecutionBudget>,
+) -> std::io::Result<Vec<u8>> {
     let mut output = Vec::new();
     let mut buffer = [0u8; 8192];
+    let mut leases = Vec::new();
 
     loop {
         let n = reader.read(&mut buffer)?;
@@ -44,10 +81,12 @@ fn read_with_limit<R: Read>(
             break;
         }
 
-        output.extend_from_slice(&buffer[..n]);
-
-        // Check absolute size limit
-        if output.len() as u64 > max_size {
+        // THREAT[TM-DOS-102]: Reject decoder growth before reserving or
+        // copying attacker-controlled expansion into the output buffer.
+        let next_len = output.len().checked_add(n).ok_or_else(|| {
+            std::io::Error::other("decompressed size overflow (zip bomb protection)")
+        })?;
+        if u64::try_from(next_len).unwrap_or(u64::MAX) > max_size {
             return Err(std::io::Error::other(format!(
                 "decompressed size exceeds {} byte limit (zip bomb protection)",
                 max_size
@@ -55,15 +94,71 @@ fn read_with_limit<R: Read>(
         }
 
         // Check decompression ratio (zip bomb detection)
-        if compressed_size > 0 && output.len() > compressed_size * MAX_DECOMPRESSION_RATIO {
+        let ratio_limit = compressed_size.saturating_mul(MAX_DECOMPRESSION_RATIO);
+        if compressed_size > 0 && next_len > ratio_limit {
             return Err(std::io::Error::other(format!(
                 "decompression ratio exceeds {}:1 (zip bomb protection)",
                 MAX_DECOMPRESSION_RATIO
             )));
         }
+
+        if let Some(budget) = budget {
+            leases.push(budget.lease_bytes(n).map_err(std::io::Error::other)?);
+        }
+        output.try_reserve_exact(n).map_err(|_| {
+            std::io::Error::other("decompression allocation failed (zip bomb protection)")
+        })?;
+        output.extend_from_slice(&buffer[..n]);
     }
 
     Ok(output)
+}
+
+fn compress_bytes(compression: ArchiveCompression, input: &[u8], command: &str) -> Result<Vec<u8>> {
+    match compression {
+        ArchiveCompression::None => Ok(input.to_vec()),
+        ArchiveCompression::Gzip => {
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(input).map_err(|err| {
+                crate::error::Error::Execution(format!("{command}: gzip compression failed: {err}"))
+            })?;
+            encoder.finish().map_err(|err| {
+                crate::error::Error::Execution(format!("{command}: gzip compression failed: {err}"))
+            })
+        }
+        ArchiveCompression::Bzip2 => {
+            let mut encoder = BzEncoder::new(Vec::new(), BzCompression::best());
+            encoder.write_all(input).map_err(|err| {
+                crate::error::Error::Execution(format!(
+                    "{command}: bzip2 compression failed: {err}"
+                ))
+            })?;
+            encoder.finish().map_err(|err| {
+                crate::error::Error::Execution(format!(
+                    "{command}: bzip2 compression failed: {err}"
+                ))
+            })
+        }
+    }
+}
+
+fn decompress_bytes(
+    compression: ArchiveCompression,
+    input: &[u8],
+    max_size: u64,
+    command: &str,
+    budget: Option<&crate::limits::ExecutionBudget>,
+) -> Result<Vec<u8>> {
+    let decoded = match compression {
+        ArchiveCompression::None => return Ok(input.to_vec()),
+        ArchiveCompression::Gzip => {
+            read_with_limit_budgeted(GzDecoder::new(input), input.len(), max_size, budget)
+        }
+        ArchiveCompression::Bzip2 => {
+            read_with_limit_budgeted(BzDecoder::new(input), input.len(), max_size, budget)
+        }
+    };
+    decoded.map_err(|err| crate::error::Error::Execution(format!("{command}: {err}")))
 }
 
 /// The tar builtin - create and extract tar archives.
@@ -84,7 +179,7 @@ impl Builtin for Tar {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
         if let Some(r) = super::check_help_version(
             ctx.args,
-            "Usage: tar [OPTION]... [FILE]...\nCreate, extract, or list tar archives.\n\n  -c\tcreate archive\n  -x\textract archive\n  -t\tlist archive contents\n  -v\tverbose output\n  -f ARCHIVE\tarchive file name\n  -z\tfilter through gzip\n  -C DIR\tchange to directory DIR\n  -O\textract files to stdout\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
+            "Usage: tar [OPTION]... [FILE]...\nCreate, extract, or list tar archives.\n\n  -c\tcreate archive\n  -x\textract archive\n  -t\tlist archive contents\n  -v\tverbose output\n  -f ARCHIVE\tarchive file name\n  -z, --gzip\tfilter through gzip\n  -j, --bzip2\tfilter through bzip2\n  -C DIR\tchange to directory DIR\n  -O\textract files to stdout\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n",
             Some("tar (bashkit) 0.1"),
         ) {
             return Ok(r);
@@ -93,7 +188,7 @@ impl Builtin for Tar {
         let mut extract = false;
         let mut list = false;
         let mut verbose = false;
-        let mut gzip = false;
+        let mut compression = ArchiveCompression::None;
         let mut to_stdout = false;
         let mut archive_file: Option<String> = None;
         let mut change_dir: Option<String> = None;
@@ -119,7 +214,13 @@ impl Builtin for Tar {
         // Parse arguments
         let mut p = super::arg_parser::ArgParser::new(args);
         while !p.is_done() {
-            if let Some(val) = p.flag_value_opt("-f") {
+            if p.current() == Some("--bzip2") {
+                compression = ArchiveCompression::Bzip2;
+                p.advance();
+            } else if p.current() == Some("--gzip") {
+                compression = ArchiveCompression::Gzip;
+                p.advance();
+            } else if let Some(val) = p.flag_value_opt("-f") {
                 archive_file = Some(val.to_string());
             } else if let Some(val) = p.flag_value_opt("-C") {
                 change_dir = Some(val.to_string());
@@ -134,7 +235,8 @@ impl Builtin for Tar {
                         'x' => extract = true,
                         't' => list = true,
                         'v' => verbose = true,
-                        'z' => gzip = true,
+                        'z' => compression = ArchiveCompression::Gzip,
+                        'j' => compression = ArchiveCompression::Bzip2,
                         'O' => to_stdout = true,
                         'f' => match p.positional() {
                             Some(val) => archive_file = Some(val.to_string()),
@@ -196,7 +298,7 @@ impl Builtin for Tar {
                 &archive_name,
                 &files,
                 verbose,
-                gzip,
+                compression,
                 change_dir.as_deref(),
             )
             .await
@@ -205,13 +307,13 @@ impl Builtin for Tar {
                 &ctx,
                 &archive_name,
                 verbose,
-                gzip,
+                compression,
                 change_dir.as_deref(),
                 to_stdout,
             )
             .await
         } else {
-            list_tar(&ctx, &archive_name, verbose, gzip).await
+            list_tar(&ctx, &archive_name, verbose, compression).await
         }
     }
 }
@@ -225,7 +327,7 @@ async fn create_tar(
     archive_name: &str,
     files: &[String],
     verbose: bool,
-    gzip: bool,
+    compression: ArchiveCompression,
     change_dir: Option<&str>,
 ) -> Result<ExecResult> {
     let mut output_data: Vec<u8> = Vec::new();
@@ -278,19 +380,12 @@ async fn create_tar(
     output_data.extend_from_slice(&[0u8; TAR_BLOCK_SIZE * 2]);
     let _tar_lease = ctx.lease_budget_bytes(output_data.len())?;
 
-    // Compress if -z
-    let final_data = if gzip {
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(&output_data).map_err(|e| {
-            crate::error::Error::Execution(format!("tar: gzip compression failed: {}", e))
-        })?;
-        encoder.finish().map_err(|e| {
-            crate::error::Error::Execution(format!("tar: gzip compression failed: {}", e))
-        })?
-    } else {
+    let final_data = if compression == ArchiveCompression::None {
         output_data
+    } else {
+        compress_bytes(compression, &output_data, "tar")?
     };
-    let _compressed_lease = if gzip {
+    let _compressed_lease = if compression != ArchiveCompression::None {
         ctx.lease_budget_bytes(final_data.len())?
     } else {
         None
@@ -576,7 +671,7 @@ async fn extract_tar(
     ctx: &Context<'_>,
     archive_name: &str,
     verbose: bool,
-    gzip: bool,
+    compression: ArchiveCompression,
     change_dir: Option<&str>,
     to_stdout: bool,
 ) -> Result<ExecResult> {
@@ -587,7 +682,7 @@ async fn extract_tar(
         ctx.cwd.clone()
     };
     let data = if archive_name == "-" {
-        ctx.stdin.map(|s| s.as_bytes().to_vec()).unwrap_or_default()
+        ctx.stdin_bytes().unwrap_or_default().to_vec()
     } else {
         let archive_path = resolve_path(ctx.cwd, archive_name);
         if !ctx.fs.exists(&archive_path).await.unwrap_or(false) {
@@ -608,15 +703,17 @@ async fn extract_tar(
     let limits = ctx.fs.limits();
     let max_size = limits.max_total_bytes;
 
-    // Decompress if -z, with size limits
-    let tar_data = if gzip {
-        let compressed_size = data.len();
-        let decoder = GzDecoder::new(data.as_slice());
-        read_with_limit(decoder, compressed_size, max_size)
-            .map_err(|e| crate::error::Error::Execution(format!("tar: {}", e)))?
+    let detected = ArchiveCompression::detect(&data);
+    let compression = if compression == ArchiveCompression::None {
+        detected
     } else {
-        data
+        compression
     };
+    let tar_data =
+        match decompress_bytes(compression, &data, max_size, "tar", ctx.execution_budget()) {
+            Ok(data) => data,
+            Err(err) => return Ok(ExecResult::err(format!("{err}\n"), 2)),
+        };
     ctx.consume_budget_input(tar_data.len())?;
     ctx.consume_budget_work(u64::try_from(tar_data.len().div_ceil(64)).unwrap_or(u64::MAX))?;
     let _tar_lease = ctx.lease_budget_bytes(tar_data.len())?;
@@ -812,10 +909,10 @@ async fn list_tar(
     ctx: &Context<'_>,
     archive_name: &str,
     verbose: bool,
-    gzip: bool,
+    compression: ArchiveCompression,
 ) -> Result<ExecResult> {
     let data = if archive_name == "-" {
-        ctx.stdin.map(|s| s.as_bytes().to_vec()).unwrap_or_default()
+        ctx.stdin_bytes().unwrap_or_default().to_vec()
     } else {
         let archive_path = resolve_path(ctx.cwd, archive_name);
         if !ctx.fs.exists(&archive_path).await.unwrap_or(false) {
@@ -834,15 +931,22 @@ async fn list_tar(
     let limits = ctx.fs.limits();
     let max_size = limits.max_total_bytes;
 
-    // Decompress if -z, with size limits
-    let tar_data = if gzip {
-        let compressed_size = data.len();
-        let decoder = GzDecoder::new(data.as_slice());
-        read_with_limit(decoder, compressed_size, max_size)
-            .map_err(|e| crate::error::Error::Execution(format!("tar: {}", e)))?
+    ctx.consume_budget_input(data.len())?;
+    let _compressed_lease = ctx.lease_budget_bytes(data.len())?;
+    let detected = ArchiveCompression::detect(&data);
+    let compression = if compression == ArchiveCompression::None {
+        detected
     } else {
-        data
+        compression
     };
+    let tar_data =
+        match decompress_bytes(compression, &data, max_size, "tar", ctx.execution_budget()) {
+            Ok(data) => data,
+            Err(err) => return Ok(ExecResult::err(format!("{err}\n"), 2)),
+        };
+    ctx.consume_budget_input(tar_data.len())?;
+    ctx.consume_budget_work(u64::try_from(tar_data.len().div_ceil(64)).unwrap_or(u64::MAX))?;
+    let _tar_lease = ctx.lease_budget_bytes(tar_data.len())?;
 
     let mut output = String::new();
     let mut offset = 0;
@@ -1178,6 +1282,227 @@ impl Builtin for Gunzip {
     }
 }
 
+/// The bzip2 family shares one bounded codec implementation.
+pub struct Bzip2;
+pub struct Bunzip2;
+pub struct Bzcat;
+
+#[derive(Clone, Copy)]
+enum Bzip2Invocation {
+    Compress,
+    Decompress,
+    DecompressStdout,
+}
+
+#[async_trait]
+impl Builtin for Bzip2 {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        execute_bzip2(ctx, Bzip2Invocation::Compress, "bzip2").await
+    }
+}
+
+#[async_trait]
+impl Builtin for Bunzip2 {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        execute_bzip2(ctx, Bzip2Invocation::Decompress, "bunzip2").await
+    }
+}
+
+#[async_trait]
+impl Builtin for Bzcat {
+    async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
+        execute_bzip2(ctx, Bzip2Invocation::DecompressStdout, "bzcat").await
+    }
+}
+
+async fn execute_bzip2(
+    ctx: Context<'_>,
+    invocation: Bzip2Invocation,
+    command: &str,
+) -> Result<ExecResult> {
+    if let Some(result) = super::check_help_version(
+        ctx.args,
+        &format!(
+            "Usage: {command} [OPTION]... [FILE]...\nCompress or decompress files with bzip2.\n\n  -c, --stdout\twrite to standard output\n  -d, --decompress\tdecompress\n  -z, --compress\tcompress\n  -k, --keep\tkeep input files\n  -f, --force\toverwrite output files\n  --help\tdisplay this help and exit\n  --version\toutput version information and exit\n"
+        ),
+        Some(&format!("{command} (bashkit) 0.1")),
+    ) {
+        return Ok(result);
+    }
+
+    let mut decompress = !matches!(invocation, Bzip2Invocation::Compress);
+    let mut stdout = matches!(invocation, Bzip2Invocation::DecompressStdout);
+    let mut keep = stdout;
+    let mut force = false;
+    let mut files = Vec::new();
+    let mut parse_options = true;
+
+    for arg in ctx.args {
+        if parse_options && arg == "--" {
+            parse_options = false;
+        } else if parse_options && arg.starts_with("--") {
+            match arg.as_str() {
+                "--stdout" => stdout = true,
+                "--decompress" => decompress = true,
+                "--compress" => decompress = false,
+                "--keep" => keep = true,
+                "--force" => force = true,
+                _ => {
+                    return Ok(ExecResult::err(
+                        format!("{command}: unrecognized option '{arg}'\n"),
+                        1,
+                    ));
+                }
+            }
+        } else if parse_options && arg.starts_with('-') && arg != "-" {
+            for flag in arg[1..].chars() {
+                match flag {
+                    'c' => stdout = true,
+                    'd' => decompress = true,
+                    'z' => decompress = false,
+                    'k' => keep = true,
+                    'f' => force = true,
+                    _ => {
+                        return Ok(ExecResult::err(
+                            format!("{command}: invalid option -- '{flag}'\n"),
+                            1,
+                        ));
+                    }
+                }
+            }
+        } else {
+            files.push(arg.clone());
+        }
+    }
+
+    if files.is_empty() {
+        let input = ctx.stdin_bytes().unwrap_or_default();
+        ctx.consume_budget_input(input.len())?;
+        let _input_lease = ctx.lease_budget_bytes(input.len())?;
+        let output = if decompress {
+            match decompress_bytes(
+                ArchiveCompression::Bzip2,
+                input,
+                ctx.fs.limits().max_file_size,
+                command,
+                ctx.execution_budget(),
+            ) {
+                Ok(output) => output,
+                Err(err) => return Ok(ExecResult::err(format!("{err}\n"), 1)),
+            }
+        } else {
+            compress_bytes(ArchiveCompression::Bzip2, input, command)?
+        };
+        ctx.consume_budget_input(output.len())?;
+        ctx.consume_budget_work(u64::try_from(output.len().div_ceil(64)).unwrap_or(u64::MAX))?;
+        let _output_lease = ctx.lease_budget_bytes(output.len())?;
+        return Ok(ExecResult {
+            stdout: output.into(),
+            ..ExecResult::default()
+        });
+    }
+
+    let mut stdout_data = Vec::new();
+    let mut stdout_leases = Vec::new();
+    for file in files {
+        let input_path = resolve_path(ctx.cwd, &file);
+        if !ctx.fs.exists(&input_path).await.unwrap_or(false) {
+            return Ok(ExecResult::err(
+                format!("{command}: {file}: No such file or directory\n"),
+                1,
+            ));
+        }
+        if ctx.fs.stat(&input_path).await?.file_type.is_dir() {
+            return Ok(ExecResult::err(
+                format!("{command}: {file}: Is a directory\n"),
+                1,
+            ));
+        }
+
+        let input = ctx.fs.read_file(&input_path).await?;
+        ctx.consume_budget_input(input.len())?;
+        let _input_lease = ctx.lease_budget_bytes(input.len())?;
+        let output = if decompress {
+            match decompress_bytes(
+                ArchiveCompression::Bzip2,
+                &input,
+                ctx.fs.limits().max_file_size,
+                command,
+                ctx.execution_budget(),
+            ) {
+                Ok(output) => output,
+                Err(err) => return Ok(ExecResult::err(format!("{err}\n"), 1)),
+            }
+        } else {
+            if file.ends_with(".bz2") {
+                return Ok(ExecResult::err(
+                    format!("{command}: {file}: already has .bz2 suffix\n"),
+                    1,
+                ));
+            }
+            compress_bytes(ArchiveCompression::Bzip2, &input, command)?
+        };
+        ctx.consume_budget_input(output.len())?;
+        ctx.consume_budget_work(u64::try_from(output.len().div_ceil(64)).unwrap_or(u64::MAX))?;
+        let _output_lease = ctx.lease_budget_bytes(output.len())?;
+
+        if stdout {
+            let next_len = stdout_data.len().checked_add(output.len()).ok_or_else(|| {
+                crate::error::Error::Execution(format!("{command}: output size overflow"))
+            })?;
+            if let Err(err) = ctx.fs.limits().check_total_bytes(0, next_len as u64) {
+                return Ok(ExecResult::err(format!("{command}: {err}\n"), 1));
+            }
+            if let Some(budget) = ctx.execution_budget() {
+                stdout_leases.push(budget.lease_bytes(output.len())?);
+            }
+            stdout_data.try_reserve_exact(output.len()).map_err(|_| {
+                crate::error::Error::Execution(format!("{command}: output allocation failed"))
+            })?;
+            stdout_data.extend_from_slice(&output);
+            continue;
+        }
+
+        let output_name = if decompress {
+            let Some(output_name) = decompressed_bzip2_name(&file) else {
+                return Ok(ExecResult::err(
+                    format!("{command}: {file}: unknown suffix -- ignored\n"),
+                    1,
+                ));
+            };
+            output_name
+        } else {
+            format!("{file}.bz2")
+        };
+        let output_path = resolve_path(ctx.cwd, &output_name);
+        if ctx.fs.exists(&output_path).await.unwrap_or(false) && !force {
+            return Ok(ExecResult::err(
+                format!("{command}: {output_name}: already exists\n"),
+                1,
+            ));
+        }
+        ctx.fs.write_file(&output_path, &output).await?;
+        if !keep {
+            ctx.fs.remove(&input_path, false).await?;
+        }
+    }
+
+    Ok(ExecResult {
+        stdout: stdout_data.into(),
+        ..ExecResult::default()
+    })
+}
+
+fn decompressed_bzip2_name(file: &str) -> Option<String> {
+    if let Some(stem) = file.strip_suffix(".bz2") {
+        Some(stem.to_string())
+    } else if let Some(stem) = file.strip_suffix(".tbz2") {
+        Some(format!("{stem}.tar"))
+    } else {
+        file.strip_suffix(".tbz").map(|stem| format!("{stem}.tar"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1256,6 +1581,62 @@ mod tests {
         let result = Tar.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 0);
         assert!(result.stdout.contains("test.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_tar_bzip2_old_style_create_list_extract_roundtrip() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+        fs.write_file(&cwd.join("payload.txt"), b"bzip2 archive payload")
+            .await
+            .unwrap();
+
+        let create_args = vec![
+            "cjf".to_string(),
+            "archive.tbz2".to_string(),
+            "payload.txt".to_string(),
+        ];
+        let create_ctx = Context::new_for_test(
+            &create_args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            None,
+        );
+        let created = Tar.execute(create_ctx).await.unwrap();
+        assert_eq!(created.exit_code, 0, "{}", created.stderr);
+
+        let archive = fs.read_file(&cwd.join("archive.tbz2")).await.unwrap();
+        assert!(archive.starts_with(b"BZh"));
+
+        let list_args = vec![
+            "--bzip2".to_string(),
+            "-tf".to_string(),
+            "archive.tbz2".to_string(),
+        ];
+        let list_ctx =
+            Context::new_for_test(&list_args, &env, &mut variables, &mut cwd, fs.clone(), None);
+        let listed = Tar.execute(list_ctx).await.unwrap();
+        assert_eq!(listed.exit_code, 0, "{}", listed.stderr);
+        assert_eq!(listed.stdout, "payload.txt\n");
+
+        fs.remove(&cwd.join("payload.txt"), false).await.unwrap();
+        let extract_args = vec!["-xjf".to_string(), "archive.tbz2".to_string()];
+        let extract_ctx = Context::new_for_test(
+            &extract_args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs.clone(),
+            None,
+        );
+        let extracted = Tar.execute(extract_ctx).await.unwrap();
+        assert_eq!(extracted.exit_code, 0, "{}", extracted.stderr);
+        assert_eq!(
+            fs.read_file(&cwd.join("payload.txt")).await.unwrap(),
+            b"bzip2 archive payload"
+        );
     }
 
     #[tokio::test]
@@ -1761,6 +2142,25 @@ mod tests {
         let result = Gunzip.execute(ctx).await.unwrap();
         assert_eq!(result.exit_code, 0);
         assert!(fs.exists(&cwd.join("test.txt")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_bunzip2_invalid_stream_error_does_not_leak_debug_shapes() {
+        let (fs, mut cwd, mut variables) = create_test_ctx().await;
+        let env = HashMap::new();
+        let args = vec!["-c".to_string()];
+        let ctx = Context::new_for_test(
+            &args,
+            &env,
+            &mut variables,
+            &mut cwd,
+            fs,
+            Some("not a bzip2 stream"),
+        );
+
+        let result = Bunzip2.execute(ctx).await.unwrap();
+        assert_eq!(result.exit_code, 1);
+        crate::builtins::debug_leak_check::assert_no_leak(&result, "bunzip2_invalid_stream", &[]);
     }
 
     // ==================== zip bomb protection tests ====================

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -136,7 +136,7 @@ mod typescript;
 mod sqlite;
 
 pub use alias::{Alias, Unalias};
-pub use archive::{Gunzip, Gzip, Tar};
+pub use archive::{Bunzip2, Bzcat, Bzip2, Gunzip, Gzip, Tar};
 pub use assert::Assert;
 pub use awk::Awk;
 pub use base64::Base64;
@@ -1577,6 +1577,9 @@ mod tests {
             "tar",
             "gzip",
             "gunzip",
+            "bzip2",
+            "bunzip2",
+            "bzcat",
             "zip",
             "unzip",
             "seq",

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -1378,6 +1378,9 @@ impl Interpreter {
             "tar" => Tar,
             "gzip" => Gzip,
             "gunzip" => Gunzip,
+            "bzip2" => Bzip2,
+            "bunzip2" => Bunzip2,
+            "bzcat" => Bzcat,
             "zip" => Zip,
             "unzip" => Unzip,
             // Numeric / math

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -30,7 +30,7 @@
 //! | Text processing | `grep`, `rg`, `sed`, `awk`, `jq` and `yq` (with `jq` feature), `head`, `tail`, `sort`, `uniq`, `cut`, `tr`, `wc`, `paste`, `column`, `diff`, `comm`, `strings`, `tac`, `rev`, `seq`, `expr`, `fold`, `expand`, `unexpand`, `join`, `split`, `iconv`, `shuf`, `template` |
 //! | File operations | `mkdir`, `mktemp`, `mkfifo`, `rm`, `cp`, `mv`, `touch`, `chmod`, `chown`, `ln`, `rmdir`, `realpath`, `readlink`, `truncate`, `glob`, `patch` |
 //! | File inspection | `file`, `stat`, `less` |
-//! | Archives | `tar`, `gzip`, `gunzip`, `zip`, `unzip` |
+//! | Archives | `tar`, `gzip`, `gunzip`, `bzip2`, `bunzip2`, `bzcat`, `zip`, `unzip` |
 //! | Byte tools | `od`, `xxd`, `hexdump`, `base64` |
 //! | Checksums | `md5sum`, `sha1sum`, `sha256sum`, `verify` |
 //! | Utilities | `sleep`, `date`, `basename`, `dirname`, `timeout`, `wait`, `watch`, `yes`, `kill`, `clear`, `numfmt`, `retry`, `parallel` |

--- a/crates/bashkit/src/tool.rs
+++ b/crates/bashkit/src/tool.rs
@@ -254,7 +254,7 @@ const BUILTINS: &str = "\
 echo printf cat read \
 grep sed awk jq head tail sort uniq cut tr wc nl paste column comm diff strings tac rev \
 cd pwd ls find mkdir mktemp rm rmdir cp mv touch chmod chown ln \
-file stat less tar gzip gunzip du df \
+file stat less tar gzip gunzip bzip2 bunzip2 bzcat du df \
 test [ true false exit return break continue \
 export set unset local shift source eval declare typeset readonly shopt getopts \
 sleep date seq expr yes wait timeout xargs tee watch \
@@ -270,7 +270,7 @@ const BUILTINS: &str = "\
 echo printf cat read \
 grep sed awk head tail sort uniq cut tr wc nl paste column comm diff strings tac rev \
 cd pwd ls find mkdir mktemp rm rmdir cp mv touch chmod chown ln \
-file stat less tar gzip gunzip du df \
+file stat less tar gzip gunzip bzip2 bunzip2 bzcat du df \
 test [ true false exit return break continue \
 export set unset local shift source eval declare typeset readonly shopt getopts \
 sleep date seq expr yes wait timeout xargs tee watch \

--- a/crates/bashkit/tests/integration/archive_bzip2_tests.rs
+++ b/crates/bashkit/tests/integration/archive_bzip2_tests.rs
@@ -1,0 +1,293 @@
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use bashkit::{Bash, ExecOptions, ExecutionLimits, FsLimits, InMemoryFs, StreamData};
+use bzip2::Compression;
+use bzip2::write::BzEncoder;
+
+fn bzip2(input: &[u8]) -> Vec<u8> {
+    let mut encoder = BzEncoder::new(Vec::new(), Compression::best());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn tar_with_entry(name: &str, content: &[u8]) -> Vec<u8> {
+    let mut header = [0u8; 512];
+    header[..name.len()].copy_from_slice(name.as_bytes());
+    header[100..108].copy_from_slice(b"0000644\0");
+    header[108..116].copy_from_slice(b"0000000\0");
+    header[116..124].copy_from_slice(b"0000000\0");
+    header[124..136].copy_from_slice(format!("{:011o}\0", content.len()).as_bytes());
+    header[136..148].copy_from_slice(b"00000000000\0");
+    header[148..156].copy_from_slice(b"        ");
+    header[156] = b'0';
+    header[257..263].copy_from_slice(b"ustar ");
+    header[263..265].copy_from_slice(b" \0");
+    let checksum: u32 = header.iter().map(|byte| u32::from(*byte)).sum();
+    header[148..156].copy_from_slice(format!("{:06o}\0 ", checksum).as_bytes());
+
+    let mut archive = header.to_vec();
+    archive.extend_from_slice(content);
+    archive.resize(512 + content.len().div_ceil(512) * 512, 0);
+    archive.extend_from_slice(&[0; 1024]);
+    archive
+}
+
+#[tokio::test]
+async fn bashkit_tar_bzip2_output_is_readable_by_system_tar() {
+    let mut bash = Bash::new();
+    let setup = bash
+        .exec("printf 'system tar reads this\\n' > payload.txt")
+        .await
+        .unwrap();
+    assert_eq!(setup.exit_code, 0, "{}", setup.stderr);
+
+    let result = bash.exec("tar -cjf - payload.txt").await.unwrap();
+    assert_eq!(result.exit_code, 0, "{}", result.stderr);
+    assert!(result.stdout.as_bytes().starts_with(b"BZh"));
+
+    let temp = tempfile::tempdir().unwrap();
+    let archive = temp.path().join("bashkit.tar.bz2");
+    std::fs::write(&archive, result.stdout.as_bytes()).unwrap();
+    let listed = Command::new("tar")
+        .args(["-tjf", archive.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        listed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&listed.stderr)
+    );
+    assert_eq!(listed.stdout, b"payload.txt\n");
+}
+
+#[tokio::test]
+async fn bashkit_lists_and_extracts_system_tar_bzip2_from_stdin() {
+    let temp = tempfile::tempdir().unwrap();
+    let input = temp.path().join("input");
+    std::fs::create_dir(&input).unwrap();
+    std::fs::write(input.join("payload.txt"), b"created by system tar\n").unwrap();
+    let archive = temp.path().join("system.tbz2");
+    let created = Command::new("tar")
+        .env("COPYFILE_DISABLE", "1")
+        .args([
+            "--format=ustar",
+            "-cjf",
+            archive.to_str().unwrap(),
+            "-C",
+            input.to_str().unwrap(),
+            "payload.txt",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        created.status.success(),
+        "{}",
+        String::from_utf8_lossy(&created.stderr)
+    );
+    let bytes = std::fs::read(archive).unwrap();
+
+    let mut bash = Bash::new();
+    let listed = bash
+        .exec_with_options(
+            "tar -tf -",
+            ExecOptions::new().stdin(StreamData::from(bytes.clone())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(listed.exit_code, 0, "{}", listed.stderr);
+    assert_eq!(listed.stdout, "payload.txt\n");
+
+    let extracted = bash
+        .exec_with_options(
+            "mkdir /out; tar -xjf - -C /out",
+            ExecOptions::new().stdin(StreamData::from(bytes)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(extracted.exit_code, 0, "{}", extracted.stderr);
+    assert_eq!(
+        bash.fs()
+            .read_file(Path::new("/out/payload.txt"))
+            .await
+            .unwrap(),
+        b"created by system tar\n"
+    );
+}
+
+#[tokio::test]
+async fn standalone_bzip2_family_preserves_binary_pipeline_bytes() {
+    let expected = vec![0, 1, 2, 0xff, 0xfe, b'Z'];
+    let mut bash = Bash::new();
+    let result = bash
+        .exec_with_options(
+            "bzip2 -c | bzcat",
+            ExecOptions::new().stdin(StreamData::from(expected.clone())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "{}", result.stderr);
+    assert_eq!(result.stdout.as_bytes(), expected);
+}
+
+#[tokio::test]
+async fn standalone_bzip2_cross_tool_roundtrips_with_system_bzip2() {
+    let payload = b"cross-tool bzip2 fixture\n";
+    let mut bash = Bash::new();
+    let encoded = bash
+        .exec_with_options(
+            "bzip2 -c",
+            ExecOptions::new().stdin(StreamData::from(payload.to_vec())),
+        )
+        .await
+        .unwrap();
+    assert_eq!(encoded.exit_code, 0, "{}", encoded.stderr);
+
+    let mut child = Command::new("bzip2")
+        .arg("-dc")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(encoded.stdout.as_bytes())
+        .unwrap();
+    let decoded = child.wait_with_output().unwrap();
+    assert!(decoded.status.success());
+    assert_eq!(decoded.stdout, payload);
+
+    let system_encoded = Command::new("bzip2")
+        .arg("-c")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            child.stdin.take().unwrap().write_all(payload)?;
+            child.wait_with_output()
+        })
+        .unwrap();
+    assert!(system_encoded.status.success());
+    let decoded = bash
+        .exec_with_options(
+            "bzcat",
+            ExecOptions::new().stdin(StreamData::from(system_encoded.stdout)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(decoded.exit_code, 0, "{}", decoded.stderr);
+    assert_eq!(decoded.stdout.as_bytes(), payload);
+}
+
+#[tokio::test]
+async fn bzip2_file_modes_keep_remove_force_and_tbz2_suffix_match_tools() {
+    let mut bash = Bash::new();
+    let result = bash
+        .exec(
+            "printf payload > data; bzip2 -k data; test -f data; test -f data.bz2; \
+             bzcat data.bz2; mv data.bz2 sample.tbz2; bunzip2 -kf sample.tbz2; \
+             test -f sample.tbz2; cat sample.tar",
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 0, "{}", result.stderr);
+    assert_eq!(result.stdout, "payloadpayload");
+
+    let listed = bash
+        .exec("tar -cjf named.tar.bz2 data; tar -tf named.tar.bz2")
+        .await
+        .unwrap();
+    assert_eq!(listed.exit_code, 0, "{}", listed.stderr);
+    assert_eq!(listed.stdout, "data\n");
+}
+
+#[tokio::test]
+/// TM-DOS-007/TM-DOS-102: malformed streams and expansion bombs fail closed.
+async fn bunzip2_rejects_truncation_corruption_crc_and_ratio_bombs() {
+    let valid = bzip2(b"bounded bzip2 payload");
+    let mut corrupt = valid.clone();
+    corrupt[10] ^= 0x40;
+    let mut bad_crc = valid.clone();
+    let crc_index = bad_crc.len() - 5;
+    bad_crc[crc_index] ^= 0x01;
+    let cases = [
+        (&valid[..valid.len() - 4], "truncated"),
+        (&corrupt, "corrupt"),
+        (&bad_crc, "crc"),
+    ];
+
+    for (input, label) in cases {
+        let mut bash = Bash::new();
+        let result = bash
+            .exec_with_options(
+                "bunzip2 -c",
+                ExecOptions::new().stdin(StreamData::from(input.to_vec())),
+            )
+            .await
+            .unwrap();
+        assert_ne!(result.exit_code, 0, "{label} input unexpectedly succeeded");
+        assert!(result.stdout.is_empty(), "{label} emitted partial output");
+    }
+
+    let bomb = bzip2(&vec![b'x'; 100_000]);
+    let mut bash = Bash::new();
+    let result = bash
+        .exec_with_options(
+            "bunzip2 -c",
+            ExecOptions::new().stdin(StreamData::from(bomb)),
+        )
+        .await
+        .unwrap();
+    assert_ne!(result.exit_code, 0);
+    assert!(result.stderr.contains("ratio"), "{}", result.stderr);
+}
+
+#[tokio::test]
+async fn compressed_tar_keeps_path_and_file_size_guards() {
+    let traversal = bzip2(&tar_with_entry("../../escape", b"blocked"));
+    let mut bash = Bash::new();
+    let result = bash
+        .exec_with_options(
+            "tar -xjf -",
+            ExecOptions::new().stdin(StreamData::from(traversal)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.exit_code, 2);
+    assert!(result.stderr.contains("path traversal blocked"));
+    assert!(!bash.fs().exists(Path::new("/escape")).await.unwrap());
+
+    let limits = FsLimits::new().max_file_size(32).max_total_bytes(1_000);
+    let fs = Arc::new(InMemoryFs::with_limits(limits));
+    let mut bash = Bash::builder().fs(fs).build();
+    let oversized = bzip2(&[b'a'; 33]);
+    let result = bash
+        .exec_with_options(
+            "bunzip2 -c",
+            ExecOptions::new().stdin(StreamData::from(oversized)),
+        )
+        .await
+        .unwrap();
+    assert_ne!(result.exit_code, 0);
+    assert!(result.stderr.contains("limit"), "{}", result.stderr);
+}
+
+#[tokio::test]
+async fn bzip2_charges_shared_input_and_live_memory_budgets() {
+    let compressed = bzip2(b"execution budget payload");
+    let limits = ExecutionLimits::new()
+        .max_aggregate_input_bytes(1_000)
+        .max_live_intermediate_bytes((compressed.len() + 8) as u64);
+    let mut bash = Bash::builder().limits(limits).build();
+    let result = bash
+        .exec_with_options(
+            "bunzip2 -c",
+            ExecOptions::new().stdin(StreamData::from(compressed)),
+        )
+        .await;
+    assert!(result.is_err(), "budget exhaustion must fail the request");
+}

--- a/crates/bashkit/tests/integration/main.rs
+++ b/crates/bashkit/tests/integration/main.rs
@@ -15,6 +15,7 @@
 
 pub mod agent_skills_publication_tests;
 pub mod allexport_tests;
+pub mod archive_bzip2_tests;
 pub mod awk_fuzz_scaffold_tests;
 pub mod awk_newline_tests;
 pub mod awk_pattern_tests;

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Zlib",
+    "bzip2-1.0.6",           # Permissive bzip2/libbzip2 license (libbz2-rs-sys)
     "MPL-2.0",                # Mozilla Public License 2.0 (colored crate)
     "Unicode-3.0",            # Unicode License v3 (icu_* crates)
     "CDLA-Permissive-2.0",    # Community Data License Agreement (webpki-root-certs)

--- a/knowledge/foundations/builtins.md
+++ b/knowledge/foundations/builtins.md
@@ -289,3 +289,26 @@ for input/output bounds.
 `curl`, `wget`, `http` require the `http_client` feature + URL allowlist.
 When `bot-auth` feature is enabled, all outbound HTTP requests are transparently
 signed with Ed25519 per RFC 9421 (see [Request Signing](../security/request-signing.md)).
+
+### Archive Compression
+
+`tar` supports plain, gzip, and bzip2 archives. It accepts GNU short/old-style
+bundles (`-cjf`, `cjf`) and `--bzip2`, and detects gzip/bzip2 magic while listing
+or extracting so `.tar.bz2`/`.tbz2` inputs work without an explicit codec flag.
+`bzip2`, `bunzip2`, and `bzcat` share the same byte-native codec path.
+
+The implementation uses `bzip2` 0.6 with its default pure-Rust
+`libbz2-rs-sys` backend. The crate is maintained by the Trifecta Tech
+Foundation, dual MIT/Apache-2.0; its backend retains the permissive
+`bzip2-1.0.6` license. Both are admitted by `deny.toml`. The release supports
+the repository's Rust floor and WASM targets and is newer than the 0.4.4 fix
+for RUSTSEC-2023-0004. Cargo-vet exemptions are limited to these versions after
+reviewing the wrapper's FFI slice bounds and stream lifecycle plus the enabled
+backend's no-stdio Rust-allocator path, pointer bounds, allocation lifecycle,
+and CRC failure path. Decoder output is checked and request-memory charged
+before buffer growth; bzip2 stream/CRC errors fail closed. Filesystem quotas,
+expansion ratio, aggregate input/work, live-memory leases, and extraction path
+validation remain layered controls.
+
+See [Threat Model](../security/threat-model.md) for TM-DOS-007/008/096/102 and
+TM-INJ-010.

--- a/knowledge/operations/limitations.md
+++ b/knowledge/operations/limitations.md
@@ -139,6 +139,8 @@ The jq input boundary alone accepts literal U+0000..U+001F controls inside JSON
 strings; controls outside strings and malformed quoting remain invalid. The
 `json` builtin, serde defaults, tool JSON contracts, `--argjson`, and
 `--jsonargs` stay strict. See [jq Input Compatibility](../foundations/jq.md).
+Archive compression is intentionally in-process and limited to gzip and bzip2;
+GNU tar selectors for xz, lzip, lzma, compress, and zstd remain unsupported.
 
 ## CLI
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -1212,6 +1212,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | TM-DOS-099 | `time -f/-o` report amplification bypasses output limits | A large attacker-controlled format repeats expanding fields and writes the result to the VFS instead of stderr | Report rendering is capped by `ExecutionLimits::max_stderr_bytes` before either stderr emission or VFS write; invalid/over-limit reports do not replace an existing `-o` target — **MITIGATED** |
 | TM-DOS-100 | jq control-character normalization amplification | A jq JSON string consisting of literal controls expands sixfold when each byte becomes `\u00XX`; an unmetered compatibility copy can exhaust memory or CPU before strict parsing | The jq-only normalizer charges input-length work before its single pass, borrows unchanged input, and acquires/grows a shared live-intermediate lease before every allocation growth (`builtins/jq/input.rs`) — **MITIGATED** |
 | TM-DOS-101 | yq structured-data amplification | YAML/JSON nesting, multi-document floods, filters, and output format expansion are all attacker-controlled | Real parsers with recursion/depth caps, aggregate budgets, shared jaq work/deadline/output controls, and a final rendered-output cap; `yq_integration_tests` covers deep input and output growth — **MITIGATED** |
+| TM-DOS-102 | Archive decoder allocation-before-check | A small gzip/bzip2 stream makes the decoder output buffer allocate beyond live-memory or filesystem quotas before the post-growth size check runs | Decoder chunks validate absolute/ratio bounds and acquire a shared execution-budget lease before `try_reserve_exact` and copy; corrupt, truncated, CRC-invalid, ratio-bomb, and live-budget tests fail closed — **MITIGATED** |
 
 ### Accepted (Low Priority)
 
@@ -1253,7 +1254,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Filename length limit (255) | TM-DOS-013 | `fs/limits.rs` | Yes |
 | Path length limit (4096) | TM-DOS-013 | `fs/limits.rs` | Yes |
 | Path char validation | TM-DOS-015 | `fs/limits.rs` | Yes |
-| Zip bomb protection | TM-DOS-007, TM-NET-013 | `builtins/archive.rs` | Yes |
+| Archive bomb protection | TM-DOS-007, TM-DOS-102, TM-NET-013 | `builtins/archive.rs` | Yes |
 | Path normalization | TM-ESC-001, TM-ESC-033, TM-INJ-005 | `fs/mod.rs`, `fs/realfs.rs` | Yes |
 | No symlink following | TM-ESC-002, TM-DOS-011 | `fs/memory.rs` | Yes |
 | Network allowlist | TM-INF-010, TM-NET-001 to TM-NET-007 | `network/allowlist.rs` | Yes |

--- a/knowledge/status/builtins.json
+++ b/knowledge/status/builtins.json
@@ -51,6 +51,18 @@
     },
     {
       "feature": null,
+      "name": "bunzip2"
+    },
+    {
+      "feature": null,
+      "name": "bzcat"
+    },
+    {
+      "feature": null,
+      "name": "bzip2"
+    },
+    {
+      "feature": null,
       "name": "caller"
     },
     {
@@ -658,5 +670,5 @@
       "name": "zip"
     }
   ],
-  "count": 164
+  "count": 167
 }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -255,6 +255,11 @@ criteria = "safe-to-deploy"
 version = "1.12.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.bzip2]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+notes = "Reviewed the slice-to-FFI stream wrapper, buffer accounting, drop paths, and pure-Rust backend selection; no ambient capabilities."
+
 [[exemptions.cast]]
 version = "0.3.0"
 criteria = "safe-to-run"
@@ -1022,6 +1027,11 @@ criteria = "safe-to-deploy"
 [[exemptions.lexical-util]]
 version = "1.0.7"
 criteria = "safe-to-deploy"
+
+[[exemptions.libbz2-rs-sys]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+notes = "Reviewed the enabled no-stdio rust-allocator codec path, pointer bounds, allocation/deallocation, stream lifecycle, and CRC failure handling."
 
 [[exemptions.libc]]
 version = "0.2.186"


### PR DESCRIPTION
## What changed
Adds GNU-compatible bzip2 archive interoperability. `tar` now creates, lists,
and extracts bzip2 archives through `j`, old-style/clustered flags, and
`--bzip2`, including stdin/stdout and `.tar.bz2`/`.tbz2` workflows. Adds
byte-native `bzip2`, `bunzip2`, and `bzcat` commands with compatible file and
pipeline behavior.

Compressed input and output are covered by request budgets, pre-growth memory
charging, expansion-ratio limits, archive/file quotas, traversal checks, and
closed failure handling for truncation, corruption, and CRC errors.

## Why
Bashkit tar could only interoperate with plain and gzip archives, leaving common
GNU tar bzip2 workflows and standalone bzip2 pipelines unsupported.

## Before / After
Before:

```text
$ tar -cjf archive.tar.bz2 file
tar: invalid option -- 'j'
```

After (end-to-end Bashkit CLI smoke):

```text
$ tar -cjf /tmp/archive.tar.bz2 -C /src p.txt
$ tar -tjf /tmp/archive.tar.bz2
p.txt
$ tar -xjf /tmp/archive.tar.bz2 -C /dst && cat /dst/p.txt
smoke payload
$ printf standalone | bzip2 -c | bzcat
standalone
```

System `tar`/`bzip2` differential tests verify both directions.

## Risk
- Medium
- Archive argument parsing and decompression process untrusted binary input.
  Existing tar/gzip behavior remains covered; new bomb, corruption, traversal,
  quota, memory, and cross-tool tests exercise the added path.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

Validation: `just pre-pr`, WASM no-default-feature check, cargo-deny license and
advisory checks, archive benchmark, and CLI smoke test all pass.
