### PR TITLE
chore(deps): add dependabot version updates for the five npm lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,74 @@ updates:
         patterns:
           - "*"
 
+  # npm / pnpm.
+  #
+  # Important decision: the five pnpm lockfiles in this repo had no
+  # `updates:` entry, so nothing kept them fresh — only the dependency graph
+  # (which drives Dependabot *alerts* and security updates) saw them, and that
+  # reacts to published advisories rather than to age. The practical cost is a
+  # tree that drifts far enough behind that the eventual security bump is a
+  # multi-major jump nobody can land quickly. One entry per lockfile below;
+  # each is grouped so a week of bumps arrives as a single reviewable PR, the
+  # same shape as the cargo entries above.
+  #
+  # `@everruns/*` is ignored everywhere: those are this repo's own published
+  # packages, pinned to the workspace version (0.16.0) and bumped by the
+  # release process (see knowledge/operations/release-process.md). Letting
+  # dependabot move them independently races that process and produces PRs
+  # that are wrong the moment a release lands.
+
+  # The docs site — a deployed Cloudflare Worker, so its tree is the only npm
+  # surface here that is reachable from the public internet at runtime.
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      site-npm:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "@everruns/*"
+
+  # Build and test toolchain for the published `@everruns/bashkit` napi
+  # package. All devDependencies, but they run in CI and produce the artifact
+  # that ships to npm, so they are supply chain, not just developer comfort.
+  - package-ecosystem: "npm"
+    directory: "/crates/bashkit-js"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      js-npm:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "@everruns/*"
+
+  # Example apps. Private (never published) but built by the Examples CI job,
+  # so a rotted lockfile breaks CI rather than users. One entry covers all
+  # three via `directories`, and they share a group so the weekly churn from
+  # the fast-moving AI SDKs stays in a single PR.
+  - package-ecosystem: "npm"
+    directories:
+      - "/examples"
+      - "/examples/browser"
+      - "/examples/bashkit-pi"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      examples-npm:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "@everruns/*"
+
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/knowledge/operations/maintenance.md
+++ b/knowledge/operations/maintenance.md
@@ -45,6 +45,40 @@ dependency rot, or security gaps ship in a release.
   - No full crates where a sub-crate suffices (e.g. `futures-util` vs `futures`)
   - Duplicate transitive versions reviewed, fix or document why unfixable
 
+#### Automated coverage
+
+`.github/dependabot.yml` drives weekly *version* updates. It is separate from
+Dependabot **alerts** and **security updates**, which run off the repository
+dependency graph and need no config — an ecosystem missing from
+`dependabot.yml` still gets alerts, it just never gets routine freshness bumps,
+so it drifts until the eventual security fix is a multi-major jump.
+
+Covered, one grouped PR per entry per week:
+
+| Ecosystem | Directory |
+|---|---|
+| cargo | `/` (workspace) |
+| cargo | `/crates/bashkit/fuzz` (separate workspace + lockfile) |
+| npm | `/site` |
+| npm | `/crates/bashkit-js` |
+| npm | `/examples`, `/examples/browser`, `/examples/bashkit-pi` |
+| github-actions | `/` |
+
+Deliberately not covered, and why:
+
+- `@everruns/*` is ignored in every npm entry. Those are this repo's own
+  published packages, pinned to the workspace version by the release process
+  ([Release Process](release-process.md)); dependabot moving them independently
+  races that process.
+- `crates/bashkit-wasm` has a `package.json` with no dependencies and no
+  lockfile, so there is nothing to update.
+- `.deepsec/` is updated by hand during the security pass below
+  (`pnpm update deepsec@latest`), because the scan is run against whatever
+  version the pass pulls, not on dependabot's schedule.
+- Python: `crates/bashkit-python/pyproject.toml` declares only optional extras
+  with open lower bounds (`>=`) and ships no lockfile, so a pip entry would
+  have nothing to pin.
+
 ### Security
 
 - Threat model ([Threat Model](../security/threat-model.md)) covers all current features


### PR DESCRIPTION
## What changed

Dependabot now opens weekly version-update PRs for the repo's five committed
pnpm lockfiles, which previously had no `updates:` entry at all:

| Entry | Directory | Resolved deps |
|---|---|---|
| `site-npm` | `/site` | 500 |
| `js-npm` | `/crates/bashkit-js` | 352 |
| `examples-npm` | `/examples`, `/examples/browser`, `/examples/bashkit-pi` | 131 |

One grouped PR per entry per week, `chore(deps)` prefix — the same shape as the
existing cargo entries, so this adds three PRs a week at most, not thirty.

`@everruns/*` is ignored in every entry. Those are this repo's own published
packages, pinned to the workspace version (`0.16.0`) in `site/package.json` and
`examples/browser/package.json` and bumped by the release process. Dependabot
moving them independently would race that process and produce PRs that go stale
the moment a release lands.

`knowledge/operations/maintenance.md` gains the coverage table and, more
usefully, the deliberate exclusions: `crates/bashkit-wasm` (a `package.json`
with no dependencies and no lockfile), `.deepsec/` (updated by hand during the
security pass, because the scan runs against whatever version that pass pulls),
and Python (`pyproject.toml` declares only optional extras with open `>=` bounds
and no lockfile, so a pip entry would have nothing to pin).

## Why

This is **not** about Dependabot alerts. Alerts and security updates run off the
repository dependency graph and need no config — they already saw these trees.
The gap is routine freshness, and the two interact: an ecosystem that only ever
moves when an advisory forces it drifts until the fix is a multi-major jump that
can't be landed under time pressure. `/site` is the sharpest case, being a
deployed Cloudflare Worker and the only npm surface here reachable from the
public internet at runtime.

The cargo and github-actions ecosystems have had this coverage since the config
was written; npm was simply never added as the JS surface grew from one package
to five.

## Before / After

Preventative, not a fix — all five trees are clean as of this commit:

```
$ for d in site crates/bashkit-js examples examples/browser examples/bashkit-pi; do
    (cd $d && pnpm audit --json | jq -c '.metadata.vulnerabilities')
  done
{"info":0,"low":0,"moderate":0,"high":0,"critical":0}   # site (500 deps)
{"info":0,"low":0,"moderate":0,"high":0,"critical":0}   # crates/bashkit-js (352)
{"info":0,"low":0,"moderate":0,"high":0,"critical":0}   # examples (44)
{"info":0,"low":0,"moderate":0,"high":0,"critical":0}   # examples/browser (79)
{"info":0,"low":0,"moderate":0,"high":0,"critical":0}   # examples/bashkit-pi (8)
```

Config coverage before → after:

```
before: cargo:/  cargo:/crates/bashkit/fuzz  github-actions:/
after:  cargo:/  cargo:/crates/bashkit/fuzz  github-actions:/
        npm:/site  npm:/crates/bashkit-js
        npm:[/examples, /examples/browser, /examples/bashkit-pi]
```

Knowledge checks pass:

```
$ just check-okf
knowledge: OKF v0.2 conformant (38 concepts, 7 index files, 1 log file)

$ just check-doc-links
docs OK: 157 relative links and 6 dependency versions across 45 files
```

## Risk

- **Low**
- No source, build, or runtime code is touched; the change is CI configuration
  plus a knowledge doc.
- The realistic downside is PR volume from the fast-moving AI SDKs in
  `/examples` (`ai`, `openai`, `@langchain/*`). Grouping holds that to one PR a
  week; if it still proves noisy, that entry can move to `monthly` without
  affecting the other two.
- `directories` (plural) is used for the examples entry. It is current
  Dependabot v2 syntax and the file parses as valid YAML, but unlike the rest of
  this repo's CI it is only truly exercised once Dependabot next runs — worth a
  glance at the Dependabot job log after merge.

## Checklist

- [x] Tests added or updated — no test surface; validated via `just check-okf`,
      `just check-doc-links`, and a YAML schema parse of the config
- [x] Backward compatibility considered — additive config only; existing cargo
      and github-actions entries are untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjmkXBAiGiCJLRxYiwqpw9)_