### PR TITLE
chore(deps): bump russh to 0.62.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.5"
+version = "0.62.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
+checksum = "b41043523e0edcbd4e31d00903e26f12994f63b21bae9904f7405c1ed92752a5"
 dependencies = [
  "aes 0.9.1",
  "aws-lc-rs",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -128,6 +128,12 @@ criteria = "safe-to-deploy"
 delta = "0.62.4 -> 0.62.5"
 notes = "Reviewed delta: rejects channel-scoped messages unless the SSH channel is confirmed, and bounds queued application output when channel windows are exhausted; no unsafe code or new ambient capabilities, with regression and backpressure coverage."
 
+[[audits.russh]]
+who = "Mykhailo Chalyi <mike@chaliy.name>"
+criteria = "safe-to-deploy"
+delta = "0.62.5 -> 0.62.6"
+notes = 'Reviewed delta: routes channel-open replies through a dedicated priority queue drained ahead of the bounded receivers, so a confirmation can no longer be silently dropped by a full queue or be overtaken by data for a channel that is not registered yet; enforces the server-side max_auth_attempts cap with a DISCONNECT while keeping publickey probes uncounted; and tolerates exactly one trailing comma in name-lists for OpenSSH interop, still rejecting "," and "a,,". No new unsafe code (unchanged single occurrence), no new dependencies, and no ambient capability changes; each behaviour change lands with test coverage.'
+
 [[audits.rustls-webpki]]
 who = "Mykhailo Chalyi <mike@chaliy.name>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -132,7 +132,7 @@ notes = "Reviewed delta: rejects channel-scoped messages unless the SSH channel 
 who = "Mykhailo Chalyi <mike@chaliy.name>"
 criteria = "safe-to-deploy"
 delta = "0.62.5 -> 0.62.6"
-notes = 'Reviewed delta: routes channel-open replies through a dedicated priority queue drained ahead of the bounded receivers, so a confirmation can no longer be silently dropped by a full queue or be overtaken by data for a channel that is not registered yet; enforces the server-side max_auth_attempts cap with a DISCONNECT while keeping publickey probes uncounted; and tolerates exactly one trailing comma in name-lists for OpenSSH interop, still rejecting "," and "a,,". No new unsafe code (unchanged single occurrence), no new dependencies, and no ambient capability changes; each behaviour change lands with test coverage.'
+notes = "Reviewed delta: routes channel-open replies through a dedicated priority queue drained ahead of the bounded receivers, so a confirmation can no longer be silently dropped by a full queue or be overtaken by data for a channel that is not registered yet; enforces the server-side max_auth_attempts cap with a DISCONNECT while keeping publickey probes uncounted; and tolerates exactly one trailing comma in name-lists for OpenSSH interop, still rejecting a bare comma and a doubled separator. No new unsafe code (unchanged single occurrence), no new dependencies, and no ambient capability changes; each behaviour change lands with test coverage."
 
 [[audits.rustls-webpki]]
 who = "Mykhailo Chalyi <mike@chaliy.name>"


### PR DESCRIPTION
Supersedes #2301.

## What changed

Bumps `russh` 0.62.5 -> 0.62.6 and records the corresponding `cargo-vet` delta audit.

Upstream changes picked up:

- **Channel-open replies now go through a dedicated priority queue** drained ahead of the bounded receivers. Previously the reply used the bounded sender via `try_send`, so a confirmation could be silently dropped when the queue was full, and channel data could overtake the confirmation for a channel that was not registered yet (dropping that data). This is a direct follow-up to the backpressure work audited in 0.62.4 -> 0.62.5.
- **Server-side `max_auth_attempts` is actually enforced**, disconnecting with `NoMoreAuthMethodsAvailable` once the cap is exceeded; publickey probes answered with `PK_OK` explicitly do not count toward it.
- **Name-lists tolerate exactly one trailing comma** for OpenSSH interop, while still rejecting `","` and `"a,,"`.

## Why

`cargo vet` gates the bump: `russh:0.62.6 missing ["safe-to-deploy"]` is the only real failure on #2301. Rather than widening the blanket exemption, this records a reviewed delta audit, keeping the existing 0.62.4 exemption + delta-audit chain intact.

The lockfile edit is deliberately scoped to russh alone. Running `cargo update -p russh --precise 0.62.6` also re-unifies unrelated crates (`tempfile`, `rustix`, `socket2`, ...) onto `windows-sys` 0.52.0 and `getrandom` 0.3.4 — churn that has nothing to do with this bump and that silently downgrades Windows bindings. That churn is what #2301 carries. russh 0.62.6 declares exactly the same dependency requirements as 0.62.5 (only the version line differs in its manifest), so the two-line lockfile edit is sufficient and stays consistent.

## Before / After

Vet gate:

```
# before (as on #2301)
Vetting Failed!
1 unvetted dependencies:
  russh:0.62.6 missing ["safe-to-deploy"]

# after
Vetting Succeeded (27 fully audited, 6 partially audited, 590 exempted)
```

Lockfile blast radius:

```
# `cargo update -p russh --precise 0.62.6` (what #2301 carries)
 Cargo.lock | 18 +++++++++---------

# this PR
 Cargo.lock | 4 ++--
```

Lock consistency and SSH behavior:

```
$ cargo metadata --locked   # LOCK OK
$ cargo test --features ssh -p bashkit --test ssh_builtin_tests
test result: ok. 24 passed; 0 failed; 0 ignored
```

No behavior change in bashkit itself — this is a dependency patch bump plus a supply-chain record.

## Risk

- Low
- The upstream delta touches SSH channel-open sequencing. bashkit drives russh as a client (`ssh`/`scp`/`sftp` builtins), and the priority-queue change strictly reduces the chance of a dropped channel-open confirmation. The server-side auth cap does not apply to bashkit's client usage. All 24 SSH builtin tests pass.
- Review notes: no new `unsafe` (unchanged single occurrence), no new dependencies, no ambient capability changes.

## Checklist
- [x] Tests added or updated — existing SSH builtin suite covers the client paths; the upstream delta lands with its own regression tests. No new bashkit-side behavior to test.
- [x] Backward compatibility considered — patch-level dependency bump, no public API change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KgKXfVQFqNKY8EzJ3CwkCs)_