### PR TITLE
fix(release): unblock the npm native publish and catch release/CI matrix drift

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -202,8 +202,18 @@ jobs:
           name: js-stubs
           path: crates/bashkit-js
 
-      - name: Test bindings
+      # ava >= 8 requires Node 22.20+, but the package still declares
+      # `engines: node >= 18`. Node 20 therefore runs the runtime-compat
+      # suite against the shipped binding instead of the ava-hosted suites,
+      # matching the same split in ci's js.yml.
+      - name: Test bindings (Node 22+ only)
+        if: matrix.node != '20'
         run: pnpm test
+        working-directory: crates/bashkit-js
+
+      - name: Test bindings - runtime compat (Node 20)
+        if: matrix.node == '20'
+        run: node --test __test__/runtime-compat/*.test.mjs
         working-directory: crates/bashkit-js
 
       - name: Run examples
@@ -323,13 +333,25 @@ jobs:
           name: js-stubs
           path: crates/bashkit-js
 
-      - name: Test bindings
+      # See the Node 20 note in test-js-macos-windows: ava >= 8 needs Node
+      # 22.20+, so Node 20 runs the runtime-compat suite instead.
+      - name: Test bindings (Node 22+ only)
+        if: matrix.node != '20'
         run: >
           docker run --rm -v ${{ github.workspace }}:${{ github.workspace }}
           -w ${{ github.workspace }}/crates/bashkit-js
           --platform ${{ steps.docker.outputs.PLATFORM }}
           ${{ steps.docker.outputs.IMAGE }}
           ./node_modules/.bin/ava
+
+      - name: Test bindings - runtime compat (Node 20)
+        if: matrix.node == '20'
+        run: >
+          docker run --rm -v ${{ github.workspace }}:${{ github.workspace }}
+          -w ${{ github.workspace }}/crates/bashkit-js
+          --platform ${{ steps.docker.outputs.PLATFORM }}
+          ${{ steps.docker.outputs.IMAGE }}
+          sh -c "node --test __test__/runtime-compat/*.test.mjs"
 
       - name: Link package for examples
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The npm native package publishes again: `publish-js.yml` no longer runs the
+  ava suites on Node 20, which ava 8 dropped support for. Node 20 keeps running
+  the runtime-compat suite against the shipped binding, matching how `js.yml`
+  already split them.
+
+### Added
+
+- `just check-workflow-parity` fails when a release workflow tests a runtime
+  version CI does not, when a shared test suite is gated to more versions at
+  release time than in CI, or when `dtolnay/rust-toolchain` pins disagree
+  across workflows. This class of drift is otherwise invisible until a tag
+  exists and part of the release has already published.
+
 ## [0.17.0] - 2026-08-22
 
 ### Highlights

--- a/justfile
+++ b/justfile
@@ -47,6 +47,7 @@ check:
     just check-capability-parity
     just check-okf
     just check-doc-links
+    just check-workflow-parity
 
 # Validate the canonical public-surface capability matrix and generated inventory.
 check-capability-parity:
@@ -55,6 +56,13 @@ check-capability-parity:
 # Regenerate the public-surface capability inventory from its canonical manifest.
 regen-capability-parity:
     python3 scripts/capability_parity.py
+
+# A release workflow that tests a runtime version CI does not is invisible
+# until the tag exists (v0.17.0 published to crates.io and PyPI while npm
+# stalled on ava running under Node 20). This compares the matrices.
+# Validate release workflows against their CI counterparts
+check-workflow-parity:
+    python3 scripts/check_workflow_parity.py
 
 # The site rewrites doc links by basename, so a cross-tree link written as a
 # bare `jq.md` renders fine on bashkit.sh while 404-ing on GitHub. This checks

--- a/knowledge/operations/release-process.md
+++ b/knowledge/operations/release-process.md
@@ -108,8 +108,31 @@ silently failed.
 
 `AGENTS.md` Pre-PR Checklist applies, plus: CI green on main, CHANGELOG.md
 has entries since last release, version consistent across all manifests
-(step 3), the core publish dry-run and CLI package check succeed, and new
-version > latest published on each registry.
+(step 3), the core publish dry-run and CLI package check succeed, `just
+check-workflow-parity` passes, and new version > latest published on each
+registry.
+
+## Release and CI Parity
+
+Release workflows must never test what CI does not. A release-only runtime
+version or an ungated suite stays invisible until the tag exists, and by then
+part of the release has already shipped: v0.17.0 reached crates.io, PyPI, and
+`@everruns/bashkit-wasm` while the native npm package stalled because
+`publish-js.yml` still ran ava on Node 20 after `js.yml` had gated it to Node
+22+ (ava >= 8 requirement).
+
+`scripts/check_workflow_parity.py` (`just check-workflow-parity`, part of `just
+check` and of the `scripts/tests` suite CI runs) compares each release workflow
+against its CI counterpart and fails on:
+
+- a runtime version tested at release time that CI does not test,
+- a suite both workflows run, gated to more versions in the release workflow
+  than in CI,
+- `dtolnay/rust-toolchain` pins that disagree between workflows or with
+  `rust-toolchain.toml`.
+
+Lanes are declared in that script's `LANES`; add one whenever a new
+publish workflow gains a runtime or version matrix.
 
 ## Post-Merge Monitoring
 
@@ -193,7 +216,9 @@ dynamically from `Cargo.toml` via maturin (`dynamic = ["version"]`).
 
 Trigger: Release published (parallel). Builds native NAPI-RS bindings
 (macOS x86_64/aarch64, Linux x86_64/aarch64, Windows x86_64,
-wasm32-wasip1-threads), tests on Node 20/22/24, publishes to npm. Secret:
+wasm32-wasip1-threads), tests on Node 20/22/24 (Node 20 runs the
+runtime-compat suite, not the ava suites, since ava >= 8 needs Node 22.20+),
+publishes to npm. Secret:
 `NPM_TOKEN` (Automation token); provenance via `id-token: write` OIDC +
 `--provenance`, same pattern as everruns/sdk. JS package version is synced
 from the workspace `Cargo.toml` by `build.rs` updating `package.json`.

--- a/scripts/check_workflow_parity.py
+++ b/scripts/check_workflow_parity.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Fail when a release workflow tests a runtime version CI does not.
+
+The v0.17.0 release shipped to crates.io, PyPI, and npm's wasm package while
+the native npm package stalled: `publish-js.yml` still ran the ava suite on
+Node 20 after ava 8 dropped it, and only `js.yml` had been given the Node 22+
+gate. Nothing compared the two matrices, so the gap stayed invisible until the
+tag already existed and half the registries were published.
+
+This checker mechanizes that comparison for every runtime with both a CI
+workflow and a release workflow:
+
+* **Version coverage** - every runtime version a release workflow tests must
+  also be tested by the CI workflow. A version CI stopped covering must not
+  keep running at release time.
+* **Suite gating** - for each test suite both workflows run, the versions it
+  runs on at release time must be a subset of the versions CI runs it on. This
+  is the Node 20 / ava failure, stated generally.
+* **Toolchain pins** - every `dtolnay/rust-toolchain@<sha> # <label>` reference
+  sharing a label must share a SHA across all workflows, and the stable label
+  must match `rust-toolchain.toml`. A release workflow left behind on an older
+  rustc is the same class of drift.
+
+`if:` expressions are read only for comparisons against the job's matrix
+version key (`matrix.node == '20'`, `matrix.version != '20'`). A version is
+considered covered by a step when every such comparison holds; conditions on
+anything else (`runner.os`, `github.event_name`) are ignored, which can only
+make this checker stricter, never more permissive.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github/workflows"
+TOOLCHAIN = ROOT / "rust-toolchain.toml"
+
+# Test suites worth comparing across workflows. A step belongs to a suite when
+# its `run:` matches the pattern; steps matching nothing (installs, smoke
+# one-liners, artifact downloads) are ignored.
+SUITES = {
+    "ava": re.compile(r"\bava\b|pnpm (?:run )?test\b"),
+    "runtime-compat": re.compile(r"--test\s+[\"']?__test__/runtime-compat"),
+    "pytest": re.compile(r"\bpytest\b"),
+}
+
+# (runtime, CI source, release sources). Each source names the workflow, the
+# job, the matrix key holding the version, and an optional matrix row filter.
+LANES = [
+    {
+        "runtime": "node",
+        "ci": [("js.yml", "build-and-test", "version", {"runtime": "node"})],
+        "release": [
+            ("publish-js.yml", "test-js-macos-windows", "node", {}),
+            ("publish-js.yml", "test-js-linux", "node", {}),
+        ],
+    },
+    {
+        "runtime": "python",
+        "ci": [("python.yml", "test", "python-version", {})],
+        "release": [("publish-python.yml", "test-builds", "python-version", {})],
+    },
+]
+
+TOOLCHAIN_REF = re.compile(r"dtolnay/rust-toolchain@([0-9a-f]{40})\s*#\s*(\S+)")
+MATRIX_COMPARISON = re.compile(r"matrix\.([\w-]+)\s*(==|!=)\s*'([^']*)'")
+
+
+class ParityError(Exception):
+    """A workflow pair drifted apart."""
+
+
+def load(workflow: str) -> dict:
+    return yaml.safe_load((WORKFLOWS / workflow).read_text())
+
+
+def matrix_versions(job: dict, version_key: str, select: dict) -> list[str]:
+    """Versions a job's matrix runs, honouring `include:` rows and a filter."""
+    matrix = job.get("strategy", {}).get("matrix", {})
+    versions = [str(v) for v in matrix.get(version_key, [])]
+    for row in matrix.get("include", []):
+        if version_key not in row:
+            continue
+        if any(str(row.get(k)) != v for k, v in select.items()):
+            continue
+        version = str(row[version_key])
+        if version not in versions:
+            versions.append(version)
+    if select and not matrix.get("include"):
+        # A filter with nothing to filter on means the lane is misconfigured.
+        raise ParityError(f"matrix filter {select} matched no include rows")
+    return versions
+
+
+def step_applies(step: dict, version_key: str, version: str) -> bool:
+    """Whether `step` runs for `version`, per its `if:` matrix comparisons."""
+    condition = str(step.get("if", ""))
+    for key, operator, literal in MATRIX_COMPARISON.findall(condition):
+        if key != version_key:
+            continue
+        if operator == "==" and version != literal:
+            return False
+        if operator == "!=" and version == literal:
+            return False
+    return True
+
+
+def suites_by_version(source: tuple[str, str, str, dict]) -> dict[str, set[str]]:
+    """Map each matrix version to the test suites that run on it."""
+    workflow_name, job_name, version_key, select = source
+    workflow = load(workflow_name)
+    job = workflow.get("jobs", {}).get(job_name)
+    if job is None:
+        raise ParityError(f"{workflow_name}: job '{job_name}' not found")
+
+    coverage = {v: set() for v in matrix_versions(job, version_key, select)}
+    if not coverage:
+        raise ParityError(f"{workflow_name}:{job_name}: no matrix versions found")
+
+    for step in job.get("steps", []):
+        command = str(step.get("run", ""))
+        if not command:
+            continue
+        tags = {tag for tag, pattern in SUITES.items() if pattern.search(command)}
+        for version in coverage:
+            if tags and step_applies(step, version_key, version):
+                coverage[version] |= tags
+    return coverage
+
+
+def merge(sources: list[tuple[str, str, str, dict]]) -> dict[str, set[str]]:
+    merged: dict[str, set[str]] = {}
+    for source in sources:
+        for version, tags in suites_by_version(source).items():
+            merged.setdefault(version, set())
+            merged[version] |= tags
+    return merged
+
+
+def check_lane(lane: dict) -> list[str]:
+    runtime = lane["runtime"]
+    ci = merge(lane["ci"])
+    release = merge(lane["release"])
+    errors = []
+
+    for version in sorted(set(release) - set(ci)):
+        errors.append(
+            f"{runtime} {version}: tested by the release workflow but not by CI; "
+            "add it to CI or drop it from the release matrix"
+        )
+
+    ci_suites = {tag for tags in ci.values() for tag in tags}
+    for version, tags in sorted(release.items()):
+        if version not in ci:
+            continue
+        for tag in sorted(tags & ci_suites - ci[version]):
+            errors.append(
+                f"{runtime} {version}: release workflow runs the '{tag}' suite, "
+                f"CI does not run it on {version}; gate them the same way"
+            )
+    return errors
+
+
+def check_toolchain_pins(
+    workflows: pathlib.Path | None = None, toolchain: pathlib.Path | None = None
+) -> list[str]:
+    workflows = workflows or WORKFLOWS
+    toolchain = toolchain or TOOLCHAIN
+    pins: dict[str, dict[str, list[str]]] = {}
+    for path in sorted(workflows.glob("*.yml")):
+        for sha, label in TOOLCHAIN_REF.findall(path.read_text()):
+            pins.setdefault(label, {}).setdefault(sha, []).append(path.name)
+
+    errors = []
+    for label, shas in sorted(pins.items()):
+        if len(shas) > 1:
+            where = "; ".join(
+                f"{sha[:8]} in {', '.join(sorted(set(files)))}"
+                for sha, files in sorted(shas.items())
+            )
+            errors.append(f"rust-toolchain '{label}' pinned to several SHAs: {where}")
+
+    channel = re.search(r'channel\s*=\s*"([^"]+)"', toolchain.read_text())
+    if channel and channel.group(1) not in pins and "nightly" != channel.group(1):
+        errors.append(
+            f"rust-toolchain.toml pins {channel.group(1)}, but no workflow "
+            f"references that version (workflows use: {', '.join(sorted(pins))})"
+        )
+    return errors
+
+
+def main() -> int:
+    errors = []
+    for lane in LANES:
+        errors += check_lane(lane)
+    errors += check_toolchain_pins()
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} release/CI parity problem(s). "
+            "A release workflow must not test what CI does not.",
+            file=sys.stderr,
+        )
+        return 1
+
+    lanes = ", ".join(lane["runtime"] for lane in LANES)
+    print(f"release workflows match CI for: {lanes}; rust toolchain pins agree")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_workflow_parity.py
+++ b/scripts/tests/test_check_workflow_parity.py
@@ -1,0 +1,150 @@
+"""Lock the release/CI parity checker to the drift that stalled v0.17.0's npm publish."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import check_workflow_parity as parity  # noqa: E402
+
+CI_WORKFLOW = """\
+jobs:
+  build-and-test:
+    strategy:
+      matrix:
+        include:
+          - runtime: node
+            version: "20"
+          - runtime: node
+            version: "22"
+          - runtime: bun
+            version: "latest"
+    steps:
+      - name: Run ava tests (Node 22+ only)
+        if: matrix.runtime == 'node' && matrix.version != '20'
+        run: pnpm test
+      - name: Run runtime-compat tests
+        if: matrix.runtime == 'node'
+        run: node --test __test__/runtime-compat/*.test.mjs
+"""
+
+RELEASE_GATED = """\
+jobs:
+  test-js:
+    strategy:
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - name: Test bindings (Node 22+ only)
+        if: matrix.node != '20'
+        run: pnpm test
+      - name: Test bindings - runtime compat (Node 20)
+        if: matrix.node == '20'
+        run: node --test __test__/runtime-compat/*.test.mjs
+"""
+
+RELEASE_UNGATED = """\
+jobs:
+  test-js:
+    strategy:
+      matrix:
+        node: ["20", "22"]
+    steps:
+      - name: Test bindings
+        run: pnpm test
+"""
+
+RELEASE_EXTRA_VERSION = """\
+jobs:
+  test-js:
+    strategy:
+      matrix:
+        node: ["22", "18"]
+    steps:
+      - name: Test bindings
+        run: pnpm test
+"""
+
+LANE = {
+    "runtime": "node",
+    "ci": [("ci.yml", "build-and-test", "version", {"runtime": "node"})],
+    "release": [("release.yml", "test-js", "node", {})],
+}
+
+
+class WorkflowParityTests(unittest.TestCase):
+    def check(self, release_workflow: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            workflows = pathlib.Path(directory)
+            (workflows / "ci.yml").write_text(CI_WORKFLOW)
+            (workflows / "release.yml").write_text(release_workflow)
+            original = parity.WORKFLOWS
+            parity.WORKFLOWS = workflows
+            try:
+                return parity.check_lane(LANE)
+            finally:
+                parity.WORKFLOWS = original
+
+    def test_matching_gates_pass(self) -> None:
+        self.assertEqual(self.check(RELEASE_GATED), [])
+
+    def test_release_only_suite_on_a_version_is_reported(self) -> None:
+        errors = self.check(RELEASE_UNGATED)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("node 20", errors[0])
+        self.assertIn("'ava'", errors[0])
+
+    def test_release_only_version_is_reported(self) -> None:
+        errors = self.check(RELEASE_EXTRA_VERSION)
+        self.assertTrue(any("node 18" in error for error in errors))
+
+    def test_toolchain_pins_must_agree_across_workflows(self) -> None:
+        stable = "e081816240890017053eacbb1bdf337761dc5582"
+        stale = "a" * 40
+        with tempfile.TemporaryDirectory() as directory:
+            workflows = pathlib.Path(directory)
+            (workflows / "ci.yml").write_text(
+                f"uses: dtolnay/rust-toolchain@{stable} # 1.95.0\n"
+            )
+            (workflows / "publish.yml").write_text(
+                f"uses: dtolnay/rust-toolchain@{stale} # 1.95.0\n"
+            )
+            toolchain = workflows / "rust-toolchain.toml"
+            toolchain.write_text(textwrap.dedent('[toolchain]\nchannel = "1.95.0"\n'))
+
+            errors = parity.check_toolchain_pins(workflows, toolchain)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("several SHAs", errors[0])
+
+    def test_toolchain_channel_must_be_referenced_by_a_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workflows = pathlib.Path(directory)
+            (workflows / "ci.yml").write_text(
+                "uses: dtolnay/rust-toolchain@%s # 1.94.0\n" % ("b" * 40)
+            )
+            toolchain = workflows / "rust-toolchain.toml"
+            toolchain.write_text('[toolchain]\nchannel = "1.95.0"\n')
+
+            errors = parity.check_toolchain_pins(workflows, toolchain)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("1.95.0", errors[0])
+
+    def test_repository_workflows_are_in_parity(self) -> None:
+        """The live check: this is what CI enforces on every push."""
+        errors = []
+        for lane in parity.LANES:
+            errors += parity.check_lane(lane)
+        errors += parity.check_toolchain_pins()
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_workflow.py
+++ b/scripts/tests/test_release_workflow.py
@@ -52,6 +52,29 @@ class ReleaseWorkflowTests(unittest.TestCase):
             with self.subTest(package_manifest=package_manifest):
                 self.assertIn(f'"version": "{workspace_version}"', manifest)
 
+    def test_publish_js_skips_ava_on_node_20(self) -> None:
+        """ava >= 8 needs Node 22.20+; publish-js must split like ci's js.yml.
+
+        The release path is the only place this gap shows up, and it shows up
+        after the tag exists (v0.17.0 shipped to crates.io and PyPI while npm
+        stalled on it).
+        """
+        publish = (ROOT / ".github/workflows/publish-js.yml").read_text()
+
+        active = "\n".join(
+            line for line in publish.splitlines() if not line.lstrip().startswith("#")
+        )
+        ava_steps = re.findall(
+            r"^      - name: Test bindings[^\n]*\n(?:(?:        .*)?\n)*",
+            active,
+            re.MULTILINE,
+        )
+        self.assertTrue(ava_steps)
+        for step in ava_steps:
+            with self.subTest(step=step.splitlines()[0]):
+                if "ava" in step or "pnpm test" in step:
+                    self.assertIn("matrix.node != '20'", step)
+
     def test_cli_publish_proxy_uses_the_published_core(self) -> None:
         justfile = (ROOT / "justfile").read_text()
 


### PR DESCRIPTION
## What changed

`@everruns/bashkit` (native npm) can publish again, and the drift that stopped it now fails a check instead of a release.

- `publish-js.yml` no longer runs the ava suites on Node 20. ava 8 requires Node 22.20+; Node 20 keeps exercising the shipped binding through the runtime-compat suite, the same split `js.yml` already had.
- `scripts/check_workflow_parity.py` (`just check-workflow-parity`, part of `just check` and of the `scripts/tests` suite CI runs on every push) compares every release workflow with its CI counterpart and fails on:
  - a runtime version tested at release time that CI does not test,
  - a suite both workflows run, gated to more versions at release time than in CI,
  - `dtolnay/rust-toolchain` pins that disagree between workflows or with `rust-toolchain.toml`.

Lanes are declared in the script's `LANES` (today: Node via `js.yml` ↔ `publish-js.yml`, Python via `python.yml` ↔ `publish-python.yml`), so a new publish workflow with a runtime matrix gets covered by adding one entry.

## Why

v0.17.0 published to crates.io, PyPI, and `@everruns/bashkit-wasm`, then stalled: `Publish JS` failed its Node 20 test jobs with `TypeError: results.values(...).filter is not a function` inside emittery, so `Release to NPM` never ran and the native package stayed at 0.16.0.

The ava 8 bump (#2339) added the Node 22+ gate to `js.yml` only. Nothing compared that gate with `publish-js.yml`, and the release path is not exercised before a tag exists, so the gap surfaced after the tag was cut and half the registries had already published. That is the general problem: any release workflow can test a runtime CI does not, and only a release finds out.

## Before / After

The checker reproduces the exact failure. Reverting just the Node 20 gate:

```text
$ python3 scripts/check_workflow_parity.py
error: node 20: release workflow runs the 'ava' suite, CI does not run it on 20; gate them the same way

1 release/CI parity problem(s). A release workflow must not test what CI does not.
```

With the gate in place:

```text
$ just check-workflow-parity
release workflows match CI for: node, python; rust toolchain pins agree
```

The Node 20 replacement suite passes locally against the built binding:

```text
$ node --test __test__/runtime-compat/*.test.mjs
# pass 163
# fail 0
```

Full JS suite on the release build is unchanged (569 ava tests pass on Node 22).

## Risk

- Low
- Workflow and test-tooling only; no library code changes.
- The checker reads `if:` conditions only for comparisons against a job's matrix version key; other conditions (`runner.os`, `github.event_name`) are ignored, which can make it stricter but never more permissive. A new publish workflow with its own matrix is invisible to it until a lane is added, which the knowledge doc and the script docstring both call out.
- After merge, `publish-js.yml` gets dispatched for v0.17.0 so the native npm package catches up with the other registries.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
