### PR TITLE
fix(docs): render inline SVG diagrams correctly

### DIFF
--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -28,7 +28,6 @@ over an in-memory base, and swap mounts at runtime.
     <text x="180" y="198" text-anchor="middle" fill="#0a1636">MountableFs · real mounts</text>
     <rect x="40" y="224" width="280" height="44" rx="4" fill="#fff" stroke="#d4a43a" stroke-width="1.5"/>
     <text x="180" y="250" text-anchor="middle" fill="#0a1636">base · InMemoryFs or custom</text>
-
     <g font-size="11" fill="#404040">
       <text x="338" y="42">Bash::mount() / unmount()</text>
       <text x="338" y="94">readonly_filesystem()</text>

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -14,18 +14,14 @@ boundary, not a convenience.
     <rect x="20" y="44" width="118" height="44" rx="4" fill="#f5f5f5" stroke="#0a1636" stroke-opacity="0.3"/>
     <text x="79" y="64" text-anchor="middle">curl / wget</text>
     <text x="79" y="80" text-anchor="middle" fill="#404040">http</text>
-
     <rect x="190" y="44" width="138" height="44" rx="4" fill="#fff" stroke="#d4a43a" stroke-width="1.5"/>
     <text x="259" y="64" text-anchor="middle">allowlist</text>
     <text x="259" y="80" text-anchor="middle" fill="#404040" font-size="11">+ private-IP block</text>
-
     <rect x="380" y="44" width="138" height="44" rx="4" fill="#fff" stroke="#0a1636" stroke-opacity="0.3"/>
     <text x="449" y="64" text-anchor="middle">sign (opt-in)</text>
     <text x="449" y="80" text-anchor="middle" fill="#404040" font-size="11">bot-auth</text>
-
     <rect x="570" y="44" width="128" height="44" rx="4" fill="#0a1636"/>
     <text x="634" y="70" text-anchor="middle" fill="#ffffff">send →</text>
-
     <g stroke="#0a1636" stroke-opacity="0.5" fill="none">
       <path d="M138 66 H190" marker-end="url(#ar)"/>
       <path d="M328 66 H380" marker-end="url(#ar)"/>

--- a/docs/request-signing.md
+++ b/docs/request-signing.md
@@ -21,16 +21,13 @@ and real audit trails.
     <rect x="24" y="68" width="150" height="52" rx="4" fill="#f5f5f5" stroke="#0a1636" stroke-opacity="0.3"/>
     <text x="99" y="90" text-anchor="middle">Bashkit agent</text>
     <text x="99" y="108" text-anchor="middle" fill="#404040" font-size="11">private seed (zeroized)</text>
-
     <rect x="546" y="68" width="150" height="52" rx="4" fill="#0a1636"/>
     <text x="621" y="90" text-anchor="middle" fill="#ffffff">target server</text>
     <text x="621" y="108" text-anchor="middle" fill="#d4a43a" font-size="11">verifies signature</text>
-
     <g stroke="#0a1636" stroke-opacity="0.6" fill="none">
       <path d="M174 86 H540" marker-end="url(#ar2)"/>
     </g>
     <text x="357" y="78" text-anchor="middle" fill="#0a1636" font-size="11">signed request + Signature-Agent: agent.example</text>
-
     <rect x="300" y="132" width="280" height="40" rx="4" fill="#fff" stroke="#d4a43a" stroke-width="1.5"/>
     <text x="440" y="150" text-anchor="middle" font-size="11">well-known key directory</text>
     <text x="440" y="164" text-anchor="middle" fill="#404040" font-size="11">JWK Thumbprint → public key</text>

--- a/docs/scripted-tools.md
+++ b/docs/scripted-tools.md
@@ -17,12 +17,10 @@ tool calls.
     <rect x="24" y="74" width="120" height="48" rx="4" fill="#f5f5f5" stroke="#0a1636" stroke-opacity="0.3"/>
     <text x="84" y="94" text-anchor="middle">LLM</text>
     <text x="84" y="111" text-anchor="middle" fill="#404040" font-size="11">one call</text>
-
     <rect x="214" y="58" width="170" height="80" rx="4" fill="#fff" stroke="#d4a43a" stroke-width="1.5"/>
     <text x="299" y="84" text-anchor="middle">bash script</text>
     <text x="299" y="104" text-anchor="middle" fill="#404040" font-size="11">pipes · vars · loops</text>
     <text x="299" y="121" text-anchor="middle" fill="#404040" font-size="11">logic-only shell</text>
-
     <g font-size="12">
       <rect x="468" y="20" width="228" height="34" rx="4" fill="#f5f5f5" stroke="#0a1636" stroke-opacity="0.3"/>
       <text x="482" y="42" fill="#0a1636">get_user --id 1  →  callback</text>
@@ -31,7 +29,6 @@ tool calls.
       <rect x="468" y="140" width="228" height="34" rx="4" fill="#f5f5f5" stroke="#0a1636" stroke-opacity="0.3"/>
       <text x="482" y="162" fill="#0a1636">create_discount --pct 10</text>
     </g>
-
     <g stroke="#0a1636" stroke-opacity="0.5" fill="none">
       <path d="M144 98 H214" marker-end="url(#ar3)"/>
       <path d="M384 92 C 420 92, 430 37, 468 37" marker-end="url(#ar3)"/>

--- a/knowledge/operations/documentation.md
+++ b/knowledge/operations/documentation.md
@@ -48,6 +48,10 @@ Repo-root `docs/` is for user-facing site articles.
   (`site/src/pages/docs/_meta.ts`), never in markdown frontmatter: the canonical
   files must stay frontmatter-free so `crates/bashkit/docs/*.md` embed cleanly
   via `include_str!` into rustdoc.
+- Inline SVG diagrams must not contain blank lines between `<svg>` and `</svg>`.
+  CommonMark ends raw HTML blocks at blank lines, which renders the remaining
+  SVG elements as code. `site/scripts/verify-inline-svg.mjs` enforces this for
+  both canonical guide trees during the site postbuild checks.
 
 ## Code Examples
 

--- a/site/package.json
+++ b/site/package.json
@@ -13,11 +13,11 @@
     "data:performance": "node scripts/build-performance-data.mjs",
     "prebuild": "node scripts/build-performance-data.mjs",
     "build": "astro build",
-    "postbuild": "node scripts/normalize-generated-html.mjs && node scripts/verify-doc-routes.mjs && node scripts/verify-doc-markdown-routes.mjs && node scripts/verify-public-links.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs && node scripts/verify-meta-descriptions.mjs && node scripts/verify-llms.mjs",
+    "postbuild": "node scripts/normalize-generated-html.mjs && node scripts/verify-doc-routes.mjs && node scripts/verify-doc-markdown-routes.mjs && node scripts/verify-inline-svg.mjs && node scripts/verify-public-links.mjs && node scripts/verify-sitemap.mjs && node scripts/verify-robots.mjs && node scripts/verify-agent-skills.mjs && node scripts/verify-link-headers.mjs && node scripts/verify-meta-descriptions.mjs && node scripts/verify-llms.mjs",
     "preview": "wrangler dev",
     "deploy": "pnpm run build && wrangler deploy",
     "check": "astro check",
-    "verify:docs": "node scripts/verify-doc-routes.mjs"
+    "verify:docs": "node scripts/verify-doc-routes.mjs && node scripts/verify-inline-svg.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.4",

--- a/site/scripts/verify-inline-svg.mjs
+++ b/site/scripts/verify-inline-svg.mjs
@@ -1,0 +1,44 @@
+// Decision: CommonMark ends raw HTML blocks at blank lines, so multiline SVG
+// diagrams must stay contiguous or their remaining elements render as code.
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const siteDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const repositoryDir = path.dirname(siteDir);
+const docsDirs = [
+  path.join(repositoryDir, "docs"),
+  path.join(repositoryDir, "crates", "bashkit", "docs"),
+];
+const failures = [];
+
+for (const docsDir of docsDirs) {
+  for (const entry of readdirSync(docsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) {
+      continue;
+    }
+
+    const filePath = path.join(docsDir, entry.name);
+    const markdown = readFileSync(filePath, "utf8");
+    for (const match of markdown.matchAll(/<svg\b[\s\S]*?<\/svg>/gi)) {
+      const blankLine = /\r?\n[\t ]*\r?\n/.exec(match[0]);
+      if (!blankLine) {
+        continue;
+      }
+
+      const offset = match.index + blankLine.index;
+      const line = markdown.slice(0, offset).split(/\r?\n/).length + 1;
+      failures.push(`${path.relative(repositoryDir, filePath)}:${line}`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(
+    `Inline SVG blocks contain blank lines and will be split by CommonMark:\n${failures
+      .map((failure) => `- ${failure}`)
+      .join("\n")}`,
+  );
+}
+
+console.log("Verified inline SVG blocks are CommonMark-safe.");


### PR DESCRIPTION
## What changed
Inline SVG diagrams now render as complete diagrams across all four affected guides instead of exposing their remaining SVG markup as code.

The site postbuild now rejects blank lines inside inline SVG blocks in both canonical guide trees, preventing the rendering failure from recurring. The durable authoring constraint is recorded in the documentation playbook.

## Why
CommonMark ends a raw HTML block at a blank line. Blank lines inside the diagrams split each SVG during Markdown rendering, leaving only the first group visible and displaying the rest as escaped source.

## Before / After
Before:

![Broken scripted-tools diagram](https://github.com/user-attachments/assets/14d6b4f8-f269-46a6-a769-a483955bc58f)

After:

![Rendered scripted-tools diagram](https://github.com/user-attachments/assets/d22c7742-b624-4ac6-ac0e-ae6518c36a73)

Proof:
- Regression verifier failed on the four affected guides before the fix and passes after it.
- Full site build and postbuild validation pass.
- Browser smoke test finds one complete SVG with 6 rectangles and 8 text labels, with zero leaked SVG source.
- `just pre-pr` passes.

## Risk
- Low
- Limited to Markdown diagram formatting and site documentation validation.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered