### PR TITLE
fix(fs): set RealFs mtime with FILE_WRITE_ATTRIBUTES on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,9 @@ jobs:
       - name: Test RealFS and overlay containment
         run: cargo test -p bashkit --test realfs_tests --features realfs windows_containment
 
+      - name: Test touch mtime on Windows (issue #2388)
+        run: cargo test -p bashkit --test realfs_tests --features realfs realfs_touch
+
   # The adoption shape this covers — bashkit as an agent's shell, with commands
   # bridged to host processes — exists to work on Windows without a real bash.
   # Kept separate from `windows-containment`: that job pins path-containment

--- a/crates/bashkit/src/fs/realfs.rs
+++ b/crates/bashkit/src/fs/realfs.rs
@@ -748,10 +748,31 @@ impl FsBackend for RealFs {
     async fn set_modified_time(&self, path: &Path, time: SystemTime) -> Result<()> {
         self.check_writable()?;
         let real = self.resolve(path).await?;
-        let file = tokio::fs::File::open(&real).await?.into_std().await;
-        tokio::task::spawn_blocking(move || file.set_modified(time))
-            .await
-            .map_err(|error| IoError::other(format!("mtime worker failed: {error}")))??;
+        // Windows `SetFileTime` requires `FILE_WRITE_ATTRIBUTES` on the handle,
+        // so a read-only open fails with `ERROR_ACCESS_DENIED` (os error 5).
+        // Unix `futimens` ignores the fd open mode. Open inside the blocking
+        // worker with the minimal access each platform needs.
+        tokio::task::spawn_blocking(move || {
+            #[cfg(windows)]
+            {
+                use std::os::windows::fs::OpenOptionsExt;
+                const FILE_WRITE_ATTRIBUTES: u32 = 0x100;
+                let file = std::fs::OpenOptions::new()
+                    .read(true)
+                    .access_mode(FILE_WRITE_ATTRIBUTES)
+                    .open(&real)?;
+                file.set_modified(time)?;
+                Ok::<_, std::io::Error>(())
+            }
+            #[cfg(not(windows))]
+            {
+                let file = std::fs::File::open(&real)?;
+                file.set_modified(time)?;
+                Ok::<_, std::io::Error>(())
+            }
+        })
+        .await
+        .map_err(|error| IoError::other(format!("mtime worker failed: {error}")))??;
         Ok(())
     }
 

--- a/crates/bashkit/tests/realfs_tests.rs
+++ b/crates/bashkit/tests/realfs_tests.rs
@@ -1104,3 +1104,38 @@ async fn runtime_mount_readwrite() {
     let content = std::fs::read_to_string(dir.path().join("runtime.txt")).unwrap();
     assert_eq!(content, "runtime write\n");
 }
+
+/// Issue #2388: built-in `touch` failed on Windows with
+/// `io error: Access denied (os error 5)`.
+/// Root cause: `RealFs::set_modified_time` opened the file read-only;
+/// Windows `SetFileTime` requires `FILE_WRITE_ATTRIBUTES` on the handle.
+/// Unix `futimens` ignores the fd open mode, so this passes before/after
+/// on Linux/macOS and only fails on Windows before the fix.
+#[tokio::test]
+async fn realfs_touch_sets_mtime_issue_2388() {
+    use bashkit::{Bash, PosixFs, RealFs, RealFsMode};
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("touched.txt"), b"data").unwrap();
+
+    let backend = RealFs::open(dir.path(), RealFsMode::ReadWrite)
+        .await
+        .unwrap();
+    let fs: Arc<dyn bashkit::FileSystem> = Arc::new(PosixFs::new(backend));
+    let mut bash = Bash::new();
+    bash.mount("/workspace", fs).unwrap();
+
+    let out = bash.exec("touch /workspace/touched.txt").await.unwrap();
+    assert_eq!(out.exit_code, 0, "touch failed: {}", out.stderr);
+
+    let mtime = std::fs::metadata(dir.path().join("touched.txt"))
+        .unwrap()
+        .modified()
+        .unwrap();
+    assert!(
+        SystemTime::now().duration_since(mtime).unwrap() < Duration::from_secs(120),
+        "mtime was not updated by touch"
+    );
+}


### PR DESCRIPTION
Fixes #2388.

## What
Builtin `touch` failed on Windows with `io error: Access denied (os error 5)`.
`RealFs::set_modified_time` opened the file read-only; Windows `SetFileTime`
requires `FILE_WRITE_ATTRIBUTES` on the handle (Unix `futimens` ignores the
fd open mode, so only Windows broke). The open now happens inside the blocking
worker with `FILE_WRITE_ATTRIBUTES` on Windows; the Unix path is unchanged.

## Proof
Before: `touch <file>` on Windows -> `os error 5` (see issue).
After:
- New regression test `realfs_touch_sets_mtime_issue_2388` (touch via
  `Bash::exec` on a RealFs mount, asserts exit 0 + mtime updated) passes.
- Full `realfs_tests` suite green (43 passed), clippy/fmt clean on Linux,
  `cargo check` + clippy clean for `x86_64-pc-windows-msvc`.
- `windows-containment` CI job now runs the touch test, so the fixed
  Windows code path is runtime-covered (previously only `windows_containment`
  filters ran there).

Note: `just pre-pr` locally shows one unrelated failure
(`malformed_command_substitution_aborts_like_bash`) caused by this sandbox's
bash 3.2 printing `ab` for `echo 'a$(|)b'`; main CI is green. Unrelated to
this diff (parser untouched).

Produced by [yolop](https://everruns.com/yolop)