### PR TITLE
fix(awk): stop number lexer swallowing following +/- operators

### DIFF
--- a/crates/bashkit/src/builtins/awk/parser.rs
+++ b/crates/bashkit/src/builtins/awk/parser.rs
@@ -1536,12 +1536,33 @@ impl<'a> AwkParser<'a> {
 
     fn parse_number(&mut self) -> Result<AwkExpr> {
         let start = self.pos;
-        while self.pos < self.input.len() {
-            let c = self.current_char().unwrap();
-            if c.is_ascii_digit() || c == '.' || c == 'e' || c == 'E' || c == '-' || c == '+' {
+        // Integer part.
+        while self.pos < self.input.len() && self.current_char().unwrap().is_ascii_digit() {
+            self.pos += 1;
+        }
+        // Fractional part: digits with an optional '.' (leading ".5" and
+        // trailing "1." both valid; lone '.' rejected below by f64 parse).
+        if self.pos < self.input.len() && self.current_char().unwrap() == '.' {
+            self.pos += 1;
+            while self.pos < self.input.len() && self.current_char().unwrap().is_ascii_digit() {
                 self.pos += 1;
-            } else {
-                break;
+            }
+        }
+        // Exponent: e/E followed by optional sign and at least one digit.
+        // Only consumed when the full exponent is present, so a binary
+        // +/- after the number stays a separate operator (GH-2389).
+        if self.pos < self.input.len() && matches!(self.current_char().unwrap(), 'e' | 'E') {
+            let mut end = self.pos + 1;
+            if end < self.input.len()
+                && (self.input.as_bytes()[end] == b'+' || self.input.as_bytes()[end] == b'-')
+            {
+                end += 1;
+            }
+            if end < self.input.len() && self.input.as_bytes()[end].is_ascii_digit() {
+                while end < self.input.len() && self.input.as_bytes()[end].is_ascii_digit() {
+                    end += 1;
+                }
+                self.pos = end;
             }
         }
 

--- a/crates/bashkit/src/builtins/awk/tests.rs
+++ b/crates/bashkit/src/builtins/awk/tests.rs
@@ -409,6 +409,35 @@ async fn test_awk_field_assignment() {
     assert_eq!(result.stdout, "one new three\n");
 }
 
+// GH-2389: number lexer must not swallow a following +/- operator.
+#[tokio::test]
+async fn test_awk_unspaced_plus_minus_after_number() {
+    for (program, expected) in [
+        ("BEGIN{print 1+2}", "3\n"),
+        ("BEGIN{print 1+ 2}", "3\n"),
+        ("BEGIN{print 3-1}", "2\n"),
+        ("BEGIN{print 1e5+2}", "100002\n"),
+        // Exponents with explicit signs still lex as one token.
+        ("BEGIN{print 1e+5}", "100000\n"),
+        ("BEGIN{print 1.5e-3}", "0.0015\n"),
+        ("{print $1+$2}", "3\n"),
+    ] {
+        let input = if program.contains("$1") {
+            Some("1 2")
+        } else {
+            None
+        };
+        let result = run_awk(&[program], input).await.unwrap();
+        assert_eq!(result.stdout, expected, "program: {program}");
+    }
+    // Negative: a lone '.' is still not a number.
+    let err = run_awk(&["BEGIN{print .}"], None).await.unwrap_err();
+    assert!(
+        err.to_string().contains("invalid number"),
+        "unexpected: {err}"
+    );
+}
+
 #[tokio::test]
 async fn test_awk_csv_to_json_pattern() {
     // This is the pattern LLMs use for CSV→JSON conversion


### PR DESCRIPTION
## What changed

awk's number lexer no longer folds a following `+`/`-` into numeric literals. Unspaced arithmetic like `awk 'BEGIN{print 1+2}'` and `awk '{print $1+$2}'` now parses, while exponents with explicit signs (`1e+5`, `1.5e-3`) still lex as single tokens. A lone `.` is still rejected as an invalid number.

## Why

Fixes #2389. `+`/`-` are the two chars legal after `e`/`E`, and the old lexer consumed them unconditionally — turning `1+2` into one invalid token. Hard error (not wrong value), and unspaced `a+b` is the form LLMs reach for first, so agents burned extra calls before abandoning awk.

## Before / After

Before (`1+2` regression test fails: `awk: invalid number: 1+2`):

| expression | before | after |
| --- | --- | --- |
| `BEGIN{print 1+2}` | `invalid number: 1+2` | `3` |
| `BEGIN{print 1+ 2}` | `invalid number: 1+` | `3` |
| `BEGIN{print 3-1}` | `invalid number: 3-1` | `2` |
| `BEGIN{print 1e5+2}` | `invalid number: 1e5+2` | `100002` |
| `{print $1+$2}` on `1 2` | `invalid number: 1+` | `3` |
| `BEGIN{print 1e+5}` | `100000` | `100000` (unchanged) |
| `BEGIN{print 1.5e-3}` | `0.0015` | `0.0015` (unchanged) |

After verified end-to-end via CLI; outputs match system awk (`3 2 100002 100000 0.0015`). New `test_awk_unspaced_plus_minus_after_number` covers all rows plus a lone-dot negative case; full awk suite (105 tests) green, fmt + clippy clean.

## Risk

- Low. Change is confined to awk's `parse_number`; sibling lexers audited (`bc`, shell arithmetic, `expr`, `jq`) — none share the pattern.
- One local-only `just pre-pr` failure in `malformed_command_substitution_aborts_like_bash`, unrelated: it asserts on real system-bash output and this Mac ships bash 3.2 (`echo a$(|)b` prints `ab` here). CI on Linux is the arbiter.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered (no compat needed — internal code; behavior now matches real awk)

Closes #2389.

Produced by [yolop](https://everruns.com/yolop)