### PR TITLE
chore(release): prepare v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-08-22
+
+### Highlights
+
+- **The native npm package ships again.** `@everruns/bashkit` stalled at 0.16.0
+  during the v0.17.0 release because the publish workflow tested Node 20 in
+  ways CI no longer did; the release path and CI now agree, and a check fails
+  when they drift apart again.
+
 ### Fixed
 
 - The npm native package publishes again: `publish-js.yml` no longer runs the
@@ -20,6 +29,21 @@
   release time than in CI, or when `dtolnay/rust-toolchain` pins disagree
   across workflows. This class of drift is otherwise invisible until a tag
   exists and part of the release has already published.
+
+### Performance
+
+- Ported coreutils builtins reuse pre-built clap `Command` definitions instead
+  of rebuilding them per invocation
+  ([#2347](https://github.com/everruns/bashkit/pull/2347)).
+
+### What's Changed
+
+* perf(builtins): cache pre-built clap Commands for ported coreutils builtins ([#2347](https://github.com/everruns/bashkit/pull/2347)) by @chaliy
+* fix(test): mount a real temp dir in the JS runtime-compat suite ([#2346](https://github.com/everruns/bashkit/pull/2346)) by @chaliy
+* fix(release): run the Node 20 compat suite under bash on Windows ([#2345](https://github.com/everruns/bashkit/pull/2345)) by @chaliy
+* fix(release): unblock the npm native publish and catch release/CI matrix drift ([#2344](https://github.com/everruns/bashkit/pull/2344)) by @chaliy
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.17.0...v0.17.1
 
 ## [0.17.0] - 2026-08-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-capi"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bashkit",
  "serde",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bashkit",
  "napi",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bashkit",
  "num-bigint",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Enable the `sqlite` feature to embed [Turso](https://github.com/tursodatabase/tu
 
 ```toml
 [dependencies]
-bashkit = { version = "0.17.0", features = ["sqlite"] }
+bashkit = { version = "0.17.1", features = ["sqlite"] }
 ```
 
 ```rust

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -37,7 +37,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # `tzdata` is listed explicitly: an interactive shell must keep honouring
 # named `TZ=` zones in `date`, which stopped being implied when chrono-tz
 # moved behind a feature.
-bashkit = { path = "../bashkit", version = "0.17.0", default-features = false, features = ["http_client", "ring", "git", "jq", "tzdata"] }
+bashkit = { path = "../bashkit", version = "0.17.1", default-features = false, features = ["http_client", "ring", "git", "jq", "tzdata"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/crates/bashkit/docs/logging.md
+++ b/crates/bashkit/docs/logging.md
@@ -14,7 +14,7 @@ Add the `logging` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.17.0", features = ["logging"] }
+bashkit = { version = "0.17.1", features = ["logging"] }
 tracing-subscriber = "0.3"  # or your preferred subscriber
 ```
 

--- a/crates/bashkit/docs/sqlite.md
+++ b/crates/bashkit/docs/sqlite.md
@@ -13,7 +13,7 @@ the `sqlite` feature. The engine is [Turso](https://github.com/tursodatabase/tur
 
 ```toml
 # Cargo.toml
-bashkit = { version = "0.17.0", features = ["sqlite"] }
+bashkit = { version = "0.17.1", features = ["sqlite"] }
 ```
 
 ```rust,ignore

--- a/crates/bashkit/fuzz/Cargo.lock
+++ b/crates/bashkit/fuzz/Cargo.lock
@@ -119,7 +119,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bashkit"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -322,7 +322,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.17.0", features = ["git"] }
+//! bashkit = { version = "0.17.1", features = ["git"] }
 //! ```
 //!
 //! ```rust,ignore
@@ -353,7 +353,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.17.0", features = ["python"] }
+//! bashkit = { version = "0.17.1", features = ["python"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/docs/builtin_typescript.md
+++ b/docs/builtin_typescript.md
@@ -12,7 +12,7 @@ Add the `typescript` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.17.0", features = ["typescript"] }
+bashkit = { version = "0.17.1", features = ["typescript"] }
 ```
 
 Enable TypeScript in the builder:

--- a/examples/hyperlight/Cargo.lock
+++ b/examples/hyperlight/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bashkit"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/knowledge/operations/release-process.md
+++ b/knowledge/operations/release-process.md
@@ -228,6 +228,13 @@ publishes to npm. Secret:
 `--provenance`, same pattern as everruns/sdk. JS package version is synced
 from the workspace `Cargo.toml` by `build.rs` updating `package.json`.
 
+Only a run whose ref is the release tag (`refs/tags/vX.Y.Z`, version matching
+`package.json`) publishes as npm `latest`; every other ref, including a manual
+dispatch from `main`, publishes under `next`. So a failed npm publish cannot be
+recovered by re-dispatching from `main`: fix the cause and cut a patch release,
+whose tag then publishes `latest`. v0.17.0 landed on `next` this way, and
+v0.17.1 is what put the native package back on `latest`.
+
 ### publish-wasm.yml
 
 Dispatched by `release.yml` from the verified release tag. Builds the


### PR DESCRIPTION
## What changed

Patch release carrying the three fixes merged since v0.17.0 (#2344, #2345, #2346) and putting `@everruns/bashkit` back on npm `latest`.

## Why

v0.17.0 published to crates.io, PyPI, and `@everruns/bashkit-wasm`, but the native npm package stalled at 0.16.0: `publish-js.yml` ran the ava suites on Node 20 after ava 8 dropped support, then (once gated) hit two more Windows-only faults — a glob Node 20 cannot expand under PowerShell, and a runtime-compat test mounting a hardcoded host `/tmp`.

With those fixed, a manual dispatch of `publish-js.yml` from `main` published 0.17.0 to npm under the **`next`** dist-tag, not `latest`. That is the workflow behaving correctly: only a run whose ref is `refs/tags/vX.Y.Z` may publish `latest`, so branch and manual refs cannot become the default install target. The v0.17.0 tag predates the fixes, so re-dispatching from that tag would just fail again. Cutting v0.17.1 is the way to get a tag that both contains the fixes and publishes `latest`.

Also records that dist-tag rule in `knowledge/operations/release-process.md`, so a failed npm publish is not chased with another dispatch from `main`.

## Before / After

Registries now:

```text
crates.io bashkit / bashkit-cli      -> 0.17.0
PyPI bashkit                         -> 0.17.0
npm @everruns/bashkit-wasm (latest)  -> 0.17.0
npm @everruns/bashkit (latest)       -> 0.16.0   (0.17.0 sits on `next`)
```

After this release all six report 0.17.1, including npm native on `latest`.

Publish-readiness:

- `just pre-pr` passed: fmt, clippy, Rust test suite, script unit tests, capability parity, OKF bundle, doc links, `just check-workflow-parity`, `cargo vet`.
- `cargo publish --dry-run -p bashkit` packaged and verified v0.17.1.
- Registry-backed `bashkit-cli` package dry-run succeeded (7 files, 229.6 KiB). The proxy now reports `kept http_client, ring, git, jq, tzdata; dropped (none)` — the published 0.17.0 core carries the features that broke it during the last release, confirming the #2343 fix generalizes.
- Version sync verified across workspace `Cargo.toml`, the CLI path-dep pin, both `package.json` files, `crates/bashkit/src/lib.rs`, README, docs snippets, and all four lockfiles.
- No API surface changed since v0.17.0 (workflow, test, and tooling only), so the self-hosted API references are untouched; `apidocs-drift` still covers them.

## Risk

- Low
- No library code changes since v0.17.0; the diff is a version bump plus changelog and knowledge.
- npm native `latest` moves 0.16.0 → 0.17.1, skipping 0.17.0, which remains installable on `next`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
