### PR TITLE
chore(deps): hold monty at 0.0.19 — 0.0.21 silently disables the Python sandbox memory ceiling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,18 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+      # monty/monty-types are held at 0.0.19 for a security reason, not just an
+      # API-churn one. 0.0.21 replaced host-side memory accounting with a probe
+      # of globals that only the `monty-alloc` global allocator writes, so an
+      # embedder that cannot install a process-wide allocator — which bashkit,
+      # as a library and a CPython extension module, cannot — silently loses the
+      # Python sandbox's `max_memory` ceiling. Four threat-model regression
+      # tests fail on the bump. Without these entries dependabot reopens the
+      # same broken PR every week (#2296, #2297).
+      # Drop the ignores once monty exposes an embedder-usable memory bound;
+      # see knowledge/runtimes/python-builtin.md § Upgrade blocker.
+      - dependency-name: "monty"
+      - dependency-name: "monty-types"
 
   # Fuzz targets are a separate cargo workspace with their own lockfile, so the
   # "/" entry above never touches them. Without this the fuzz lockfile silently

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -106,6 +106,20 @@ os_display = "0.1.3"
 # Registry dep since monty 0.0.19 — the first version published to crates.io.
 # Keeps `python` usable for downstream crates and lets the publish workflow
 # ship the feature instead of stripping it.
+#
+# Important decision (security): held at 0.0.19. Cargo treats `0.0.z` as its own
+# compatibility range (`^0.0.19` == `>=0.0.19, <0.0.20`), so this is already an
+# exact pin; the matching `ignore` entries in .github/dependabot.yml stop the
+# bump PRs from being regenerated.
+#
+# 0.0.21 moves `max_memory` enforcement from host-side accounting to a probe of
+# the `LIVE_MEMORY`/`BASELINE_MEMORY` globals, which only the separate
+# `monty-alloc` crate writes — and only when installed as the process-wide
+# global allocator. Bashkit is an embeddable library (and bashkit-python is a
+# CPython extension module), so it cannot impose a global allocator on its
+# hosts. Without one, `probe_memory()` is `0.saturating_sub(usize::MAX)` == 0
+# and the Python sandbox's memory ceiling silently stops being enforced.
+# See knowledge/runtimes/python-builtin.md § Upgrade blocker.
 monty = { version = "0.0.19", optional = true }
 monty-types = { version = "0.0.19", optional = true }
 

--- a/knowledge/runtimes/python-builtin.md
+++ b/knowledge/runtimes/python-builtin.md
@@ -81,6 +81,62 @@ remain independently enforced.
 Since Monty 0.0.4 the parser also enforces a nesting-depth limit (200
 release / 35 debug) against stack overflow from deeply nested expressions.
 
+### Upgrade blocker: Monty is held at 0.0.19
+
+`monty` and `monty-types` are pinned to 0.0.19 and ignored in
+`.github/dependabot.yml`. This is a security hold, not API-churn convenience.
+
+Monty 0.0.21 changed how `max_memory` is enforced:
+
+| | 0.0.19 | 0.0.21 |
+|---|---|---|
+| Enforcement | `LimitedTracker::on_grow` accounts VM heap growth in-process | `probe_memory()` reads the `LIVE_MEMORY` / `BASELINE_MEMORY` statics |
+| Who populates it | the tracker itself | only `monty-alloc`, installed as the **process-wide global allocator** |
+| Embedder needs | nothing | to own the host's global allocator |
+
+Neither `monty` nor `monty-types` depends on `monty-alloc`. When it is absent
+the statics keep their initial values and `probe_memory()` evaluates to
+`0.saturating_sub(usize::MAX)` == 0, so `check_allocation` — and therefore both
+`max_memory` and `check_large_result` — can never trip. The ceiling is not
+merely weakened; it is silently unenforced, with no error or warning.
+
+Bashkit cannot supply the missing allocator. It is an embeddable library, so
+the global allocator belongs to the downstream binary, and `bashkit-python` is a
+CPython extension module where the allocator is CPython's. `monty-alloc` is
+built for Monty's own out-of-process worker model ("a Monty *worker's* hard
+memory ceiling"), which bashkit does not use.
+
+Four existing threat-model regression tests fail on the bump and are the
+standing guard for this — they need no new test to be added:
+
+- `python_security_tests::whitebox_resource_limits::nested_list_bomb`
+- `python_security_tests::whitebox_resource_limits::successive_allocations_accumulate`
+- `python_security_tests::whitebox_resource_limits::tight_memory_blocks_many_small_objects`
+- `threat_model_tests::python_security_regressions::threat_python_pow_exhaustion`
+
+The duration, recursion, and print-collect-cap limits are unaffected and still
+pass, which localises the regression to allocator-backed memory.
+
+Two further changes land in the same bump and must be handled when the hold is
+lifted; neither is a blocker on its own:
+
+- `ResourceTracker` became a concrete struct (upstream pydantic/monty#613), so
+  the host can no longer wrap VM checkpoints. `BudgetTracker`'s bridge into the
+  shared `ExecutionBudget` has to move outside the VM — charging work around
+  each synchronous `start`/`resume` section instead of inside it. The
+  per-entry admission reservation that enforces TM-DOS-096 is independent of
+  the tracker and survives either way.
+- `ResourceLimits::new()` is replaced by `Default`, and its builders take plain
+  values rather than `Option`s.
+
+Lifting the hold also **removes** a `[patch.crates-io]` git pin: the patch in
+the root `Cargo.toml` exists only because `monty 0.0.19` requires
+`jiter ^0.15.0`, whose published release holds the graph below pyo3 0.29.
+Monty 0.0.21 depends on the published `jiter 0.16.0`, which already tracks
+pyo3 0.29, so the workspace would build from crates.io alone with no git
+dependency in the release graph. That is a real supply-chain win waiting on the
+memory fix — it is not a reason to take the bump early.
+
 ### Python Feature Support
 
 Monty implements a subset of Python 3.12. Supported: functions (incl.


### PR DESCRIPTION
## What changed

Blocks the `monty` / `monty-types` 0.0.19 → 0.0.21 upgrade instead of taking it, and records why.

- `.github/dependabot.yml`: ignore `monty` and `monty-types` so the broken bump is not regenerated every week.
- `crates/bashkit/Cargo.toml`: document the hold at the dependency (the `0.0.19` requirement is already an exact pin — Cargo treats each `0.0.z` as its own compatibility range).
- `knowledge/runtimes/python-builtin.md`: new **Upgrade blocker** section covering the regression, the API migration the bump needs, and the supply-chain win that unlocks when it is safe.

No product code changes.

**Supersedes #2296 and #2297** — both should be closed.

## Why

Dependabot split one upstream release across two PRs, each bumping half of a version-locked pair, so both fail every check. Fixing that split surfaced the real problem.

Monty 0.0.21 changes how `max_memory` is enforced:

| | 0.0.19 | 0.0.21 |
|---|---|---|
| Enforcement | `LimitedTracker::on_grow` accounts VM heap growth in-process | `probe_memory()` reads the `LIVE_MEMORY` / `BASELINE_MEMORY` statics |
| Who populates it | the tracker itself | only `monty-alloc`, as the **process-wide global allocator** |
| Embedder needs | nothing | to own the host's global allocator |

Neither `monty` nor `monty-types` depends on `monty-alloc`. With it absent the statics keep their initial values, so `probe_memory()` is `0.saturating_sub(usize::MAX)` == 0 and `check_allocation` — backing both `max_memory` and `check_large_result` — can never trip. The ceiling is not weakened, it is **silently unenforced**: no error, no warning.

Bashkit cannot supply the missing allocator. It is an embeddable library, so the global allocator belongs to the downstream binary, and `bashkit-python` is a CPython extension module where the allocator is CPython's. `monty-alloc` is built for Monty's own out-of-process worker model, which bashkit does not use.

## Before / After

Verified locally by applying the full bump (both crates together, plus the `ResourceTracker` / `ResourceLimits` migration needed to compile) and running the Python resource-limit suites.

**With monty 0.0.21** — a sandboxed script allocates without bound:

```
test python_security_tests::whitebox_resource_limits::successive_allocations_accumulate ... FAILED
test python_security_tests::whitebox_resource_limits::nested_list_bomb ... FAILED
test python_security_tests::whitebox_resource_limits::tight_memory_blocks_many_small_objects ... FAILED
test threat_model_tests::python_security_regressions::threat_python_pow_exhaustion ... FAILED

test result: FAILED. 9 passed; 4 failed; 1457 filtered out
```

```
assertion `left != right` failed: Creating 1M list items should hit limits
  left: 0
 right: 0
```

**On this branch (monty 0.0.19):**

```
test result: ok. 13 passed; 0 failed; 0 ignored; 1457 filtered out
```

The duration, recursion, string-bomb and print-collect-cap tests pass in both runs, which localises the regression to allocator-backed memory rather than resource limits generally.

## Risk

- **Low.** Comments, dependabot config, and knowledge only — no code or resolved dependency versions change, so `Cargo.lock` is untouched.
- The cost of holding is staying on 0.0.19: no upstream Python-feature work, and the `[patch.crates-io]` git pin of `jiter` stays until the hold lifts. Both are recorded in the knowledge doc, including the two API changes (`ResourceTracker` becoming a concrete struct, `ResourceLimits::new()` → `Default`) and the fact that monty 0.0.21's move to the published `jiter 0.16.0` would remove the last git dependency from the release graph — a real supply-chain win, but not a reason to take a silent sandbox regression early.

## Checklist
- [x] Tests added or updated — no new test needed; four existing threat-model regression tests already fail on the bump and are the standing guard. They are named in the knowledge doc so the next person to attempt the upgrade knows what must stay green.
- [x] Backward compatibility considered — no public API or resolved dependency version changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqgRDJJbJLk4sZy8xWWUu1)_