### PR TITLE
chore(deps): stop dependabot reopening the unbuildable get-size2 bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,27 @@ updates:
       # rationale comment above [patch.crates-io] in the root Cargo.toml.
       - dependency-name: "idna_adapter"
 
+      # get-size2 is not a dependency bashkit uses — no bashkit source
+      # references it. It is declared under the `python` feature purely to
+      # hold the *whole graph* at 0.10.1, which is the last version that
+      # implements `GetSize` for compact_str 0.9. monty 0.0.19's
+      # ruff_python_ast derives `get_size2::GetSize` on nodes holding a
+      # `CompactString` from compact_str 0.9, so any get-size2 >= 0.10.2
+      # (which moved those impls to compact_str 0.10) leaves the derive with
+      # no impl:
+      #
+      #   error[E0277]: the trait bound `CompactString: GetSize` is not
+      #   satisfied --> ruff_python_ast-0.0.3/src/nodes.rs:411:41
+      #   note: there are multiple different versions of crate `compact_str`
+      #
+      # Bumping bashkit's declared version does not just fail to help, it
+      # removes the constraint that keeps ruff's copy pinned, letting it
+      # float to 0.10.3 and break (#2381, all 22 build jobs red). Ignore
+      # outright rather than by update-type: the breaking move was a patch
+      # release. Drop this once monty's ruff moves to compact_str 0.10; the
+      # pin comment sits next to the dep in crates/bashkit/Cargo.toml.
+      - dependency-name: "get-size2"
+
   # Fuzz targets are a separate cargo workspace with their own lockfile, so the
   # "/" entry above never touches them. Without this the fuzz lockfile silently
   # rots between releases (it drifted onto an unsound `anyhow` and two yanked

--- a/crates/bashkit/Cargo.toml
+++ b/crates/bashkit/Cargo.toml
@@ -129,6 +129,11 @@ monty = { version = "=0.0.19", optional = true }
 monty-types = { version = "=0.0.19", optional = true }
 # Monty's ruff AST uses compact_str 0.9; get-size2 >=0.10.2 only implements
 # GetSize for compact_str 0.10. Enforce downstream too, not only in Cargo.lock.
+#
+# No bashkit source uses this crate. It is declared solely to hold the whole
+# graph at 0.10.1 — bumping it releases ruff's copy to float to 0.10.3 and
+# breaks the `GetSize` derive (#2381). Dependabot ignores it for that reason;
+# keep the ignore in .github/dependabot.yml in step with this pin.
 get-size2 = { version = "=0.10.1", optional = true }
 
 # Embedded TypeScript interpreter (optional)


### PR DESCRIPTION
## What changed

Adds `get-size2` to the cargo `ignore:` list in `.github/dependabot.yml`, and expands the pin comment in `crates/bashkit/Cargo.toml` to say why the pin exists and to point at the ignore.

Config and comments only — the pin itself (`get-size2 = { version = "=0.10.1" }`) is unchanged, and no lockfile moves.

## Why

`get-size2` is not a dependency bashkit uses; no bashkit source references it. It is declared under the `python` feature purely to hold the **whole graph** at 0.10.1, the last version that implements `GetSize` for `compact_str` 0.9. monty 0.0.19's `ruff_python_ast` derives `get_size2::GetSize` on nodes holding a `CompactString` from compact_str 0.9, so any get-size2 >= 0.10.2 — which moved those impls to compact_str 0.10 — leaves the derive with no impl.

The subtlety that makes an ignore the right tool: bumping bashkit's *declared* version does not just fail to help, it **removes the constraint** that keeps ruff's copy pinned. #2381 shows the result — the lockfile floats ruff to get-size2 0.10.3 while ruff keeps compact_str 0.9.1:

```
error[E0277]: the trait bound `CompactString: GetSize` is not satisfied
   --> ruff_python_ast-0.0.3/src/nodes.rs:411:41
    |
411 | #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
    |                                         ^^^^^^^^^^^^^^^^^^ the trait `GetSize` is not implemented for `CompactString`
    = note: there are multiple different versions of crate `compact_str` in the dependency graph
error: could not compile `ruff_python_ast` (lib) due to 2 previous errors
```

All 22 build jobs on #2381 are red. Without an ignore, Dependabot reopens that same unbuildable PR every week — the identical failure mode the `monty`, `monty-types` and `num-bigint` entries directly above already exist to prevent (the config's own comment notes #2296/#2297 for monty).

Ignored outright rather than by `update-types`, because the breaking move was a **patch** release (0.10.1 → 0.10.2); a semver-major/minor filter would not catch it.

## Before / After

**Before** — Dependabot proposes `=0.10.1` → `=0.11.0` weekly, CI goes red across the board, the PR is closed, and it returns the following week.

**After** — no `get-size2` PR is opened. The constraint and its reason are documented in both places a reader lands: next to the dep, and next to the ignore.

Verified the config still parses and the manifest is unaffected:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/dependabot.yml')); ..."
parsed OK; ignores: ['num-bigint', 'monty', 'monty-types', 'idna_adapter', 'get-size2', '@everruns/*', ...]

$ cargo metadata --no-deps --format-version 1 >/dev/null && echo OK
OK

$ grep -n 'get-size2 = ' crates/bashkit/Cargo.toml
137:get-size2 = { version = "=0.10.1", optional = true }
```

## Risk

- **Low.** No dependency versions change; no code changes.
- The one real cost of an ignore is that it hides genuine updates, including security ones. Accepted here because the crate is a build-time size-accounting helper that bashkit does not call, and because the entry carries an explicit removal condition: drop it once monty's ruff moves to compact_str 0.10. That is the same contract the neighbouring `monty` ignore uses.

## Checklist

- [x] Tests added or updated — n/a, config and comments only; validated by parsing the YAML and `cargo metadata`
- [x] Backward compatibility considered — no build or dependency behaviour changes

Closes #2381.

https://claude.ai/code/session_014CLqD3xrcs1G5decN6uNcQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014CLqD3xrcs1G5decN6uNcQ)_