### PR TITLE
perf(builtins): cache pre-built clap Commands for ported coreutils builtins

### DIFF
--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -265,6 +265,10 @@ name = "hotpath"
 harness = false
 
 [[bench]]
+name = "builtin_args"
+harness = false
+
+[[bench]]
 name = "file_ops"
 harness = false
 

--- a/crates/bashkit/benches/builtin_args.rs
+++ b/crates/bashkit/benches/builtin_args.rs
@@ -18,15 +18,24 @@
 //!     `printf` (hand-parsed) and `:` (no args at all). The `:` row is the
 //!     loop-and-dispatch floor; everything above it is arg handling plus body.
 //!   - `arg_surface_size`: `cat` (12 args) against `ls` (~60 args) on inputs
-//!     sized so the bodies do near-identical work. Command construction scales
-//!     with the number of `.arg(...)` calls while the body does not, so this
-//!     delta is the sharpest available signal for build cost specifically.
-//!   - `flag_count`: same builtin, more flags on the command line. Isolates
-//!     match/parse cost from construction cost (construction is constant here).
+//!     sized so the bodies do near-identical work. clap's per-parse cost scales
+//!     with the number of declared args while the body does not, so this delta
+//!     tracks arg-surface cost.
+//!   - `flag_count`: same builtin, more flags on the command line. Costs ~0.45
+//!     µs per extra flag — note this measures only the *matching* of additional
+//!     argv entries, NOT the fixed per-parse cost, which dominates (see below).
 //!
 //! Each bench runs `INVOCATIONS` calls inside one script and declares
 //! `Throughput::Elements(INVOCATIONS)`, so criterion reports per-invocation
 //! time directly and the one-time `Bash::new()` cost amortizes away.
+//!
+//! What this measured, and what came of it: clap costs ~10 µs per `cat`
+//! invocation and ~73% of an `ls` invocation. The expensive part is *parsing*,
+//! not constructing the `Command` (construction is ~1.1 µs of `cat`'s 7.3 µs
+//! round trip) — but most of that parse cost is clap's one-time `_build_self`,
+//! which `builtins::clap_cache` now hoists into a cached pre-built `Command`.
+//! Worth −15% on `ls` end-to-end, −2% on `cat`. Keep this bench as the guard:
+//! a regression here means the cache stopped being hit.
 //!
 //! Run with: `cargo bench --bench builtin_args`
 //! Save baseline: `cargo bench --bench builtin_args -- --save-baseline before`

--- a/crates/bashkit/benches/builtin_args.rs
+++ b/crates/bashkit/benches/builtin_args.rs
@@ -1,0 +1,169 @@
+//! Per-invocation argument-parsing cost for builtins.
+//!
+//! Motivation: every ported coreutils builtin rebuilds its whole `clap::Command`
+//! on each invocation (`cat_command()` in `builtins/generated/cat_args.rs` is
+//! called from `builtins/cat.rs` per exec, and the same holds for `ls`, `od`,
+//! `stat`, …). Real scripts call these in loops, so the arg tree is constructed
+//! N times for N invocations. This bench exists to answer one question: is that
+//! construction cost visible next to the interpreter and the builtin body, or
+//! is it noise?
+//!
+//! Decision: measured end-to-end through the public `Bash::exec` API, not
+//! against `cat_command()` directly. `mod builtins` is private in `lib.rs`, and
+//! widening the public surface for a bench is worse than reading the cost as a
+//! difference between comparable scripts. The numbers are therefore read as
+//! deltas, not absolutes:
+//!
+//!   - `clap_vs_handrolled`: `cat` / `ls` (clap-parsed) against `echo` /
+//!     `printf` (hand-parsed) and `:` (no args at all). The `:` row is the
+//!     loop-and-dispatch floor; everything above it is arg handling plus body.
+//!   - `arg_surface_size`: `cat` (12 args) against `ls` (~60 args) on inputs
+//!     sized so the bodies do near-identical work. Command construction scales
+//!     with the number of `.arg(...)` calls while the body does not, so this
+//!     delta is the sharpest available signal for build cost specifically.
+//!   - `flag_count`: same builtin, more flags on the command line. Isolates
+//!     match/parse cost from construction cost (construction is constant here).
+//!
+//! Each bench runs `INVOCATIONS` calls inside one script and declares
+//! `Throughput::Elements(INVOCATIONS)`, so criterion reports per-invocation
+//! time directly and the one-time `Bash::new()` cost amortizes away.
+//!
+//! Run with: `cargo bench --bench builtin_args`
+//! Save baseline: `cargo bench --bench builtin_args -- --save-baseline before`
+//! Compare:      `cargo bench --bench builtin_args -- --baseline before`
+//!
+//! First-run results belong in `crates/bashkit/benches/results/` as
+//! `criterion-builtin_args-<moniker>-<timestamp>.md` (see AGENTS.md → Benches).
+
+use bashkit::{Bash, FileSystem, InMemoryFs};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+/// Invocations per iteration. Large enough that `Bash::new()` and parse of the
+/// surrounding loop amortize out, small enough that a 100-sample criterion run
+/// stays under a minute per bench.
+const INVOCATIONS: u64 = 500;
+
+/// Seed a VFS with one tiny file in a single-entry directory.
+///
+/// Both are deliberately minimal: a 4-byte file so `cat`'s body is one small
+/// read, and a directory holding exactly that file so `ls`'s body is one small
+/// readdir. Keeping the bodies trivial is what makes the `cat` vs `ls` delta
+/// readable as arg-surface cost rather than as I/O.
+fn seed(rt: &Runtime) -> Arc<InMemoryFs> {
+    let fs = Arc::new(InMemoryFs::new());
+    rt.block_on(async {
+        let fs_dyn: Arc<dyn FileSystem> = fs.clone();
+        fs_dyn.mkdir(Path::new("/d"), true).await.expect("mkdir /d");
+        fs_dyn
+            .write_file(Path::new("/d/f"), b"abc\n")
+            .await
+            .expect("write /d/f");
+    });
+    fs
+}
+
+/// Wrap `body` in a loop of `INVOCATIONS` iterations.
+///
+/// `for ((...))` rather than `for x in $(seq ...)`: the C-style loop keeps the
+/// measured work to the builtin under test, with no command substitution and no
+/// `seq` invocation in the middle of the thing we are timing.
+fn loop_script(body: &str) -> String {
+    format!("for ((i=0; i<{INVOCATIONS}; i++)); do {body}; done")
+}
+
+fn run(rt: &Runtime, fs: &Arc<InMemoryFs>, script: &str) {
+    rt.block_on(async {
+        let mut bash = Bash::builder().fs(fs.clone()).build();
+        let result = bash.exec(script).await.expect("exec failed");
+        std::hint::black_box(result);
+    });
+}
+
+/// Register one `INVOCATIONS`-sized loop bench in `g`.
+fn bench_loop(
+    g: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    rt: &Runtime,
+    fs: &Arc<InMemoryFs>,
+    name: &str,
+    body: &str,
+) {
+    let script = loop_script(body);
+    g.bench_function(name, |b| b.iter(|| run(rt, fs, &script)));
+}
+
+/// clap-parsed builtins against hand-parsed ones and against the empty floor.
+fn bench_clap_vs_handrolled(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed(&rt);
+    let mut g = c.benchmark_group("builtin_args/clap_vs_handrolled");
+    g.throughput(Throughput::Elements(INVOCATIONS));
+
+    // Floor: loop + dispatch only, no arguments, no body.
+    bench_loop(&mut g, &rt, &fs, "colon_noop", ":");
+    // Hand-parsed builtins, one argument each.
+    bench_loop(&mut g, &rt, &fs, "echo_handrolled", "echo x > /dev/null");
+    bench_loop(
+        &mut g,
+        &rt,
+        &fs,
+        "printf_handrolled",
+        "printf x > /dev/null",
+    );
+    // clap-parsed builtins, one argument each.
+    bench_loop(&mut g, &rt, &fs, "cat_clap", "cat /d/f > /dev/null");
+    bench_loop(&mut g, &rt, &fs, "ls_clap", "ls /d > /dev/null");
+
+    g.finish();
+}
+
+/// Small vs large clap arg surface, bodies held near-constant.
+///
+/// `cat` declares ~12 args, `ls` ~60. If `Command` construction dominates, this
+/// gap tracks the arg count; if it does not, the two rows land close together
+/// and caching the built `Command` is not worth doing.
+fn bench_arg_surface_size(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed(&rt);
+    let mut g = c.benchmark_group("builtin_args/arg_surface_size");
+    g.throughput(Throughput::Elements(INVOCATIONS));
+
+    bench_loop(&mut g, &rt, &fs, "cat_12_args", "cat /d/f > /dev/null");
+    bench_loop(&mut g, &rt, &fs, "ls_60_args", "ls /d > /dev/null");
+
+    g.finish();
+}
+
+/// Same builtin, growing flag count on the command line.
+///
+/// Construction cost is identical across these rows, so any spread is match /
+/// value-parse cost. Splitting the two matters for the fix: caching a built
+/// `Command` helps only the construction half.
+fn bench_flag_count(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let fs = seed(&rt);
+    let mut g = c.benchmark_group("builtin_args/flag_count");
+    g.throughput(Throughput::Elements(INVOCATIONS));
+
+    bench_loop(&mut g, &rt, &fs, "cat_0_flags", "cat /d/f > /dev/null");
+    bench_loop(&mut g, &rt, &fs, "cat_1_flag", "cat -n /d/f > /dev/null");
+    bench_loop(
+        &mut g,
+        &rt,
+        &fs,
+        "cat_3_flags",
+        "cat -n -E -T /d/f > /dev/null",
+    );
+
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_clap_vs_handrolled,
+    bench_arg_surface_size,
+    bench_flag_count
+);
+criterion_main!(benches);

--- a/crates/bashkit/benches/results/criterion-builtin_args-baseline-linux-x86_64-1787421390.md
+++ b/crates/bashkit/benches/results/criterion-builtin_args-baseline-linux-x86_64-1787421390.md
@@ -28,29 +28,62 @@ Question this run answers: ported coreutils builtins rebuild their whole
 
 ## Reading
 
-1. **clap is the dominant per-invocation cost for `cat`.** `cat` on a 4-byte
-   file costs 14.0 µs against 4.0 µs for `echo` — a builtin whose body does
-   comparable work minus the file read. Roughly 10 µs per invocation is arg
-   handling.
-2. **Matching flags is cheap; building the `Command` is not.** Adding flags to
-   the same `cat` command line costs ~0.45 µs each, so parse/match is a small
-   fraction of the 10 µs. The remainder is construction of the arg tree, paid
-   once per invocation and thrown away.
-3. **Cost scales with arg-surface size.** `ls` (~60 args) costs 59–61 µs
+1. **clap is the dominant per-invocation cost.** `cat` on a 4-byte file costs
+   14.0 µs against 4.0 µs for `echo` — a builtin whose body does comparable
+   work minus the file read. Roughly 10 µs per invocation is arg handling. For
+   `ls` the clap share is ~73% of a 60.8 µs invocation.
+2. **Cost scales with arg-surface size.** `ls` (~60 args) costs 59–61 µs
    against `cat`'s 14 µs. `ls`'s body does more than `cat`'s (readdir, stat,
-   column layout), so this row is not a clean isolation — but the direction
-   matches (1) and (2), and it is the largest number on the board.
+   column layout), so this row is not a clean isolation, but it is the largest
+   number on the board.
+3. **The `flag_count` rows do NOT isolate construction cost.** Adding flags to
+   the argv costs ~0.45 µs each, which initially read as "construction
+   dominates, matching is cheap". A follow-up standalone clap harness showed
+   that inference is wrong — see below.
 
-## Implication
+## Correction: where the time actually goes
 
-A script doing `for f in *; do cat "$f"; done` over 1000 files pays ~10 ms in
-`clap::Command` construction alone, and an `ls`-heavy loop several times that.
-Caching the built `Command` (e.g. `LazyLock` + clone, or bypassing clap for the
-common no-flag path) targets the construction half, which is where nearly all
-of the cost sits.
+Measured directly against `cat_command()` outside bashkit (200k iterations):
 
-Not measured here: whether `Command::clone()` is meaningfully cheaper than
-`<util>_command()`. That is the next experiment before committing to a fix.
+| step | `cat` |
+|---|---|
+| construct `Command` only | 1.09 µs |
+| `Command::clone()` only | 0.83 µs |
+| construct + `try_get_matches_from` | 7.69 µs |
+| parse alone (clone + parse − clone) | 6.27 µs |
+
+**Parsing dominates, not construction** — 6.3 µs of the 7.7 µs round trip.
+Caching to skip construction alone is worth ~1 µs of `cat`'s 14 µs, and
+`Command::clone()` is not even cheaper than rebuilding (0.83 vs 1.09 µs, inside
+noise end-to-end; a naive `LazyLock` + clone prototype measured as a 2.7%
+*regression*).
+
+The cacheable part is inside the parse: clap finalizes a `Command`
+(`_build_self` — resolves groups, propagates settings, indexes args) on first
+parse and skips it when the `Built` flag is set. Calling `Command::build()`
+once and cloning the finalized value carries that flag:
+
+| | `cat` (12 args) | `ls` (~60 args) |
+|---|---|---|
+| fresh build + parse | 7.34 µs | 44.65 µs |
+| cached *unbuilt* + parse | 7.02 µs (−4.3%) | 37.80 µs (−15.3%) |
+| cached *built* + parse | 6.50 µs (−11.4%) | 35.53 µs (−20.4%) |
+
+## Outcome
+
+Implemented as `builtins::clap_cache::cached_command!` across all 11 ported
+builtins. End-to-end re-run on this host (`--save-baseline cached`):
+
+| bench | before | after | change |
+|---|---|---|---|
+| `clap_vs_handrolled/cat_clap` | 7.006 ms | 6.862 ms | −2.1% |
+| `clap_vs_handrolled/ls_clap` | 30.408 ms | 25.852 ms | **−15.0%** |
+| `arg_surface_size/cat_12_args` | 7.017 ms | 6.717 ms | −4.3% |
+| `arg_surface_size/ls_60_args` | 29.497 ms | 26.728 ms | −9.4% |
+| `flag_count/cat_0_flags` | 7.263 ms | 6.553 ms | −9.8% |
+
+`ls` drops from 60.8 to 51.7 µs per invocation. The win tracks arg-surface
+size, so the large ports gain most and `cat` gains little.
 
 ## Context
 

--- a/crates/bashkit/benches/results/criterion-builtin_args-baseline-linux-x86_64-1787421390.md
+++ b/crates/bashkit/benches/results/criterion-builtin_args-baseline-linux-x86_64-1787421390.md
@@ -1,0 +1,60 @@
+# builtin_args — first run (baseline)
+
+`cargo bench --bench builtin_args -- --warm-up-time 1 --measurement-time 3`
+
+Host: 4× Intel Xeon @ 2.10 GHz, linux-x86_64, cloud runner (noisy; treat
+absolutes as indicative, deltas as the signal).
+Bashkit: v0.17.0, `4b634fd`.
+
+Question this run answers: ported coreutils builtins rebuild their whole
+`clap::Command` on every invocation. Is that visible?
+
+## Raw
+
+500 invocations per iteration; per-invocation column is `time ÷ 500`.
+
+| bench | time / 500 inv | per invocation | vs `:` floor |
+|---|---|---|---|
+| `clap_vs_handrolled/colon_noop` | 1.658 ms | 3.32 µs | — |
+| `clap_vs_handrolled/echo_handrolled` | 2.002 ms | 4.00 µs | +0.69 µs |
+| `clap_vs_handrolled/printf_handrolled` | 2.049 ms | 4.10 µs | +0.78 µs |
+| `clap_vs_handrolled/cat_clap` | 7.006 ms | 14.01 µs | +10.70 µs |
+| `clap_vs_handrolled/ls_clap` | 30.408 ms | 60.82 µs | +57.50 µs |
+| `arg_surface_size/cat_12_args` | 7.017 ms | 14.03 µs | +10.71 µs |
+| `arg_surface_size/ls_60_args` | 29.497 ms | 58.99 µs | +55.68 µs |
+| `flag_count/cat_0_flags` | 7.263 ms | 14.53 µs | — |
+| `flag_count/cat_1_flag` | 7.484 ms | 14.97 µs | +0.44 µs / flag |
+| `flag_count/cat_3_flags` | 7.952 ms | 15.90 µs | +0.46 µs / flag |
+
+## Reading
+
+1. **clap is the dominant per-invocation cost for `cat`.** `cat` on a 4-byte
+   file costs 14.0 µs against 4.0 µs for `echo` — a builtin whose body does
+   comparable work minus the file read. Roughly 10 µs per invocation is arg
+   handling.
+2. **Matching flags is cheap; building the `Command` is not.** Adding flags to
+   the same `cat` command line costs ~0.45 µs each, so parse/match is a small
+   fraction of the 10 µs. The remainder is construction of the arg tree, paid
+   once per invocation and thrown away.
+3. **Cost scales with arg-surface size.** `ls` (~60 args) costs 59–61 µs
+   against `cat`'s 14 µs. `ls`'s body does more than `cat`'s (readdir, stat,
+   column layout), so this row is not a clean isolation — but the direction
+   matches (1) and (2), and it is the largest number on the board.
+
+## Implication
+
+A script doing `for f in *; do cat "$f"; done` over 1000 files pays ~10 ms in
+`clap::Command` construction alone, and an `ls`-heavy loop several times that.
+Caching the built `Command` (e.g. `LazyLock` + clone, or bypassing clap for the
+common no-flag path) targets the construction half, which is where nearly all
+of the cost sits.
+
+Not measured here: whether `Command::clone()` is meaningfully cheaper than
+`<util>_command()`. That is the next experiment before committing to a fix.
+
+## Context
+
+Run in response to the usage-rs question (jdx/usage). Conclusion on adoption was
+no — our clap definitions are codegen output from uutils' `uu_app()`, not
+hand-maintained CLI boilerplate — but the perf claim behind it pointed at a real
+cost, which this bench now quantifies and guards.

--- a/crates/bashkit/src/builtins/cat.rs
+++ b/crates/bashkit/src/builtins/cat.rs
@@ -5,6 +5,7 @@
 //! `crates/bashkit-coreutils-port/`. Behaviour is implemented locally
 //! against the bashkit VFS.
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 use std::ffi::OsString;
 use std::path::Path;
@@ -15,6 +16,10 @@ use crate::interpreter::ExecResult;
 
 pub struct Cat;
 
+// Cached `cat` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(cat_cmd, super::generated::cat_args::cat_command());
+
 #[async_trait]
 impl Builtin for Cat {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -23,12 +28,7 @@ impl Builtin for Cat {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        // GNU coreutils' help layout opens with the usage line; clap's
-        // default template leads with the `about`. uutils handles this via
-        // uucore's `localized_help_template`, which we drop during codegen
-        // because it pulls in Fluent. Re-apply a GNU-equivalent template.
-        let cmd = cat_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match cat_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -192,8 +192,3 @@ fn emit_byte(out: &mut Vec<u8>, b: u8, show_tabs: bool, show_nonprinting: bool) 
         _ => out.push(b),
     }
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `cat` arg surface — see `builtins::clap_cache`.
-cached_command!(cat_cmd, super::generated::cat_args::cat_command());

--- a/crates/bashkit/src/builtins/cat.rs
+++ b/crates/bashkit/src/builtins/cat.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use std::ffi::OsString;
 use std::path::Path;
 
-use super::generated::cat_args::cat_command;
 use super::{Builtin, Context};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
@@ -28,7 +27,7 @@ impl Builtin for Cat {
         // default template leads with the `about`. uutils handles this via
         // uucore's `localized_help_template`, which we drop during codegen
         // because it pulls in Fluent. Re-apply a GNU-equivalent template.
-        let cmd = cat_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = cat_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -193,3 +192,8 @@ fn emit_byte(out: &mut Vec<u8>, b: u8, show_tabs: bool, show_nonprinting: bool) 
         _ => out.push(b),
     }
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `cat` arg surface — see `builtins::clap_cache`.
+cached_command!(cat_cmd, super::generated::cat_args::cat_command());

--- a/crates/bashkit/src/builtins/clap_cache.rs
+++ b/crates/bashkit/src/builtins/clap_cache.rs
@@ -1,0 +1,131 @@
+//! Cached `clap::Command` construction for the coreutils-ported builtins.
+//!
+//! # Decision: cache a *built* `Command`, clone per invocation
+//!
+//! Every ported builtin used to call `<util>_command()` (generated from
+//! uutils' `uu_app()`) on each invocation, so a script running `cat` in a
+//! loop reconstructed the whole arg tree N times. Measured on a 4-core Xeon
+//! (`cargo bench --bench builtin_args`, plus a standalone clap micro-harness),
+//! per invocation:
+//!
+//! | | `cat` (12 args) | `ls` (~60 args) |
+//! |---|---|---|
+//! | construct `Command` only | 1.1 µs | — |
+//! | construct + `try_get_matches_from` | 7.3 µs | 44.7 µs |
+//! | clone cached *unbuilt* + parse | 7.0 µs | 37.8 µs |
+//! | clone cached *built* + parse | 6.5 µs | 35.5 µs |
+//!
+//! Two things follow, and both shaped this module:
+//!
+//! 1. **Construction is not the expensive half — parsing is.** Building `cat`'s
+//!    tree costs 1.1 µs of the 7.3 µs round trip. Caching to avoid construction
+//!    alone is worth ~4%, which is why this is not a plain `LazyLock<Command>`
+//!    holding the output of `<util>_command()`.
+//! 2. **Most of the parse cost is `_build_self`, and it is cacheable.** clap
+//!    finalizes a `Command` (resolves groups, propagates settings, indexes
+//!    args) on first parse, and skips that work when the `Built` flag is
+//!    already set. Calling [`clap::Command::build`] once and cloning the
+//!    finalized value carries the flag along, so each invocation pays only
+//!    matching: −11% for `cat`, −20% for `ls`.
+//!
+//! The win scales with arg-surface size, so the large ports (`ls`, `stat`,
+//! `od`) benefit most. `Command::clone` is *not* cheaper than
+//! `<util>_command()` on its own (0.83 µs vs 1.1 µs, and the difference is
+//! inside noise end-to-end) — the skipped `_build_self` is the entire point.
+//!
+//! `help_template` must be applied before `build()`, which is why the macro
+//! owns both steps rather than leaving the template to callers.
+
+/// GNU coreutils' help layout opens with the usage line; clap's default
+/// template leads with the `about`. uutils handles this via uucore's
+/// `localized_help_template`, which codegen drops because it pulls in Fluent
+/// (see `knowledge/runtimes/coreutils-args-port.md`). Re-applied here so every
+/// ported builtin renders GNU-equivalent help from one definition.
+pub const GNU_HELP_TEMPLATE: &str = "Usage: {usage}\n{about}\n\n{all-args}\n";
+
+/// Define a cached accessor for a generated `clap::Command`.
+///
+/// Expands to `fn $name() -> clap::Command` returning a clone of a
+/// process-lifetime `Command` that has already had [`GNU_HELP_TEMPLATE`]
+/// applied and [`clap::Command::build`] called on it.
+///
+/// ```ignore
+/// cached_command!(cat_cmd, super::generated::cat_args::cat_command());
+/// let matches = cat_cmd().try_get_matches_from(argv)?;
+/// ```
+macro_rules! cached_command {
+    ($(#[$attr:meta])* $name:ident, $builder:expr) => {
+        $(#[$attr])*
+        fn $name() -> clap::Command {
+            static CACHE: std::sync::LazyLock<clap::Command> = std::sync::LazyLock::new(|| {
+                let mut cmd = $builder.help_template($crate::builtins::clap_cache::GNU_HELP_TEMPLATE);
+                // Finalize once. Clones inherit the `Built` flag, so
+                // `try_get_matches_from` skips `_build_self` per invocation.
+                cmd.build();
+                cmd
+            });
+            CACHE.clone()
+        }
+    };
+}
+
+pub(crate) use cached_command;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    cached_command!(cat_cmd, crate::builtins::generated::cat_args::cat_command());
+
+    /// A cached, pre-built command must parse identically to a freshly
+    /// constructed one. Guards the `build()`-then-`clone()` shortcut against
+    /// clap changing what `Built` implies.
+    #[test]
+    fn cached_command_parses_like_a_fresh_one() {
+        let argv = ["cat", "-n", "-E", "/d/f"];
+        let fresh = crate::builtins::generated::cat_args::cat_command()
+            .help_template(GNU_HELP_TEMPLATE)
+            .try_get_matches_from(argv)
+            .expect("fresh parse");
+        let cached = cat_cmd().try_get_matches_from(argv).expect("cached parse");
+
+        assert_eq!(fresh.get_flag("number"), cached.get_flag("number"));
+        assert_eq!(fresh.get_flag("show-ends"), cached.get_flag("show-ends"));
+        assert_eq!(fresh.get_flag("show-tabs"), cached.get_flag("show-tabs"));
+        let raw = |m: &clap::ArgMatches| {
+            m.get_raw("file")
+                .map(|v| v.map(|s| s.to_owned()).collect::<Vec<_>>())
+        };
+        assert_eq!(raw(&fresh), raw(&cached));
+    }
+
+    /// Repeated calls must not accumulate state — each clone parses from
+    /// scratch, and a parse error on one call must not poison the next.
+    #[test]
+    fn cached_command_is_reusable_across_calls() {
+        assert!(cat_cmd().try_get_matches_from(["cat", "--nope"]).is_err());
+        let ok = cat_cmd()
+            .try_get_matches_from(["cat", "-n", "/d/f"])
+            .expect("parse after an earlier error");
+        assert!(ok.get_flag("number"));
+        // Same argv twice yields the same result (no residue on the cache).
+        let again = cat_cmd()
+            .try_get_matches_from(["cat", "-n", "/d/f"])
+            .expect("second parse");
+        assert!(again.get_flag("number"));
+    }
+
+    /// Help rendering must survive the pre-`build()` template application —
+    /// the GNU layout leads with `Usage:`, clap's default does not.
+    #[test]
+    fn cached_command_renders_gnu_help_layout() {
+        let err = cat_cmd()
+            .try_get_matches_from(["cat", "--help"])
+            .expect_err("--help exits via Err");
+        let rendered = err.render().to_string();
+        assert!(
+            rendered.starts_with("Usage:"),
+            "help must open with the usage line, got: {rendered}"
+        );
+    }
+}

--- a/crates/bashkit/src/builtins/fileops.rs
+++ b/crates/bashkit/src/builtins/fileops.rs
@@ -4,6 +4,7 @@
 // THREAT[TM-INF-018]: timezone-naive `touch -t` stamps are UTC; host-local
 // conversion would leak process timezone through a later `date -r`.
 
+use super::clap_cache::cached_command;
 use crate::time_compat::SystemTime;
 use async_trait::async_trait;
 use chrono::{DateTime, Datelike, NaiveDate, Utc};
@@ -1015,6 +1016,10 @@ fn mktemp_name(template: Option<&str>, suffix: &str) -> String {
     }
 }
 
+// Cached `mktemp` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(mktemp_cmd, super::generated::mktemp_args::mktemp_command());
+
 #[async_trait]
 impl Builtin for Mktemp {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -1025,8 +1030,7 @@ impl Builtin for Mktemp {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = mktemp_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match mktemp_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -1133,12 +1137,6 @@ impl Builtin for Mktemp {
         Ok(ExecResult::err(msg, 1))
     }
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `mktemp` arg surface — see `builtins::clap_cache`.
-cached_command!(mktemp_cmd, super::generated::mktemp_args::mktemp_command());
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/fileops.rs
+++ b/crates/bashkit/src/builtins/fileops.rs
@@ -1018,7 +1018,6 @@ fn mktemp_name(template: Option<&str>, suffix: &str) -> String {
 #[async_trait]
 impl Builtin for Mktemp {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        use super::generated::mktemp_args::mktemp_command;
         use std::ffi::OsString;
         use std::path::PathBuf;
 
@@ -1026,7 +1025,7 @@ impl Builtin for Mktemp {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = mktemp_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = mktemp_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -1134,6 +1133,11 @@ impl Builtin for Mktemp {
         Ok(ExecResult::err(msg, 1))
     }
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `mktemp` arg surface — see `builtins::clap_cache`.
+cached_command!(mktemp_cmd, super::generated::mktemp_args::mktemp_command());
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/hextools.rs
+++ b/crates/bashkit/src/builtins/hextools.rs
@@ -1,5 +1,6 @@
 //! od, xxd, and hexdump builtins - byte-level inspection tools
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 
 use super::{Builtin, Context};
@@ -221,6 +222,10 @@ fn od_dump(data: &[u8], opts: &OdOptions) -> String {
     output
 }
 
+// Cached `od` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(od_cmd, super::generated::od_args::od_command());
+
 #[async_trait]
 impl Builtin for Od {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -230,8 +235,7 @@ impl Builtin for Od {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = od_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match od_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -661,12 +665,6 @@ async fn collect_input(
 
     Ok(data)
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `od` arg surface — see `builtins::clap_cache`.
-cached_command!(od_cmd, super::generated::od_args::od_command());
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/hextools.rs
+++ b/crates/bashkit/src/builtins/hextools.rs
@@ -224,14 +224,13 @@ fn od_dump(data: &[u8], opts: &OdOptions) -> String {
 #[async_trait]
 impl Builtin for Od {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        use super::generated::od_args::od_command;
         use std::ffi::OsString;
 
         let argv: Vec<OsString> = std::iter::once(OsString::from("od"))
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = od_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = od_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -662,6 +661,11 @@ async fn collect_input(
 
     Ok(data)
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `od` arg surface — see `builtins::clap_cache`.
+cached_command!(od_cmd, super::generated::od_args::od_command());
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/inspect.rs
+++ b/crates/bashkit/src/builtins/inspect.rs
@@ -1,5 +1,6 @@
 //! File inspection builtins - less, file, stat
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 
 use super::{Builtin, Context, resolve_path};
@@ -253,6 +254,10 @@ fn determine_file_content_type(content: &[u8]) -> String {
 /// unsupported tokens are echoed verbatim.
 pub struct Stat;
 
+// Cached `stat` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(stat_cmd, super::generated::stat_args::stat_command());
+
 #[async_trait]
 impl Builtin for Stat {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -262,8 +267,7 @@ impl Builtin for Stat {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = stat_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match stat_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -436,12 +440,6 @@ fn default_stat_format(name: &str, metadata: &crate::fs::Metadata) -> String {
         modified,
     )
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `stat` arg surface — see `builtins::clap_cache`.
-cached_command!(stat_cmd, super::generated::stat_args::stat_command());
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/inspect.rs
+++ b/crates/bashkit/src/builtins/inspect.rs
@@ -256,14 +256,13 @@ pub struct Stat;
 #[async_trait]
 impl Builtin for Stat {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        use super::generated::stat_args::stat_command;
         use std::ffi::OsString;
 
         let argv: Vec<OsString> = std::iter::once(OsString::from("stat"))
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = stat_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = stat_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -437,6 +436,11 @@ fn default_stat_format(name: &str, metadata: &crate::fs::Metadata) -> String {
         modified,
     )
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `stat` arg surface — see `builtins::clap_cache`.
+cached_command!(stat_cmd, super::generated::stat_args::stat_command());
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/ls/list.rs
+++ b/crates/bashkit/src/builtins/ls/list.rs
@@ -3,6 +3,7 @@
 // Uses unwrap() for validated single-char strings.
 #![allow(clippy::unwrap_used)]
 
+use crate::builtins::clap_cache::cached_command;
 use async_trait::async_trait;
 use std::ffi::OsString;
 use std::path::Path;
@@ -63,6 +64,10 @@ pub(super) struct LsOptions {
 ///   -d   List directories themselves, not their contents
 pub struct Ls;
 
+// Cached `ls` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(ls_cmd, super::super::generated::ls_args::ls_command());
+
 #[async_trait]
 impl Builtin for Ls {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -76,12 +81,7 @@ impl Builtin for Ls {
         // see TM-INF-024 and `builtins/clap_env.rs`.
         let argv = apply_env_defaults(argv, LS_ENV_DEFAULTS, ctx.env);
 
-        // GNU coreutils' help layout opens with the usage line; clap's
-        // default template leads with the `about`. uutils handles this via
-        // uucore's `localized_help_template`, which we drop during codegen
-        // because it pulls in Fluent. Re-apply a GNU-equivalent template.
-        let cmd = ls_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match ls_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -469,8 +469,3 @@ fn human_readable_size(size: u64) -> String {
         format!("{:>6}", size)
     }
 }
-
-use super::super::clap_cache::cached_command;
-
-// Cached `ls` arg surface — see `builtins::clap_cache`.
-cached_command!(ls_cmd, super::super::generated::ls_args::ls_command());

--- a/crates/bashkit/src/builtins/ls/list.rs
+++ b/crates/bashkit/src/builtins/ls/list.rs
@@ -8,7 +8,7 @@ use std::ffi::OsString;
 use std::path::Path;
 
 use crate::builtins::clap_env::apply_env_defaults;
-use crate::builtins::generated::ls_args::{LS_ENV_DEFAULTS, ls_command};
+use crate::builtins::generated::ls_args::LS_ENV_DEFAULTS;
 use crate::builtins::{Builtin, Context, resolve_path};
 use crate::error::Result;
 use crate::fs::FileType;
@@ -80,7 +80,7 @@ impl Builtin for Ls {
         // default template leads with the `about`. uutils handles this via
         // uucore's `localized_help_template`, which we drop during codegen
         // because it pulls in Fluent. Re-apply a GNU-equivalent template.
-        let cmd = ls_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = ls_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -469,3 +469,8 @@ fn human_readable_size(size: u64) -> String {
         format!("{:>6}", size)
     }
 }
+
+use super::super::clap_cache::cached_command;
+
+// Cached `ls` arg surface — see `builtins::clap_cache`.
+cached_command!(ls_cmd, super::super::generated::ls_args::ls_command());

--- a/crates/bashkit/src/builtins/mod.rs
+++ b/crates/bashkit/src/builtins/mod.rs
@@ -32,6 +32,7 @@ mod bc;
 mod caller;
 mod cat;
 mod checksum;
+mod clap_cache;
 mod clap_env;
 mod clear;
 mod column;

--- a/crates/bashkit/src/builtins/path.rs
+++ b/crates/bashkit/src/builtins/path.rs
@@ -1,5 +1,6 @@
 //! Path manipulation builtins - basename, dirname
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 use std::path::Path;
 
@@ -145,6 +146,13 @@ impl Builtin for Dirname {
 /// `-L`/`-P`/`--strip` collapse to the same lexical canonicalisation.
 pub struct Realpath;
 
+// Cached `realpath` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(
+    realpath_cmd,
+    super::generated::realpath_args::realpath_command()
+);
+
 #[async_trait]
 impl Builtin for Realpath {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -154,8 +162,7 @@ impl Builtin for Realpath {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = realpath_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match realpath_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -254,6 +261,13 @@ impl Builtin for Realpath {
 ///   (no flag) print symlink target without canonicalization
 pub struct Readlink;
 
+// Cached `readlink` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(
+    readlink_cmd,
+    super::generated::readlink_args::readlink_command()
+);
+
 #[async_trait]
 impl Builtin for Readlink {
     #[allow(clippy::collapsible_if)]
@@ -262,8 +276,7 @@ impl Builtin for Readlink {
             .chain(ctx.args.iter().map(std::ffi::OsString::from))
             .collect();
 
-        let cmd = readlink_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match readlink_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -478,21 +491,6 @@ async fn follow_readlink_symlinks(
         }
     }
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `realpath` arg surface — see `builtins::clap_cache`.
-cached_command!(
-    realpath_cmd,
-    super::generated::realpath_args::realpath_command()
-);
-
-// Cached `readlink` arg surface — see `builtins::clap_cache`.
-cached_command!(
-    readlink_cmd,
-    super::generated::readlink_args::readlink_command()
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/path.rs
+++ b/crates/bashkit/src/builtins/path.rs
@@ -148,14 +148,13 @@ pub struct Realpath;
 #[async_trait]
 impl Builtin for Realpath {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        use super::generated::realpath_args::realpath_command;
         use std::ffi::OsString;
 
         let argv: Vec<OsString> = std::iter::once(OsString::from("realpath"))
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = realpath_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = realpath_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -263,8 +262,7 @@ impl Builtin for Readlink {
             .chain(ctx.args.iter().map(std::ffi::OsString::from))
             .collect();
 
-        let cmd = super::generated::readlink_args::readlink_command()
-            .help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = readlink_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -480,6 +478,20 @@ async fn follow_readlink_symlinks(
         }
     }
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `realpath` arg surface — see `builtins::clap_cache`.
+cached_command!(
+    realpath_cmd,
+    super::generated::realpath_args::realpath_command()
+);
+
+// Cached `readlink` arg surface — see `builtins::clap_cache`.
+cached_command!(
+    readlink_cmd,
+    super::generated::readlink_args::readlink_command()
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/pipeline.rs
+++ b/crates/bashkit/src/builtins/pipeline.rs
@@ -288,14 +288,13 @@ pub struct Tee;
 #[async_trait]
 impl Builtin for Tee {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
-        use super::generated::tee_args::tee_command;
         use std::ffi::OsString;
 
         let argv: Vec<OsString> = std::iter::once(OsString::from("tee"))
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = tee_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = tee_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -419,6 +418,11 @@ impl Builtin for Watch {
         Ok(ExecResult::ok(output))
     }
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `tee` arg surface — see `builtins::clap_cache`.
+cached_command!(tee_cmd, super::generated::tee_args::tee_command());
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/pipeline.rs
+++ b/crates/bashkit/src/builtins/pipeline.rs
@@ -1,5 +1,6 @@
 //! Pipeline control builtins - xargs, tee, watch
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 
 use super::{Builtin, Context, ExecutionPlan, SubCommand, resolve_path};
@@ -285,6 +286,10 @@ impl Builtin for Xargs {
 /// the bashkit VFS.
 pub struct Tee;
 
+// Cached `tee` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(tee_cmd, super::generated::tee_args::tee_command());
+
 #[async_trait]
 impl Builtin for Tee {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -294,8 +299,7 @@ impl Builtin for Tee {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = tee_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match tee_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -418,12 +422,6 @@ impl Builtin for Watch {
         Ok(ExecResult::ok(output))
     }
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `tee` arg surface — see `builtins::clap_cache`.
-cached_command!(tee_cmd, super::generated::tee_args::tee_command());
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/shuf.rs
+++ b/crates/bashkit/src/builtins/shuf.rs
@@ -9,6 +9,7 @@
 //! reject outputs that exceed ExecutionLimits before allocation and must never
 //! materialize numeric ranges only to apply `-n` afterward.
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -22,6 +23,10 @@ use crate::limits::ExecutionLimits;
 
 pub struct Shuf;
 
+// Cached `shuf` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(shuf_cmd, super::generated::shuf_args::shuf_command());
+
 #[async_trait]
 impl Builtin for Shuf {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -29,8 +34,7 @@ impl Builtin for Shuf {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = shuf_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match shuf_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -416,12 +420,6 @@ impl SmallRng {
         }
     }
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `shuf` arg surface — see `builtins::clap_cache`.
-cached_command!(shuf_cmd, super::generated::shuf_args::shuf_command());
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/shuf.rs
+++ b/crates/bashkit/src/builtins/shuf.rs
@@ -15,7 +15,6 @@ use std::ffi::OsString;
 use std::ops::RangeInclusive;
 use std::path::Path;
 
-use super::generated::shuf_args::shuf_command;
 use super::{Builtin, Context, read_text_file};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
@@ -30,7 +29,7 @@ impl Builtin for Shuf {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = shuf_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = shuf_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -417,6 +416,11 @@ impl SmallRng {
         }
     }
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `shuf` arg surface — see `builtins::clap_cache`.
+cached_command!(shuf_cmd, super::generated::shuf_args::shuf_command());
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/textrev.rs
+++ b/crates/bashkit/src/builtins/textrev.rs
@@ -4,6 +4,7 @@
 //! `bashkit-coreutils-port` — see `generated/tac_args.rs`. `rev` keeps a
 //! handwritten parser because uutils does not ship a `rev` (BSD-only).
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 use std::ffi::OsString;
 use std::path::Path;
@@ -52,6 +53,10 @@ async fn read_input(ctx: &Context<'_>) -> std::result::Result<String, ExecResult
 /// The tac builtin — concatenate and print files in reverse (line order).
 pub struct Tac;
 
+// Cached `tac` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(tac_cmd, super::generated::tac_args::tac_command());
+
 #[async_trait]
 impl Builtin for Tac {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -59,8 +64,7 @@ impl Builtin for Tac {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = tac_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match tac_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -202,12 +206,6 @@ impl Builtin for Rev {
         Ok(ExecResult::ok(output))
     }
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `tac` arg surface — see `builtins::clap_cache`.
-cached_command!(tac_cmd, super::generated::tac_args::tac_command());
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bashkit/src/builtins/textrev.rs
+++ b/crates/bashkit/src/builtins/textrev.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use std::ffi::OsString;
 use std::path::Path;
 
-use super::generated::tac_args::tac_command;
 use super::{Builtin, Context, read_text_file};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
@@ -60,7 +59,7 @@ impl Builtin for Tac {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = tac_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = tac_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -203,6 +202,11 @@ impl Builtin for Rev {
         Ok(ExecResult::ok(output))
     }
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `tac` arg surface — see `builtins::clap_cache`.
+cached_command!(tac_cmd, super::generated::tac_args::tac_command());
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/truncate.rs
+++ b/crates/bashkit/src/builtins/truncate.rs
@@ -13,7 +13,6 @@
 use async_trait::async_trait;
 use std::ffi::OsString;
 
-use super::generated::truncate_args::truncate_command;
 use super::{Builtin, Context, resolve_path};
 use crate::error::Result;
 use crate::interpreter::ExecResult;
@@ -27,7 +26,7 @@ impl Builtin for Truncate {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = truncate_command().help_template("Usage: {usage}\n{about}\n\n{all-args}\n");
+        let cmd = truncate_cmd();
         let matches = match cmd.try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
@@ -266,6 +265,14 @@ fn parse_size_number(raw: &str) -> Option<u64> {
     };
     n.checked_mul(mul)
 }
+
+use super::clap_cache::cached_command;
+
+// Cached `truncate` arg surface — see `builtins::clap_cache`.
+cached_command!(
+    truncate_cmd,
+    super::generated::truncate_args::truncate_command()
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/bashkit/src/builtins/truncate.rs
+++ b/crates/bashkit/src/builtins/truncate.rs
@@ -10,6 +10,7 @@
 //! configured limits before resizing buffers. `write_file` enforces those
 //! limits too late to guard this built-in's in-memory zero-fill path.
 
+use super::clap_cache::cached_command;
 use async_trait::async_trait;
 use std::ffi::OsString;
 
@@ -19,6 +20,13 @@ use crate::interpreter::ExecResult;
 
 pub struct Truncate;
 
+// Cached `truncate` arg surface: pre-built once, cloned per invocation.
+// See `builtins::clap_cache` for why it is built, not just constructed.
+cached_command!(
+    truncate_cmd,
+    super::generated::truncate_args::truncate_command()
+);
+
 #[async_trait]
 impl Builtin for Truncate {
     async fn execute(&self, ctx: Context<'_>) -> Result<ExecResult> {
@@ -26,8 +34,7 @@ impl Builtin for Truncate {
             .chain(ctx.args.iter().map(OsString::from))
             .collect();
 
-        let cmd = truncate_cmd();
-        let matches = match cmd.try_get_matches_from(argv) {
+        let matches = match truncate_cmd().try_get_matches_from(argv) {
             Ok(m) => m,
             Err(e) => {
                 let kind = e.kind();
@@ -265,15 +272,6 @@ fn parse_size_number(raw: &str) -> Option<u64> {
     };
     n.checked_mul(mul)
 }
-
-use super::clap_cache::cached_command;
-
-// Cached `truncate` arg surface — see `builtins::clap_cache`.
-cached_command!(
-    truncate_cmd,
-    super::generated::truncate_args::truncate_command()
-);
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/knowledge/runtimes/coreutils-args-port.md
+++ b/knowledge/runtimes/coreutils-args-port.md
@@ -68,6 +68,41 @@ codegen**, not by depending on `uu_*` crates at runtime.
 5. Emits `crates/bashkit/src/builtins/generated/<util>_args.rs` with a clean
    `pub fn <util>_command() -> clap::Command`.
 
+## Per-invocation cost: cache a *built* `Command`
+
+`<util>_command()` is codegen output, so calling it per invocation rebuilt the
+whole arg tree on every `cat`/`ls`/`stat` in a script loop. Benchmarked
+(`cargo bench --bench builtin_args`, results under
+`crates/bashkit/benches/results/`): clap accounts for ~10 µs of a 14 µs `cat`
+invocation and ~73% of a 60 µs `ls` invocation.
+
+The naive fix does not work. Construction is only ~1.1 µs of `cat`'s 7.3 µs
+clap round trip, and `Command::clone()` (0.83 µs) is not meaningfully cheaper
+than rebuilding — a `LazyLock<Command>` + clone prototype measured as a
+regression. **Parsing dominates**, and most of it is clap's `_build_self`
+(group resolution, setting propagation, arg indexing), which clap skips when
+the `Built` flag is already set.
+
+So `builtins::clap_cache::cached_command!` caches a `Command` that has had
+`GNU_HELP_TEMPLATE` applied and `Command::build()` called on it, and hands out
+clones. Clones inherit `Built`, so each invocation pays only matching: −11% for
+`cat`, −20% for `ls` on the clap portion; −15% end-to-end for `ls`.
+
+Constraints this encodes:
+
+- `help_template` must be applied **before** `build()`, so the macro owns both
+  steps rather than leaving the template to callers. `GNU_HELP_TEMPLATE` is
+  therefore defined once in `clap_cache`, not repeated per builtin.
+- The gain scales with arg-surface size. Small surfaces (`cat`, `tac`) gain
+  little; the cache is uniform across all 11 ports for consistency, not because
+  each one needs it.
+- `apply_env_defaults` (TM-INF-024) rewrites argv, never the `Command`, so it
+  composes with the cache unchanged.
+
+`builtins::clap_cache::tests` guards the shortcut: a cached command must parse
+identically to a fresh one, stay reusable after a parse error, and still render
+the GNU help layout. `benches/builtin_args.rs` is the perf guard.
+
 bashkit's `Builtin::execute` calls `<util>_command().try_get_matches_from(...)`
 and implements behaviour against the VFS. `clap` is an unconditional
 dependency, no feature flag for the ported path or the `ClapBuiltin` trait.


### PR DESCRIPTION
## What changed

Ported coreutils builtins (`cat`, `ls`, `od`, `stat`, `tee`, `shuf`, `tac`, `truncate`, `realpath`, `readlink`, `mktemp`) no longer rebuild their generated `clap::Command` on every invocation. A new `builtins::clap_cache::cached_command!` macro caches a `Command` that has already had the GNU help template applied and `Command::build()` called on it, and hands out clones.

`ls` drops from **60.8 to 51.7 µs per invocation (-15%)**. No behavior change: same parsing, same help output, same exit codes.

Also adds `benches/builtin_args.rs`, the criterion bench that found this and now guards it.

## Why

Every ported builtin called `<util>_command()` per invocation, so a script running `cat` in a loop reconstructed the whole arg tree N times. Nothing measured it.

The obvious fix does not work, and the bench is what showed that:

| | `cat` |
|---|---|
| construct `Command` only | 1.09 µs |
| `Command::clone()` only | 0.83 µs |
| construct + `try_get_matches_from` | 7.69 µs |
| parse alone | 6.27 µs |

Construction is only ~1.1 µs of the round trip, and `clone()` is not cheaper than rebuilding — a plain `LazyLock<Command>` + clone prototype measured as a 2.7% *regression*.

**Parsing dominates, and most of it is cacheable.** clap finalizes a `Command` (`_build_self`: resolves groups, propagates settings, indexes args) on first parse and skips that work when the `Built` flag is set. Calling `build()` once and cloning the finalized value carries the flag along, so each invocation pays only matching:

| | `cat` (12 args) | `ls` (~60 args) |
|---|---|---|
| fresh build + parse | 7.34 µs | 44.65 µs |
| cached *unbuilt* + parse | 7.02 µs (-4.3%) | 37.80 µs (-15.3%) |
| cached *built* + parse | 6.50 µs (**-11.4%**) | 35.53 µs (**-20.4%**) |

The gain tracks arg-surface size, so the large ports benefit most and `cat` gains little.

Context: this came out of evaluating whether to adopt usage-rs (jdx/usage). Adoption answer was no — our clap definitions are codegen output from uutils' `uu_app()`, not the hand-maintained CLI boilerplate usage-rs replaces — but the perf claim behind it pointed at a real cost.

## Before / After

End-to-end, `cargo bench --bench builtin_args` on a 4-core Xeon @ 2.10 GHz (500 invocations per iteration):

| bench | before | after | change |
|---|---|---|---|
| `clap_vs_handrolled/cat_clap` | 7.006 ms | 6.862 ms | -2.1% |
| `clap_vs_handrolled/ls_clap` | 30.408 ms | 25.852 ms | **-15.0%** |
| `arg_surface_size/cat_12_args` | 7.017 ms | 6.717 ms | -4.3% |
| `arg_surface_size/ls_60_args` | 29.497 ms | 26.728 ms | -9.4% |
| `flag_count/cat_0_flags` | 7.263 ms | 6.553 ms | -9.8% |

Behavior unchanged — all 11 builtins smoke-tested, GNU usage-first help layout preserved:

```
$ cat -n /d/f          $ cat -A /d/g          $ od -c <<< AB
     1  a              x^Iy$                  0000000 A B
     2  b                                     0000002

$ cat --help      → Usage: cat [OPTION]... [FILE]...
$ ls --help       → Usage: ls [OPTION]... [FILE]...
$ stat --help     → Usage: stat [OPTION]... FILE...
$ realpath --help → Usage: realpath [OPTION]... FILE...
      (all 11 verified usage-first)
```

Full run in `crates/bashkit/benches/results/criterion-builtin_args-baseline-linux-x86_64-1787421390.md`.

## Risk

- **Low**
- The one real risk is the `build()`-then-`clone()` shortcut: if clap changed what the `Built` flag implies, a cached command could parse differently from a fresh one. `clap_cache::tests` pins exactly that — parse parity against a freshly constructed `Command`, reuse after a parse error (no residue on the cache), and GNU help layout. The 11 ported builtins keep their existing test and spec coverage, all green.
- `apply_env_defaults` (TM-INF-024) rewrites argv, never the `Command`, so it composes with the cache unchanged.
- One process-lifetime `Command` per ported builtin is now resident instead of transient. Bounded and small.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (internal code, no public API change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ra8mB73wDLfisfs7FwARcg)_