### PR TITLE
chore(ship): require public docs for user-facing features

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -46,7 +46,8 @@ Review the changes and update project artifacts where applicable. Skip items tha
 2. **Threat model** (`knowledge/security/threat-model.md`): if the change introduces new attack surfaces, external inputs, authentication/authorization changes, or data handling — add or update threat entries using the `TM-<CATEGORY>-<NNN>` format and add `// THREAT[TM-XXX-NNN]` code comments at mitigation points
 3. **AGENTS.md**: if the change adds new knowledge, commands, or modifies development workflows — update the relevant section
 4. **Limitations** (`knowledge/operations/limitations.md`): if a limitation was added or lifted, update the table; if builtins changed, run `just regen-builtins` and commit the JSON
-5. **Documentation** (`crates/bashkit/docs/`): if the change affects public APIs, tools, or features — update the relevant guide markdown files
+5. **Public documentation** (`docs/`): for every user-facing feature or behavior change, update the relevant public docs or create a new article when no suitable page exists; follow `knowledge/operations/documentation.md` for site metadata and link requirements
+6. **Rustdoc guides** (`crates/bashkit/docs/`): if the change affects public APIs or tools, update the relevant guide markdown files
 
 ### Phase 3b: Code Simplification
 


### PR DESCRIPTION
## What changed

The ship workflow now requires updating existing public documentation or creating a new article for every user-facing feature or behavior change. Public site docs and Rustdoc guides are handled as separate artifacts.

## Why

The previous instruction mentioned only Rustdoc guides, allowing user-facing features to ship without corresponding public site documentation.

## Before / After

Before: artifact review covered `crates/bashkit/docs/` but did not explicitly require `docs/` updates.

After: artifact review requires update-or-create work in `docs/` and points to the canonical site metadata and link requirements.

## Risk

- Low
- Workflow text only; no runtime behavior changes.

## Checklist

- [x] Tests added or updated (not needed for a workflow-only documentation change)
- [x] Backward compatibility considered