### PR TITLE
chore(deps): move chacha20 off yanked 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,9 +743,9 @@ checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher 0.5.2",
@@ -5273,7 +5273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -289,7 +289,7 @@ version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.chacha20]]
-version = "0.10.1"
+version = "0.10.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.chrono]]


### PR DESCRIPTION
## What changed

Two lockfile/metadata changes, no source changes:

1. `Cargo.lock` — pins `chacha20` to `0.10.2`, replacing the **yanked** `0.10.1`.
2. `supply-chain/config.toml` — moves the existing `cargo vet` exemption for
   `chacha20` from `0.10.1` to `0.10.2`.

## Why

`cargo deny check advisories` reports `0.10.1` as a yanked release:

```
warning[yanked]: detected yanked crate (try `cargo update -p chacha20`)
59 │ chacha20 0.10.1 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
```

It is not a leaf dependency. It reaches **every** bashkit crate via `rand`,
`turso_core` via `twox-hash`, and — relevant below — the SSH transport via
`russh` and `ssh-cipher`/`ssh-key`:

```
chacha20 v0.10.2
├── rand v0.10.2
│   ├── bashkit  (→ bench, capi, cli, eval, js, python, wasm)
│   ├── internal-russh-num-bigint v0.5.0 → russh v0.62.7
│   ├── russh v0.62.7
│   └── twox-hash v2.1.3 → turso_core v0.8.0-pre.7
└── ssh-cipher v0.3.0 → ssh-key v0.7.0-rc.11 → russh v0.62.7
```

Both `0.10.0` and `0.10.1` are yanked upstream. `0.10.2` shipped 2026-08-27 and
un-yanks the `0.10.x` line, so the fix is a lockfile pin rather than a
version-requirement change.

Dependabot does not open PRs for transitive lockfile entries that become yanked,
so this needed doing by hand.

## Before / After

**Before**

```
$ cargo deny check advisories
warning[yanked]: detected yanked crate (try `cargo update -p chacha20`)
  chacha20 0.10.1 ... yanked version
advisories ok
```

**After**

```
$ cargo deny check advisories
advisories ok

$ cargo vet --locked
Vetting Succeeded (26 fully audited, 5 partially audited, 587 exempted)
```

Also verified clean, no changes needed:

- `cargo deny check licenses bans sources` — ok
- `cargo deny check advisories` in the `crates/bashkit/fuzz` workspace — ok
- `pnpm audit` in `site`, `examples/bashkit-pi`, `examples/browser` — "No known vulnerabilities found"

### On the `cargo vet` exemption

The first commit alone failed the Audit job:

```
Vetting Failed!
1 unvetted dependencies:
  chacha20:0.10.2 missing ["safe-to-deploy"]
```

The exemption was pinned to the exact version. Second commit repoints it.

It is deliberately still an **exemption**, not a `cargo vet certify` audit —
same crate, same `safe-to-deploy` criteria, same trust level as `0.10.1` had,
only the version changes. Writing a real audit record would assert a source
review that has not happened. This matches the repo's existing posture (587
exemptions vs 26 audits). Happy to do a genuine `0.10.1 → 0.10.2` delta audit
instead if that is preferred.

### On the second `Cargo.lock` hunk

The diff touches one line beyond `chacha20`: the `tempfile` → `getrandom` edge
re-points from `0.4.3` to `0.3.4`. This is cargo's own dedup during
re-resolution, not a downgrade of anything shipped:

- `getrandom 0.3.4` was **already** in the lockfile before this change
- `getrandom 0.4.3` is **still** in the lockfile, used by 9 other edges
- `tempfile`'s own version and checksum are unchanged

It appears identically under `cargo update -p chacha20 --precise 0.10.2`, so it
cannot be avoided while keeping the lockfile self-consistent.

### On `RUSTSEC-2023-0071`

`cargo deny` additionally warns that the `rsa` suppression "was not
encountered". **Left in place deliberately** — not a stale entry. The advisory
has `patched = []` (every release affected); it stops matching only because
`rsa` currently resolves to a prerelease (`0.10.0-rc.18`), which semver ranges
exclude. Dropping the ignore would silently re-break CI the moment `rsa 0.10.0`
finalizes. `deny.toml`, the mirrored `cargo audit --ignore` flags, and the
"Suppressed advisories" table in `knowledge/security/threat-model.md` are
unchanged and still accurate.

## Risk

- **Low**
- Patch-level bump of a stream cipher, no API or source change.
- `chacha20` sits in the SSH transport path, so the live-network SSH test was
  the thing to check. The `Examples` job runs `cargo test --features ssh -p
  bashkit --test ssh_supabase_tests` (a real connection to `supabase.sh`) and
  **passes** on this branch.

## Checklist

- [x] Tests added or updated — n/a, no behavior delta; covered by the existing suite, including the live SSH test above
- [x] Backward compatibility considered — no API or behavior change