### PR TITLE
chore(ship): prompt for PR evidence in the ship skill

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -130,7 +130,8 @@ gh pr view --json url 2>/dev/null
 If no PR exists, create one:
 
 - **Title**: conventional commit style from the branch commits
-- **Body**: summary of What, Why, How, and what tests were added/verified
+- **Body**: use `.github/pull_request_template.md`; center it on functional change and impact, not a code-location walkthrough
+- **Evidence**: attach a Before / After with proof — CLI output, differential-test results against real Bash, or a terminal recording (e.g. VHS/asciinema) for a CLI demo. Say so when there is no observable behavior change
 - Use `gh pr create`
 
 If a PR already exists, update it if needed and report its URL.


### PR DESCRIPTION
## What changed

The `/ship` skill's Push-and-PR phase now prompts for **evidence in the PR body** — a Before / After with proof a reviewer can check: CLI output, **differential-test results against real Bash**, or a terminal recording (VHS/asciinema) for a CLI demo. The Body line also points at `.github/pull_request_template.md` and asks to center the description on functional change and impact rather than a code walkthrough.

## Why

The ship flow already gathers validation, but the skill didn't tell the agent to attach that proof to the PR. Reviewers benefit from seeing the change work, not reading that it does.

## Before / After

Docs/skill-guidance only — no runtime behavior changes.

- **Before:** Body step said "summary of What, Why, How, and what tests were added/verified."
- **After:** Body references the PR template + functional framing, and adds an Evidence line (CLI output, differential-test results, or a terminal recording), noting when there's no observable change.

## Risk

- Low
- Skill/docs only; no source, config, or CI logic touched.

## Checklist

- [x] Tests added or updated — N/A (skill/docs only)
- [x] Backward compatibility considered — no code paths affected

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_