### PR TITLE
chore(release): prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,96 @@
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-06
+
+### Highlights
+
+- **Browser WASM can run directly against host-owned storage.** The browser
+  bindings now accept asynchronous filesystem adapters for Durable Objects,
+  IndexedDB, OPFS, and similar stores, and add analysis, cancellation,
+  streaming, snapshots, and binary VFS APIs to reach native-binding parity
+  ([#2275](https://github.com/everruns/bashkit/pull/2275),
+  [#2255](https://github.com/everruns/bashkit/pull/2255)).
+- **Execution boundaries are typed, shared, and revocable.** New execution
+  profiles configure coherent limits across runtimes, one request budget
+  follows work across subsystem boundaries, and host capabilities stop working
+  when their execution ends. Hosts can also suspend a live shell for a
+  process-local callback and resume it with byte-exact input and output
+  ([#2254](https://github.com/everruns/bashkit/pull/2254),
+  [#2253](https://github.com/everruns/bashkit/pull/2253),
+  [#2264](https://github.com/everruns/bashkit/pull/2264),
+  [#2256](https://github.com/everruns/bashkit/pull/2256)).
+- **Shell streams preserve arbitrary bytes end to end.** Pipelines, redirects,
+  command results, callbacks, custom builtins, and Rust, C, Python, Node, and
+  browser bindings retain NUL, invalid UTF-8, and high bytes without lossy text
+  conversion ([#2252](https://github.com/everruns/bashkit/pull/2252)).
+- **`yq` replaces the narrow `yaml` helper.** The jq-backed builtin handles
+  YAML and JSON files, streams, selection, mapping, assignment, format
+  conversion, and atomic in-place updates under shared resource limits
+  ([#2266](https://github.com/everruns/bashkit/pull/2266),
+  [#2269](https://github.com/everruns/bashkit/pull/2269)).
+- **More common shell workflows run inside the sandbox.** GNU-compatible
+  bzip2 archives and standalone compression commands interoperate with system
+  tools, while `time` reports truthful elapsed time, status, and Bashkit-owned
+  work counters without fabricating host CPU or memory data
+  ([#2265](https://github.com/everruns/bashkit/pull/2265),
+  [#2263](https://github.com/everruns/bashkit/pull/2263)).
+
+### Breaking Changes
+
+- **Rust stream fields are now byte-native.** Public fields that previously
+  used `String` now use `StreamData`; callers constructing results or options
+  should pass bytes through `StreamData` and convert to text explicitly at
+  their application boundary. Language bindings retain their text views and
+  add raw-byte stdout/stderr fields.
+- **Execution-scoped host access expires with the request.** Extension and
+  callback consumers must use `ExecutionCapability::try_with` or `run`, and
+  handle revocation-aware `ToolArgs` context getters. Hosts that deliberately
+  need session-lived raw VFS access must register through
+  `BuiltinRegistry::insert_trusted`.
+- **The nonstandard `yaml` builtin is removed.** Enable the existing `jq`
+  feature and invoke `yq` with jq-style filters. YAML is converted through a
+  JSON value model, so comments, styles, anchors, and source key order are not
+  preserved; unsupported tags and non-string keys fail closed.
+
+### What's Changed
+
+* feat(wasm): host-backed filesystem for the wasm bindings ([#2275](https://github.com/everruns/bashkit/pull/2275)) by @chaliy
+* chore(ship): prompt for PR evidence in the ship skill ([#2274](https://github.com/everruns/bashkit/pull/2274)) by @chaliy
+* docs: keep dependency examples current ([#2271](https://github.com/everruns/bashkit/pull/2271)) by @chaliy
+* chore(ship): require public docs for user-facing features ([#2270](https://github.com/everruns/bashkit/pull/2270)) by @chaliy
+* fix(yq): reject lossy numbers and harden coverage ([#2269](https://github.com/everruns/bashkit/pull/2269)) by @chaliy
+* docs(fs): clarify adapter atomicity contract ([#2268](https://github.com/everruns/bashkit/pull/2268)) by @chaliy
+* feat(yq): add jq-backed YAML processor ([#2266](https://github.com/everruns/bashkit/pull/2266)) by @chaliy
+* feat(archives): add bzip2 interoperability ([#2265](https://github.com/everruns/bashkit/pull/2265)) by @chaliy
+* fix(security): revoke execution-scoped host capabilities ([#2264](https://github.com/everruns/bashkit/pull/2264)) by @chaliy
+* feat(shell): add truthful time reporting ([#2263](https://github.com/everruns/bashkit/pull/2263)) by @chaliy
+* fix(fs): certify filesystem security invariants ([#2262](https://github.com/everruns/bashkit/pull/2262)) by @chaliy
+* fix(jq): accept literal controls in input strings ([#2261](https://github.com/everruns/bashkit/pull/2261)) by @chaliy
+* fix(security): close request execution boundaries ([#2260](https://github.com/everruns/bashkit/pull/2260)) by @chaliy
+* fix(date): sandbox timezone handling ([#2259](https://github.com/everruns/bashkit/pull/2259)) by @chaliy
+* feat(security): charge buffer growth before allocation ([#2258](https://github.com/everruns/bashkit/pull/2258)) by @chaliy
+* fix(fs): harden Windows path containment ([#2257](https://github.com/everruns/bashkit/pull/2257)) by @chaliy
+* feat(execution): add process-local host-call suspension ([#2256](https://github.com/everruns/bashkit/pull/2256)) by @chaliy
+* feat(wasm): add browser binding parity ([#2255](https://github.com/everruns/bashkit/pull/2255)) by @chaliy
+* feat(config): add typed execution profiles ([#2254](https://github.com/everruns/bashkit/pull/2254)) by @chaliy
+* feat(security): share execution budget across request ([#2253](https://github.com/everruns/bashkit/pull/2253)) by @chaliy
+* feat(streams): preserve byte-native shell transport ([#2252](https://github.com/everruns/bashkit/pull/2252)) by @chaliy
+* perf(regex): cache runtime regex compilation ([#2251](https://github.com/everruns/bashkit/pull/2251)) by @chaliy
+* fix(compat): add competitor regression lane ([#2250](https://github.com/everruns/bashkit/pull/2250)) by @chaliy
+* test(adoption): cover the agent-bash-tool embedding shape, on Windows too ([#2249](https://github.com/everruns/bashkit/pull/2249)) by @chaliy
+* feat(fs): publish host mount table for VFS-to-host path mapping ([#2248](https://github.com/everruns/bashkit/pull/2248)) by @chaliy
+* feat(builtins): add CommandResolver for last-chance name resolution ([#2247](https://github.com/everruns/bashkit/pull/2247)) by @chaliy
+* test(api): centralize capability parity contract ([#2246](https://github.com/everruns/bashkit/pull/2246)) by @chaliy
+* feat(analysis): publish command-wrapper list for permission gating ([#2245](https://github.com/everruns/bashkit/pull/2245)) by @chaliy
+* feat(curl): support ordered data options ([#2242](https://github.com/everruns/bashkit/pull/2242)) by @chaliy
+* docs(readme): fix agent friendly badge link ([#2241](https://github.com/everruns/bashkit/pull/2241)) by @chaliy
+* fix(release): initialize MSVC for C API builds ([#2240](https://github.com/everruns/bashkit/pull/2240)) by @chaliy
+* chore(deps): bump the rust-dependencies group across 1 directory with 7 updates ([#2237](https://github.com/everruns/bashkit/pull/2237)) by @dependabot
+* chore(ci): bump taiki-e/install-action from 2.85.2 to 2.85.5 in the github-actions group ([#2230](https://github.com/everruns/bashkit/pull/2230)) by @dependabot
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.15.0...v0.16.0
+
 ## [0.15.0] - 2026-08-03
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-capi"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bashkit",
  "serde",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Enable the `sqlite` feature to embed [Turso](https://github.com/tursodatabase/tu
 
 ```toml
 [dependencies]
-bashkit = { version = "0.15.0", features = ["sqlite"] }
+bashkit = { version = "0.16.0", features = ["sqlite"] }
 ```
 
 ```rust

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.15.0", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.16.0", default-features = false, features = ["http_client", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/crates/bashkit/docs/logging.md
+++ b/crates/bashkit/docs/logging.md
@@ -14,7 +14,7 @@ Add the `logging` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.15.0", features = ["logging"] }
+bashkit = { version = "0.16.0", features = ["logging"] }
 tracing-subscriber = "0.3"  # or your preferred subscriber
 ```
 

--- a/crates/bashkit/docs/sqlite.md
+++ b/crates/bashkit/docs/sqlite.md
@@ -13,7 +13,7 @@ the `sqlite` feature. The engine is [Turso](https://github.com/tursodatabase/tur
 
 ```toml
 # Cargo.toml
-bashkit = { version = "0.15.0", features = ["sqlite"] }
+bashkit = { version = "0.16.0", features = ["sqlite"] }
 ```
 
 ```rust,ignore

--- a/crates/bashkit/fuzz/Cargo.lock
+++ b/crates/bashkit/fuzz/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bashkit"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -322,7 +322,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.15.0", features = ["git"] }
+//! bashkit = { version = "0.16.0", features = ["git"] }
 //! ```
 //!
 //! ```rust,ignore
@@ -353,7 +353,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.15.0", features = ["python"] }
+//! bashkit = { version = "0.16.0", features = ["python"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/docs/builtin_typescript.md
+++ b/docs/builtin_typescript.md
@@ -12,7 +12,7 @@ Add the `typescript` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.15.0", features = ["typescript"] }
+bashkit = { version = "0.16.0", features = ["typescript"] }
 ```
 
 Enable TypeScript in the builder:

--- a/site/src/content/apidocs/typescript.md
+++ b/site/src/content/apidocs/typescript.md
@@ -1297,6 +1297,9 @@ Options for creating a Bash or BashTool instance.
 
   Must specify either `allow` (list of URL patterns) or `allowAll: true`,
   not both. `blockPrivateIps` defaults to `true`.
+- **`profile?`** — `ExecutionProfileName`
+
+  Named resource-policy baseline. Individual limit options override it.
 - **`python?`** — `boolean`
 
   Enable embedded Python execution (`python`/`python3` builtins).
@@ -1401,8 +1404,10 @@ Result from executing bash commands.
 - **`exitCode`** — `number`
 - **`finalEnv?`** — `Record<string, string>`
 - **`stderr`** — `string`
+- **`stderrBytes`** — `number[]`
 - **`stderrTruncated`** — `boolean`
 - **`stdout`** — `string`
+- **`stdoutBytes`** — `number[]`
 - **`stdoutTruncated`** — `boolean`
 - **`success`** — `boolean`
 
@@ -1677,6 +1682,12 @@ fine, so snapshots keep restoring after a bashkit upgrade adds one.
 type CheckoutPolicy = "strict" | "superset" | "force"
 ```
 
+## ExecutionProfileName
+
+```typescript
+type ExecutionProfileName = typeof ExecutionProfile[keyof typeof ExecutionProfile]
+```
+
 ## FileValue
 
 A file value: either a string, a sync function returning a string,
@@ -1933,6 +1944,9 @@ Options for configuring the bash tool adapter.
 
   Must specify either `allow` (list of URL patterns) or `allowAll: true`,
   not both. `blockPrivateIps` defaults to `true`.
+- **`profile?`** — `ExecutionProfileName`
+
+  Named resource-policy baseline. Individual limit options override it.
 - **`python?`** — `boolean`
 
   Enable embedded Python execution (`python`/`python3` builtins).
@@ -2155,6 +2169,9 @@ Options for configuring the bash tool adapter.
 
   Must specify either `allow` (list of URL patterns) or `allowAll: true`,
   not both. `blockPrivateIps` defaults to `true`.
+- **`profile?`** — `ExecutionProfileName`
+
+  Named resource-policy baseline. Individual limit options override it.
 - **`python?`** — `boolean`
 
   Enable embedded Python execution (`python`/`python3` builtins).
@@ -2352,6 +2369,9 @@ Options for configuring the bash tool adapter.
 
   Must specify either `allow` (list of URL patterns) or `allowAll: true`,
   not both. `blockPrivateIps` defaults to `true`.
+- **`profile?`** — `ExecutionProfileName`
+
+  Named resource-policy baseline. Individual limit options override it.
 - **`python?`** — `boolean`
 
   Enable embedded Python execution (`python`/`python3` builtins).


### PR DESCRIPTION
## What changed

Prepares Bashkit v0.16.0 across Rust, CLI, Python, native Node, browser WASM, and C ABI release artifacts. The release adds host-backed browser filesystems, byte-native streams, typed and revocable execution boundaries, jq-backed `yq`, bzip2 interoperability, and truthful `time` reporting.

The changelog includes migration guidance for `StreamData`, execution-scoped host capabilities, and replacing the removed `yaml` helper with `yq`. Self-hosted TypeScript API references are refreshed for execution profiles and raw-byte result fields.

## Why

There are 34 verified commits since v0.15.0, including new public APIs and intentional breaking changes that require a minor release. Local history and the GitHub compare API both report 34 commits; all public registries currently report v0.15.0.

## Before / After

Before:

```text
cargo search bashkit                 -> 0.15.0
pip index versions bashkit           -> 0.15.0
npm @everruns/bashkit latest         -> 0.15.0
npm @everruns/bashkit-wasm latest    -> 0.15.0
```

Prepared and smoke-tested:

```text
bashkit 0.16.0
yq smoke                 -> ["apple","pear"]
bzip2 | bzcat smoke      -> binary-smoke
time smoke                -> status=0 commands=1
Python ABI3 wheel         -> 0.16.0 python-wheel-smoke
C ABI consumer            -> Hello from Bashkit! User: sandbox Time: ...
Node release tests        -> 554 passed
Browser WASM tests        -> 63 passed
```

Publish-readiness:

- `just release-check` passed: fmt, clippy, full Rust/unit/integration/doc/security suite, script tests, capability parity, OKF, doc links, cargo-vet, nightly/fuzz health.
- `cargo publish --dry-run -p bashkit` packaged and verified v0.16.0.
- Disposable registry-backed `bashkit-cli` package dry-run succeeded.
- Native Node optimized build, TypeScript compile, and tests passed.
- Browser WASM optimized build and headless integration suite passed.
- Python cp39-abi3 release wheel built, installed into a clean environment, and executed.
- C shared library built, linked with `-std=c11 -Wall -Wextra -Werror`, and executed.

## Risk

- Medium
- This is a multi-registry minor release with intentional public API changes documented in the changelog.
- Publishing remains CI-managed; post-merge monitoring will verify GitHub Release, crates.io, PyPI, both npm packages, Homebrew, and all C ABI archives before declaring the release shipped.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
