### PR TITLE
fix(builtins): compile bashkit for WASI targets + CI check for wasm32-wasip2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     # compiling for browser/wasm-bindgen consumers; the feature list is the
     # supported wasm32-unknown-unknown surface (python is excluded: monty pulls
     # getrandom 0.3 without its wasm_js feature).
-    name: WASM (wasm32-unknown-unknown)
+    name: WASM (wasm32-unknown-unknown, wasm32-wasip2)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -80,7 +80,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown, wasm32-wasip2
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
@@ -89,6 +89,15 @@ jobs:
         env:
           # getrandom needs an explicit JS backend opt-in on this target.
           RUSTFLAGS: --cfg getrandom_backend="wasm_js" -D warnings
+
+      # WASI keeps the crate usable in non-JS wasm runtimes (wasmtime, and the
+      # wasmtime-in-a-micro-VM guest of hyperlight-wasm). Same feature surface
+      # as the browser package; no getrandom cfg here (wasip2 has a native
+      # backend). Check-only: there is no WASI entry-point crate yet.
+      - name: Check bashkit for wasm32-wasip2
+        run: cargo check -p bashkit --target wasm32-wasip2 --features scripted_tool,jq
+        env:
+          RUSTFLAGS: -D warnings
 
   wasm-web:
     # Build the browser package (@everruns/bashkit-wasm) and run its headless

--- a/crates/bashkit/src/builtins/generated/format_support.rs
+++ b/crates/bashkit/src/builtins/generated/format_support.rs
@@ -6,7 +6,7 @@
 
 use std::ffi::{OsStr, OsString};
 
-#[cfg(any(unix, target_os = "wasi"))]
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
 
 #[derive(Debug)]
@@ -37,8 +37,11 @@ pub trait UError: std::error::Error {}
 
 #[cfg_attr(any(unix, target_os = "wasi"), expect(clippy::unnecessary_wraps))]
 pub fn os_str_as_bytes(os_string: &OsStr) -> Result<&[u8], NonUtf8OsStrError> {
-    #[cfg(any(unix, target_os = "wasi"))]
+    #[cfg(unix)]
     return Ok(os_string.as_bytes());
+
+    #[cfg(target_os = "wasi")]
+    return Ok(os_string.as_encoded_bytes());
 
     #[cfg(not(any(unix, target_os = "wasi")))]
     os_string

--- a/knowledge/runtimes/browser-package.md
+++ b/knowledge/runtimes/browser-package.md
@@ -199,3 +199,31 @@ pattern as `publish-js.yml`. Browser example smoke testing writes a file under
   any host filesystem.
 - Custom-builtin `ctx` exposes `{ name, argv, stdin, env, cwd, fs }`, where `fs`
   is a live handle to the same VFS the script sees (mirrors the napi bindings).
+
+## Non-JS wasm: WASI targets (`wasm32-wasip1`, `wasm32-wasip2`)
+
+The `bashkit-wasm` crate is JS-host-only (wasm-bindgen glue). The **library**
+itself, however, compiles for the WASI targets with the same reduced feature
+surface (`scripted_tool,jq`), which is what a non-JS wasm runtime
+(`wasmtime`/`wasmer`, or the wasmtime-in-a-micro-VM guest of
+[hyperlight-wasm](https://github.com/hyperlight-dev/hyperlight-wasm)) needs.
+CI's `wasm` job checks `wasm32-wasip2` alongside `wasm32-unknown-unknown`.
+
+Decisions and constraints:
+
+- **Check-only, no entry point.** There is no WASI crate exporting a
+  `exec(script) -> {stdout, stderr, code}` interface (WIT component or `_start`
+  binary) yet. The CI job exists to keep the library from regressing off the
+  target, not to ship an artifact.
+- **`OsStr` bytes.** `builtins/generated/format_support.rs` uses
+  `OsStrExt::as_bytes` on unix and stable `as_encoded_bytes()` on
+  `target_os = "wasi"`. `std::os::wasi::ffi::OsStrExt` must not be used: it does
+  not exist on `wasm32-wasip1` and is unstable on `wasm32-wasip2`.
+- **No getrandom cfg.** Unlike `wasm32-unknown-unknown`, WASI targets have a
+  native `getrandom` backend, so `--cfg getrandom_backend="wasm_js"` must not be
+  set there.
+- **Feature surface matches the browser package**, and for the same reasons:
+  no sockets (`http_client`, `ssh`), no host FS (`realfs`), no `python`.
+  `sqlite` additionally fails to build on WASI (tokio feature selection), so it
+  stays out until that is resolved.
+- **Single-threaded**, same inline-execution consequences as the browser build.


### PR DESCRIPTION
## What changed

The bashkit library now compiles for the WASI targets (`wasm32-wasip1`,
`wasm32-wasip2`) with the browser package's reduced feature surface
(`scripted_tool,jq`), and CI checks `wasm32-wasip2` so it stays that way.

This opens bashkit to non-JS wasm runtimes (`wasmtime`, `wasmer`) and to the
wasmtime-in-a-micro-VM guest of
[hyperlight-wasm](https://github.com/hyperlight-dev/hyperlight-wasm). The
existing `bashkit-wasm` crate cannot serve those: it is `wasm32-unknown-unknown`
+ wasm-bindgen JS glue.

Check-only for now — no WASI entry-point crate (WIT component) ships here. The
CI job exists so the library does not silently regress off the target before
that lands.

## Why

Question came up whether bashkit can run inside Hyperlight. Raw Hyperlight
guests are `no_std` ELF binaries — not viable for a std-heavy interpreter. The
Hyperlight-Wasm route is, since its guest is wasmtime and bashkit already runs
single-threaded over an in-memory VFS. The only thing standing in the way was a
broken `cfg`.

## Before / After

Before:

```
$ cargo check -p bashkit --target wasm32-wasip1 --features scripted_tool,jq
error[E0433]: failed to resolve: could not find `unix` in `os`
error[E0599]: no method named `as_bytes` found for reference `&std::ffi::OsStr`
error: could not compile `bashkit` (lib) due to 2 previous errors

$ cargo check -p bashkit --target wasm32-wasip2 --features scripted_tool,jq
error[E0658]: use of unstable library feature `wasip2`
```

`format_support.rs` imported `std::os::unix::ffi::OsStrExt` under
`target_os = "wasi"`, where that module does not exist; the wasi equivalent is
unstable on `wasm32-wasip2`. Fixed by using stable `as_encoded_bytes()` on WASI.

After:

```
$ cargo check -p bashkit --target wasm32-wasip1 --features scripted_tool,jq
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.43s

$ RUSTFLAGS="-D warnings" cargo check -p bashkit --target wasm32-wasip2 --features scripted_tool,jq
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.22s
```

No observable behavior change on any currently supported target: the unix path
still uses `OsStrExt::as_bytes`, and the non-unix fallback is untouched.

Known gap, documented rather than fixed here: `--features sqlite` still fails on
WASI (tokio feature selection).

## Risk

- Low
- Blast radius is one `cfg` in `os_str_as_bytes`. Unix behavior is byte-identical;
  only WASI, previously uncompilable, takes the new branch. The added CI step can
  only fail the build, never change artifacts.

## Checklist

- [x] Tests added or updated — the coverage for this is the `wasm32-wasip2` CI
      check (a `cfg`-gated import cannot be exercised from host tests); host
      suite re-run green (`cargo test -p bashkit --lib --features scripted_tool,jq`:
      3076 passed), plus `cargo fmt --all --check` and
      `cargo clippy -p bashkit --all-targets -- -D warnings`
- [x] Backward compatibility considered — internal code, no API change


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku85yRwtEtWpuUrsaBwrg5)_