### PR TITLE
fix(deps): bump spin to 0.9.9 to clear yanked-crate warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,9 +5073,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1925,7 +1925,7 @@ version = "0.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.spin]]
-version = "0.9.8"
+version = "0.9.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.spki]]


### PR DESCRIPTION
## What changed

`spin` moves `0.9.8 -> 0.9.9` in `Cargo.lock`, and the cargo-vet exemption is
repinned to match. No source changes, no API or behavior changes.

## Why

`spin 0.9.8` was yanked from crates.io, so `cargo audit` flagged it as a yanked
dependency. `0.9.9` is a semver-compatible patch release that still satisfies the
existing `heapless 0.7` requirement, so only the lockfile moves — nothing else in
the graph re-resolves.

Found while sweeping the dependency tree for advisories. Everything else came back
clean: `cargo audit` reports **0 vulnerabilities** (even with no `--ignore` flags),
and `pnpm audit` is clean across all five JS workspaces.

## Before / After

Before:

```
Crate:     spin
Version:   0.9.8
Warning:   yanked

warning: 3 allowed warnings found
```

After:

```
warning: 2 allowed warnings found
```

The two remaining warnings are the pre-existing, already-triaged `unmaintained`
notices for `atomic-polyfill` (RUSTSEC-2023-0089) and `proc-macro-error2`
(RUSTSEC-2026-0173), both ignored in `deny.toml`.

Supply-chain check still passes with the repinned exemption:

```
$ cargo vet --locked
Vetting Succeeded (28 fully audited, 6 partially audited, 589 exempted)
```

Also verified locally: `cargo fmt --check`, `cargo check --workspace --features
http_client,ssh,sqlite`, and `cargo test --workspace --lib --features
http_client,ssh,sqlite` all pass.

## Risk

- Low
- Lockfile-only patch bump of a transitive dependency (`heapless 0.7` -> `spin`).
  `spin 0.9.9` is the yank-replacement for `0.9.8` with the same dependency set
  (`lock_api`). Risk is limited to the embedded-Python path that pulls in
  `heapless` via `postcard`; the full CI matrix covers it.

## Checklist

- [x] Tests added or updated — n/a, no source change; existing suites re-run as verification
- [x] Backward compatibility considered — no public surface affected
