### PR TITLE
feat(http): make the rustls crypto backend a feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- The rustls crypto backend used by `http_client` is now selectable: `ring`
+  (enabled by default, unchanged behavior) or `aws-lc-rs` for consumers that
+  need a FIPS-capable backend or already link aws-lc-rs. `http_client` no
+  longer implies a backend; building it with neither is a compile error.
+  Consumers on `--no-default-features` must name one alongside `http_client`.
+
 ## [0.16.0] - 2026-08-06
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4563,6 +4563,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4626,6 +4627,7 @@ version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,12 +40,14 @@ jaq-std = "3.0"
 jaq-json = "2.0"
 
 # HTTP client (for curl and API calls)
-# IMPORTANT: rustls-no-provider keeps the aws-lc-rs C crypto out of the dep tree so
-# we don't depend on cross-toolchain glibc headers (e.g. AT_HWCAP2 on aarch64
-# manylinux). The ring provider below is installed at runtime in
-# bashkit::network::client.
+# IMPORTANT: rustls-no-provider leaves the backend choice to bashkit, whose
+# default (`ring`) keeps the aws-lc-rs C crypto out of the dep tree so we don't
+# depend on cross-toolchain glibc headers (e.g. AT_HWCAP2 on aarch64 manylinux).
+# The provider is installed at runtime in bashkit::network::client.
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider", "stream"] }
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+# No crypto backend selected here: bashkit picks one via its `ring` (default)
+# / `aws-lc-rs` features; other workspace members enable a backend explicitly.
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "logging"] }
 
 # Regex
 regex = "1"

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -34,7 +34,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # The CLI drives the `Bash` interpreter directly and never touches the LLM
 # `BashTool` wrapper, so it opts out of the default `bash_tool` feature to
 # avoid pulling in tower / futures-core.
-bashkit = { path = "../bashkit", version = "0.16.0", default-features = false, features = ["http_client", "git", "jq"] }
+bashkit = { path = "../bashkit", version = "0.16.0", default-features = false, features = ["http_client", "ring", "git", "jq"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-eval/Cargo.toml
+++ b/crates/bashkit-eval/Cargo.toml
@@ -33,7 +33,8 @@ reqwest.workspace = true
 # Direct rustls dep so we can install the `ring` crypto provider before
 # any HTTPS request — paired with reqwest's `rustls-no-provider`. See
 # bashkit::network::client for the same pattern in the http_client path.
-rustls = { workspace = true }
+# The workspace dep picks no backend, so name `ring` here.
+rustls = { workspace = true, features = ["ring"] }
 regex.workspace = true
 async-trait.workspace = true
 chrono.workspace = true

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -42,8 +42,10 @@ chrono-tz = { workspace = true }
 
 # HTTP client (for curl/wget) - optional, enabled with http_client feature
 reqwest = { workspace = true, optional = true }
-# Direct rustls dep so we can install the `ring` crypto provider at runtime
-# (paired with reqwest's `rustls-no-provider` feature). Optional, gated under http_client.
+# Direct rustls dep so we can install the crypto provider ourselves at runtime
+# (paired with reqwest's `rustls-no-provider` feature). Optional, gated under
+# http_client. The backend is chosen by the `ring` (default) / `aws-lc-rs`
+# features, not pinned here.
 rustls = { workspace = true, optional = true }
 
 # SSH client (for ssh/scp/sftp) - optional, enabled with ssh feature
@@ -131,7 +133,7 @@ zapcode-core = { version = "1.5.1", optional = true }
 turso_core = { workspace = true, optional = true }
 
 [features]
-default = ["bash_tool"]
+default = ["bash_tool", "ring"]
 # Enable the LLM-facing `BashTool` wrapper: the `Tool` trait, `ToolExecution`,
 # OpenAI tool-definition/JSON-schema helpers, and the `tower::Service` bridge.
 # On by default. Disable with `--no-default-features` to compile just the
@@ -141,7 +143,22 @@ bash_tool = ["dep:tower", "dep:futures-core"]
 # Enable jq builtin via embedded jaq interpreter
 # Usage: cargo build --features jq
 jq = ["dep:jaq-core", "dep:jaq-std", "dep:jaq-json", "dep:serde_yaml_ng"]
+# HTTP client (curl/wget) over rustls. Does NOT imply a crypto backend: pick
+# `ring` (on by default) or `aws-lc-rs`. Enabling neither is a compile error.
 http_client = ["reqwest", "rustls"]
+# Crypto backend for the rustls-based HTTP client. Exactly one is used at
+# runtime; `ring` wins when both are on, which keeps Cargo's additive feature
+# unification sound (a consumer asking for `aws-lc-rs` still compiles and still
+# installs exactly one provider when something else re-enables `ring`).
+#
+# Important decision: `ring` is the default because it keeps the dependency
+# tree free of C-compiled crypto (no aws-lc-sys), which is what keeps
+# cross-compiled aarch64 manylinux wheel builds green — that cross sysroot is
+# missing `AT_HWCAP2` and aws-lc-sys trips over it. `aws-lc-rs` exists for
+# consumers who need a FIPS-capable backend or who already link aws-lc-rs and
+# want to avoid shipping two crypto libraries.
+ring = ["rustls?/ring"]
+aws-lc-rs = ["rustls?/aws-lc-rs"]
 # Enable Ed25519 request signing per RFC 9421 / web-bot-auth profile
 bot-auth = ["http_client", "dep:ed25519-dalek", "dep:rand", "dep:zeroize"]
 # Enable fail points for security/fault injection testing

--- a/crates/bashkit/examples/agent_tool.rs
+++ b/crates/bashkit/examples/agent_tool.rs
@@ -264,7 +264,10 @@ impl Agent {
 async fn main() -> anyhow::Result<()> {
     // reqwest is built with `rustls-no-provider`, so a CryptoProvider must be
     // installed process-wide before `reqwest::Client::new()` is called.
+    #[cfg(feature = "ring")]
     let _ = rustls::crypto::ring::default_provider().install_default();
+    #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     println!("=== Bashkit LLM Agent Example ===\n");
 

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -420,6 +420,17 @@
 #![warn(clippy::unwrap_used)]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
+// The rustls-backed HTTP client installs its own crypto provider (reqwest is
+// built with `rustls-no-provider`), so a backend must be selected. Fail here
+// instead of at the first TLS handshake.
+#[cfg(all(
+    feature = "http_client",
+    not(any(feature = "ring", feature = "aws-lc-rs"))
+))]
+compile_error!(
+    "bashkit's `http_client` needs a crypto backend: enable `ring` (default) or `aws-lc-rs`"
+);
+
 /// Static, pre-execution introspection of a script.
 pub mod analysis;
 mod builtins;

--- a/crates/bashkit/src/network/client.rs
+++ b/crates/bashkit/src/network/client.rs
@@ -750,13 +750,18 @@ impl HttpClient {
     }
 }
 
-/// Install the rustls `ring` crypto provider as the process-wide default.
+/// Install the selected rustls crypto provider as the process-wide default.
 ///
-/// We pair reqwest's `rustls-no-provider` feature with an explicit `ring`
-/// install so the dep tree contains zero C-compiled crypto (no aws-lc-sys).
-/// That keeps cross-compiled wheel builds (notably aarch64 manylinux, where
-/// the cross sysroot is missing `AT_HWCAP2`) green and removes a class of
-/// toolchain-specific build failures.
+/// We pair reqwest's `rustls-no-provider` feature with an explicit provider
+/// install so the backend is bashkit's choice, not a transitive one. The
+/// backend comes from the `ring` (default) / `aws-lc-rs` features; `ring` wins
+/// when both are enabled, so feature unification can never leave two providers
+/// racing for the default slot.
+///
+/// The `ring` default keeps the dep tree free of C-compiled crypto (no
+/// aws-lc-sys). That keeps cross-compiled wheel builds (notably aarch64
+/// manylinux, where the cross sysroot is missing `AT_HWCAP2`) green and removes
+/// a class of toolchain-specific build failures.
 ///
 /// Idempotent: safe to call from multiple call sites and across crates.
 /// `install_default` errors if a provider is already installed (e.g. set by
@@ -766,7 +771,10 @@ fn install_default_crypto_provider() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
+        #[cfg(feature = "ring")]
         let _ = rustls::crypto::ring::default_provider().install_default();
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     });
 }
 
@@ -988,18 +996,22 @@ mod tests {
     }
 
     #[test]
-    fn test_build_client_installs_ring_crypto_provider() {
+    fn test_build_client_installs_crypto_provider() {
         // Regression: with reqwest's `rustls-no-provider` feature, rustls panics
         // on first TLS handshake unless a default crypto provider is installed.
-        // build_client must install the ring provider via the `Once` guard so
-        // every code path (default client + per-request timeout client) is safe.
-        // The dep tree must NOT include aws-lc-sys/aws-lc-rs (verified by
-        // `cargo tree -i aws-lc-sys` returning no match).
+        // build_client must install the selected provider via the `Once` guard
+        // so every code path (default client + per-request timeout client) is
+        // safe. On the default (`ring`) backend the dep tree must NOT include
+        // aws-lc-sys/aws-lc-rs (verified by `cargo tree -i aws-lc-sys`
+        // returning no match).
         let _ = build_client(Duration::from_secs(30), None, true);
         // A provider is now installed process-wide. `install_default` returns
         // Err on the second call — that's our invariant: the first install
         // succeeded.
+        #[cfg(feature = "ring")]
         let second_install = rustls::crypto::ring::default_provider().install_default();
+        #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
+        let second_install = rustls::crypto::aws_lc_rs::default_provider().install_default();
         assert!(
             second_install.is_err(),
             "build_client must install a default crypto provider before \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,8 @@ let mut bash = Bash::builder()
 ## Network allowlist
 
 HTTP for `curl`/`wget` requires the `http_client` feature and an explicit
-allowlist, outbound requests are denied by default:
+allowlist, outbound requests are denied by default. `http_client` also needs a
+rustls crypto backend, `ring` (default) or `aws-lc-rs`:
 
 ```rust
 use bashkit::{Bash, NetworkAllowlist};

--- a/docs/start-rust.md
+++ b/docs/start-rust.md
@@ -22,8 +22,16 @@ cargo add bashkit --features realfs
 cargo add bashkit --features scripted_tool
 ```
 
-`http_client` enables `curl`/`wget` and the network allowlist. `python`
-embeds the [Monty](https://github.com/pydantic/monty) interpreter, see the
+`http_client` enables `curl`/`wget` and the network allowlist; it uses rustls
+and needs a crypto backend, `ring` (enabled by default) or `aws-lc-rs`. With
+`--no-default-features`, name one explicitly:
+
+```bash
+cargo add bashkit --no-default-features --features http_client,ring
+cargo add bashkit --no-default-features --features http_client,aws-lc-rs
+```
+
+`python` embeds the [Monty](https://github.com/pydantic/monty) interpreter, see the
 [Python builtin](../crates/bashkit/docs/python.md) guide to run Python inside the shell, and [Get
 started in Python](start-python.md) to embed Bashkit *in* a Python app.
 

--- a/knowledge/security/http-transport.md
+++ b/knowledge/security/http-transport.md
@@ -32,6 +32,14 @@ Embedding hosts (reference consumer: [everruns](https://github.com/everruns/ever
 8. **Disabled by default, unchanged.** The transport does not widen network access: without the `http_client` feature *and* a `BashBuilder::network(allowlist)` call, HTTP builtins cannot make requests and the transport is never invoked.
 9. **`HttpHandler` removed, not deprecated.** Per repo policy (no compatibility shims), the legacy `HttpHandler`/`set_handler`/`http_handler` surface is deleted in the same release; `HttpTransport` is the single extension point. Migration is mechanical: wrap the old `(method, url, body, headers)` logic in `execute(HttpTransportRequest)` and return typed errors.
 10. **`Arc`, not `Box`.** Hosts that build one `Bash` per execution share a single transport across instances.
+11. **The rustls crypto backend is a feature, not a hard-coded choice.** reqwest is taken with `rustls-no-provider` and bashkit installs the provider itself, so the backend is selected by the `ring` (default) / `aws-lc-rs` features rather than pinned in the dependency. `ring` stays the default because it keeps the tree free of C-compiled crypto, which is what keeps cross-compiled aarch64 manylinux wheel builds green (`aws-lc-sys` trips over the missing `AT_HWCAP2` in that cross sysroot). `aws-lc-rs` exists for consumers who need a FIPS-capable backend, or who already link aws-lc-rs elsewhere and do not want two crypto libraries in one binary.
+
+## Crypto Backend Selection
+
+- `default = ["bash_tool", "ring"]`; `http_client` implies no backend, and the backend features are `rustls?/ring` / `rustls?/aws-lc-rs`, so enabling `ring` without `http_client` pulls nothing.
+- `http_client` with neither backend is a `compile_error!` in `lib.rs`, so the failure lands at build time instead of at the first TLS handshake.
+- `ring` wins when both are enabled. Cargo features are additive: a consumer selecting `aws-lc-rs` while another crate in the graph re-enables `ring` must still compile and must still install exactly one provider.
+- Consumers on `default-features = false` that want `http_client` must name a backend. In-tree: `bashkit-cli` names `ring`; `bashkit-eval` names `ring` on its own direct `rustls` dep (the workspace dep selects no backend).
 
 ## Request Pipeline
 
@@ -51,6 +59,7 @@ Embedding hosts (reference consumer: [everruns](https://github.com/everruns/ever
 
 ## Testing
 
+- Backend selection (`network/client.rs`): `test_build_client_installs_crypto_provider` and `test_install_default_crypto_provider_is_idempotent` are per-backend, run under both the default set and `--no-default-features --features http_client,aws-lc-rs`.
 - Unit (`network/client.rs`, `network/transport.rs`): merged signing headers reach the transport, pinned addrs for IP literals, timeout/cap forwarding, deadline + size enforcement around misbehaving transports; error Display ↔ exit-code contract.
 - Integration (`tests/integration/network_security_tests.rs`, `custom_transport` module): curl/wget end-to-end through a mock transport, allowlist still enforced ahead of the transport, `Denied`→7 / `Timeout`→28 / `TooLarge`→63 / `Transport`→1 exit codes.
 


### PR DESCRIPTION
## What changed

Embedders can now choose which crypto backend bashkit's rustls HTTP client uses,
instead of inheriting `ring` unconditionally:

- `ring` — the default, behavior identical to today
- `aws-lc-rs` — for consumers who need a FIPS-capable backend, or who already
  link aws-lc-rs elsewhere and don't want two crypto libraries in one binary

`http_client` no longer implies a backend. `ring` wins when both features are
enabled, so Cargo's additive unification can never leave two providers racing
for the default slot. Building `http_client` with neither backend is a
`compile_error!` rather than a panic at the first TLS handshake.

**Compatibility:** additive. `default = ["bash_tool", "ring"]`, so existing
consumers see the same provider and the same dependency tree. Consumers on
`default-features = false` must now name a backend alongside `http_client`;
in-tree, `bashkit-cli` names `ring` and `bashkit-eval` names it on its own
direct `rustls` dep.

## Why

Because the backend was pinned in the dependency itself, a single crate
selecting `rustls/ring` pinned `ring` for its entire graph. Downstream trees
that also link aws-lc-rs ended up shipping both — roughly 800 KiB (~5.8%) of the
release `everruns` CLI in duplicated AES-GCM and P-256 code, plus two C/assembly
crypto libraries to track CVEs against, two FIPS stories, and a `CryptoProvider`
ambiguity each embedder had to resolve by hand.

bashkit had already done the hard part: it takes reqwest with
`rustls-no-provider` and installs the provider itself. Only the *choice* was
hard-coded, so this is a small change with real downstream leverage.

`ring` stays the default deliberately — it keeps the tree free of C-compiled
crypto, which is what keeps cross-compiled aarch64 manylinux wheel builds green
(`aws-lc-sys` trips over the missing `AT_HWCAP2` in that cross sysroot).

This does not on its own remove `ring` from the everruns graph — `ureq` (via
`rakers`) pins it too and needs a separate upstream fix. This is the first and
most tractable step.

## Before / After

**Selecting a backend actually changes the tree.** Before, no combination of
features could drop `ring`. After:

```
$ cargo tree -p bashkit --no-default-features --features http_client,aws-lc-rs -i ring
warning: nothing to print.

$ cargo tree -p bashkit --no-default-features --features http_client,aws-lc-rs -i aws-lc-sys
aws-lc-sys v0.44.0
└── aws-lc-rs v1.18.0
    └── rustls v0.23.43
        ├── bashkit v0.16.0
        └── hyper-rustls v0.27.9 → reqwest v0.13.4
```

**The default set is unchanged** — `aws-lc-sys` is still absent, exactly as before:

```
$ cargo tree -p bashkit --features http_client -i aws-lc-sys
error: package ID specification `aws-lc-sys` did not match any packages
```

**A missing backend fails at build time, not at the first handshake:**

```
$ cargo check -p bashkit --no-default-features --features http_client
error: bashkit's `http_client` needs a crypto backend: enable `ring` (default) or `aws-lc-rs`
   --> crates/bashkit/src/lib.rs:430:1
```

**Both backends install a provider correctly** (`network::client` suite, which
includes the provider-install regression and idempotency tests):

| Feature set | Result |
|---|---|
| default (`ring`) | 27 passed, 0 failed |
| `--no-default-features --features http_client,aws-lc-rs` | 27 passed, 0 failed |

## Risk

- **Low**
- The only way to break an existing consumer is `default-features = false` +
  `http_client` with no backend named — and that fails loudly at compile time
  with a message naming the fix, rather than silently changing TLS behavior.
- CI's `--all-features` clippy/doc jobs now compile `aws-lc-sys` (builds clean
  locally; adds a few minutes to those two jobs). No new packages enter
  `Cargo.lock` — aws-lc-rs was already there with cargo-vet exemptions, so
  `cargo deny` / `cargo vet` are unaffected.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered