### PR TITLE
fix(sqlite): count work performed inside a single engine step (TM-SQL-014)

### DIFF
--- a/crates/bashkit/benches/results/criterion-sqlite-vm-linux-x86_64-1788221595.md
+++ b/crates/bashkit/benches/results/criterion-sqlite-vm-linux-x86_64-1788221595.md
@@ -1,0 +1,89 @@
+# Criterion SQLite Builtin Benchmark
+
+Measures the `sqlite` builtin (Turso embedded engine) end-to-end through
+the bashkit interpreter. Per-invocation overhead (interpreter setup, script
+parse, engine open, VFS flush) is included in every number — these are
+"what a script author observes", not isolated engine micro-benchmarks.
+
+## System Information
+
+- **Moniker**: `vm-linux-x86_64`
+- **Hostname**: vm
+- **OS**: linux
+- **Architecture**: x86_64
+- **CPUs**: 4
+- **Timestamp**: 1788221595
+
+## CRUD (insert / update, Memory vs Vfs backend, n rows)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_crud/insert_mem/100 | 1.4289 ms |
+| sqlite_crud/insert_vfs/100 | 2.7726 ms |
+| sqlite_crud/update_mem/100 | 1.8710 ms |
+| sqlite_crud/update_vfs/100 | 2.4754 ms |
+| sqlite_crud/insert_mem/1000 | 4.8250 ms |
+| sqlite_crud/insert_vfs/1000 | 6.1664 ms |
+| sqlite_crud/update_mem/1000 | 5.5788 ms |
+| sqlite_crud/update_vfs/1000 | 6.5787 ms |
+| sqlite_crud/insert_mem/10000 | 37.890 ms |
+| sqlite_crud/insert_vfs/10000 | 38.609 ms |
+| sqlite_crud/update_mem/10000 | 40.244 ms |
+| sqlite_crud/update_vfs/10000 | 40.999 ms |
+
+## Indexing (create index, indexed lookup, full scan)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_index/create_index_mem/100 | 2.0668 ms |
+| sqlite_index/indexed_lookup_mem/100 | 2.0851 ms |
+| sqlite_index/full_scan_mem/100 | 1.6733 ms |
+| sqlite_index/create_index_mem/1000 | 7.2668 ms |
+| sqlite_index/indexed_lookup_mem/1000 | 8.3068 ms |
+| sqlite_index/full_scan_mem/1000 | 5.1298 ms |
+| sqlite_index/create_index_mem/10000 | 64.863 ms |
+| sqlite_index/indexed_lookup_mem/10000 | 64.357 ms |
+| sqlite_index/full_scan_mem/10000 | 40.238 ms |
+
+## Query (GROUP BY aggregate)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_query/aggregate_mem/100 | 1.7619 ms |
+| sqlite_query/aggregate_vfs/100 | 2.4821 ms |
+| sqlite_query/aggregate_in_memory/100 | 1.5772 ms |
+| sqlite_query/aggregate_mem/1000 | 6.1686 ms |
+| sqlite_query/aggregate_vfs/1000 | 7.1580 ms |
+| sqlite_query/aggregate_in_memory/1000 | 5.2710 ms |
+| sqlite_query/aggregate_mem/10000 | 46.446 ms |
+| sqlite_query/aggregate_vfs/10000 | 46.823 ms |
+| sqlite_query/aggregate_in_memory/10000 | 36.241 ms |
+
+## Output mode formatters (1k rows)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_output_mode/list | 6.0063 ms |
+| sqlite_output_mode/csv | 6.2784 ms |
+| sqlite_output_mode/json | 5.8009 ms |
+| sqlite_output_mode/markdown | 7.0190 ms |
+| sqlite_output_mode/box | 6.8177 ms |
+
+## Persistence (cost per invocation)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_persistence/two_invocations_mem | 5.2902 ms |
+| sqlite_persistence/two_invocations_vfs | 6.7096 ms |
+| sqlite_persistence/memory_db_baseline | 5.1001 ms |
+
+## Parallel sessions (N concurrent over shared VFS)
+
+| Benchmark | Time |
+|-----------|------|
+| sqlite_parallel/mem/4 | 7.3641 ms |
+| sqlite_parallel/vfs/4 | 8.4376 ms |
+| sqlite_parallel/mem/16 | 22.687 ms |
+| sqlite_parallel/vfs/16 | 26.859 ms |
+| sqlite_parallel/mem/64 | 80.248 ms |
+| sqlite_parallel/vfs/64 | 98.657 ms |

--- a/crates/bashkit/docs/threat-model.md
+++ b/crates/bashkit/docs/threat-model.md
@@ -715,6 +715,7 @@ Both paths are tested so SQL cannot intentionally read host files.
 | Cross-database access (TM-SQL-009) | `ATTACH DATABASE '/tmp/x'` | `ATTACH`/`DETACH` rejected by policy | MITIGATED |
 | Dangerous PRAGMAs (TM-SQL-010) | `PRAGMA main."cache_size"=...` | Default `pragma_deny` list, including quoted/schema-qualified names | MITIGATED |
 | Host path errors (TM-SQL-011) | Upstream error includes `/rustc/...` | Sanitizer strips host path annotations | MITIGATED |
+| Unbounded work inside one engine step (TM-SQL-014) | `WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM r) SELECT count(*) FROM r` | VM progress handler charges the execution budget every 1024 instructions and interrupts on deadline/budget breach | MITIGATED |
 
 Black-box coverage drives `Bash::exec` through
 `tests/sqlite_integration_tests.rs` and `tests/sqlite_security_tests.rs`.

--- a/crates/bashkit/src/builtins/sqlite/engine.rs
+++ b/crates/bashkit/src/builtins/sqlite/engine.rs
@@ -16,8 +16,8 @@
 //! which backend is active.
 
 use crate::time_compat::Instant;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use turso_core::{
     Connection, Database, IO, MemoryIO, Numeric, OpenFlags, SqliteDialect, StepResult, Value,
@@ -47,6 +47,77 @@ impl Deadline {
     /// Returns true once the budget is exhausted.
     pub(super) fn expired(&self) -> bool {
         self.deadline.map(|d| Instant::now() >= d).unwrap_or(false)
+    }
+}
+
+/// VM instructions between progress-handler callbacks.
+///
+/// Design: the step loop in [`SqliteEngine::execute`] can only check limits
+/// *between* `Statement::step()` calls, and a step returns only when a row is
+/// produced, the program halts, or IO is needed. A query whose rows are all
+/// consumed inside the VDBE (a recursive CTE feeding an aggregate, a filtered
+/// cross join) therefore performs unbounded work inside one step. Turso's
+/// SQLite-compatible progress handler is consulted every N VM instructions
+/// *inside* the instruction loop, which is the only place work of that shape
+/// can be counted and interrupted. `THREAT[TM-SQL-014]`.
+///
+/// 1024 keeps the callback cost in the noise (one `Instant::now()` plus two
+/// atomic loads per 1024 instructions) while bounding overshoot past the
+/// deadline to microseconds.
+const PROGRESS_HANDLER_OPS: u64 = 1024;
+
+/// Why the VDBE was interrupted from inside a step, recorded by the progress
+/// handler so the step loop can report the real limit rather than a generic
+/// "interrupted".
+type InterruptReason = Arc<Mutex<Option<String>>>;
+
+/// Installs a progress handler on a connection and clears it on drop, so an
+/// early `?` return never leaves a stale callback (and its cloned budget)
+/// attached to a pooled connection.
+struct ProgressHandlerGuard<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> ProgressHandlerGuard<'a> {
+    /// Install a handler that interrupts the VDBE once the invocation deadline
+    /// passes or the request's execution budget is exhausted.
+    fn install(
+        conn: &'a Connection,
+        deadline: Deadline,
+        budget: Option<crate::limits::ExecutionBudget>,
+    ) -> (Self, InterruptReason) {
+        let reason: InterruptReason = Arc::new(Mutex::new(None));
+        let callback_reason = Arc::clone(&reason);
+        conn.set_progress_handler(
+            PROGRESS_HANDLER_OPS,
+            Some(Box::new(move || {
+                let stop = if deadline.expired() {
+                    Some("query timed out".to_string())
+                } else if let Some(budget) = &budget {
+                    budget
+                        .consume_work(1)
+                        .err()
+                        .map(|failure| failure.to_string())
+                } else {
+                    None
+                };
+                match stop {
+                    Some(message) => {
+                        let mut slot = callback_reason.lock().expect("interrupt reason lock");
+                        slot.get_or_insert(message);
+                        true
+                    }
+                    None => false,
+                }
+            })),
+        );
+        (Self { conn }, reason)
+    }
+}
+
+impl Drop for ProgressHandlerGuard<'_> {
+    fn drop(&mut self) {
+        self.conn.set_progress_handler(0, None);
     }
 }
 
@@ -172,13 +243,21 @@ impl SqliteEngine {
     ///
     /// `deadline` carries the wall-clock budget shared across all statements
     /// in this invocation. Once it expires, we issue `stmt.interrupt()` and
-    /// return a timeout error rather than continuing the step loop.
+    /// return a timeout error rather than continuing the step loop. Work done
+    /// inside a single `step()` is bounded by the progress handler installed
+    /// here, which charges the execution budget one unit per
+    /// [`PROGRESS_HANDLER_OPS`] VM instructions and interrupts the VDBE when
+    /// the deadline or the budget is exhausted.
     pub(super) fn execute(
         &self,
         sql: &str,
         deadline: Deadline,
         limits: QueryLimits,
     ) -> EngineResult<StatementOutcome> {
+        // Bounds work done *inside* a step; the loop below bounds work
+        // *between* steps. Both are needed: see `PROGRESS_HANDLER_OPS`.
+        let (_progress_guard, interrupt_reason) =
+            ProgressHandlerGuard::install(&self.conn, deadline, limits.execution_budget.clone());
         let mut stmt = self.conn.prepare(sql).map_err(turso_msg)?;
         let mut outcome = StatementOutcome::default();
         for idx in 0..stmt.num_columns() {
@@ -250,8 +329,18 @@ impl SqliteEngine {
                 StepResult::IO | StepResult::Yield | StepResult::Sleep { .. } => {
                     self.io_step()?;
                 }
-                StepResult::Busy | StepResult::Interrupt => {
-                    return Err("query was interrupted or database is busy".to_string());
+                // The progress handler records why it asked for the
+                // interrupt, so a deadline or budget breach inside one step
+                // reports the same message it would between steps.
+                StepResult::Interrupt => {
+                    let reason = interrupt_reason
+                        .lock()
+                        .expect("interrupt reason lock")
+                        .take();
+                    return Err(reason.unwrap_or_else(|| "query was interrupted".to_string()));
+                }
+                StepResult::Busy => {
+                    return Err("database is busy".to_string());
                 }
             }
         }

--- a/crates/bashkit/src/builtins/sqlite/tests.rs
+++ b/crates/bashkit/src/builtins/sqlite/tests.rs
@@ -1019,3 +1019,63 @@ mod prop {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// TM-SQL-014: work performed inside a single `Statement::step()` is bounded.
+//
+// A recursive CTE whose rows are consumed by an aggregate never yields a row,
+// so the pre-step deadline/budget checks in `SqliteEngine::execute` are never
+// reached: the whole recursion runs inside one `step()` call. The turso
+// progress handler is what makes these terminate.
+// ---------------------------------------------------------------------------
+
+const UNBOUNDED_RECURSIVE_CTE: &str =
+    "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) SELECT count(*) FROM r;";
+
+#[tokio::test]
+async fn unbounded_recursive_cte_hits_deadline() {
+    let limits = SqliteLimits::default().max_duration(std::time::Duration::from_millis(250));
+    let r = run_with_limits(&[":memory:", UNBOUNDED_RECURSIVE_CTE], None, limits).await;
+    assert_eq!(r.exit_code, 1);
+    assert!(r.stderr.contains("timed out"), "stderr was: {}", r.stderr);
+}
+
+/// Recursion is not the distinguishing property: any query that produces no
+/// rows for a long time hides its work inside one step. Denying
+/// `WITH RECURSIVE` would leave this shape open, so the bound has to live in
+/// the VM, not in the SQL policy.
+#[tokio::test]
+async fn rowless_cross_join_hits_deadline() {
+    let limits = SqliteLimits::default().max_duration(std::time::Duration::from_millis(250));
+    let r = run_with_limits(
+        &[
+            ":memory:",
+            "CREATE TABLE t(n); \
+             WITH RECURSIVE seed(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seed WHERE n < 400) \
+             INSERT INTO t SELECT n FROM seed; \
+             SELECT * FROM t a, t b, t c, t d WHERE a.n < 0;",
+        ],
+        None,
+        limits,
+    )
+    .await;
+    assert_eq!(r.exit_code, 1);
+    assert!(r.stderr.contains("timed out"), "stderr was: {}", r.stderr);
+}
+
+/// The bound must not cost us the feature: a terminating recursive CTE still
+/// runs and returns every row.
+#[tokio::test]
+async fn bounded_recursive_cte_still_runs() {
+    let r = run(
+        &[
+            ":memory:",
+            "WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r WHERE n < 5) \
+             SELECT n FROM r;",
+        ],
+        None,
+    )
+    .await;
+    assert_eq!(r.exit_code, 0, "stderr: {}", r.stderr);
+    assert_eq!(r.stdout, "1\n2\n3\n4\n5\n");
+}

--- a/crates/bashkit/tests/integration/execution_budget_tests.rs
+++ b/crates/bashkit/tests/integration/execution_budget_tests.rs
@@ -213,3 +213,29 @@ async fn sqlite_steps_consume_shared_work_budget() {
     let sql = "SELECT 1;".repeat(400);
     assert_budget_exhausted(bash.exec(&format!("sqlite :memory: '{sql}'")).await);
 }
+
+#[cfg(feature = "sqlite")]
+#[tokio::test]
+/// TM-SQL-014: work done inside a single `Statement::step()` is charged too.
+///
+/// The rows of this recursive CTE are swallowed by the aggregate, so the query
+/// never returns from its first step. Without the VM progress handler the
+/// request would spin forever with the budget untouched.
+async fn unbounded_recursive_cte_consumes_shared_work_budget() {
+    let limits = ExecutionLimits::new()
+        .max_work_units(2_000)
+        .max_aggregate_input_bytes(100_000);
+    let mut bash = Bash::builder()
+        .limits(limits)
+        .sqlite()
+        .env("BASHKIT_ALLOW_INPROCESS_SQLITE", "1")
+        .build();
+
+    assert_budget_exhausted(
+        bash.exec(
+            "sqlite :memory: 'WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) \
+             SELECT count(*) FROM r;'",
+        )
+        .await,
+    );
+}

--- a/knowledge/runtimes/sqlite-builtin.md
+++ b/knowledge/runtimes/sqlite-builtin.md
@@ -52,7 +52,8 @@ comment/string-aware split of SQL & dot-commands) → `dot_commands` →
 
 All layers retain the host request's `ExecutionBudget`. SQL and database file
 bytes consume aggregate input, statement splitting consumes shared work, and
-every Turso `Statement::step()` consumes another work unit. Recursive `.read`,
+every Turso `Statement::step()` consumes another work unit, as does every 1024
+VM instructions executed *inside* a step (see TM-SQL-014). Recursive `.read`,
 cached file-backed engines, dot-commands, and query materialisation receive
 clones of the same budget rather than new counters. SQLite-specific size,
 statement, row, result, and duration ceilings remain independently enforced.
@@ -76,6 +77,38 @@ wasm targets this builtin ships to. Upstream documents that callers which do
 not track time may treat `Sleep` exactly like `IO`. Spinning stays bounded by
 the wall-clock deadline (TM-SQL-005a) and by the `ExecutionBudget` work unit
 consumed on every loop iteration.
+
+### Bounding work *inside* one step (TM-SQL-014)
+
+The step loop can only check limits **between** `step()` calls, and a step
+returns only when a row is produced, the program halts, or IO is needed. A
+query whose rows are consumed inside the VDBE never comes back:
+
+```sql
+WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r)
+SELECT count(*) FROM r;         -- aggregate swallows every row
+SELECT count(*) FROM a, b, c WHERE 0;  -- same shape, no CTE involved
+```
+
+Both spin forever inside a single `Statement::step()`, so `max_duration` and
+the `ExecutionBudget` never get a turn. Recursion is not the distinguishing
+property, "produces no rows for a long time" is; denying `WITH RECURSIVE`
+would leave the class open while removing a supported feature.
+
+`engine::ProgressHandlerGuard` installs turso's SQLite-compatible progress
+handler (`Connection::set_progress_handler`, available since 0.8.0-pre.7),
+which the VDBE consults every `PROGRESS_HANDLER_OPS` (1024) instructions from
+inside its instruction loop. The callback:
+
+- charges the request `ExecutionBudget` one work unit per callback, so in-VDBE
+  instructions are counted rather than free;
+- returns `true` once the invocation deadline has passed or the budget is
+  exhausted, which makes the VDBE return `StepResult::Interrupt`;
+- records *why* it interrupted, so the step loop reports `query timed out` or
+  the budget error instead of a generic "interrupted".
+
+The guard clears the handler on drop, so an early return never leaves a stale
+callback (holding a cloned budget) on a cached file-backed connection.
 
 The match over `StepResult` is kept **exhaustive on purpose**: a new upstream
 variant must break the build so its pacing semantics get reviewed rather than
@@ -220,6 +253,7 @@ rows → `[]\n`), `markdown`. Empty column list → empty string; empty row set
 | TM-SQL-011    | Information leakage via host-side error strings      | `sanitize()` strips ` at /…:N:M` annotations from turso errors          |
 | TM-SQL-012    | Sandbox escape via `VACUUM INTO` writing host files  | Policy rejects `VACUUM` (with/without `INTO`) at the keyword sniffer; tested via `vacuum_into_blocked`/`vacuum_plain_blocked`/`vacuum_blocked_with_leading_comment` |
 | TM-SQL-013    | DoS via `.dump` cumulative output bypass            | `.dump` previously built the full string before `max_output_bytes` was applied; `bounded_append()` enforces the cap after each schema/row chunk with the remaining budget passed from `run_statements`; `THREAT[TM-DOS-091]`; tested via `dump_respects_output_cap` and `dump_output_cap_enforced_across_multiple_tables` |
+| TM-SQL-014    | DoS via work performed inside a single `Statement::step()` (recursive CTE feeding an aggregate, filtered cross join) | turso progress handler every 1024 VM instructions charges the `ExecutionBudget` and interrupts on deadline/budget breach; tested via `unbounded_recursive_cte_hits_deadline`, `rowless_cross_join_hits_deadline`, `unbounded_recursive_cte_consumes_shared_work_budget` |
 
 ## Test Plan
 

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -1356,7 +1356,7 @@ This section maps former vulnerability IDs to the new threat ID scheme and track
 | Log injection prevention | TM-LOG-005, TM-LOG-006 | `logging.rs` | Yes |
 | Log value truncation | TM-LOG-007, TM-LOG-008 | `logging.rs` | Yes |
 | Python resource limits | TM-PY-001 to TM-PY-003 | `builtins/python.rs` | Yes |
-| SQLite opt-in and limits | TM-SQL-001 to TM-SQL-011 | `builtins/sqlite/` | Yes |
+| SQLite opt-in and limits | TM-SQL-001 to TM-SQL-014 | `builtins/sqlite/` | Yes |
 | Path char validation (bidi) | TM-DOS-015, TM-UNI-003, TM-UNI-011 | `fs/limits.rs` | Partial (bidi yes, zero-width/tags no) |
 | Builtin panic catching | TM-INT-001, TM-UNI-001, TM-UNI-002, TM-UNI-015, TM-UNI-016, TM-UNI-017 | `interpreter/mod.rs` | Yes (catch_unwind) |
 | Reviewed competitor fixtures | TM-INF-032 | `tests/fixtures/competitor-regressions/`, `competitor_regression_tests.rs` | Yes |
@@ -1879,6 +1879,7 @@ filesystem.
 | TM-SQL-009 | Cross-database access via `ATTACH`/`DETACH` | High | Case/comment-aware policy rejection | `tm_sql_009_attach_detach_rejected`, `attach_blocked_even_with_leading_comment` |
 | TM-SQL-010 | DoS or fingerprinting via dangerous PRAGMAs | High | `SqliteLimits::pragma_deny` default deny list; policy parser handles comments plus quoted/schema-qualified names | `tm_sql_010_pragma_deny_blocks_resource_knobs`, `pragma_schema_qualified_match` |
 | TM-SQL-011 | Host-side error string disclosure | Medium | `sanitize()` strips host path annotations from Turso errors | Manual exploratory review |
+| TM-SQL-014 | DoS via work performed inside a single `Statement::step()` (recursive CTE feeding an aggregate, filtered cross join) | High | turso progress handler consulted every 1024 VM instructions charges the `ExecutionBudget` and interrupts on deadline/budget breach | `unbounded_recursive_cte_hits_deadline`, `rowless_cross_join_hits_deadline`, `unbounded_recursive_cte_consumes_shared_work_budget` |
 
 ### Test Shape
 


### PR DESCRIPTION
Supersedes #2367 — same threat, counted instead of denied.

## What changed

SQL work performed *inside* one `Statement::step()` is now counted and bounded. Every 1024 VM instructions, turso's SQLite-compatible progress handler charges the request's `ExecutionBudget` one work unit and interrupts the VDBE once `max_duration` has passed or the budget is exhausted. The handler records why it fired, so the user-visible error stays `query timed out` / the budget error rather than a generic "interrupted", and an RAII guard clears it so an early return never leaves a stale callback (holding a cloned budget) on a cached file-backed connection.

`WITH RECURSIVE` keeps working, including the existing differential parity test against host `sqlite3`.

## Why

The engine can only check limits *between* `step()` calls, and a step returns only when a row is produced, the program halts, or IO is needed. A query whose rows are consumed inside the VDBE never comes back, so neither the deadline nor the budget gets a turn:

```sql
WITH RECURSIVE r(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM r) SELECT count(*) FROM r;
SELECT * FROM t a, t b, t c, t d WHERE a.n < 0;   -- same shape, no CTE
```

Recursion is not the distinguishing property — "produces no rows for a long time" is. #2367 rejects `WITH RECURSIVE` at the SQL policy, which removes a supported feature and still leaves the filtered-cross-join case wide open. Turso exposes `Connection::set_progress_handler` as of 0.8.0-pre.7 (already the pinned version), so the in-flight callback that approach was waiting for now exists.

## Before / After

Same query, same limits (`max_duration` 250 ms):

**Before** — spins at 100% CPU inside one step, budget untouched. Killed manually after 38 minutes:

```
root 6178 99.9 0.2 147724 41388 ? Sl 22:58 38:22 bashkit-764130e212dee038 unbounded_recursive_cte
```

**After**:

```
test builtins::sqlite::tests::unbounded_recursive_cte_hits_deadline ... ok
test result: ok. 1 passed; finished in 0.25s
```

stderr: `sqlite: query timed out`

Terminating recursive CTEs are unaffected — `bounded_recursive_cte_still_runs` asserts `1\n2\n3\n4\n5\n`.

Benchmarks: `scripts/bench-sqlite.sh` run committed under `crates/bashkit/benches/results/`, plus a same-machine criterion A/B against `main`. Deltas straddle zero in both directions (±10% on this noisy 4-CPU runner); no overhead attributable to the handler.

## Risk

- Low
- The handler is installed per `execute()` and cleared on drop, so a leaked callback would keep charging a stale budget on a cached connection — covered by the guard and by the existing file-backed engine cache tests. Queries that were previously "slow but finishing" now abort if they exceed the configured deadline or work budget; that is the intended enforcement, and both ceilings are operator-configurable (`Duration::ZERO` still disables the deadline).

## Checklist

- [x] Tests added or updated — `unbounded_recursive_cte_hits_deadline`, `rowless_cross_join_hits_deadline` (the non-CTE shape #2367 misses), `bounded_recursive_cte_still_runs`, `unbounded_recursive_cte_consumes_shared_work_budget`
- [x] Backward compatibility considered — no API change; `WITH RECURSIVE` stays supported

Docs: TM-SQL-014 added to `knowledge/runtimes/sqlite-builtin.md` (with a new "Bounding work inside one step" section), the threat-model ledger, and the public `crates/bashkit/docs/threat-model.md`.

Verification: sqlite lib slice (111 tests) and the integration binary (1265 tests) green; `cargo fmt`, `cargo clippy --all-targets -D warnings`, `scripts/check_okf.py`, and the doc-link check clean.