### PR TITLE
fix(docs): keep dependency scan line-local

### DIFF
--- a/knowledge/operations/documentation.md
+++ b/knowledge/operations/documentation.md
@@ -42,6 +42,8 @@ Repo-root `docs/` is for user-facing site articles.
   built routes and cannot see this class of breakage. The same check also
   validates `bashkit = { version = "..." }` dependency snippets in the
   prose trees and crate-level Rustdoc against `[workspace.package].version`.
+  Its multiline dependency matcher keeps horizontal whitespace line-local;
+  newline-matching whitespace can make blank-line-heavy input quadratic.
 - Page titles and descriptions live in `DOC_META`
   (`site/src/pages/docs/_meta.ts`), never in markdown frontmatter: the canonical
   files must stay frontmatter-free so `crates/bashkit/docs/*.md` embed cleanly

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -38,7 +38,7 @@ EXTERNAL = re.compile(r"\A(?:[a-z][a-z0-9+.-]*:|//|/|#)")
 # examples containing `](`) must not be read as links.
 CODE = re.compile(r"^```.*?^```|``.*?``|`[^`\n]*`", re.DOTALL | re.MULTILINE)
 BASHKIT_DEPENDENCY = re.compile(
-    r'^\s*(?://!\s*)?bashkit\s*=\s*\{[^}\n]*\bversion\s*=\s*"([^"]+)"',
+    r'^[ \t]*(?://![ \t]*)?bashkit[ \t]*=[ \t]*\{[^}\n]*\bversion[ \t]*=[ \t]*"([^"]+)"',
     re.MULTILINE,
 )
 WORKSPACE_PACKAGE = re.compile(r"(?ms)^\[workspace\.package]\s*$.*?(?=^\[|\Z)")

--- a/scripts/tests/test_check_doc_links.py
+++ b/scripts/tests/test_check_doc_links.py
@@ -118,6 +118,15 @@ class CheckDocLinksTest(unittest.TestCase):
             result.stderr,
         )
 
+    def test_dependency_scan_does_not_cross_line_boundaries(self) -> None:
+        self.write('\n\n\nbashkit = { version = "1.2.2" }\n')
+        result = self.check()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            'docs/page.md:4: stale bashkit dependency version 1.2.2; expected 1.2.3',
+            result.stderr,
+        )
+
     def test_current_bashkit_dependency_version_accepted(self) -> None:
         self.write('```toml\nbashkit = { version = "1.2.3", features = ["sqlite"] }\n```\n')
         self.assertEqual(self.check().returncode, 0)


### PR DESCRIPTION
### Motivation

- The `BASHKIT_DEPENDENCY` matcher used `\s*` under `re.MULTILINE`, and in Python `\s` includes newlines so large runs of blank lines could trigger quadratic backtracking and exhaust CI time.
- Restricting optional whitespace to horizontal whitespace preserves the intended detection of in-line `bashkit = { version = "..." }` snippets while preventing a CI denial-of-service vector.

### Description

- Tighten the dependency regex in `scripts/check_doc_links.py` from `r'^\s*(?://!\s*)?bashkit\s*=\s*\{...` to a line-local form using `[ \t]` so optional whitespace does not match newlines. The matcher remains `re.MULTILINE`.
- Add a regression test `test_dependency_scan_does_not_cross_line_boundaries` in `scripts/tests/test_check_doc_links.py` to ensure dependencies after blank lines are located on the correct line and that the scan does not absorb blank lines.
- Document the change and rationale in `knowledge/operations/documentation.md` noting that the dependency matcher is intentionally line-local to avoid performance problems on blank-line-heavy input.

### Testing

- Ran `python3 -m unittest scripts.tests.test_check_doc_links` and all tests passed (18 tests).
- Ran `just check-doc-links` and the checker reported success (`docs OK` with link/version counts).
- Ran `just check-okf` and the knowledge checks reported OKF conformance.
- Executed a micro-benchmark by calling `check_file` over a file with 25,000 blank lines and observed the scan complete in ~0.002s, demonstrating the quadratic backtracking issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7569bc64b4832bbaa210158b3c9f0a)