### PR TITLE
fix(sqlite): handle turso StepResult::Sleep and bump to 0.8.0-pre.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5644,9 +5644,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso_core"
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841bf28f752f3d91496e66ac024aae881290934b3c44deeef6e8892d427dfe76"
+checksum = "91d21d176e7cc7dc607778f33b186ad981003969451ca0e3dca7494ea5ebb08a"
 dependencies = [
  "aegis",
  "aes 0.8.4",
@@ -5716,9 +5716,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ff611dfc3c8d104ee92fd5fbf44a7ed69d14cb3342eedb3c50991a96c5fdd5"
+checksum = "d9c1d40548fd1ddfa1e9486b864de3e625658a9c9013031a0d7f69ffbcab2773"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -5727,9 +5727,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0fbc94903fa3f5e7a09cbee0ecd72a64e390e57493917f0b074c93cc10f05bb"
+checksum = "20622919c832ac37fb4f784e450f5dfe10598ffbd42c735aa9b2e756c4044137"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5738,9 +5738,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7c2706b7b21a708ccb625dcea40d996acc6bd92a75fd18447301a975419081"
+checksum = "5aad14b801fcb7ec1970f51c135e9ddcbbd79d7bce99b16eeb6a2213e536d478"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",

--- a/crates/bashkit/benches/results/criterion-sqlite-vm-linux-x86_64-1786872580.md
+++ b/crates/bashkit/benches/results/criterion-sqlite-vm-linux-x86_64-1786872580.md
@@ -1,0 +1,89 @@
+# Criterion SQLite Builtin Benchmark
+
+Measures the `sqlite` builtin (Turso embedded engine) end-to-end through
+the bashkit interpreter. Per-invocation overhead (interpreter setup, script
+parse, engine open, VFS flush) is included in every number — these are
+"what a script author observes", not isolated engine micro-benchmarks.
+
+## System Information
+
+- **Moniker**: `vm-linux-x86_64`
+- **Hostname**: vm
+- **OS**: linux
+- **Architecture**: x86_64
+- **CPUs**: 4
+- **Timestamp**: 1786872580
+
+## CRUD (insert / update, Memory vs Vfs backend, n rows)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_crud/insert_mem/100 | 1.5815 ms |
+| sqlite_crud/insert_vfs/100 | 2.1505 ms |
+| sqlite_crud/update_mem/100 | 1.5770 ms |
+| sqlite_crud/update_vfs/100 | 2.1971 ms |
+| sqlite_crud/insert_mem/1000 | 4.4522 ms |
+| sqlite_crud/insert_vfs/1000 | 5.0772 ms |
+| sqlite_crud/update_mem/1000 | 4.7909 ms |
+| sqlite_crud/update_vfs/1000 | 5.2744 ms |
+| sqlite_crud/insert_mem/10000 | 33.482 ms |
+| sqlite_crud/insert_vfs/10000 | 36.968 ms |
+| sqlite_crud/update_mem/10000 | 40.663 ms |
+| sqlite_crud/update_vfs/10000 | 40.667 ms |
+
+## Indexing (create index, indexed lookup, full scan)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_index/create_index_mem/100 | 1.8766 ms |
+| sqlite_index/indexed_lookup_mem/100 | 1.9933 ms |
+| sqlite_index/full_scan_mem/100 | 1.5917 ms |
+| sqlite_index/create_index_mem/1000 | 6.6359 ms |
+| sqlite_index/indexed_lookup_mem/1000 | 6.6437 ms |
+| sqlite_index/full_scan_mem/1000 | 5.4651 ms |
+| sqlite_index/create_index_mem/10000 | 61.268 ms |
+| sqlite_index/indexed_lookup_mem/10000 | 59.069 ms |
+| sqlite_index/full_scan_mem/10000 | 36.494 ms |
+
+## Query (GROUP BY aggregate)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_query/aggregate_mem/100 | 1.6842 ms |
+| sqlite_query/aggregate_vfs/100 | 2.3234 ms |
+| sqlite_query/aggregate_in_memory/100 | 1.4605 ms |
+| sqlite_query/aggregate_mem/1000 | 5.1008 ms |
+| sqlite_query/aggregate_vfs/1000 | 5.6511 ms |
+| sqlite_query/aggregate_in_memory/1000 | 4.2516 ms |
+| sqlite_query/aggregate_mem/10000 | 41.015 ms |
+| sqlite_query/aggregate_vfs/10000 | 42.004 ms |
+| sqlite_query/aggregate_in_memory/10000 | 33.062 ms |
+
+## Output mode formatters (1k rows)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_output_mode/list | 5.0912 ms |
+| sqlite_output_mode/csv | 5.8390 ms |
+| sqlite_output_mode/json | 5.1766 ms |
+| sqlite_output_mode/markdown | 5.9508 ms |
+| sqlite_output_mode/box | 5.8332 ms |
+
+## Persistence (cost per invocation)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_persistence/two_invocations_mem | 4.7396 ms |
+| sqlite_persistence/two_invocations_vfs | 6.1163 ms |
+| sqlite_persistence/memory_db_baseline | 4.5421 ms |
+
+## Parallel sessions (N concurrent over shared VFS)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_parallel/mem/4 | 5.7387 ms |
+| sqlite_parallel/vfs/4 | 7.0490 ms |
+| sqlite_parallel/mem/16 | 20.482 ms |
+| sqlite_parallel/vfs/16 | 25.568 ms |
+| sqlite_parallel/mem/64 | 67.982 ms |
+| sqlite_parallel/vfs/64 | 83.281 ms |

--- a/crates/bashkit/src/builtins/sqlite/engine.rs
+++ b/crates/bashkit/src/builtins/sqlite/engine.rs
@@ -231,11 +231,23 @@ impl SqliteEngine {
                 StepResult::Done => break,
                 // `IO` means the VDBE is blocked on outstanding completions;
                 // `Yield` (added in turso 0.7) means it voluntarily paused to let
-                // the program state machines advance. In both cases the caller
-                // drives pending completions and re-steps. Our backends are
-                // synchronous, so `io_step` returns immediately when nothing is
-                // pending, and the deadline check above bounds the loop.
-                StepResult::IO | StepResult::Yield => {
+                // the program state machines advance. `Sleep` (added in turso
+                // 0.8.0-pre.4) asks us to back off for a duration before
+                // re-stepping, e.g. after a busy handler chose to retry. In all
+                // three cases the caller drives pending completions and re-steps.
+                // Our backends are synchronous, so `io_step` returns immediately
+                // when nothing is pending, and the deadline check above bounds
+                // the loop.
+                //
+                // We deliberately do not honour `Sleep`'s duration. Blocking the
+                // thread would be wrong here: the engine is single-threaded and
+                // driven synchronously, so nothing else can make the progress the
+                // sleep is waiting for, and `std::thread::sleep` is unavailable on
+                // the wasm targets this builtin also ships to. Upstream documents
+                // that callers which don't track time may treat `Sleep` exactly
+                // like `IO`. Spinning is bounded by both the wall-clock deadline
+                // (TM-SQL-005a) and the per-iteration execution budget above.
+                StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
                     self.io_step()?;
                 }
                 StepResult::Busy | StepResult::Interrupt => {

--- a/knowledge/runtimes/sqlite-builtin.md
+++ b/knowledge/runtimes/sqlite-builtin.md
@@ -57,6 +57,31 @@ cached file-backed engines, dot-commands, and query materialisation receive
 clones of the same budget rather than new counters. SQLite-specific size,
 statement, row, result, and duration ceilings remain independently enforced.
 
+### Step-loop pacing signals
+
+`Statement::step()` returns three non-terminal "come back later" results, and
+the engine treats all of them the same way: drive pending completions via
+`io_step()` and re-step.
+
+| Result   | Meaning                                                   |
+| -------- | --------------------------------------------------------- |
+| `IO`     | Blocked on outstanding completions                         |
+| `Yield`  | Voluntarily paused so program state machines can advance (turso 0.7) |
+| `Sleep`  | Asks the caller to back off for a duration, e.g. a busy-handler retry (turso 0.8.0-pre.4) |
+
+`Sleep`'s duration is deliberately **not** honoured. The engine is
+single-threaded and driven synchronously, so nothing else can produce the
+progress the sleep waits for, and `std::thread::sleep` is unavailable on the
+wasm targets this builtin ships to. Upstream documents that callers which do
+not track time may treat `Sleep` exactly like `IO`. Spinning stays bounded by
+the wall-clock deadline (TM-SQL-005a) and by the `ExecutionBudget` work unit
+consumed on every loop iteration.
+
+The match over `StepResult` is kept **exhaustive on purpose**: a new upstream
+variant must break the build so its pacing semantics get reviewed rather than
+silently falling into a catch-all. `Sleep` was caught exactly this way when
+turso 0.8.0-pre.4 introduced it.
+
 ### Phase 1 — `Backend::Memory` (default)
 
 Read entire DB file from VFS into memory → fresh `MemoryIO`-backed turso

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2125,19 +2125,19 @@ version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_core]]
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_ext]]
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_macros]]
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_parser]]
-version = "0.8.0-pre.3"
+version = "0.8.0-pre.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.twox-hash]]


### PR DESCRIPTION
Supersedes #2302.

## What changed

Bumps `turso_core` (and `turso_ext` / `turso_macros` / `turso_parser`) 0.8.0-pre.3 -> 0.8.0-pre.4, and teaches the sqlite engine's step loop about the new `StepResult::Sleep { duration }` variant.

`Sleep` joins the `IO | Yield` arm: drive pending completions via `io_step()` and re-step. **The duration is deliberately not honoured.** Blocking would be wrong here — the engine is single-threaded and driven synchronously, so nothing else can produce the progress the sleep is waiting for, and `std::thread::sleep` is unavailable on the wasm targets this builtin also ships to. Upstream documents the fallback explicitly:

> The statement asks the caller to wait for `duration` before stepping again, e.g. because a busy handler decided to retry after a delay. **Callers that don't track time may treat this exactly like `IO`**: drive the event loop and step again.

Spinning stays bounded by the existing wall-clock deadline (TM-SQL-005a) and by the `ExecutionBudget` work unit consumed on every loop iteration, so this cannot become an unbounded busy-wait.

The match over `StepResult` is kept exhaustive on purpose — that is exactly what surfaced this variant instead of letting it fall into a catch-all. Documented in `knowledge/runtimes/sqlite-builtin.md`.

## Why

Without this, turso 0.8.0-pre.4 does not compile:

```
error[E0004]: non-exhaustive patterns: `StepResult::Sleep { .. }` not covered
   --> crates/bashkit/src/builtins/sqlite/engine.rs:196
error: could not compile `bashkit` (lib) due to 1 previous error
```

That is what takes down 21 jobs on #2302 — every Rust, Python, Node, WASM and coverage job fails on the same build error.

## Before / After

Build and tests:

```
# before (turso 0.8.0-pre.4, unpatched — i.e. #2302)
error[E0004]: non-exhaustive patterns: `StepResult::Sleep { .. }` not covered
error: could not compile `bashkit` (lib) due to 1 previous error
error: could not compile `bashkit` (lib test) due to 1 previous error

# after
$ cargo build -p bashkit --features sqlite      # Finished, exit 0
$ cargo test  -p bashkit --features sqlite sqlite
test result: ok. 108 passed; 0 failed
test result: ok.  66 passed; 0 failed
$ cargo vet --locked      # Vetting Succeeded
$ cargo fmt --check       # clean
```

Performance — `just bench-sqlite`, same machine, pre.3 vs pre.4 across all 44 benchmarks:

| benchmark | pre.3 | pre.4 | delta |
|---|---|---|---|
| sqlite_index/indexed_lookup_mem/10000 | 64163 µs | 59069 µs | −7.9% |
| sqlite_query/aggregate_mem/10000 | 43728 µs | 41015 µs | −6.2% |
| ... | | | |
| sqlite_parallel/vfs/16 | 22345 µs | 25568 µs | +14.4% |
| sqlite_index/full_scan_mem/1000 | 4724 µs | 5465 µs | +15.7% |

**median −1.6%, mean +0.1%** (n=44, range −7.9% to +15.7%) — noise on a 4-CPU VM, no regression.

Note for reviewers: do **not** diff this against `criterion-sqlite-vm-linux-x86_64-1777865268.md` (May). That baseline reports ~780 µs for *every* row count including 10000, which is not comparable to the current bench shape and makes pre.4 look ~50x slower. The numbers above are a fresh same-machine A/B run of pre.3 against pre.4.

## Risk

- Low
- The only behavioral surface is how the step loop paces itself when turso returns `Sleep`. If a future workload genuinely depends on backing off (a contended busy handler), this spins instead of sleeping until the deadline or budget trips — bounded, never unbounded, and it returns the existing `query timed out` error rather than hanging. Honouring the duration would require a wasm-safe sleep and a non-synchronous driver, neither of which exists today.
- Lockfile edit is scoped to the four turso crates; pre.4 changes only its internal version pins, so the unrelated `windows-sys` 0.52.0 / `getrandom` 0.3.4 re-unification that #2302 carries is avoided. Verified with `cargo metadata --locked`.

## Checklist
- [x] Tests added or updated — existing 174 sqlite tests cover the step loop on both backends. `Sleep` is not reachable from bashkit's synchronous single-connection backends (it comes from a busy-handler retry under contention), so there is no deterministic way to assert it from a test; the exhaustive match is the compile-time guard, and the rationale is recorded in knowledge.
- [x] Backward compatibility considered — internal dependency bump, no public API change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KgKXfVQFqNKY8EzJ3CwkCs)_