### PR TITLE
chore(deps): upgrade tabled to 0.22 and retire RUSTSEC-2026-0173

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,28 +3819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "proc-macro-utils"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,9 +5213,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
+checksum = "2d2596a104db1900b943f97d793a6c99addca918c4525c999f751a0f17d472eb"
 dependencies = [
  "papergrid",
  "tabled_derive",
@@ -5246,12 +5224,11 @@ dependencies = [
 
 [[package]]
 name = "tabled_derive"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+checksum = "7dca1937322a1e892b1a65f6a6736183bb0a29d3b4234d1d53bc436dff9beb76"
 dependencies = [
  "heck",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/crates/bashkit-bench/Cargo.toml
+++ b/crates/bashkit-bench/Cargo.toml
@@ -25,4 +25,4 @@ tempfile.workspace = true
 
 # Terminal output
 colored = "3"
-tabled = "0.21"
+tabled = "0.22"

--- a/deny.toml
+++ b/deny.toml
@@ -50,10 +50,6 @@ ignore = [
     # atomic-polyfill: transitive via monty -> postcard -> heapless
     # Unmaintained but no security vulnerability; upstream dep we can't control
     "RUSTSEC-2023-0089",
-    # proc-macro-error2: transitive via bashkit-bench -> tabled -> tabled_derive
-    # Unmaintained build-time proc-macro in the bench harness only (not shipped
-    # library code); no upgrade available (tabled 0.21 is latest)
-    "RUSTSEC-2026-0173",
 ]
 
 [bans]

--- a/knowledge/security/threat-model.md
+++ b/knowledge/security/threat-model.md
@@ -1574,8 +1574,7 @@ the two lists in sync so a local `cargo deny check advisories` matches CI.
 | Advisory | Crate | Why suppressed | Remove when |
 |----------|-------|----------------|-------------|
 | RUSTSEC-2023-0071 | `rsa` | Marvin timing sidechannel (TM-CRY-002). No patched version exists; reachable only via the opt-in `ssh` feature | `rsa` ships a constant-time release |
-| RUSTSEC-2023-0089 | `atomic-polyfill` | Unmaintained, no known vulnerability; transitive via `monty` → `postcard` → `heapless` | Upstream drops the dependency |
-| RUSTSEC-2026-0173 | `proc-macro-error2` | Unmaintained build-time proc-macro, bench harness only (not shipped library code); transitive via `tabled` | `tabled` releases a version without it |
+| RUSTSEC-2023-0089 | `atomic-polyfill` | Unmaintained, no known vulnerability; transitive via `monty` → `postcard` → `heapless` (pinned at 0.7, which still requires it) | Upstream drops the dependency |
 
 A suppression that stops matching is not evidence that it can be dropped.
 `cargo deny check advisories` currently warns `advisory-not-detected` for
@@ -1585,6 +1584,13 @@ The advisory still carries `patched = []`, so the exposure is unchanged and
 matching resumes as soon as `rsa` ships a stable release. Before removing any
 entry above, check the advisory's own `patched` list rather than the scanner's
 silence.
+
+Retired: RUSTSEC-2026-0173 (`proc-macro-error2`, unmaintained). Its recorded
+removal condition — "`tabled` releases a version without it" — was met by
+`tabled` 0.22 / `tabled_derive` 0.12, which drops the dependency. The bench
+harness was moved to 0.22 and the crate is gone from `Cargo.lock`, so the
+suppression was deleted rather than left to rot. This is the shape a removal
+should take: the dependency is actually gone, not merely unmatched.
 
 ### Fuzzing Targets
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1937,11 +1937,11 @@ version = "1.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.tabled]]
-version = "0.21.0"
+version = "0.22.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tabled_derive]]
-version = "0.11.0"
+version = "0.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tap]]


### PR DESCRIPTION
## What changed

One fewer advisory suppression, because the underlying dependency is actually gone.

`tabled_derive` 0.12 — pulled in by `tabled` 0.22 — no longer depends on the unmaintained `proc-macro-error2`. That was the exact removal condition recorded for the RUSTSEC-2026-0173 suppression, so the bench harness moves to `tabled` 0.22 and the suppression is deleted rather than left to rot:

- `proc-macro-error2` and `proc-macro-error-attr2` drop out of `Cargo.lock` entirely.
- The `RUSTSEC-2026-0173` entry is removed from the `[advisories] ignore` list in `deny.toml`.
- The matching row is removed from the "Suppressed advisories" table in `knowledge/security/threat-model.md`, with a short note recording *why* it was legitimately retired — the section already warns that a suppression which merely stops matching is not evidence it can be dropped, so the distinction is worth writing down.
- `cargo vet` exemptions for `tabled`/`tabled_derive` are bumped to the new versions. This is required, not cosmetic: `cargo vet --locked` runs in CI and fails without it (proof below).

The two remaining suppressions stay, because neither removal condition is met:

| Advisory | Crate | Why it stays |
|---|---|---|
| RUSTSEC-2023-0071 | `rsa` | No patched version exists for any release; opt-in `ssh` feature only |
| RUSTSEC-2023-0089 | `atomic-polyfill` | `heapless` is still pinned at 0.7 (via `monty` → `postcard`), which requires it |

The `atomic-polyfill` row also gains that pin detail, so the next reader doesn't have to re-derive why it can't move yet.

## Why

Routine scheduled maintenance. Auditing all four workspace lockfiles against OSV turned up three advisories; all three were already accepted in `deny.toml`, but one of them had a removal condition that upstream has since satisfied. Suppressions that outlive their justification are how an audit list stops being a signal, so it gets cleared the moment it can be.

## Before / After

Advisory scan across every `Cargo.lock` in the repo (OSV, all four workspaces):

**Before**
```
Cargo.lock: 629 crates, 3 vulnerable
    ('atomic-polyfill', '1.0.3', ['RUSTSEC-2023-0089'])
    ('proc-macro-error2', '2.0.1', ['RUSTSEC-2026-0173'])
    ('rsa', '0.10.0-rc.18', ['RUSTSEC-2023-0071'])
```

**After**
```
Cargo.lock: 627 crates, 2 vulnerable
    ('atomic-polyfill', '1.0.3', ['RUSTSEC-2023-0089'])
    ('rsa', '0.10.0-rc.18', ['RUSTSEC-2023-0071'])
crates/bashkit/fuzz/Cargo.lock:      184 crates, 0 vulnerable
examples/hyperlight/Cargo.lock:      170 crates, 0 vulnerable
examples/hyperlight/host/Cargo.lock: 118 crates, 0 vulnerable
```

`cargo vet --locked`, with the exemption bump and without it:

```
$ cargo vet --locked
Vetting Succeeded (26 fully audited, 61 partially audited, 531 exempted)

$ git stash push supply-chain/config.toml && cargo vet --locked
Vetting Failed!
2 unvetted dependencies:
  tabled:0.22.0 missing ["safe-to-deploy"]
  tabled_derive:0.12.0 missing ["safe-to-deploy"]
```

Bench table rendering is unchanged across the `tabled` major bump (`--category arithmetic`, headers and `Tabled` derive attributes intact):

```
+------------+---------------+---------+-----------+--------+-------+-------+--------+-------+
| Category   | Benchmark     | Runner  | Mean (ms) | StdDev | Min   | Max   | Errors | Match |
+------------+---------------+---------+-----------+--------+-------+-------+--------+-------+
| arithmetic | arith_basic   | bashkit | 0.456     | ±0.001 | 0.455 | 0.457 | -      | ✓     |
+------------+---------------+---------+-----------+--------+-------+-------+--------+-------+
| arithmetic | arith_basic   | bash    | 2.110     | ±0.070 | 2.040 | 2.181 | -      | ✓     |
+------------+---------------+---------+-----------+--------+-------+-------+--------+-------+
```

The committed `results/*.md` reports are unaffected: `generate_markdown_report` builds those by hand with `push_str` and never touches `tabled`, so the `/benches` site aggregation contract is untouched.

## Risk

- **Low.** `tabled` is a build/dev-time table formatter used only by `bashkit-bench`, a benchmarking binary. It is not part of any shipped library, binding, or ABI surface.
- What could break: terminal table formatting in the bench harness. Verified by running the harness and diffing the output shape — unchanged. `cargo clippy -p bashkit-bench --all-targets -- -D warnings` is clean, and all 7 bench unit tests pass.
- Licenses unchanged (`tabled`, `tabled_derive`, `papergrid`, `testing_table` are all MIT, already allow-listed), so `cargo deny check licenses sources` is unaffected.

## Checklist

- [x] Tests added or updated — no new tests; this is a dependency bump with no behavior change. Existing `bashkit-bench` tests (7) pass, and the advisory removal is itself verified by `cargo vet --locked` in CI.
- [x] Backward compatibility considered — dev-dependency of a benchmark binary only; no public API, ABI, or serialized-format surface is touched.
