### PR TITLE
fix(ci): install a pinned wasm-opt instead of apt, and bound the wasm jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,11 @@ jobs:
     # wasm-bindgen version in Cargo.lock.
     name: WASM web package
     runs-on: ubuntu-latest
+    # A hung install step here took `main` red twice by burning the 6-hour job
+    # ceiling (see scripts/install-binaryen.sh). This job's slowest healthy run
+    # is well under 10 minutes, so anything past 30 is stuck, not slow — fail
+    # fast and leave a re-runnable red instead of a cancelled run.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -121,7 +126,7 @@ jobs:
         run: cargo install wasm-bindgen-cli --version 0.2.126 --locked
 
       - name: Install binaryen (wasm-opt)
-        run: sudo apt-get update && sudo apt-get install -y binaryen
+        run: sudo ./scripts/install-binaryen.sh
 
       - name: Build web bundle
         run: bash crates/bashkit-wasm/scripts/build.sh release

--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -45,6 +45,9 @@ jobs:
     name: Build web bundle
     needs: verify-source
     runs-on: ubuntu-latest
+    # Same reasoning as ci.yml's wasm-web job: a stalled install must not hold
+    # a release for six hours before anyone sees it.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -58,8 +61,10 @@ jobs:
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli --version "$WASM_BINDGEN_VERSION" --locked
 
+      # Pinned + checksummed, because this job's output is what ships to npm.
+      # See scripts/install-binaryen.sh.
       - name: Install binaryen (wasm-opt)
-        run: sudo apt-get update && sudo apt-get install -y binaryen
+        run: sudo ./scripts/install-binaryen.sh
 
       - name: Build wasm bundle
         run: bash crates/bashkit-wasm/scripts/build.sh release

--- a/knowledge/runtimes/browser-package.md
+++ b/knowledge/runtimes/browser-package.md
@@ -164,9 +164,25 @@ core already gates off under `cfg(target_family = "wasm")` (see
 ```bash
 rustup target add wasm32-unknown-unknown
 cargo install wasm-bindgen-cli
+sudo ./scripts/install-binaryen.sh                       # optional, -Oz pass
 bash crates/bashkit-wasm/scripts/build.sh                          # -> pkg/
 node --test "crates/bashkit-wasm/__test__/*.test.mjs"                # verify
 ```
+
+`wasm-opt` is optional locally — `build.sh` skips the `-Oz` pass when it is not
+on PATH — but both CI (`ci.yml` wasm-web) and the release (`publish-wasm.yml`
+build-wasm) install it through `scripts/install-binaryen.sh`, which pins the
+binaryen version and the archive's SHA-256.
+
+Important decision: that script replaced `apt-get install -y binaryen`. `apt`
+stalled indefinitely on two separate `main` runs and, with no step timeout,
+each burned the 6-hour job ceiling and took the whole run down as `cancelled` —
+`main` went red twice for a mirror problem unrelated to any diff. Both jobs now
+carry `timeout-minutes: 30`, so a future stall fails fast and re-runnable.
+Pinning the version also keeps the `-Oz` output reproducible rather than
+tracking whatever binaryen the runner image's Ubuntu carries, which matters
+because that artifact is what ships to npm. Bump the version and checksum
+together in `scripts/install-binaryen.sh`.
 
 `--target web` output is a bundler-agnostic ES module; the consumer calls
 `initBashkit()` once before constructing `Bash`.

--- a/scripts/install-binaryen.sh
+++ b/scripts/install-binaryen.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install a pinned `wasm-opt` (binaryen) onto PATH.
+#
+# Important decision: this replaces `apt-get update && apt-get install -y
+# binaryen` in the two workflows that build the browser bundle. `apt-get`
+# stalled indefinitely on two separate `main` runs (32170059933, 32218864077);
+# with no step timeout each burned the 6-hour job ceiling and took the whole CI
+# run down as `cancelled`, so `main` went red twice for an apt mirror problem
+# unrelated to any diff.
+#
+# Two things change here. The download is bounded — explicit connect/total
+# timeouts and retries, so a stalled mirror fails in minutes instead of hours —
+# and the version is pinned, so `wasm-opt -Oz` output no longer depends on
+# whichever binaryen the runner image's Ubuntu happens to carry. That matters
+# beyond CI hygiene: publish-wasm.yml ships the optimized artifact to npm.
+#
+# The archive's checksum is pinned too. Binaryen publishes no signature or
+# per-release checksum file, so this is the only thing standing between a
+# compromised release asset and a wasm bundle we push to npm.
+#
+# Only `bin/wasm-opt` is extracted: it is statically linked (the archive's
+# `lib/` holds just `libbinaryen.a`), so 19 MB of the 102 MB archive is all
+# that is needed.
+set -euo pipefail
+
+BINARYEN_VERSION="${BINARYEN_VERSION:-125}"
+BINARYEN_SHA256="${BINARYEN_SHA256:-7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4}"
+DEST="${DEST:-/usr/local/bin}"
+
+archive="binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz"
+url="https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/${archive}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "==> downloading binaryen ${BINARYEN_VERSION}"
+curl -fsSL \
+    --retry 3 --retry-all-errors --retry-delay 5 \
+    --connect-timeout 30 --max-time 300 \
+    -o "$tmp/$archive" "$url"
+
+echo "==> verifying checksum"
+echo "${BINARYEN_SHA256}  $tmp/$archive" | sha256sum -c -
+
+echo "==> installing wasm-opt to ${DEST}"
+# `bin/wasm-opt` only; --strip-components=2 drops the `binaryen-version_N/bin/`
+# prefix so the binary lands directly in DEST.
+tar xzf "$tmp/$archive" -C "$DEST" --strip-components=2 \
+    "binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt"
+
+"$DEST/wasm-opt" --version

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -9,6 +9,10 @@ import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
+# Single source of truth for the pinned wasm-opt install, shared by CI and the
+# release workflow. See the script's header for why apt is not used.
+INSTALLER = "scripts/install-binaryen.sh"
+
 
 class ReleaseWorkflowTests(unittest.TestCase):
     def test_release_dispatches_every_publish_workflow(self) -> None:
@@ -64,7 +68,64 @@ class ReleaseWorkflowTests(unittest.TestCase):
         ):
             self.assertIn(stable_feature, build_script)
         self.assertNotIn("--all-features", build_script)
-        self.assertIn("apt-get install -y binaryen", ci_workflow)
+
+        # CI must install wasm-opt the same way the release does, so the -Oz
+        # pass that ships to npm is the one CI exercises. Both go through
+        # scripts/install-binaryen.sh rather than each carrying its own copy
+        # of an install command that can drift apart.
+        publish_workflow = (ROOT / ".github/workflows/publish-wasm.yml").read_text()
+        self.assertIn(INSTALLER, ci_workflow)
+        self.assertIn(INSTALLER, publish_workflow)
+
+    def test_binaryen_install_is_pinned_and_bounded(self) -> None:
+        """`apt-get install binaryen` stalled indefinitely on two separate main
+        runs (32170059933, 32218864077). With no step timeout each burned the
+        6-hour job ceiling and took the whole run down as `cancelled`, so main
+        went red twice for a mirror problem unrelated to any diff. Guard the
+        three properties that fix has to keep."""
+        installer = (ROOT / INSTALLER).read_text()
+
+        # No apt: that is the mechanism that hung. The step may still be
+        # *named* "Install binaryen"; what must not come back is installing it
+        # through a package manager.
+        for workflow in ("ci.yml", "publish-wasm.yml"):
+            contents = (ROOT / ".github/workflows" / workflow).read_text()
+            offenders = [
+                line
+                for line in contents.splitlines()
+                if "binaryen" in line and ("apt-get" in line or "apt " in line)
+            ]
+            with self.subTest(workflow=workflow):
+                self.assertEqual(offenders, [], f"{workflow} installs binaryen via apt")
+
+        # Bounded: a stalled download must fail in minutes, not hours.
+        self.assertIn("--max-time", installer)
+        self.assertIn("--connect-timeout", installer)
+
+        # Pinned version + checksum. The version keeps `-Oz` output
+        # reproducible instead of tracking the runner image's Ubuntu; the
+        # checksum is the only integrity check available, since binaryen
+        # publishes no signature or checksum file for its release assets.
+        self.assertRegex(installer, r'BINARYEN_VERSION:?="?\$\{BINARYEN_VERSION:-\d+\}')
+        self.assertRegex(installer, r"BINARYEN_SHA256.*[0-9a-f]{64}")
+        self.assertIn("sha256sum -c", installer)
+
+    def test_wasm_build_jobs_cannot_hang_past_the_job_ceiling(self) -> None:
+        """A job with no `timeout-minutes` inherits GitHub's 6-hour ceiling, so
+        a stuck step wastes a runner for six hours and reports `cancelled`
+        rather than a re-runnable failure. Both jobs that build the wasm bundle
+        must bound themselves."""
+        for workflow, job in (
+            (".github/workflows/ci.yml", "wasm-web"),
+            (".github/workflows/publish-wasm.yml", "build-wasm"),
+        ):
+            contents = (ROOT / workflow).read_text()
+            with self.subTest(workflow=workflow, job=job):
+                block = contents.split(f"\n  {job}:\n", 1)
+                self.assertEqual(len(block), 2, f"job {job} not found in {workflow}")
+                # Only the job's own header, up to its `steps:` key.
+                header = block[1].split("\n    steps:", 1)[0]
+                self.assertRegex(header, r"timeout-minutes: \d+")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

The `WASM web package` job no longer installs binaryen from apt. Both it and
`publish-wasm.yml`'s `build-wasm` go through a new
`scripts/install-binaryen.sh`, which fetches a **version-pinned,
SHA-256-verified** binaryen release archive with explicit connect/total
timeouts and retries, and extracts `bin/wasm-opt` only (it is statically
linked, so 19 MB of the 102 MB archive is all that is needed).

Both jobs also gain `timeout-minutes: 30`.

Three things improve beyond unblocking CI:

- **`wasm-opt -Oz` output becomes reproducible.** It previously tracked
  whichever binaryen the runner image's Ubuntu happened to carry. That binary
  optimizes the artifact published to npm.
- **The download is integrity-checked.** Binaryen ships no signature and no
  checksum file for its release assets, so the pinned SHA-256 is the only thing
  between a tampered asset and a published wasm bundle.
- **CI and the release can no longer drift apart** on how they install the
  tool, since there is now one script instead of two copies of a shell line.

## Why

`apt-get update && apt-get install -y binaryen` stalled indefinitely on two
separate `main` runs:

| Run | Commit | Outcome |
|---|---|---|
| [32170059933](https://github.com/everruns/bashkit/actions/runs/32170059933) | `136f11b3` | binaryen step ran 6h00m → run `cancelled` |
| [32218864077](https://github.com/everruns/bashkit/actions/runs/32218864077) | `986bfc7` | binaryen step 4h+ when caught, cancelled manually |

That step's healthy duration is **9–14 seconds**:

```
run 32123897979  binaryen step  14s  ✅
run 32120969690  binaryen step   9s  ✅
run 32070967641  binaryen step   9s  ✅
run 32170059933  binaryen step  6h  ❌ cancelled at the job ceiling
```

So `main` went red twice for an apt mirror stall unrelated to any diff, and
each time it held a runner for six hours. Two independent faults made that
possible — an unbounded network install, and no `timeout-minutes` on the job
(`ci.yml` has none on any job, while every other workflow in this repo sets
them). This fixes both for the affected jobs.

`publish-wasm.yml` carried the identical apt call, so the same stall would have
silently held a release for six hours.

## Before / After

**Before** — unpinned, unbounded, duplicated in two workflows:

```yaml
- name: Install binaryen (wasm-opt)
  run: sudo apt-get update && sudo apt-get install -y binaryen
```

**After** — one script, pinned and bounded:

```
$ sudo ./scripts/install-binaryen.sh
==> downloading binaryen 125
==> verifying checksum
binaryen-version_125-x86_64-linux.tar.gz: OK
==> installing wasm-opt to /usr/local/bin
wasm-opt version 125 (version_125)
```

Verified locally that the installed binary accepts the exact flag set
`crates/bashkit-wasm/scripts/build.sh` passes
(`-Oz --enable-bulk-memory --enable-nontrapping-float-to-int --enable-sign-ext`),
and that re-running the script is idempotent.

`main` is green again on the re-run of the cancelled job
([32218864077 attempt 2](https://github.com/everruns/bashkit/actions/runs/32218864077)),
so this PR is the durable fix rather than the unblock.

**Tests.** `test_web_ci_exercises_release_wasm_optimization` asserted the literal
string `apt-get install -y binaryen`, so it had to change; it now asserts CI and
the release install through the *same* script, which is a stronger invariant than
the string it replaced. Two new tests guard what the fix must keep — no
apt-installed binaryen, a bounded download, a pinned version and checksum, and a
timeout on both wasm build jobs. Each was mutation-checked:

```
mutation: restore the apt install   → FAIL test_binaryen_install_is_pinned_and_bounded
mutation: drop timeout-minutes      → FAIL test_wasm_build_jobs_cannot_hang_past_the_job_ceiling
mutation: drop the checksum verify  → FAIL test_binaryen_install_is_pinned_and_bounded
restored                            → OK (53 tests)
```

## Risk

- **Low**
- No library, build, or runtime code changes; CI configuration, one shell
  script, and its tests.
- If the pinned binaryen URL ever 404s the job fails fast and loudly, rather
  than degrading — which is the intent. Bumping means editing version and
  checksum together in one file.
- `build.sh` still treats `wasm-opt` as optional and skips `-Oz` when it is
  absent, so local builds without the tool are unaffected.
- Not addressed here deliberately: the other nine `ci.yml` jobs still carry no
  `timeout-minutes`. Only these two demonstrated a hang, so I scoped the change
  to them rather than picking values for jobs I have no timing evidence for.
  Worth a follow-up.

## Checklist

- [x] Tests added or updated — one updated, two added, all three mutation-checked
- [x] Backward compatibility considered — `wasm-opt` stays optional for local
      builds; no consumer-visible change

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjmkXBAiGiCJLRxYiwqpw9)_