### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,141 @@
 
 ## [Unreleased]
 
-### Added
+## [0.17.0] - 2026-08-22
 
-- The rustls crypto backend used by `http_client` is now selectable: `ring`
-  (enabled by default, unchanged behavior) or `aws-lc-rs` for consumers that
-  need a FIPS-capable backend or already link aws-lc-rs. `http_client` no
-  longer implies a backend; building it with neither is a compile error.
-  Consumers on `--no-default-features` must name one alongside `http_client`.
+### Highlights
+
+- **Bashkit runs as a plain wasm component, with no JS engine and no WASI.**
+  A component-model guest exposes shell execution over WIT, so hosts such as
+  Hyperlight micro-VMs can embed the interpreter without shipping a JavaScript
+  runtime or a WASI implementation, and `bashkit` now builds cleanly for WASI
+  targets under CI coverage
+  ([#2311](https://github.com/everruns/bashkit/pull/2311),
+  [#2310](https://github.com/everruns/bashkit/pull/2310)).
+- **Untrusted input costs bounded work everywhere it is parsed.** Script
+  analysis, zip archive buffers, pipeline stderr aggregation, real-filesystem
+  appends, snapshot chunk expansion, C ABI script intake, and CLI host stdin
+  reads now charge or cap resources before allocating or blocking
+  ([#2333](https://github.com/everruns/bashkit/pull/2333),
+  [#2330](https://github.com/everruns/bashkit/pull/2330),
+  [#2326](https://github.com/everruns/bashkit/pull/2326),
+  [#2327](https://github.com/everruns/bashkit/pull/2327),
+  [#2282](https://github.com/everruns/bashkit/pull/2282),
+  [#2334](https://github.com/everruns/bashkit/pull/2334),
+  [#2335](https://github.com/everruns/bashkit/pull/2335)).
+- **Sandbox escapes closed at the host boundary.** The host bridge no longer
+  interpolates into a shell, `HostMounts` normalizes VFS paths before mapping,
+  backend symlink reads are refused, YAML aliases are rejected before parsing,
+  and arithmetic command substitutions are flagged by static analysis
+  ([#2337](https://github.com/everruns/bashkit/pull/2337),
+  [#2281](https://github.com/everruns/bashkit/pull/2281),
+  [#2279](https://github.com/everruns/bashkit/pull/2279),
+  [#2280](https://github.com/everruns/bashkit/pull/2280),
+  [#2283](https://github.com/everruns/bashkit/pull/2283)).
+- **The always-on dependency graph is 21 crates smaller and the browser wasm
+  bundle 911 KB lighter.** Timezone data moved behind a default-on `tzdata`
+  feature, the ICU4X stack pulled in by `url` is gone, and `date` fails loudly
+  instead of silently formatting a named zone as UTC when `tzdata` is off
+  ([#2321](https://github.com/everruns/bashkit/pull/2321)).
+- **Every cargo lockfile in the tree is audited, clearing 16 wasmtime
+  advisories plus the fuzz lockfile gap** and the outstanding npm advisories in
+  the example and site lockfiles
+  ([#2340](https://github.com/everruns/bashkit/pull/2340),
+  [#2293](https://github.com/everruns/bashkit/pull/2293),
+  [#2285](https://github.com/everruns/bashkit/pull/2285),
+  [#2284](https://github.com/everruns/bashkit/pull/2284)).
+
+### Breaking Changes
+
+- **`http_client` no longer implies a rustls crypto backend.** Pick `ring`
+  (previous behavior, enabled by default) or `aws-lc-rs` for a FIPS-capable
+  backend. Enabling `http_client` with neither is a compile error. Only
+  consumers building with `--no-default-features` need to act.
+
+  Before:
+
+  ```toml
+  bashkit = { default-features = false, features = ["http_client"] }
+  ```
+
+  After:
+
+  ```toml
+  bashkit = { default-features = false, features = ["http_client", "ring"] }
+  ```
+
+- **Timezone data is behind the `tzdata` feature.** It is on by default, so
+  default builds are unchanged. Builds with `--no-default-features` that use
+  `TZ=<named zone>` must add `tzdata`; without it `date` reports that it cannot
+  honour the zone and exits 1 rather than returning a plausible-looking UTC
+  time.
+
+- **Non-ASCII domain names are rejected rather than normalized.** Pinning
+  `idna_adapter` drops UTS 46 normalization, which removes the homograph and
+  punycode-confusion class from allowlist matching. Hosts that relied on
+  internationalized domain names in HTTP allowlists must supply their punycode
+  form.
+
+### What's Changed
+
+* chore(deps): bump wit-bindgen from 0.51.0 to 0.60.0 in /examples/hyperlight in the example-cargo group across 1 directory ([#2342](https://github.com/everruns/bashkit/pull/2342)) by @dependabot
+* chore(deps): bump the examples-npm group across 1 directory with 2 updates ([#2341](https://github.com/everruns/bashkit/pull/2341)) by @dependabot
+* fix(deps): clear 16 wasmtime advisories and audit every cargo lockfile ([#2340](https://github.com/everruns/bashkit/pull/2340)) by @chaliy
+* chore(deps): bump ava to 8.0.1 and oxlint to 1.79.0 in bashkit-js ([#2339](https://github.com/everruns/bashkit/pull/2339)) by @chaliy
+* fix(justfile): invoke bashkit-cli the way the CLI parses args ([#2338](https://github.com/everruns/bashkit/pull/2338)) by @chaliy
+* fix(security): prevent host bridge shell injection ([#2337](https://github.com/everruns/bashkit/pull/2337)) by @chaliy
+* fix(docs): keep dependency scan line-local ([#2336](https://github.com/everruns/bashkit/pull/2336)) by @chaliy
+* fix(cli): bound host stdin reads by execution timeout ([#2335](https://github.com/everruns/bashkit/pull/2335)) by @chaliy
+* fix(c-api): reject oversized scripts before UTF-8 validation ([#2334](https://github.com/everruns/bashkit/pull/2334)) by @chaliy
+* fix(analysis): bound command validation work to prevent CPU amplification ([#2333](https://github.com/everruns/bashkit/pull/2333)) by @chaliy
+* fix(tools): enforce referenced input schemas ([#2332](https://github.com/everruns/bashkit/pull/2332)) by @chaliy
+* fix(streams): consume binary lines by byte offset ([#2331](https://github.com/everruns/bashkit/pull/2331)) by @chaliy
+* fix(zip): budget archive buffers before allocation ([#2330](https://github.com/everruns/bashkit/pull/2330)) by @chaliy
+* fix(interpreter): contain CommandResolver panics ([#2328](https://github.com/everruns/bashkit/pull/2328)) by @chaliy
+* fix(realfs): bound append memory usage by streaming into staging ([#2327](https://github.com/everruns/bashkit/pull/2327)) by @chaliy
+* fix(interpreter): bound pipeline stderr aggregation ([#2326](https://github.com/everruns/bashkit/pull/2326)) by @chaliy
+* chore(ci): bump taiki-e/install-action from 2.86.1 to 2.86.3 in the github-actions group ([#2325](https://github.com/everruns/bashkit/pull/2325)) by @dependabot
+* chore(deps): bump ai from 7.0.66 to 7.0.67 in /examples in the examples-npm group across 1 directory ([#2324](https://github.com/everruns/bashkit/pull/2324)) by @dependabot
+* chore(deps): bump the site-npm group in /site with 3 updates ([#2323](https://github.com/everruns/bashkit/pull/2323)) by @dependabot
+* chore(deps): trim always-on dependency graph, gate chrono-tz behind tzdata ([#2321](https://github.com/everruns/bashkit/pull/2321)) by @chaliy
+* fix(testing): match shell echoes the shell actually produces ([#2320](https://github.com/everruns/bashkit/pull/2320)) by @chaliy
+* fix(redirect): report redirection failures with bash's strerror wording ([#2319](https://github.com/everruns/bashkit/pull/2319)) by @chaliy
+* fix(deps): pin a pnpm release cooldown so dependabot npm runs stop failing ([#2318](https://github.com/everruns/bashkit/pull/2318)) by @chaliy
+* feat(http): make the rustls crypto backend a feature ([#2317](https://github.com/everruns/bashkit/pull/2317)) by @chaliy
+* fix(examples): pin vite exactly and run the browser example's tests in CI ([#2316](https://github.com/everruns/bashkit/pull/2316)) by @chaliy
+* chore(ci): bump taiki-e/install-action from 2.85.13 to 2.86.1 ([#2315](https://github.com/everruns/bashkit/pull/2315)) by @dependabot
+* fix(ci): install a pinned wasm-opt instead of apt, and bound the wasm jobs ([#2314](https://github.com/everruns/bashkit/pull/2314)) by @chaliy
+* chore(deps): bump vite from 6.4.3 to 8.2.1 in /examples/browser ([#2313](https://github.com/everruns/bashkit/pull/2313)) by @dependabot
+* chore(deps): add dependabot version updates for the five npm lockfiles ([#2312](https://github.com/everruns/bashkit/pull/2312)) by @chaliy
+* feat(wasm): run bashkit as a wasm component with no JS and no WASI ([#2311](https://github.com/everruns/bashkit/pull/2311)) by @chaliy
+* fix(builtins): compile bashkit for WASI targets + CI check for wasm32-wasip2 ([#2310](https://github.com/everruns/bashkit/pull/2310)) by @chaliy
+* feat(coreutils-port): resolve uucore Fluent messages at port time ([#2309](https://github.com/everruns/bashkit/pull/2309)) by @chaliy
+* chore(deps): update dependencies ([#2308](https://github.com/everruns/bashkit/pull/2308)) by @chaliy
+* chore(ci): bump the github-actions group with 2 updates ([#2307](https://github.com/everruns/bashkit/pull/2307)) by @dependabot
+* fix(sqlite): handle turso StepResult::Sleep and bump to 0.8.0-pre.4 ([#2306](https://github.com/everruns/bashkit/pull/2306)) by @chaliy
+* chore(deps): bump russh to 0.62.6 ([#2305](https://github.com/everruns/bashkit/pull/2305)) by @chaliy
+* docs: remove em-dashes and AI-tell wording from markdown prose ([#2304](https://github.com/everruns/bashkit/pull/2304)) by @chaliy
+* chore(ci): bump the github-actions group with 2 updates ([#2303](https://github.com/everruns/bashkit/pull/2303)) by @dependabot
+* chore(deps): hold monty at 0.0.19 — 0.0.21 silently disables max_memory ([#2300](https://github.com/everruns/bashkit/pull/2300)) by @chaliy
+* chore(deps): bump the rust-dependencies group with 5 updates ([#2299](https://github.com/everruns/bashkit/pull/2299)) by @chaliy
+* chore(ci): bump taiki-e/install-action from 2.85.10 to 2.85.11 in the github-actions group ([#2295](https://github.com/everruns/bashkit/pull/2295)) by @dependabot
+* fix(security): clear fuzz lockfile advisories and close the audit gap ([#2293](https://github.com/everruns/bashkit/pull/2293)) by @chaliy
+* feat(bindings): host env and mounts applied after construction survive reset ([#2292](https://github.com/everruns/bashkit/pull/2292)) by @chaliy
+* docs(security): record RUSTSEC-2023-0071 as TM-CRY-002; bump futures-util ([#2290](https://github.com/everruns/bashkit/pull/2290)) by @chaliy
+* chore(deps): bump turso_core from 0.8.0-pre.2 to 0.8.0-pre.3 ([#2289](https://github.com/everruns/bashkit/pull/2289)) by @dependabot
+* chore(deps): bump the rust-dependencies group with 6 updates ([#2288](https://github.com/everruns/bashkit/pull/2288)) by @dependabot
+* chore(ci): bump the github-actions group with 4 updates ([#2287](https://github.com/everruns/bashkit/pull/2287)) by @dependabot
+* fix(deps): bump spin to 0.9.9 to clear yanked-crate warning ([#2286](https://github.com/everruns/bashkit/pull/2286)) by @chaliy
+* fix(deps): patch nanoid and brace-expansion advisories ([#2285](https://github.com/everruns/bashkit/pull/2285)) by @chaliy
+* fix(deps): bump js-yaml override to ^4.3.1 for CVE-2026-59870 ([#2284](https://github.com/everruns/bashkit/pull/2284)) by @chaliy
+* fix(analysis): flag arithmetic command substitutions ([#2283](https://github.com/everruns/bashkit/pull/2283)) by @chaliy
+* fix(snapshot): enforce fs limits before expanding v2 snapshot chunks ([#2282](https://github.com/everruns/bashkit/pull/2282)) by @chaliy
+* fix(fs): normalize VFS paths in HostMounts to prevent host traversal ([#2281](https://github.com/everruns/bashkit/pull/2281)) by @chaliy
+* fix(yq): reject YAML aliases before parsing ([#2280](https://github.com/everruns/bashkit/pull/2280)) by @chaliy
+* fix(fs): reject backend symlink reads ([#2279](https://github.com/everruns/bashkit/pull/2279)) by @chaliy
+* fix(printf): sync uutils 0.10 formatting ([#2278](https://github.com/everruns/bashkit/pull/2278)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.16.0...v0.17.0
 
 ## [0.16.0] - 2026-08-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-capi"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bashkit",
  "serde",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Enable the `sqlite` feature to embed [Turso](https://github.com/tursodatabase/tu
 
 ```toml
 [dependencies]
-bashkit = { version = "0.16.0", features = ["sqlite"] }
+bashkit = { version = "0.17.0", features = ["sqlite"] }
 ```
 
 ```rust

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -37,7 +37,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # `tzdata` is listed explicitly: an interactive shell must keep honouring
 # named `TZ=` zones in `date`, which stopped being implied when chrono-tz
 # moved behind a feature.
-bashkit = { path = "../bashkit", version = "0.16.0", default-features = false, features = ["http_client", "ring", "git", "jq", "tzdata"] }
+bashkit = { path = "../bashkit", version = "0.17.0", default-features = false, features = ["http_client", "ring", "git", "jq", "tzdata"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/crates/bashkit/docs/logging.md
+++ b/crates/bashkit/docs/logging.md
@@ -14,7 +14,7 @@ Add the `logging` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.16.0", features = ["logging"] }
+bashkit = { version = "0.17.0", features = ["logging"] }
 tracing-subscriber = "0.3"  # or your preferred subscriber
 ```
 

--- a/crates/bashkit/docs/sqlite.md
+++ b/crates/bashkit/docs/sqlite.md
@@ -13,7 +13,7 @@ the `sqlite` feature. The engine is [Turso](https://github.com/tursodatabase/tur
 
 ```toml
 # Cargo.toml
-bashkit = { version = "0.16.0", features = ["sqlite"] }
+bashkit = { version = "0.17.0", features = ["sqlite"] }
 ```
 
 ```rust,ignore

--- a/crates/bashkit/fuzz/Cargo.lock
+++ b/crates/bashkit/fuzz/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bashkit"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -322,7 +322,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.16.0", features = ["git"] }
+//! bashkit = { version = "0.17.0", features = ["git"] }
 //! ```
 //!
 //! ```rust,ignore
@@ -353,7 +353,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.16.0", features = ["python"] }
+//! bashkit = { version = "0.17.0", features = ["python"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/docs/builtin_typescript.md
+++ b/docs/builtin_typescript.md
@@ -12,7 +12,7 @@ Add the `typescript` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.16.0", features = ["typescript"] }
+bashkit = { version = "0.17.0", features = ["typescript"] }
 ```
 
 Enable TypeScript in the builder:

--- a/examples/hyperlight/Cargo.lock
+++ b/examples/hyperlight/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bashkit"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/justfile
+++ b/justfile
@@ -378,11 +378,10 @@ release-check:
     # verifies the matching core before publishing the CLI.
     CLI_VERIFY_ROOT=$(mktemp -d)
     trap 'rm -rf "$CLI_VERIFY_ROOT"' EXIT
-    rsync -a \
-        --exclude .git \
-        --exclude node_modules \
-        --exclude target \
-        ./ "$CLI_VERIFY_ROOT/workspace/"
+    # tar, not rsync: rsync is absent from some cloud release sandboxes.
+    mkdir -p "$CLI_VERIFY_ROOT/workspace"
+    tar -c --exclude .git --exclude node_modules --exclude target . \
+        | tar -x -C "$CLI_VERIFY_ROOT/workspace"
     LATEST_CORE=$(cargo search bashkit --limit 1 | sed -n 's/^bashkit = "\([^"]*\)".*/\1/p')
     if [ -z "$LATEST_CORE" ]; then
         echo "Error: could not determine latest published bashkit version"
@@ -394,14 +393,12 @@ release-check:
         "s/version = \"$WORKSPACE_VERSION\"/version = \"$LATEST_CORE\"/" \
         "$CLI_TOML"
     rm "$CLI_TOML.bak"
-    # The latest published core predates Monty's crates.io publication and
-    # therefore lacks the Python feature. The exact new core package dry-run
-    # above validates that feature. Resolve the proxy from crates.io rather
-    # than the copied path crate, and omit Python only in this disposable copy.
-    perl -0pi.bak -e \
-        's/path = "\.\.\/bashkit", //; s/^python = \["bashkit\/python"\]\n//m; s/"python", //g; s/, "python"//g' \
-        "$CLI_TOML"
-    rm "$CLI_TOML.bak"
+    # The proxy resolves the core from crates.io, so it can only request
+    # features the published core already has. Features added in this release
+    # cycle (and Python, which the published core predates) are dropped in the
+    # disposable copy only; the exact new core package dry-run above validates
+    # them. Failing here means real packaging drift, not a missing feature.
+    python3 scripts/cli_publish_proxy.py "$CLI_TOML" "$LATEST_CORE"
     cargo publish \
         --manifest-path "$CLI_VERIFY_ROOT/workspace/Cargo.toml" \
         -p bashkit-cli \

--- a/knowledge/operations/release-process.md
+++ b/knowledge/operations/release-process.md
@@ -64,7 +64,12 @@ silently failed.
      `bashkit-cli` in a disposable copy against the latest published
      registry core version (remove the local path in the copy) as a structural
      proxy; Cargo cannot resolve the CLI's new
-     registry dependency until the core crate is live. Normal workspace checks
+     registry dependency until the core crate is live. The proxy may only ask
+     the published core for features it already exposes, so
+     `scripts/cli_publish_proxy.py` reads that crate's feature set from
+     crates.io and drops the ones added in the current cycle (plus `python`,
+     which predates Monty's crates.io publication) from the disposable copy
+     only. A failure there is real packaging drift, not a missing feature. Normal workspace checks
      still compile the CLI against the new local core, and `publish.yml` waits
      for the core registry version before publishing the CLI. Packaging caught
      the v0.4.0 → v0.4.1 incident: the rustdoc guide lived outside the crate

--- a/scripts/cli_publish_proxy.py
+++ b/scripts/cli_publish_proxy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Rewrite a disposable bashkit-cli manifest so it packages against the
+published core crate.
+
+`cargo publish --dry-run -p bashkit-cli` cannot resolve the core version being
+released, because it is not on crates.io yet. `just release-check` therefore
+packages a throwaway copy of the workspace against the latest *published* core
+as a structural proxy. That copy may only request features the published core
+already exposes, so this script drops the local path dependency and any feature
+the published core lacks (features added in the current cycle, plus `python`,
+which predates Monty's crates.io publication). The exact new core package is
+validated by its own dry-run, so nothing here weakens the release gate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+
+API = "https://crates.io/api/v1/crates/bashkit/{version}"
+UA = "bashkit-release-check (https://github.com/everruns/bashkit)"
+DEPENDENCY = re.compile(r"^bashkit = \{[^}\n]*\}$", re.MULTILINE)
+FEATURES = re.compile(r"features = \[([^\]]*)\]")
+
+
+class ManifestError(Exception):
+    """The copied manifest does not have the shape the proxy can rewrite."""
+
+
+def published_features(version: str) -> set[str]:
+    request = urllib.request.Request(API.format(version=version), headers={"User-Agent": UA})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = json.load(response)
+    return set(payload["version"]["features"])
+
+
+def rewrite(manifest: str, available: set[str]) -> tuple[str, list[str], list[str]]:
+    """Return the rewritten manifest plus the kept and dropped feature names."""
+    dependency = DEPENDENCY.search(manifest)
+    if dependency is None:
+        raise ManifestError("bashkit dependency line not found")
+    line = dependency.group(0)
+    requested = FEATURES.search(line)
+    if requested is None:
+        raise ManifestError("bashkit dependency has no feature list")
+
+    names = [name.strip().strip('"') for name in requested.group(1).split(",") if name.strip()]
+    kept = [name for name in names if name in available]
+    dropped = [name for name in names if name not in available]
+
+    line = (
+        line[: requested.start()]
+        + "features = [%s]" % ", ".join('"%s"' % name for name in kept)
+        + line[requested.end() :]
+    )
+    line = line.replace('path = "../bashkit", ', "")
+    manifest = manifest[: dependency.start()] + line + manifest[dependency.end() :]
+
+    # Drop CLI features that forward to a core feature the published core lacks.
+    for name in dropped:
+        manifest = re.sub(
+            r'^%s = \["bashkit/%s"\]\n' % (re.escape(name), re.escape(name)),
+            "",
+            manifest,
+            flags=re.MULTILINE,
+        )
+        manifest = manifest.replace('"%s", ' % name, "").replace(', "%s"' % name, "")
+
+    return manifest, kept, dropped
+
+
+def main(argv: list[str]) -> int:
+    manifest_path, core_version = argv[1], argv[2]
+    with open(manifest_path) as handle:
+        manifest = handle.read()
+    try:
+        rewritten, kept, dropped = rewrite(manifest, published_features(core_version))
+    except ManifestError as error:
+        print("error: %s" % error, file=sys.stderr)
+        return 1
+    with open(manifest_path, "w") as handle:
+        handle.write(rewritten)
+    print(
+        "proxy core %s: kept %s; dropped %s"
+        % (core_version, ", ".join(kept) or "(none)", ", ".join(dropped) or "(none)")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/tests/test_cli_publish_proxy.py
+++ b/scripts/tests/test_cli_publish_proxy.py
@@ -1,0 +1,59 @@
+"""Lock the release-check CLI packaging proxy to the published core's features."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from cli_publish_proxy import ManifestError, rewrite  # noqa: E402
+
+MANIFEST = """\
+[package]
+name = "bashkit-cli"
+
+[features]
+default = ["http_client", "python", "tzdata"]
+python = ["bashkit/python"]
+tzdata = ["bashkit/tzdata"]
+
+[dependencies]
+bashkit = { path = "../bashkit", version = "0.17.0", default-features = false, features = ["http_client", "ring", "git", "python", "tzdata"] }
+"""
+
+
+class CliPublishProxyTests(unittest.TestCase):
+    def test_drops_features_the_published_core_lacks(self) -> None:
+        rewritten, kept, dropped = rewrite(MANIFEST, {"http_client", "git"})
+        self.assertEqual(kept, ["http_client", "git"])
+        self.assertEqual(dropped, ["ring", "python", "tzdata"])
+        self.assertIn('features = ["http_client", "git"]', rewritten)
+        self.assertNotIn('path = "../bashkit"', rewritten)
+        self.assertNotIn('python = ["bashkit/python"]', rewritten)
+        self.assertNotIn('tzdata = ["bashkit/tzdata"]', rewritten)
+        self.assertIn('default = ["http_client"]', rewritten)
+
+    def test_keeps_everything_when_core_has_all_features(self) -> None:
+        available = {"http_client", "ring", "git", "python", "tzdata"}
+        rewritten, kept, dropped = rewrite(MANIFEST, available)
+        self.assertEqual(dropped, [])
+        self.assertIn(
+            'features = ["http_client", "ring", "git", "python", "tzdata"]', rewritten
+        )
+        self.assertIn('python = ["bashkit/python"]', rewritten)
+
+    def test_rejects_a_manifest_without_the_dependency(self) -> None:
+        with self.assertRaises(ManifestError):
+            rewrite("[package]\nname = \"bashkit-cli\"\n", {"git"})
+
+    def test_rejects_a_dependency_without_features(self) -> None:
+        manifest = '[dependencies]\nbashkit = { path = "../bashkit", version = "0.17.0" }\n'
+        with self.assertRaises(ManifestError):
+            rewrite(manifest, {"git"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -55,7 +55,12 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_cli_publish_proxy_uses_the_published_core(self) -> None:
         justfile = (ROOT / "justfile").read_text()
 
-        self.assertIn(r's/path = "\.\.\/bashkit", //', justfile)
+        # The proxy manifest rewrite lives in scripts/cli_publish_proxy.py so it
+        # can be unit tested; release-check must still call it.
+        self.assertIn(
+            'python3 scripts/cli_publish_proxy.py "$CLI_TOML" "$LATEST_CORE"', justfile
+        )
+        self.assertTrue((ROOT / "scripts/cli_publish_proxy.py").is_file())
 
     def test_web_ci_exercises_release_wasm_optimization(self) -> None:
         build_script = (ROOT / "crates/bashkit-wasm/scripts/build.sh").read_text()


### PR DESCRIPTION
## What changed

Prepares Bashkit v0.17.0 across Rust, CLI, Python, native Node, browser WASM, and C ABI release artifacts. 56 commits since v0.16.0.

Release content:

- Bashkit runs as a plain wasm component with no JS engine and no WASI (Hyperlight guest), and builds cleanly for WASI targets under CI coverage.
- The rustls crypto backend is selectable: `ring` (default) or `aws-lc-rs`. `http_client` no longer implies a backend.
- The always-on dependency graph is 21 crates smaller and the browser wasm bundle 911 KB lighter; timezone data moved behind a default-on `tzdata` feature.
- Untrusted input costs bounded work at every parse point touched this cycle: script analysis, zip buffers, pipeline stderr, realfs appends, snapshot chunks, C ABI script intake, CLI host stdin.
- Sandbox escapes closed at the host boundary: host bridge shell injection, `HostMounts` path normalization, backend symlink reads, YAML aliases, arithmetic command substitutions.
- Every cargo lockfile in the tree is audited, clearing 16 wasmtime advisories plus the fuzz lockfile gap.

The changelog documents three breaking changes with migration guidance (rustls backend selection, `tzdata`, non-ASCII domain names rejected instead of UTS 46 normalized). All three only affect builds with `--no-default-features` or hosts that fed internationalized domain names to the HTTP allowlist.

This PR also fixes the CLI packaging proxy in `just release-check`. The proxy resolves the core crate from crates.io, so it may only request features the *published* core exposes; `ring` and `tzdata` are new this cycle, so the proxy failed to resolve. `scripts/cli_publish_proxy.py` now reads the published feature set from the registry and drops the missing ones in the disposable copy only, with unit tests under `scripts/tests/`. The workspace copy also uses `tar` instead of `rsync`, which is absent from the release sandbox.

## Why

There are 56 verified commits since v0.16.0, including new public features and intentional feature-flag breaking changes, so this is a minor release. All registries currently report v0.16.0.

## Before / After

Registries before this release:

```text
crates.io bashkit                   -> 0.16.0
crates.io bashkit-cli               -> 0.16.0
PyPI bashkit                        -> 0.16.0
npm @everruns/bashkit (latest)      -> 0.16.0
npm @everruns/bashkit-wasm (latest) -> 0.16.0
```

Prepared and smoke-tested at 0.17.0:

```text
$ cargo run -q -p bashkit-cli -- --version
bashkit 0.17.0

$ python -c "import bashkit, importlib.metadata as m; print(m.version('bashkit'), bashkit.Bash().execute_sync('echo hello').stdout)"
0.17.0 hello
```

Publish-readiness report:

- `just pre-pr` passed: fmt, clippy, Rust test suite, script unit tests, capability parity, OKF bundle, doc links, `cargo vet`.
- `cargo publish --dry-run -p bashkit` packaged and verified v0.17.0.
- Disposable registry-backed `bashkit-cli` package dry-run succeeded (7 files, 232.0 KiB) with the fixed proxy.
- Nightly and Fuzz workflows green on their most recent runs on `main`.
- Native Node release binding built; full ava suite green (569 tests).
- Browser WASM release build plus headless Node integration suite green (63 tests).
- Python cp39-abi3 release wheel built, installed into a clean virtualenv, and executed.
- `just apidocs` regenerated the Python and TypeScript API references: no drift.
- Version sync verified across workspace `Cargo.toml`, `bashkit-cli` path-dep pin, both `package.json` files, `crates/bashkit/src/lib.rs` docs, README, docs snippets, and all lockfiles.

## Risk

- Medium
- Multi-registry minor release with intentional feature-flag changes documented in the changelog.
- Publishing remains CI-managed; post-merge monitoring will verify the GitHub Release, crates.io, PyPI, both npm packages, Homebrew, and the C ABI archives before the release is declared shipped.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
