### PR TITLE
fix(justfile): invoke bashkit-cli the way the CLI parses args

### DIFF
--- a/justfile
+++ b/justfile
@@ -196,11 +196,11 @@ run *args:
 
 # Run REPL
 repl:
-    cargo run -p bashkit-cli -- repl
+    cargo run -p bashkit-cli
 
 # Run a script file
-run-script file:
-    cargo run -p bashkit-cli -- run {{file}}
+run-script file *args:
+    cargo run -p bashkit-cli -- {{file}} {{args}}
 
 # === Benchmarks ===
 


### PR DESCRIPTION
## What changed

`just run-script <file>` and `just repl` now actually run the script / REPL.

The CLI has no subcommands — it takes an optional positional `[SCRIPT]`. Both
recipes passed a made-up subcommand word, so `just run-script foo.sh` tried to
execute a script literally named `run` (and `just repl` a script named `repl`),
failing before the real target was ever read.

`run-script` also forwards trailing arguments now, so `$1`, `$2`… reach the
script.

## Why

`run-script` is part of the documented smoke-test loop (`.agents/skills/ship`
step 2: "run example scripts via `just run-script <file>`"), so the broken
recipe silently removed a verification step. `repl` had the same defect.

## Before / After

Script under test: `echo hello $1`

Before:
```
$ cargo run -q -p bashkit-cli -- run t.sh world      # what the old recipe expanded to
Error: Failed to read script: run

Caused by:
    No such file or directory (os error 2)
$ echo $?
1
```

After:
```
$ just run-script t.sh world
     Running `target/debug/bashkit t.sh world`
hello world
```

`just --dry-run repl` now expands to `cargo run -p bashkit-cli` (no args = REPL)
instead of `cargo run -p bashkit-cli -- repl`.

## Risk

- Low
- Developer tooling only; no crate, library, or CLI source is touched.

## Checklist
- [x] Tests added or updated — n/a, justfile-only change; verified by running
      both recipes (`just --dry-run` for expansion, real execution for
      `run-script`) plus `just pre-pr` green
- [x] Backward compatibility considered — recipes were non-functional before;
      no callers depended on the old behavior
