### PR TITLE
fix(test): mount a real temp dir in the JS runtime-compat suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   the runtime-compat suite against the shipped binding, matching how `js.yml`
   already split them; that suite runs under `bash` so the Windows runner
   expands its glob, which Node 20 cannot do itself.
+- The JS runtime-compat `mount and unmount` test mounts a real temporary
+  directory instead of a hardcoded `/tmp`, so it passes on the Windows runners
+  the release workflow tests on.
 
 ### Added
 

--- a/crates/bashkit-js/__test__/runtime-compat/vfs.test.mjs
+++ b/crates/bashkit-js/__test__/runtime-compat/vfs.test.mjs
@@ -2,6 +2,9 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Bash } from "./_setup.mjs";
 
 describe("VFS API", () => {
@@ -123,15 +126,22 @@ describe("VFS API", () => {
   });
 
   it("mount and unmount", () => {
-    const bash = new Bash({ allowedMountPaths: ["/tmp"] });
-    // Mount /tmp as a real filesystem at /host-tmp (read-only by default)
-    bash.mount("/tmp", "/host-tmp");
-    // The mount should be accessible
-    const r = bash.executeSync("ls /host-tmp 2>/dev/null; echo status=$?");
-    assert.ok(r.stdout.includes("status=0"));
-    // Unmount
-    bash.unmount("/host-tmp");
-    const r2 = bash.executeSync("ls /host-tmp 2>/dev/null; echo status=$?");
-    assert.ok(r2.stdout.includes("status="));
+    // A real host directory, not a hardcoded "/tmp": this suite runs on
+    // Windows too, where that path does not exist and mount() fails.
+    const hostDir = mkdtempSync(path.join(tmpdir(), "bashkit-mount-"));
+    try {
+      const bash = new Bash({ allowedMountPaths: [hostDir] });
+      // Mount the host directory at /host-tmp (read-only by default)
+      bash.mount(hostDir, "/host-tmp");
+      // The mount should be accessible
+      const r = bash.executeSync("ls /host-tmp 2>/dev/null; echo status=$?");
+      assert.ok(r.stdout.includes("status=0"));
+      // Unmount
+      bash.unmount("/host-tmp");
+      const r2 = bash.executeSync("ls /host-tmp 2>/dev/null; echo status=$?");
+      assert.ok(r2.stdout.includes("status="));
+    } finally {
+      rmSync(hostDir, { recursive: true, force: true });
+    }
   });
 });

--- a/knowledge/operations/release-process.md
+++ b/knowledge/operations/release-process.md
@@ -134,6 +134,11 @@ against its CI counterpart and fails on:
 Lanes are declared in that script's `LANES`; add one whenever a new
 publish workflow gains a runtime or version matrix.
 
+Platforms are deliberately outside the check. Release workflows test macOS and
+Windows that CI does not, and that extra breadth is worth keeping: it is what
+caught a runtime-compat test mounting a hardcoded `/tmp`, which cannot exist on
+a Windows runner.
+
 ## Post-Merge Monitoring
 
 Confirm each target (workflow → check):

--- a/scripts/check_workflow_parity.py
+++ b/scripts/check_workflow_parity.py
@@ -21,6 +21,11 @@ workflow and a release workflow:
   must match `rust-toolchain.toml`. A release workflow left behind on an older
   rustc is the same class of drift.
 
+Platforms are deliberately *not* compared: release workflows test macOS and
+Windows that CI does not, and that breadth is the point (it is what caught a
+runtime-compat test mounting a hardcoded `/tmp`). Only runtime versions and
+suite gating are held to parity.
+
 `if:` expressions are read only for comparisons against the job's matrix
 version key (`matrix.node == '20'`, `matrix.version != '20'`). A version is
 considered covered by a step when every such comparison holds; conditions on


### PR DESCRIPTION
## What changed

The runtime-compat `mount and unmount` test mounts a `mkdtemp` directory (and removes it afterwards) instead of a hardcoded host `/tmp`, the way the ava `vfs.spec.ts` suite already does.

## Why

With the glob fixed (#2345), the Windows Node 20 leg of `Publish JS` ran the suite for the first time and 162 of 163 tests passed. The one failure is a real portability bug in the test:

```text
not ok 15 - mount and unmount
  error: "Invalid host_path '/tmp': The system cannot find the file specified. (os error 2)"
  location: '...\__test__\runtime-compat\vfs.test.mjs:125:3'
```

`/tmp` is a host path here, not a VFS path — every other `/tmp` in this suite is inside the VFS and is fine anywhere. CI runs runtime-compat only on `ubuntu-latest`, so nothing had ever mounted it from Windows. `Release to NPM` needs every test job, so this single red job is what still holds `@everruns/bashkit` at 0.16.0.

Also documents, in `scripts/check_workflow_parity.py` and `knowledge/operations/release-process.md`, that platforms are deliberately outside the parity check added in #2344: release workflows testing macOS and Windows where CI does not is extra coverage worth keeping, and it is exactly what surfaced this.

## Before / After

Before, on Windows Node 20:

```text
# tests 163
# pass 162
# fail 1
```

After, locally on the same suite:

```text
$ node --test __test__/runtime-compat/*.test.mjs
# pass 163
# fail 0
```

## Risk

- Low
- Test-only change; the assertions are unchanged, only the host directory being mounted.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
