### PR TITLE
fix(c-api): reject oversized scripts before UTF-8 validation

### DIFF
--- a/crates/bashkit-capi/src/lib.rs
+++ b/crates/bashkit-capi/src/lib.rs
@@ -5,7 +5,7 @@
 // boundary and reports a generic error so unwinding cannot enter the foreign
 // caller and the returned error does not include panic details.
 
-use bashkit::{Bash, Error as BashError, FileSystem};
+use bashkit::{Bash, Error as BashError, ExecutionLimits, FileSystem, LimitExceeded};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -67,6 +67,7 @@ impl BashkitBytes {
 struct State {
     runtime: Runtime,
     bash: Bash,
+    max_input_bytes: usize,
 }
 
 pub struct Bashkit {
@@ -190,7 +191,7 @@ fn make_runtime() -> Result<Runtime, ApiFailure> {
         })
 }
 
-fn build_from_config(config: ConfigV1) -> Result<Bash, ApiFailure> {
+fn build_from_config(config: ConfigV1) -> Result<(Bash, usize), ApiFailure> {
     if config.schema_version != 1 {
         return Err(ApiFailure::new(
             BashkitStatus::InvalidConfig,
@@ -221,6 +222,7 @@ fn build_from_config(config: ConfigV1) -> Result<Bash, ApiFailure> {
         limits.max_stderr_bytes = value;
     }
     limits.capture_final_env = config.capture_final_env;
+    let max_input_bytes = limits.max_input_bytes;
 
     let mut builder = Bash::builder()
         .profile(profile)
@@ -241,7 +243,7 @@ fn build_from_config(config: ConfigV1) -> Result<Bash, ApiFailure> {
     for (path, content) in config.files {
         builder = builder.mount_text(path, content);
     }
-    Ok(builder.build())
+    Ok((builder.build(), max_input_bytes))
 }
 
 fn truncate_error(message: String) -> Vec<u8> {
@@ -372,6 +374,7 @@ pub unsafe extern "C" fn bashkit_create_default(
                 state: Mutex::new(State {
                     runtime: make_runtime()?,
                     bash: Bash::new(),
+                    max_input_bytes: ExecutionLimits::default().max_input_bytes,
                 }),
             };
             *out_bash = Box::into_raw(Box::new(bash));
@@ -405,10 +408,12 @@ pub unsafe extern "C" fn bashkit_create_json(
                     format!("invalid configuration: {error}"),
                 )
             })?;
+            let (bash, max_input_bytes) = build_from_config(config)?;
             let bash = Bashkit {
                 state: Mutex::new(State {
                     runtime: make_runtime()?,
-                    bash: build_from_config(config)?,
+                    bash,
+                    max_input_bytes,
                 }),
             };
             *out_bash = Box::into_raw(Box::new(bash));
@@ -444,11 +449,16 @@ pub unsafe extern "C" fn bashkit_execute(
         ffi_boundary(out_error, || {
             let out_result = output_slot(out_result, "out_result")?;
             let bash = handle(bash)?;
-            let script = input_str(script, "script")?;
             let mut state = bash.state.lock().map_err(|_| {
                 ApiFailure::new(BashkitStatus::InternalError, "bash instance is unavailable")
             })?;
-            let State { runtime, bash } = &mut *state;
+            if script.len > state.max_input_bytes {
+                return Err(ApiFailure::from_bash(BashError::ResourceLimit(
+                    LimitExceeded::InputTooLarge(script.len, state.max_input_bytes),
+                )));
+            }
+            let script = input_str(script, "script")?;
+            let State { runtime, bash, .. } = &mut *state;
             let result = runtime
                 .block_on(bash.exec(script))
                 .map_err(ApiFailure::from_bash)?;

--- a/crates/bashkit-capi/tests/abi.rs
+++ b/crates/bashkit-capi/tests/abi.rs
@@ -201,6 +201,28 @@ fn rejects_bad_inputs_with_owned_errors() {
 }
 
 #[test]
+fn rejects_oversized_script_before_utf8_validation() {
+    unsafe {
+        let config = br#"{"schema_version":1,"limits":{"max_input_bytes":1}}"#;
+        let mut bash = ptr::null_mut();
+        let mut error = ptr::null_mut();
+        assert_eq!(
+            bashkit_create_json(bytes(config), &mut bash, &mut error),
+            BashkitStatus::Ok
+        );
+
+        let mut result = ptr::null_mut();
+        assert_eq!(
+            bashkit_execute(bash, bytes(&[b':', 0xff]), &mut result, &mut error),
+            BashkitStatus::ExecutionError
+        );
+        assert!(result.is_null());
+        assert!(error_message(error).contains("input too large"));
+        bashkit_free(bash);
+    }
+}
+
+#[test]
 fn rejects_unknown_config_fields_and_versions() {
     unsafe {
         for (config, expected) in [

--- a/knowledge/runtimes/c-api.md
+++ b/knowledge/runtimes/c-api.md
@@ -32,6 +32,10 @@ layouts, allocators, traits, futures, and Tokio types never cross the boundary.
 Each exported Rust function contains panics; fallible functions report a capped
 error object rather than unwinding into the host.
 
+The handle retains its configured script-size limit so execution rejects an
+oversized byte view before dereferencing it or validating UTF-8. This preserves
+the core input resource limit at the untrusted native boundary.
+
 Execution is synchronous in v1. Each handle owns a current-thread Tokio runtime
 and mutex-protected `Bash`; same-handle calls serialize, while distinct handles
 can execute concurrently. Callers own lifetime synchronization and cannot race
@@ -61,9 +65,9 @@ library unload rules before becoming permanent ABI.
 ## Verification
 
 Rust contract tests cover success, shell failure, configuration, binary VFS
-content, invalid UTF-8, null outputs, and version rejection. The C example runner
-compiles the public header under C11 with warnings denied and executes two
-programs against the built shared library.
+content, invalid UTF-8, pre-validation script limits, null outputs, and version
+rejection. The C example runner compiles the public header under C11 with
+warnings denied and executes two programs against the built shared library.
 
 ## See also
 


### PR DESCRIPTION
### Motivation

- The C ABI previously validated caller-provided script bytes with `str::from_utf8` before the runtime `max_input_bytes` gate in `Bash::exec`, allowing large valid-UTF-8 inputs to be scanned and consume CPU before being rejected.

### Description

- Preserve each `Bashkit` handle's configured script-size limit by storing `max_input_bytes` in the FFI `State` and returning it from `build_from_config`.
- Enforce a cheap length check on the incoming `BashkitBytes` in `bashkit_execute` before calling `input_str` (UTF-8 validation), returning the existing resource-limit `ExecutionError` on oversize inputs.
- Add a contract test `rejects_oversized_script_before_utf8_validation` in `crates/bashkit-capi/tests/abi.rs` that ensures oversized buffers are rejected prior to UTF-8 validation.
- Update `knowledge/runtimes/c-api.md` to document the pre-validation input-size invariant.

### Testing

- Ran `cargo test -p bashkit-capi --test abi` and observed the ABI tests pass (11 passed, 0 failed). 
- Ran formatting and linters with `cargo fmt --all --check` and `cargo clippy -p bashkit-capi --all-targets -- -D warnings` which completed without errors. 
- Ran repository OKF check `just check-okf` which reported OKF v0.2 conformant for the knowledge bundle. 
- All automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7569bceb64832ba8798c50b2b6c6b1)