### PR TITLE
chore(deps): bump turso_core from 0.8.0-pre.4 to 0.8.0-pre.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1474,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4487,7 +4487,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4545,7 +4545,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5276,7 +5276,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5605,9 +5605,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turso_core"
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d21d176e7cc7dc607778f33b186ad981003969451ca0e3dca7494ea5ebb08a"
+checksum = "ae723f6e4b3271dfa3d3e11dedab5b9146c278409fe948bdfccc2658af8a09eb"
 dependencies = [
  "aegis",
  "aes 0.8.4",
@@ -5677,9 +5677,9 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c1d40548fd1ddfa1e9486b864de3e625658a9c9013031a0d7f69ffbcab2773"
+checksum = "a9704b1b4b5dc8dbdc56fd4c3a44fb7be47d91e9d240cada262a1d6f55b0fc08"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -5688,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20622919c832ac37fb4f784e450f5dfe10598ffbd42c735aa9b2e756c4044137"
+checksum = "f0c72bcec01a1828c7494cd7f12a7d6749897eb579681bc1de401b4a6c7f3c1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5699,9 +5699,9 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad14b801fcb7ec1970f51c135e9ddcbbd79d7bce99b16eeb6a2213e536d478"
+checksum = "e32af53f89c67f2d202e25ea9c4913f596e85fcddaf587295ae8e1f404599960"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
@@ -6087,7 +6087,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2089,19 +2089,19 @@ version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_core]]
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_ext]]
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_macros]]
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.turso_parser]]
-version = "0.8.0-pre.4"
+version = "0.8.0-pre.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.twox-hash]]


### PR DESCRIPTION
## What changed

Bumps the embedded SQLite engine (`turso_core` and its `turso_ext`,
`turso_macros`, `turso_parser` siblings) from `0.8.0-pre.4` to `0.8.0-pre.7`,
and moves the four matching `cargo vet` `safe-to-deploy` exemptions to the new
version in the same commit.

No bashkit source changes. The exhaustive `StepResult` match in the sqlite
builtin still compiles, so upstream added no new pacing variant that would need
review.

## Why

Supersedes dependabot PR #2351, which bumped `Cargo.lock` alone and left CI red.

The turso exemptions in `supply-chain/config.toml` are pinned to an exact
version, so a lockfile-only bump makes `cargo vet` fail. Dependabot cannot edit
the vet config, so every turso bump lands red until the exemptions move in
lockstep — this PR does both halves together.

## Before / After

**Before** (#2351, Audit job):

```
Vetting Failed!

4 unvetted dependencies:
  turso_core:0.8.0-pre.7 missing ["safe-to-deploy"]
  turso_ext:0.8.0-pre.7 missing ["safe-to-deploy"]
  turso_macros:0.8.0-pre.7 missing ["safe-to-deploy"]
  turso_parser:0.8.0-pre.7 missing ["safe-to-deploy"]
##[error]Process completed with exit code 255.
```

The `Check` aggregate gate then failed only as a consequence of `Audit` — it was
the sole root cause.

**After** (this branch, locally):

```
$ cargo vet --locked
Vetting Succeeded (26 fully audited, 5 partially audited, 587 exempted)

$ cargo test -p bashkit --features sqlite --lib --tests
test result: ok. 2787 passed; 0 failed; 0 ignored
test result: ok. 1264 passed; 0 failed; 2 ignored
test result: ok. 27 passed; 0 failed; 0 ignored
# 174 of these are sqlite-builtin tests, all passing

$ cargo fmt --check                                        # clean
$ cargo clippy --workspace --features sqlite --all-targets -- -D warnings   # clean
```

The `Cargo.lock` delta is byte-identical to the one dependabot generated in
#2351 (14 insertions, 14 deletions).

## Risk

- **Low**
- Pre-release engine bump, so upstream behavior could shift between `pre.4` and
  `pre.7`. Mitigated by the 174 sqlite-builtin tests passing unchanged and by the
  deliberately exhaustive `StepResult` match, which would fail the build rather
  than silently ignore a new upstream pacing variant.
- The vet exemptions are re-asserted, not re-audited — same posture these four
  crates already had at `pre.4`.

## Checklist

- [x] Tests added or updated — no new tests; existing sqlite suite (174 tests) covers the engine swap, and no bashkit behavior changes
- [x] Backward compatibility considered — internal dependency bump, no public API change

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjRFhHhYwZEAUDuPiSo2ig)_