### PR TITLE
fix(realfs): bound append memory usage by streaming into staging

### DIFF
--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -45,6 +45,7 @@ through configurable limits.
 | Tar bomb (TM-DOS-008) | `tar -xf bomb.tar` | FS limits | MITIGATED |
 | Recursive copy (TM-DOS-009) | `cp -r /tmp /tmp/copy` | FS limits | MITIGATED |
 | Append flood (TM-DOS-010) | `while true; do echo x >> f; done` | FS + loop limits | MITIGATED |
+| RealFs append memory exhaustion (TM-DOS-105) | Tiny append to a large writable host file | Stream existing bytes into atomic sibling staging with bounded memory | MITIGATED |
 | Symlink loops (TM-DOS-011) | `ln -s /a /b; ln -s /b /a` | No symlink following | MITIGATED |
 | Deep dirs (TM-DOS-012) | `mkdir -p a/b/c/.../z` (1000 levels) | `max_path_depth` (100) | MITIGATED |
 | Long filenames (TM-DOS-013) | 10KB filename | `max_filename_length` (255) + `max_path_length` (4096) | MITIGATED |

--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -365,6 +365,44 @@ impl RealFs {
         result
     }
 
+    /// THREAT[TM-DOS-105]: Stream the existing file into sibling staging so
+    /// atomic append uses bounded memory even when the host file is large.
+    async fn append_atomically(&self, path: &Path, content: &[u8]) -> std::io::Result<()> {
+        use tokio::io::AsyncWriteExt;
+
+        if path == self.root {
+            return Err(IoError::new(ErrorKind::IsADirectory, "is a directory"));
+        }
+        let existing = match tokio::fs::File::open(path).await {
+            Ok(file) => Some(file),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        let existing_permissions = tokio::fs::metadata(path)
+            .await
+            .ok()
+            .map(|metadata| metadata.permissions());
+        let (temporary, mut staged) = Self::temporary_sibling(path).await?;
+        let result = async {
+            if let Some(mut existing) = existing {
+                tokio::io::copy(&mut existing, &mut staged).await?;
+            }
+            staged.write_all(content).await?;
+            staged.flush().await?;
+            staged.sync_all().await?;
+            drop(staged);
+            if let Some(permissions) = existing_permissions {
+                tokio::fs::set_permissions(&temporary, permissions).await?;
+            }
+            tokio::fs::rename(&temporary, path).await
+        }
+        .await;
+        if result.is_err() {
+            let _ = tokio::fs::remove_file(&temporary).await;
+        }
+        result
+    }
+
     async fn copy_atomically(&self, from: &Path, to: &Path) -> std::io::Result<()> {
         if to == self.root {
             return Err(IoError::new(ErrorKind::IsADirectory, "is a directory"));
@@ -499,13 +537,7 @@ impl FsBackend for RealFs {
         self.check_writable()?;
         // Issue #1575: same leaf-symlink rejection as write().
         let real = self.resolve_for_create(path).await?;
-        let mut combined = match tokio::fs::read(&real).await {
-            Ok(existing) => existing,
-            Err(error) if error.kind() == ErrorKind::NotFound => Vec::new(),
-            Err(error) => return Err(error.into()),
-        };
-        combined.extend_from_slice(content);
-        self.write_atomically(&real, &combined).await?;
+        self.append_atomically(&real, content).await?;
         Ok(())
     }
 
@@ -862,6 +894,28 @@ mod tests {
             .unwrap();
         let data = fs.read(Path::new("/hello.txt")).await.unwrap();
         assert_eq!(data, b"hello world appended");
+    }
+
+    #[tokio::test]
+    async fn append_large_sparse_file_without_materializing_it() {
+        const LARGE_FILE_SIZE: u64 = 128 * 1024 * 1024;
+
+        let dir = setup();
+        let path = dir.path().join("large.bin");
+        std::fs::File::create(&path)
+            .unwrap()
+            .set_len(LARGE_FILE_SIZE)
+            .unwrap();
+        let fs = RealFs::new(dir.path(), RealFsMode::ReadWrite).unwrap();
+
+        fs.append(Path::new("/large.bin"), b"ok").await.unwrap();
+
+        let mut file = std::fs::File::open(path).unwrap();
+        use std::io::{Read, Seek, SeekFrom};
+        file.seek(SeekFrom::Start(LARGE_FILE_SIZE)).unwrap();
+        let mut suffix = Vec::new();
+        file.read_to_end(&mut suffix).unwrap();
+        assert_eq!(suffix, b"ok");
     }
 
     #[tokio::test]

--- a/knowledge/foundations/vfs.md
+++ b/knowledge/foundations/vfs.md
@@ -111,7 +111,8 @@ Do you need a custom filesystem?
   empty file after applying target-containment validation. Pre-existing host
   symlinks and junctions are supported and containment-checked.
 - Replacement write, append, and copy stage a sibling file and rename it only
-  after a complete flush, so partial host I/O retains the prior destination
+  after a complete flush, so partial host I/O retains the prior destination;
+  append streams existing bytes into staging instead of buffering the host file
 - Copy and rename act on a symlink entry itself instead of dereferencing it
 - Builder: `mount_real_readonly[_at]()`, `mount_real_readwrite()`; CLI:
   `--mount-ro` / `--mount-rw` (`host:vfs` syntax for mount point)

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -138,6 +138,7 @@ at subsystem or descendant boundaries; exhaustion poisons that request. Separate
 | TM-DOS-008 | Tar bomb | `tar -xf bomb.tar` (many files / large files) | FS limits | **MITIGATED** |
 | TM-DOS-009 | Recursive copy | `cp -r /tmp /tmp/copy` | FS limits | **MITIGATED** |
 | TM-DOS-010 | Append flood | `while true; do echo x >> file; done` | FS limits + loop limit | **MITIGATED** |
+| TM-DOS-105 | RealFs append memory exhaustion | A tiny append to a large writable host file buffers the full existing file | Stream existing bytes into atomic sibling staging with bounded memory | **MITIGATED** |
 | TM-DOS-034 | TOCTOU in append_file | Concurrent appends between read-lock and write-lock bypass size checks | Single write lock for entire read-check-write | **FIXED** |
 | TM-DOS-035 | OverlayFs limit check upper-only | `check_write_limits()` ignores lower layer usage, allowing combined usage to exceed limits | `OverlayFs::check_write_limits` now uses `compute_usage()` (combined upper + lower minus overrides); upper layer is type-fixed to `InMemoryFs` so its own limits are bypassable but irrelevant | **MITIGATED** |
 | TM-DOS-036 | OverlayFs usage double-count | `compute_usage()` double-counts overwritten/whited-out files | `compute_usage()` subtracts shadowed lower files when the upper layer carries an override or whiteout | **MITIGATED** |


### PR DESCRIPTION
### Motivation

- RealFs `append` previously read the entire existing host file into memory before writing the suffix, allowing a tiny append to a large host file to exhaust process memory. 
- RealFs intentionally reports unlimited `FsLimits` for `ReadWrite` mounts, so the unbounded read is a security availability regression. 

### Description

- Add `append_atomically` to `crates/bashkit/src/fs/realfs.rs` that streams an existing host file into a temporary sibling staging file using `tokio::io::copy` and then writes the appended bytes, preserving atomic rename/permissions and cleaning up on failure. 
- Replace the previous read-into-Vec append path with a call to the streaming `append_atomically` implementation. 
- Add a unit test `append_large_sparse_file_without_materializing_it` that appends to a 128 MiB sparse host file and verifies the suffix without materializing the whole file. 
- Update documentation and threat-model entries to record the mitigation (add `TM-DOS-104`) and note that append now streams existing bytes into staging. 

### Testing

- Ran formatting and static checks with `cargo fmt --check` and `cargo clippy` (with `realfs` feature); both passed. 
- Ran focused unit tests for RealFs and the new append regression via `cargo test --features realfs -p bashkit` and targeted test runs; RealFs tests including the new `append_large_sparse_file_without_materializing_it` passed. 
- Ran repository checks `just check-okf` and `just check-doc-links`; both completed successfully. 
- CI-style smoke: documentation and threat-model updates verified by the doc-link checker; all automated checks mentioned above succeeded locally in the development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7569bceb60832b8c81dc8ace9473f5)