### PR TITLE
docs: keep dependency examples current

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Enable the `sqlite` feature to embed [Turso](https://github.com/tursodatabase/tu
 
 ```toml
 [dependencies]
-bashkit = { version = "0.13", features = ["sqlite"] }
+bashkit = { version = "0.15.0", features = ["sqlite"] }
 ```
 
 ```rust

--- a/crates/bashkit/docs/logging.md
+++ b/crates/bashkit/docs/logging.md
@@ -14,7 +14,7 @@ Add the `logging` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.1", features = ["logging"] }
+bashkit = { version = "0.15.0", features = ["logging"] }
 tracing-subscriber = "0.3"  # or your preferred subscriber
 ```
 

--- a/crates/bashkit/docs/sqlite.md
+++ b/crates/bashkit/docs/sqlite.md
@@ -13,7 +13,7 @@ the `sqlite` feature. The engine is [Turso](https://github.com/tursodatabase/tur
 
 ```toml
 # Cargo.toml
-bashkit = { version = "0.2", features = ["sqlite"] }
+bashkit = { version = "0.15.0", features = ["sqlite"] }
 ```
 
 ```rust,ignore

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -279,7 +279,8 @@
 //!
 //! Enable the `http_client` feature and configure an allowlist for network access:
 //!
-//! ```rust,ignore
+//! ```rust,no_run
+//! # async fn example() -> bashkit::Result<()> {
 //! use bashkit::{Bash, NetworkAllowlist};
 //!
 //! let mut bash = Bash::builder()
@@ -290,6 +291,8 @@
 //! // curl and wget now work for allowed URLs
 //! let result = bash.exec("curl -s https://httpbin.org/get").await?;
 //! assert!(result.stdout.contains("httpbin.org"));
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! Security features:
@@ -319,7 +322,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.1", features = ["git"] }
+//! bashkit = { version = "0.15.0", features = ["git"] }
 //! ```
 //!
 //! ```rust,ignore
@@ -350,7 +353,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.1", features = ["python"] }
+//! bashkit = { version = "0.15.0", features = ["python"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/docs/builtin_typescript.md
+++ b/docs/builtin_typescript.md
@@ -12,7 +12,7 @@ Add the `typescript` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.1", features = ["typescript"] }
+bashkit = { version = "0.15.0", features = ["typescript"] }
 ```
 
 Enable TypeScript in the builder:

--- a/knowledge/operations/documentation.md
+++ b/knowledge/operations/documentation.md
@@ -39,7 +39,9 @@ Repo-root `docs/` is for user-facing site articles.
   accepts either form while only the source-relative one works on GitHub.
   Enforced by `just check-doc-links` (`scripts/check_doc_links.py`, in
   `just check` and CI) — the `site/scripts/verify-doc-*.mjs` verifiers check
-  built routes and cannot see this class of breakage.
+  built routes and cannot see this class of breakage. The same check also
+  validates `bashkit = { version = "..." }` dependency snippets in the
+  prose trees and crate-level Rustdoc against `[workspace.package].version`.
 - Page titles and descriptions live in `DOC_META`
   (`site/src/pages/docs/_meta.ts`), never in markdown frontmatter: the canonical
   files must stay frontmatter-free so `crates/bashkit/docs/*.md` embed cleanly

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -37,6 +37,12 @@ EXTERNAL = re.compile(r"\A(?:[a-z][a-z0-9+.-]*:|//|/|#)")
 # Fenced blocks first, then inline spans: prose about markdown (and shell
 # examples containing `](`) must not be read as links.
 CODE = re.compile(r"^```.*?^```|``.*?``|`[^`\n]*`", re.DOTALL | re.MULTILINE)
+BASHKIT_DEPENDENCY = re.compile(
+    r'^\s*(?://!\s*)?bashkit\s*=\s*\{[^}\n]*\bversion\s*=\s*"([^"]+)"',
+    re.MULTILINE,
+)
+WORKSPACE_PACKAGE = re.compile(r"(?ms)^\[workspace\.package]\s*$.*?(?=^\[|\Z)")
+PACKAGE_VERSION = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
 
 
 def strip_code(text: str) -> str:
@@ -44,11 +50,31 @@ def strip_code(text: str) -> str:
     return CODE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
 
 
-def check_file(path: pathlib.Path, rel: str, errors: list[str]) -> int:
-    """Append an error for every relative link target that does not exist."""
-    text = strip_code(path.read_text())
+def workspace_version(root: pathlib.Path) -> str:
+    """Read the canonical package version used by published dependency snippets."""
+    manifest = root / "Cargo.toml"
+    if not manifest.is_file():
+        raise ValueError(f"workspace manifest not found: {manifest}")
+    package = WORKSPACE_PACKAGE.search(manifest.read_text())
+    version = PACKAGE_VERSION.search(package.group(0)) if package else None
+    if not version:
+        raise ValueError(f"workspace package version not found in {manifest}")
+    return version.group(1)
+
+
+def check_file(
+    path: pathlib.Path,
+    rel: str,
+    expected_version: str,
+    errors: list[str],
+    *,
+    check_links: bool = True,
+) -> tuple[int, int]:
+    """Append errors for dangling links and stale Bashkit dependency snippets."""
+    source = path.read_text()
+    text = strip_code(source)
     checked = 0
-    for match in LINK.finditer(text):
+    for match in LINK.finditer(text) if check_links else ():
         target = match.group(1).strip()
         if not target or EXTERNAL.match(target):
             continue
@@ -59,7 +85,19 @@ def check_file(path: pathlib.Path, rel: str, errors: list[str]) -> int:
         if not (path.parent / resolved).exists():
             line = text[: match.start()].count("\n") + 1
             errors.append(f"{rel}:{line}: link target does not exist: {target}")
-    return checked
+
+    versions_checked = 0
+    for match in BASHKIT_DEPENDENCY.finditer(source):
+        versions_checked += 1
+        documented_version = match.group(1)
+        if documented_version == expected_version:
+            continue
+        line = source[: match.start()].count("\n") + 1
+        errors.append(
+            f"{rel}:{line}: stale bashkit dependency version {documented_version}; "
+            f"expected {expected_version}"
+        )
+    return checked, versions_checked
 
 
 def markdown_files(root: pathlib.Path, tree: str) -> list[pathlib.Path]:
@@ -73,11 +111,28 @@ def markdown_files(root: pathlib.Path, tree: str) -> list[pathlib.Path]:
 
 def check_trees(root: pathlib.Path, trees: tuple[str, ...]) -> tuple[list[str], dict[str, int]]:
     errors: list[str] = []
-    stats = {"files": 0, "links": 0}
+    stats = {"files": 0, "links": 0, "versions": 0}
+    expected_version = workspace_version(root)
     for tree in trees:
         for path in markdown_files(root, tree):
             stats["files"] += 1
-            stats["links"] += check_file(path, str(path.relative_to(root)), errors)
+            links, versions = check_file(
+                path, str(path.relative_to(root)), expected_version, errors
+            )
+            stats["links"] += links
+            stats["versions"] += versions
+
+    crate_rustdoc = root / "crates" / "bashkit" / "src" / "lib.rs"
+    if crate_rustdoc.is_file():
+        stats["files"] += 1
+        _, versions = check_file(
+            crate_rustdoc,
+            str(crate_rustdoc.relative_to(root)),
+            expected_version,
+            errors,
+            check_links=False,
+        )
+        stats["versions"] += versions
     return errors, stats
 
 
@@ -97,13 +152,20 @@ def main(argv: list[str] | None = None) -> int:
         print(f"not a directory: {root}", file=sys.stderr)
         return 2
 
-    errors, stats = check_trees(root, tuple(args.trees or DEFAULT_ROOTS))
+    try:
+        errors, stats = check_trees(root, tuple(args.trees or DEFAULT_ROOTS))
+    except ValueError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
     for error in errors:
         print(error, file=sys.stderr)
     if errors:
-        print(f"\n{len(errors)} broken relative link(s)", file=sys.stderr)
+        print(f"\n{len(errors)} documentation error(s)", file=sys.stderr)
         return 1
-    print(f"doc links OK: {stats['links']} relative links across {stats['files']} files")
+    print(
+        f"docs OK: {stats['links']} relative links and {stats['versions']} dependency "
+        f"versions across {stats['files']} files"
+    )
     return 0
 
 

--- a/scripts/tests/test_check_doc_links.py
+++ b/scripts/tests/test_check_doc_links.py
@@ -32,6 +32,9 @@ class CheckDocLinksTest(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
         self.root = pathlib.Path(self._tmp.name)
+        (self.root / "Cargo.toml").write_text(
+            '[workspace.package]\nversion = "1.2.3"\n'
+        )
         (self.root / "docs").mkdir()
         (self.root / "guides").mkdir()
         (self.root / "guides" / "jq.md").write_text("# jq\n")
@@ -47,7 +50,7 @@ class CheckDocLinksTest(unittest.TestCase):
         self.write("See [jq](../guides/jq.md).\n")
         result = self.check()
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("doc links OK", result.stdout)
+        self.assertIn("docs OK", result.stdout)
 
     def test_dangling_link_rejected(self) -> None:
         self.write("See [jq](jq.md).\n")
@@ -105,6 +108,40 @@ class CheckDocLinksTest(unittest.TestCase):
     def test_missing_root_rejected(self) -> None:
         result = run(self.root / "nope", "docs")
         self.assertEqual(result.returncode, 2)
+
+    def test_stale_bashkit_dependency_version_rejected(self) -> None:
+        self.write('```toml\nbashkit = { version = "1.2.2" }\n```\n')
+        result = self.check()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            'docs/page.md:2: stale bashkit dependency version 1.2.2; expected 1.2.3',
+            result.stderr,
+        )
+
+    def test_current_bashkit_dependency_version_accepted(self) -> None:
+        self.write('```toml\nbashkit = { version = "1.2.3", features = ["sqlite"] }\n```\n')
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_non_dependency_code_is_ignored(self) -> None:
+        self.write('```toml\nother = { version = "0.1" }\n```\n')
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_stale_crate_level_rustdoc_dependency_version_rejected(self) -> None:
+        rustdoc = self.root / "crates" / "bashkit" / "src" / "lib.rs"
+        rustdoc.parent.mkdir(parents=True)
+        rustdoc.write_text('//! bashkit = { version = "1.0.0", features = ["git"] }\n')
+        result = self.check()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            'crates/bashkit/src/lib.rs:1: stale bashkit dependency version 1.0.0; expected 1.2.3',
+            result.stderr,
+        )
+
+    def test_missing_workspace_version_rejected(self) -> None:
+        (self.root / "Cargo.toml").write_text('[workspace]\nmembers = []\n')
+        result = self.check()
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("workspace package version not found", result.stderr)
 
 
 class ReadmeLinksTest(unittest.TestCase):


### PR DESCRIPTION
## What changed
Keep published Bashkit dependency examples synchronized with the workspace package version. Documentation validation now checks dependency snippets in public Markdown and crate-level Rustdoc, and the HTTP Rustdoc example is compiled without making a network request.

## Why
Several README and guide snippets had drifted to old crate versions. Ignored Rustdoc also allowed an HTTP example to drift without compiler coverage.

## Before / After
Before: dependency snippets ranged from `0.1` to `0.13`, and the HTTP example was ignored by doctests.

After:
```text
docs OK: 194 relative links and 7 dependency versions across 83 files
test result: ok. 145 passed; 0 failed; 42 ignored
```

## Risk
- Low
- The checker could reject an intentionally historical `bashkit = { version = "..." }` snippet; current documentation contains no such example.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered

## Validation
- `python3 -m unittest scripts.tests.test_check_doc_links`
- `just check-doc-links`
- `cargo test -p bashkit --doc --features http_client`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p bashkit --no-deps --features http_client`
- `just pre-pr` (one unrelated differential test failed before rebasing; it passes on current `origin/main`)

Produced by [yolop](https://everruns.com/yolop)
