### PR TITLE
fix(interpreter): contain CommandResolver panics

### DIFF
--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -553,6 +553,7 @@ All unexpected errors are caught and converted to safe, human-readable messages.
 | C ABI unwind (TM-INT-008) | Rust panic enters a foreign runtime or leaks details | Catch every exported operation and return a generic error | **MITIGATED** |
 | Binary output bypasses resource limits (TM-INT-009) | Invalid UTF-8 exceeds configured caps when counted as text | Byte-native accumulation and callbacks truncate by exact byte length | **MITIGATED** |
 | Invalid UTF-8 line input panics (TM-INT-010) | `read`/`select` apply a lossy-text newline offset to raw pipeline bytes | Line consumers find and split newlines in the authoritative byte buffer | **MITIGATED** |
+| Command resolver panic (TM-INT-011) | Unresolved command name triggers a panic in embedder resolver code | `catch_unwind` wrapper and sanitized shell error | **MITIGATED** |
 
 **Panic Recovery:**
 

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -443,8 +443,9 @@ impl BuiltinRegistry {
 /// Decision: resolvers return a [`Builtin`] rather than executing directly.
 /// The resolved builtin runs through the same dispatch path as every other
 /// builtin, so `before_tool` hooks fire with the resolved name and can veto it,
-/// `catch_unwind` still contains panics, and redirects and stdin behave
-/// identically. A bespoke execution path would have to re-earn all of that.
+/// `catch_unwind` contains panics from both resolution and execution, and
+/// redirects and stdin behave identically. A bespoke execution path would have
+/// to re-earn all of that.
 ///
 /// Returning `None` falls through to the normal `command not found` error.
 ///
@@ -456,6 +457,8 @@ impl BuiltinRegistry {
 /// the set of names reaching host code stops being enumerable in advance, so
 /// `Bash::builtin_names()` no longer bounds it. `before_tool` remains the
 /// enforcement backstop; see `knowledge/integrations/script-analysis.md`.
+/// Resolver panics become a sanitized, non-zero shell result rather than
+/// unwinding through the interpreter.
 ///
 /// # Example
 ///

--- a/crates/bashkit/src/interpreter/mod.rs
+++ b/crates/bashkit/src/interpreter/mod.rs
@@ -6631,11 +6631,23 @@ impl Interpreter {
             // Last-chance resolver. Dispatches through `execute_builtin_arc`
             // like every other builtin, so `before_tool` fires with the
             // resolved name and can veto it.
-            if let Some(builtin) = self
-                .command_resolver
-                .as_ref()
-                .and_then(|resolver| resolver.resolve(name))
-            {
+            // THREAT[TM-INT-011]: Resolver host code receives attacker-controlled names.
+            // Contain its panics before dispatching the builtin it returns.
+            let resolved = match self.command_resolver.as_ref() {
+                Some(resolver) => {
+                    match std::panic::catch_unwind(AssertUnwindSafe(|| resolver.resolve(name))) {
+                        Ok(builtin) => builtin,
+                        Err(_panic) => {
+                            return Ok(ExecResult::err(
+                                format!("bash: {}: resolver failed unexpectedly\n", name),
+                                1,
+                            ));
+                        }
+                    }
+                }
+                None => None,
+            };
+            if let Some(builtin) = resolved {
                 return self
                     .execute_builtin_arc(
                         name,

--- a/crates/bashkit/tests/integration/command_resolver_tests.rs
+++ b/crates/bashkit/tests/integration/command_resolver_tests.rs
@@ -148,6 +148,29 @@ async fn no_resolver_keeps_command_not_found() {
     assert_eq!(result.exit_code, 127);
 }
 
+#[tokio::test]
+async fn resolver_panic_becomes_a_sanitized_shell_error() {
+    struct PanickingResolver;
+
+    impl CommandResolver for PanickingResolver {
+        fn resolve(&self, _name: &str) -> Option<Arc<dyn Builtin>> {
+            panic!("sensitive host resolver detail")
+        }
+    }
+
+    let mut bash = Bash::builder()
+        .command_resolver(Arc::new(PanickingResolver))
+        .build();
+    let result = bash.exec("attacker-controlled-name").await.unwrap();
+
+    assert_eq!(result.exit_code, 1);
+    assert_eq!(
+        result.stderr,
+        "bash: attacker-controlled-name: resolver failed unexpectedly\n"
+    );
+    assert!(!result.stderr.contains("sensitive host resolver detail"));
+}
+
 /// The security contract from `knowledge/integrations/script-analysis.md`:
 /// `before_tool` is the enforcement backstop, and it must keep working for
 /// names that only exist because a resolver produced them.

--- a/knowledge/foundations/builtins.md
+++ b/knowledge/foundations/builtins.md
@@ -133,8 +133,10 @@ pub trait CommandResolver: Send + Sync {
 Decision: resolvers return a `Builtin` rather than executing directly. The
 resolved builtin runs through `execute_builtin_arc`, the same path as every
 other builtin, so `before_tool` fires with the resolved name and can veto it,
-`catch_unwind` still contains panics, and stdin/redirects behave identically. A
-bespoke execution path would have to re-earn all of that.
+`catch_unwind` contains panics from both resolution and execution, and
+stdin/redirects behave identically. Resolver panic details are discarded and
+the command returns a sanitized non-zero shell result. A bespoke execution path
+would have to re-earn all of that.
 
 Consequences to keep in mind:
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -906,10 +906,13 @@ session's isolated VFS.
 | TM-INT-008 | Panic crosses the C ABI boundary | Rust unwind enters a foreign runtime or exposes panic details | Every exported C operation uses `catch_unwind`; fallible calls return a generic, capped `BASHKIT_INTERNAL_ERROR` | **MITIGATED** |
 | TM-INT-009 | Binary output bypasses resource limits | Byte-native output or callbacks count characters instead of bytes, allowing invalid UTF-8 to exceed configured caps | Accumulation and streaming callbacks truncate `StreamData` by exact byte length before delivery; regression tests assert binary output-limit behavior | **MITIGATED** |
 | TM-INT-010 | Invalid UTF-8 line input panics the interpreter | `read` or `select` finds a newline in lossy text, then applies that expanded replacement-character offset to raw pipeline bytes | Line consumers find and split newlines in the authoritative byte buffer, then lossily decode only the consumed shell-text line; binary regressions cover both paths | **MITIGATED** |
+| TM-INT-011 | Command resolver panic crash | Attacker-controlled unresolved command names trigger a panic in embedder resolver code | `catch_unwind` around `CommandResolver::resolve`; sanitized shell error | **MITIGATED** |
 
 **Current Risk**: LOW. Implementation: `interpreter/mod.rs` wraps every builtin call in
 `AssertUnwindSafe(..).catch_unwind()` (TM-INT-001) and converts panics to the sanitized
 `bash: <name>: builtin failed unexpectedly` error, never exposing panic details (TM-INT-002).
+Last-chance command resolution applies the same boundary around embedder resolver code
+before builtin dispatch (TM-INT-011).
 
 **Date Format Validation** (TM-INT-003): `builtins/date.rs::validate_format()` pre-validates
 strftime formats via `StrftimeItems`, rejecting `Item::Error` before `chrono::format()` can panic.


### PR DESCRIPTION
### Motivation

- `CommandResolver::resolve` ran embedder host code on attacker-controlled unresolved names without a panic boundary, allowing resolver panics to unwind out of `Bash::exec` and break the interpreter availability guarantees (TM-INT-001).
- The goal is to ensure resolver failures behave like builtin failures: sanitized shell errors with non-zero exit codes instead of unwinding the process.

### Description

- Wrap the resolver call in `std::panic::catch_unwind(AssertUnwindSafe(...))` in `crates/bashkit/src/interpreter/mod.rs` and return a sanitized `ExecResult::err(..., 1)` on panic. 
- Preserve the existing dispatch: a successfully returned `Arc<dyn Builtin>` still runs via `execute_builtin_arc` so `before_tool` and the builtin `catch_unwind` boundary remain in effect.
- Add an integration regression test `resolver_panic_becomes_a_sanitized_shell_error` in `crates/bashkit/tests/integration/command_resolver_tests.rs` that asserts a resolver panic becomes a sanitized shell error and does not leak panic payloads.
- Update API/docs and canonical knowledge (`crates/bashkit/src/builtins/mod.rs`, `knowledge/foundations/builtins.md`, `knowledge/security/threat-model.md`, `crates/bashkit/docs/threat-model.md`) to document that resolver resolution is panic-contained (TM-INT-010).

### Testing

- Ran the new integration test `cargo test -p bashkit --test integration command_resolver_tests::resolver_panic_becomes_a_sanitized_shell_error -- --exact`, which passed. 
- Ran the resolver integration subset `cargo test -p bashkit --test integration command_resolver_tests::`, and all resolver-related tests passed (12 passed, 0 failed).
- Ran formatting and policy checks with `cargo fmt --all` and `just check-okf`, both of which exited successfully. 
- Ran `cargo clippy -p bashkit --tests -- -D warnings`, which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7569bc58d8832b9e3bb0559f52f8e4)