### PR TITLE
fix(examples): pin vite exactly and run the browser example's tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,26 @@ jobs:
           TICKET_REF: 194b71a8bbc3771da1ce9f579395937c976bbddc
         run: bash examples/ticket-cli.sh
 
+      # examples/browser ships its own suite: unit tests for the browser-local
+      # helper, plus a reproducibility guard asserting every dependency is
+      # pinned to an exact version alongside a committed lockfile.
+      #
+      # Important decision: it runs here rather than in js.yml. The suite is
+      # plain `node --test` with no install step (its fakes replace the wasm
+      # package), so it costs ~1s, while js.yml both builds the napi binding
+      # and filters on paths that exclude examples/browser — the guard would
+      # not fire on the package.json edits it exists to catch. Nothing ran this
+      # suite before, which is how `vite` drifted to a caret range unnoticed
+      # and stayed there across a two-major bump.
+      - name: Run browser example tests
+        working-directory: examples/browser
+        # `node --test` exits 0 when its argument matches no file, so a renamed
+        # or moved suite would report green having run nothing. Assert the
+        # files exist first.
+        run: |
+          ls *.test.js
+          node --test *.test.js
+
       # Detect whether DOPPLER_TOKEN is configured. Only set on push to
       # main (trusted code); PRs — including same-repo branches — must
       # never see the secret. Subsequent Doppler steps gate on

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -13,7 +13,7 @@
     "@everruns/bashkit-wasm": "0.16.0"
   },
   "devDependencies": {
-    "vite": "^8.2.1"
+    "vite": "8.2.1"
   },
   "pnpm": {
     "overrides": {

--- a/examples/browser/pnpm-lock.yaml
+++ b/examples/browser/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 0.16.0
     devDependencies:
       vite:
-        specifier: ^8.2.1
+        specifier: 8.2.1
         version: 8.2.1
 
 packages:

--- a/knowledge/operations/maintenance.md
+++ b/knowledge/operations/maintenance.md
@@ -143,6 +143,18 @@ Deliberately not covered, and why:
   the next `bashkit-wasm` release, then review and update both the dependency
   pin and lockfile.
 
+  The exact-version half of that is now enforced by CI rather than left to this
+  checklist: `examples/browser/dependency-security.test.js` asserts every
+  dependency matches `MAJOR.MINOR.PATCH` with a committed lockfile, and the
+  `Examples` job in `ci.yml` runs the suite. Important decision: it runs there,
+  not in `js.yml`, because the suite is plain `node --test` with no install
+  step, while `js.yml` builds the napi binding and filters on paths that
+  exclude `examples/browser` — the guard would not fire on the `package.json`
+  edits it exists to catch. The test existed before but nothing ran it, so
+  `vite` sat on a caret range (`^6.4.3`) through a two-major dependabot bump
+  (\#2313) without anyone noticing. Dependabot preserves whatever range style
+  it finds, so an exact pin keeps future bumps exact.
+
 ### Specs
 
 - Each spec status reflects reality


### PR DESCRIPTION
## What changed

`examples/browser` pins `vite` to an exact `8.2.1` instead of `^8.2.1`, and the
`Examples` job in `ci.yml` now runs that example's test suite.

## Why

`examples/browser/dependency-security.test.js` already asserts every dependency
is pinned to an exact version alongside a committed lockfile — the
reproducibility guard for the one example that loads a *published* npm package.
**Nothing in CI ran it.**

So it quietly stopped holding. `vite` was sitting on `^6.4.3`, and dependabot
preserves whatever range style it finds, so the caret rode straight through a
two-major bump to `^8.2.1` in #2313. A caret range next to a lockfile means any
`pnpm install` that doesn't use the lockfile resolves a version nobody reviewed
— which is the exact property the test was written to prevent.

I found this while verifying #2313 by hand (no CI job builds this example, so
its green checks proved nothing about it). The failure reproduced identically on
`main`, so it was pre-existing rather than introduced by that bump — which is
why #2313 shipped and this is separate.

## Before / After

Before, on `main`:

```
$ node --test examples/browser/*.test.js
  error: 'vite must use an exact version'
  actual: '^8.2.1'
# pass 8
# fail 1
```

After:

```
$ node --test *.test.js
# tests 9
# pass 9
# fail 0
```

Still installs and builds cleanly with the exact pin:

```
$ pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Already up to date

$ npx vite build
dist/assets/bashkit_wasm_bg-CzmxDPD4.wasm  8,016.04 kB │ gzip: 2,861.04 kB
✓ built in 554ms
```

## Notes on the CI placement

The step runs from the `Examples` job rather than `js.yml`, deliberately:

- The suite is plain `node --test` with **no install step** — its fakes stand in
  for the wasm package, so the whole thing costs about a second. I verified it
  runs green with `node_modules` absent entirely.
- `js.yml` builds the napi binding *and* filters on paths that exclude
  `examples/browser`, so the guard would not fire on the `package.json` edits it
  exists to catch.

The step asserts the test files exist before running them:

```yaml
run: |
  ls *.test.js
  node --test *.test.js
```

`node --test` exits **0** when its argument matches nothing, so without the `ls`
a renamed or moved suite would report green having run zero tests. Verified: the
guard exits 2 on an empty directory. That footgun is what made this class of
rot invisible in the first place, so it seemed worth closing rather than
repeating.

## Risk

- **Low**
- Example-only dependency change plus one CI step; no library, build, or runtime
  code is touched.
- The new step adds ~1s to a job that already runs for minutes.
- Exact pinning means dependabot now proposes each vite bump as an explicit
  version change rather than one silently absorbed by a caret. That is more PRs,
  and the point.

## Checklist

- [x] Tests added or updated — no new test; an existing one is repaired and
      wired into CI, which is the actual gap
- [x] Backward compatibility considered — private example, not published;
      `pnpm install --frozen-lockfile` and `vite build` both verified

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjmkXBAiGiCJLRxYiwqpw9)_