### PR TITLE
chore(deps): bump the rust-dependencies group with 5 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -961,7 +961,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1525,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2976,13 +2976,14 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f71d6bc097c4a6eb853c3f24991ab8c9f50f57d1f719e305175541482217e36"
+checksum = "459197f1592f4c3dbbf9c1b13f5a4599a343e4ef66b96bc340e2a518b36a6662"
 dependencies = [
  "bitflags 2.13.1",
  "ctor",
  "futures",
+ "libc",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -2992,15 +2993,15 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5282704fbe8d49b0cf8b08e3f33233416a528658f205c7e5ace63b582de0b11c"
+checksum = "60fdf9b392c50e7c4170fa633bd909490ed7835cea4c046776d1a4dd8d2ae0ab"
 
 [[package]]
 name = "napi-derive"
-version = "3.6.2"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9002b2940f0184444754546e0fcd15182f56948e6f381968b019d549387c42"
+checksum = "0fa55ea69990c90b888e9e77044410e304ce7f35de599dc6d0b5c1923d2e59af"
 dependencies = [
  "convert_case",
  "ctor",
@@ -3012,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60b5d773ad46c698c8cc2cd9fde0b283d39cbb7f71c04bee633c7bdba4423bd"
+checksum = "df4056ac7c18e4438ccf0edaed4340ca0d269278c8ec19284f7b23cb039fd0ae"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4521,7 +4522,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4578,7 +4579,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5314,7 +5315,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5355,18 +5356,18 @@ checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6125,7 +6126,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -136,7 +136,7 @@ version = "0.1.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.async-trait]]
-version = "0.1.91"
+version = "0.1.92"
 criteria = "safe-to-deploy"
 
 [[exemptions.atomic-polyfill]]
@@ -1155,19 +1155,19 @@ version = "0.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.napi]]
-version = "3.12.0"
+version = "3.12.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.napi-build]]
-version = "2.4.0"
+version = "2.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.napi-derive]]
-version = "3.6.2"
+version = "3.6.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.napi-derive-backend]]
-version = "6.1.1"
+version = "6.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.napi-sys]]
@@ -2029,11 +2029,11 @@ version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread_local]]


### PR DESCRIPTION
## What changed

Takes the `rust-dependencies` group bump from #2294 and adds the supply-chain exemption updates that PR was missing, so it can actually go green. Supersedes #2294.

| Crate | From | To |
|---|---|---|
| `async-trait` | 0.1.91 | 0.1.92 |
| `napi` | 3.12.0 | 3.12.1 |
| `napi-build` | 2.4.0 | 2.4.1 |
| `napi-derive` | 3.6.2 | 3.6.3 |
| `napi-derive-backend` | 6.1.1 | 6.1.2 |
| `thiserror` / `thiserror-impl` | 2.0.19 | 2.0.20 |

No source changes — lockfile plus the matching `supply-chain/config.toml` exemptions.

## Why

`supply-chain/config.toml` pins every exemption to an **exact** version, so any dependency bump that doesn't carry a matching exemption bump fails `cargo vet --locked`. Dependabot doesn't know about that file, so #2294's Audit job went red.

Worth noting for anyone reading #2294's CI log: it looks like only `thiserror` is missing, because the surrounding log grep matches on the substring `error` — which `thiserror` happens to contain. Running `cargo vet` directly shows all seven.

## Before / After

**Before** (on #2294's head):

```
$ cargo vet --locked
Vetting Failed!

7 unvetted dependencies:
  async-trait:0.1.92 missing ["safe-to-deploy"]
  napi:3.12.1 missing ["safe-to-deploy"]
  napi-build:2.4.1 missing ["safe-to-deploy"]
  napi-derive:3.6.3 missing ["safe-to-deploy"]
  napi-derive-backend:6.1.2 missing ["safe-to-deploy"]
  thiserror:2.0.20 missing ["safe-to-deploy"]
  thiserror-impl:2.0.20 missing ["safe-to-deploy"]
```

**After**:

```
$ cargo vet --locked
Vetting Succeeded (27 fully audited, 6 partially audited, 590 exempted)

$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo audit
warning: 2 allowed warnings found        # the two already-suppressed unmaintained advisories
                                         # no vulnerabilities
```

## Risk

- **Low**
- Patch-level bumps within existing semver ranges, no source changes. The exemptions were bumped to track the locked versions rather than widened or loosened, so supply-chain coverage is unchanged in kind.

## Checklist
- [x] Tests added or updated — n/a, dependency-only; covered by the existing suite and the `cargo vet` / `cargo audit` gates
- [x] Backward compatibility considered


---
_Generated by [Claude Code](https://claude.ai/code/session_014KSUiRr2RqUa1wyuh7beXB)_