### PR TITLE
fix(release): run the Node 20 compat suite under bash on Windows

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -211,8 +211,12 @@ jobs:
         run: pnpm test
         working-directory: crates/bashkit-js
 
+      # `shell: bash` because Node 20 cannot expand a glob in `--test` itself
+      # and PowerShell, the default shell on the Windows runner, passes the
+      # pattern through literally.
       - name: Test bindings - runtime compat (Node 20)
         if: matrix.node == '20'
+        shell: bash
         run: node --test __test__/runtime-compat/*.test.mjs
         working-directory: crates/bashkit-js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - The npm native package publishes again: `publish-js.yml` no longer runs the
   ava suites on Node 20, which ava 8 dropped support for. Node 20 keeps running
   the runtime-compat suite against the shipped binding, matching how `js.yml`
-  already split them.
+  already split them; that suite runs under `bash` so the Windows runner
+  expands its glob, which Node 20 cannot do itself.
 
 ### Added
 


### PR DESCRIPTION
## What changed

The Node 20 runtime-compat step in `publish-js.yml` now runs with `shell: bash`.

## Why

With the Doppler token rotated and the ava/Node 20 gate in place (#2344), the dispatched `Publish JS` run got 21 of 22 jobs green — including every AI-example job — and stalled on one: `Test JS on x86_64-pc-windows-msvc - node@20`.

```text
Run node --test __test__/runtime-compat/*.test.mjs
shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
Could not find 'D:\a\bashkit\bashkit\crates\bashkit-js\__test__\runtime-compat\*.test.mjs'
```

Node 20 cannot expand a glob passed to `--test` (that landed in Node 21), and PowerShell, the Windows runner's default shell, passes the pattern through literally. On Linux and macOS the default `bash` expands it, which is why only the Windows leg failed. The neighbouring example step already pins `shell: bash` for the same reason.

`Release to NPM` needs every test job, so this one skipped job is all that still holds `@everruns/bashkit` at 0.16.0.

Audited the other `node --test` glob invocations while here: ci.yml (wasm + browser example), coverage.yml, js.yml, publish-wasm.yml, and the justfile all run on Linux, so none share the problem.

## Before / After

Before: `Test JS on x86_64-pc-windows-msvc - node@20` fails on the literal pattern, `Release to NPM` is skipped, npm native stays at 0.16.0.

After: the step runs under bash, which expands the glob before Node sees it — the same 163 runtime-compat tests the Linux and macOS Node 20 legs already pass.

## Risk

- Low
- One `shell:` key in one workflow step; no change to what is executed.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
