### PR TITLE
feat(bindings): add read-only filesystem mounts

### DIFF
--- a/crates/bashkit-js/__test__/runtime-extension.spec.ts
+++ b/crates/bashkit-js/__test__/runtime-extension.spec.ts
@@ -198,3 +198,83 @@ test("Bash: a mount+env+builtin bundle survives reset intact", async (t) => {
   t.is(result.exitCode, 0);
   t.is(result.stdout, "# my-skill\n# my-skill\n");
 });
+
+// ----------------------------------------------------------------------------
+// read-only FileSystem mounts (issue #2387)
+// ----------------------------------------------------------------------------
+
+test("Bash: read-only FileSystem mount serves reads but blocks writes", (t) => {
+  const data = new FileSystem();
+  data.writeFile("/report.txt", "revenue 40,200,000\n");
+
+  const bash = new Bash();
+  bash.mount("/corpus", data, true);
+  t.is(
+    bash.executeSync("cat /corpus/report.txt").stdout,
+    "revenue 40,200,000\n",
+  );
+
+  const overwrite = bash.executeSync(
+    "echo 'revenue 999' > /corpus/report.txt; echo rc=$?",
+  );
+  t.true(overwrite.stdout.includes("rc=1"));
+  t.is(
+    bash.executeSync("cat /corpus/report.txt").stdout,
+    "revenue 40,200,000\n",
+  );
+});
+
+test("Bash: read-only mount blocks mkdir/chmod and keeps /tmp writable", (t) => {
+  const data = new FileSystem();
+  data.writeFile("/report.txt", "revenue 40,200,000\n");
+
+  const bash = new Bash();
+  bash.mount("/corpus", data, true);
+  t.not(bash.executeSync("mkdir /corpus/newdir").exitCode, 0);
+  t.not(bash.executeSync("chmod 600 /corpus/report.txt").exitCode, 0);
+
+  const tmp = bash.executeSync("echo work > /tmp/work.txt && cat /tmp/work.txt");
+  t.is(tmp.exitCode, 0);
+  t.true(tmp.stdout.includes("work"));
+});
+
+test("Bash: read-only mount survives reset, default mount stays writable", (t) => {
+  const data = new FileSystem();
+  data.writeFile("/report.txt", "revenue 40,200,000\n");
+
+  const bash = new Bash();
+  bash.mount("/corpus", data, true);
+  bash.reset();
+  t.is(
+    bash.executeSync("cat /corpus/report.txt").stdout,
+    "revenue 40,200,000\n",
+  );
+  t.true(
+    bash.executeSync("echo x > /corpus/report.txt; echo rc=$?").stdout.includes("rc=1"),
+  );
+
+  const writable = new Bash();
+  const data2 = new FileSystem();
+  data2.writeFile("/report.txt", "revenue 40,200,000\n");
+  writable.mount("/corpus", data2);
+  t.is(
+    writable.executeSync("echo 'revenue 999' > /corpus/report.txt && cat /corpus/report.txt").exitCode,
+    0,
+  );
+});
+
+test("BashTool: read-only FileSystem mount blocks writes and survives reset", (t) => {
+  const data = new FileSystem();
+  data.writeFile("/report.txt", "revenue 40,200,000\n");
+
+  const tool = new BashTool();
+  tool.mount("/corpus", data, true);
+  t.is(
+    tool.executeSync("cat /corpus/report.txt").stdout,
+    "revenue 40,200,000\n",
+  );
+  tool.reset();
+  t.true(
+    tool.executeSync("echo x > /corpus/report.txt; echo rc=$?").stdout.includes("rc=1"),
+  );
+});

--- a/crates/bashkit-js/src/lib.rs
+++ b/crates/bashkit-js/src/lib.rs
@@ -21,7 +21,7 @@ use bashkit::{
     Bash as RustBash, BashTool as RustBashTool, Builtin, BuiltinContext, BuiltinRegistry,
     Credential, ExecResult as RustExecResult, ExecutionLimits, ExtFunctionResult,
     FileSystem as BashFileSystem, FileType, InMemoryFs, Metadata, MontyObject, NetworkAllowlist,
-    OutputCallback, PosixFs, PythonExternalFnHandler, RealFs, RealFsMode,
+    OutputCallback, PosixFs, PythonExternalFnHandler, ReadOnlyFs, RealFs, RealFsMode,
     ScriptedTool as RustScriptedTool, SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs,
     ToolDef, ToolRequest, async_trait,
 };
@@ -2441,9 +2441,28 @@ impl Bash {
     }
 
     /// Mount a filesystem handle without rebuilding the interpreter.
+    ///
+    /// With `read_only=true` the filesystem is wrapped in `ReadOnlyFs`: reads
+    /// keep working while mutations (and `chmod`) fail at the host layer, so
+    /// sandboxed code cannot rewrite the mounted tree. This is host-enforced
+    /// protection — POSIX mode bits remain metadata-only and are not enforced.
+    /// The recorded handle is the wrapped one, so `reset()` replays the
+    /// protection. The default (`read_only=false`/`None`) mounts writable.
     #[napi]
-    pub fn mount_file_system(&self, vfs_path: String, fs: Unknown<'_>) -> napi::Result<()> {
+    pub fn mount_file_system(
+        &self,
+        vfs_path: String,
+        fs: Unknown<'_>,
+        read_only: Option<bool>,
+    ) -> napi::Result<()> {
         let mounted_fs = import_external_file_system(fs)?;
+        // Host-enforced read-only projection; the recorded handle is the
+        // wrapped one, so `reset()` replays the protection.
+        let mounted_fs: Arc<dyn BashFileSystem> = if read_only.unwrap_or(false) {
+            Arc::new(ReadOnlyFs::new(mounted_fs))
+        } else {
+            mounted_fs
+        };
         block_on_with(&self.state, |s| async move {
             let bash = s.inner.lock().await;
             bash.mount(Path::new(&vfs_path), Arc::clone(&mounted_fs))
@@ -3120,9 +3139,28 @@ impl BashTool {
     }
 
     /// Mount a filesystem handle without rebuilding the interpreter.
+    ///
+    /// With `read_only=true` the filesystem is wrapped in `ReadOnlyFs`: reads
+    /// keep working while mutations (and `chmod`) fail at the host layer, so
+    /// sandboxed code cannot rewrite the mounted tree. This is host-enforced
+    /// protection — POSIX mode bits remain metadata-only and are not enforced.
+    /// The recorded handle is the wrapped one, so `reset()` replays the
+    /// protection. The default (`read_only=false`/`None`) mounts writable.
     #[napi]
-    pub fn mount_file_system(&self, vfs_path: String, fs: Unknown<'_>) -> napi::Result<()> {
+    pub fn mount_file_system(
+        &self,
+        vfs_path: String,
+        fs: Unknown<'_>,
+        read_only: Option<bool>,
+    ) -> napi::Result<()> {
         let mounted_fs = import_external_file_system(fs)?;
+        // Host-enforced read-only projection; the recorded handle is the
+        // wrapped one, so `reset()` replays the protection.
+        let mounted_fs: Arc<dyn BashFileSystem> = if read_only.unwrap_or(false) {
+            Arc::new(ReadOnlyFs::new(mounted_fs))
+        } else {
+            mounted_fs
+        };
         block_on_with(&self.state, |s| async move {
             let bash = s.inner.lock().await;
             bash.mount(Path::new(&vfs_path), Arc::clone(&mounted_fs))

--- a/crates/bashkit-js/wrapper.ts
+++ b/crates/bashkit-js/wrapper.ts
@@ -1320,19 +1320,31 @@ export class Bash {
     return FileSystem.fromNative(this.native.fs());
   }
 
-  mount(vfsPath: string, fs: FileSystem): void;
+  mount(vfsPath: string, fs: FileSystem, readOnly?: boolean): void;
   mount(hostPath: string, vfsPath: string, writable?: boolean): void;
-  /** Mount either a host directory or a FileSystem into the VFS. */
+  /**
+   * Mount either a host directory or a FileSystem into the VFS.
+   *
+   * With `readOnly=true` a FileSystem is wrapped in `ReadOnlyFs`: reads keep
+   * working while mutations (and `chmod`) fail at the host layer, so
+   * sandboxed code cannot rewrite the mounted tree. This is host-enforced
+   * protection — POSIX mode bits remain metadata-only and are not enforced.
+   * Recorded, so `reset()` replays the protection. Default mounts writable.
+   */
   mount(
     hostPathOrVfsPath: string,
     vfsPathOrFs: string | FileSystem,
-    writable?: boolean,
+    writableOrReadOnly?: boolean,
   ): void {
     if (isFileSystemLike(vfsPathOrFs)) {
-      this.native.mountFileSystem(hostPathOrVfsPath, vfsPathOrFs.toExternal());
+      this.native.mountFileSystem(
+        hostPathOrVfsPath,
+        vfsPathOrFs.toExternal(),
+        writableOrReadOnly,
+      );
       return;
     }
-    this.native.mount(hostPathOrVfsPath, vfsPathOrFs, writable);
+    this.native.mount(hostPathOrVfsPath, vfsPathOrFs, writableOrReadOnly);
   }
 
   /** Unmount a previously mounted filesystem. */
@@ -1792,19 +1804,31 @@ export class BashTool {
     return FileSystem.fromNative(this.native.fs());
   }
 
-  mount(vfsPath: string, fs: FileSystem): void;
+  mount(vfsPath: string, fs: FileSystem, readOnly?: boolean): void;
   mount(hostPath: string, vfsPath: string, writable?: boolean): void;
-  /** Mount either a host directory or a FileSystem into the VFS. */
+  /**
+   * Mount either a host directory or a FileSystem into the VFS.
+   *
+   * With `readOnly=true` a FileSystem is wrapped in `ReadOnlyFs`: reads keep
+   * working while mutations (and `chmod`) fail at the host layer, so
+   * sandboxed code cannot rewrite the mounted tree. This is host-enforced
+   * protection — POSIX mode bits remain metadata-only and are not enforced.
+   * Recorded, so `reset()` replays the protection. Default mounts writable.
+   */
   mount(
     hostPathOrVfsPath: string,
     vfsPathOrFs: string | FileSystem,
-    writable?: boolean,
+    writableOrReadOnly?: boolean,
   ): void {
     if (isFileSystemLike(vfsPathOrFs)) {
-      this.native.mountFileSystem(hostPathOrVfsPath, vfsPathOrFs.toExternal());
+      this.native.mountFileSystem(
+        hostPathOrVfsPath,
+        vfsPathOrFs.toExternal(),
+        writableOrReadOnly,
+      );
       return;
     }
-    this.native.mount(hostPathOrVfsPath, vfsPathOrFs, writable);
+    this.native.mount(hostPathOrVfsPath, vfsPathOrFs, writableOrReadOnly);
   }
 
   /** Unmount a previously mounted filesystem. */

--- a/crates/bashkit-python/bashkit/_bashkit.pyi
+++ b/crates/bashkit-python/bashkit/_bashkit.pyi
@@ -903,12 +903,19 @@ class Bash:
         """
         ...
 
-    def mount(self, vfs_path: str, fs: FileSystem) -> None:
+    def mount(self, vfs_path: str, fs: FileSystem, *, read_only: bool = ...) -> None:
         """Mount an external filesystem at the given VFS path.
+
+        With ``read_only=True`` the filesystem is wrapped in ``ReadOnlyFs``:
+        reads keep working while mutations (and ``chmod``) fail at the host
+        layer. This is host-enforced protection — POSIX mode bits remain
+        metadata-only and are not enforced. Recorded, so ``reset()`` replays
+        the protection. The default (``read_only=False``) mounts writable.
 
         Args:
             vfs_path: Mount point inside the VFS.
             fs: FileSystem instance to mount.
+            read_only: Mount read-only via ``ReadOnlyFs``.
 
         Example::
 
@@ -1500,8 +1507,14 @@ class BashTool:
         """
         ...
 
-    def mount(self, vfs_path: str, fs: FileSystem) -> None:
+    def mount(self, vfs_path: str, fs: FileSystem, *, read_only: bool = ...) -> None:
         """Mount an external filesystem at the given VFS path.
+
+        With ``read_only=True`` the filesystem is wrapped in ``ReadOnlyFs``:
+        reads keep working while mutations (and ``chmod``) fail at the host
+        layer. This is host-enforced protection — POSIX mode bits remain
+        metadata-only and are not enforced. Recorded, so ``reset()`` replays
+        the protection. The default (``read_only=False``) mounts writable.
 
         Example::
 

--- a/crates/bashkit-python/src/lib.rs
+++ b/crates/bashkit-python/src/lib.rs
@@ -26,8 +26,9 @@ use bashkit::{
     ExecutionLimits, ExtFunctionResult, FileSystem, FileSystemExt, FileType as FsFileType,
     FsLimits, InMemoryFs, Metadata as FsMetadata, MontyException, MontyObject, NetworkAllowlist,
     OutputCallback as RustOutputCallback, OverlayFs, PosixFs, PythonExternalFnHandler,
-    PythonLimits, ScriptedTool as RustScriptedTool, ShellStateView as RustShellStateView,
-    SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs, ToolDef, ToolRequest, async_trait,
+    PythonLimits, ReadOnlyFs, ScriptedTool as RustScriptedTool,
+    ShellStateView as RustShellStateView, SnapshotOptions as RustSnapshotOptions, Tool, ToolArgs,
+    ToolDef, ToolRequest, async_trait,
 };
 
 /// Typed named execution-policy selector for Python constructors.
@@ -5426,7 +5427,20 @@ impl PyBash {
     /// Mount a filesystem at `vfs_path` without rebuilding the interpreter.
     ///
     /// Recorded, so `reset()` replays it — see `runtime_mounts`.
-    fn mount(&self, py: Python<'_>, vfs_path: String, fs: PyRef<'_, PyFileSystem>) -> PyResult<()> {
+    ///
+    /// With `read_only=True` the filesystem is wrapped in `ReadOnlyFs`: reads
+    /// keep working while mutations (and `chmod`) fail at the host layer, so
+    /// sandboxed code cannot rewrite the mounted tree. This is host-enforced
+    /// protection — POSIX mode bits remain metadata-only and are not enforced.
+    /// The default (`read_only=False`) mounts writable.
+    #[pyo3(signature = (vfs_path, fs, *, read_only=false))]
+    fn mount(
+        &self,
+        py: Python<'_>,
+        vfs_path: String,
+        fs: PyRef<'_, PyFileSystem>,
+        read_only: bool,
+    ) -> PyResult<()> {
         self.reject_external_handler_reentry()?;
         let inner = self.inner.clone();
         let source = fs.inner.clone();
@@ -5434,6 +5448,13 @@ impl PyBash {
         py.detach(|| {
             self.rt.block_on(async move {
                 let mounted_fs = source.resolve().await?;
+                // Host-enforced read-only projection: the recorded handle is the
+                // wrapped one, so `reset()` replays the protection.
+                let mounted_fs: Arc<dyn FileSystem> = if read_only {
+                    Arc::new(ReadOnlyFs::new(mounted_fs))
+                } else {
+                    mounted_fs
+                };
                 let bash = inner.lock().await;
                 bash.mount(Path::new(&vfs_path), Arc::clone(&mounted_fs))
                     .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
@@ -6282,13 +6303,33 @@ impl BashTool {
     /// Mount a filesystem at `vfs_path` without rebuilding the interpreter.
     ///
     /// Recorded, so `reset()` replays it — see `runtime_mounts`.
-    fn mount(&self, py: Python<'_>, vfs_path: String, fs: PyRef<'_, PyFileSystem>) -> PyResult<()> {
+    ///
+    /// With `read_only=True` the filesystem is wrapped in `ReadOnlyFs`: reads
+    /// keep working while mutations (and `chmod`) fail at the host layer, so
+    /// sandboxed code cannot rewrite the mounted tree. This is host-enforced
+    /// protection — POSIX mode bits remain metadata-only and are not enforced.
+    /// The default (`read_only=False`) mounts writable.
+    #[pyo3(signature = (vfs_path, fs, *, read_only=false))]
+    fn mount(
+        &self,
+        py: Python<'_>,
+        vfs_path: String,
+        fs: PyRef<'_, PyFileSystem>,
+        read_only: bool,
+    ) -> PyResult<()> {
         let inner = self.inner.clone();
         let source = fs.inner.clone();
         let runtime_mounts = self.runtime_mounts.clone();
         py.detach(|| {
             self.rt.block_on(async move {
                 let mounted_fs = source.resolve().await?;
+                // Host-enforced read-only projection: the recorded handle is the
+                // wrapped one, so `reset()` replays the protection.
+                let mounted_fs: Arc<dyn FileSystem> = if read_only {
+                    Arc::new(ReadOnlyFs::new(mounted_fs))
+                } else {
+                    mounted_fs
+                };
                 let bash = inner.lock().await;
                 bash.mount(Path::new(&vfs_path), Arc::clone(&mounted_fs))
                     .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;

--- a/crates/bashkit-python/tests/test_readonly_mounts.py
+++ b/crates/bashkit-python/tests/test_readonly_mounts.py
@@ -1,0 +1,76 @@
+"""Read-only corpus mounts (issue #2387).
+
+A FileSystem mounted with read_only=True is a read-only projection: reads
+work, mutations and chmod fail, /tmp stays writable, and the protection
+survives reset(). The default stays writable.
+"""
+
+import pytest
+
+from bashkit import Bash, BashTool, FileSystem
+
+
+def make_corpus():
+    fs = FileSystem()
+    fs.write_file("/report.txt", b"revenue 40,200,000\n")
+    return fs
+
+
+def test_bash_read_only_mount_reads():
+    bash = Bash()
+    bash.mount("/corpus", make_corpus(), read_only=True)
+    r = bash.execute_sync("cat /corpus/report.txt")
+    assert r.exit_code == 0
+    assert "40,200,000" in r.stdout
+
+
+def test_bash_read_only_mount_blocks_overwrite():
+    bash = Bash()
+    bash.mount("/corpus", make_corpus(), read_only=True)
+    r = bash.execute_sync("echo 'revenue 999' > /corpus/report.txt; echo rc=$?")
+    assert "rc=1" in r.stdout
+    assert bash.execute_sync("cat /corpus/report.txt").stdout == "revenue 40,200,000\n"
+
+
+def test_bash_read_only_mount_blocks_mkdir_and_chmod():
+    bash = Bash()
+    bash.mount("/corpus", make_corpus(), read_only=True)
+    assert bash.execute_sync("mkdir /corpus/newdir").exit_code != 0
+    with pytest.raises(Exception):
+        bash.chmod("/corpus/report.txt", 0o600)
+
+
+def test_bash_read_only_mount_keeps_tmp_writable():
+    bash = Bash()
+    bash.mount("/corpus", make_corpus(), read_only=True)
+    r = bash.execute_sync("echo work > /tmp/work.txt && cat /tmp/work.txt")
+    assert r.exit_code == 0
+    assert "work" in r.stdout
+
+
+def test_bash_read_only_mount_survives_reset():
+    bash = Bash()
+    bash.mount("/corpus", make_corpus(), read_only=True)
+    bash.reset()
+    assert bash.execute_sync("cat /corpus/report.txt").stdout == "revenue 40,200,000\n"
+    r = bash.execute_sync("echo 'revenue 999' > /corpus/report.txt; echo rc=$?")
+    assert "rc=1" in r.stdout
+
+
+def test_bash_default_mount_stays_writable():
+    bash = Bash()
+    bash.mount("/corpus", make_corpus())
+    r = bash.execute_sync("echo 'revenue 999' > /corpus/report.txt && cat /corpus/report.txt")
+    assert r.exit_code == 0
+    assert "revenue 999" in r.stdout
+
+
+def test_tool_read_only_mount():
+    tool = BashTool()
+    tool.mount("/corpus", make_corpus(), read_only=True)
+    assert tool.execute_sync("cat /corpus/report.txt").stdout == "revenue 40,200,000\n"
+    r = tool.execute_sync("echo 'revenue 999' > /corpus/report.txt; echo rc=$?")
+    assert "rc=1" in r.stdout
+    tool.reset()
+    r = tool.execute_sync("echo 'revenue 999' > /corpus/report.txt; echo rc=$?")
+    assert "rc=1" in r.stdout

--- a/crates/bashkit/docs/live_mounts.md
+++ b/crates/bashkit/docs/live_mounts.md
@@ -68,6 +68,26 @@ bash.mount("/mnt/data", fs)?;
 
 **Errors:** Returns `Err` if `vfs_path` is not absolute (after normalization).
 
+### Read-only mounts (Python and Node bindings)
+
+The Python and Node bindings expose a per-mount `read_only` / `readOnly`
+flag on `mount()` (both `Bash` and the agent tool surface). A read-only
+mount wraps the mounted filesystem in [`ReadOnlyFs`]: reads keep working
+while mutations — shell redirections, `cp`, `mv`, `mkdir`, `rm` — and
+`chmod` fail at the host layer, so sandboxed code cannot rewrite a mounted
+corpus. `/tmp` and the rest of the VFS stay writable. The recorded handle
+is the wrapped one, so `reset()` replays the protection.
+
+```python
+corpus = FileSystem()
+corpus.write_file("/report.txt", b"revenue 40,200,000\n")
+bash.mount("/corpus", corpus, read_only=True)
+```
+
+This is host-enforced protection: POSIX mode bits remain metadata-only and
+are *not* enforced — `chmod 444` alone does not stop a write. Use the
+`read_only` flag for projections nothing inside the sandbox may rewrite.
+
 ### `Bash::unmount(vfs_path)`
 
 Removes the mount at `vfs_path`. Paths that previously resolved to the mounted

--- a/knowledge/foundations/vfs.md
+++ b/knowledge/foundations/vfs.md
@@ -89,6 +89,11 @@ Do you need a custom filesystem?
   with `PermissionDenied`
 - Useful for inspection-only tool sessions where even in-memory writes to
   `/tmp`, redirections, `cp`, `mv`, `mkdir`, `rm`, and `chmod` must fail
+- Python `Bash.mount()` / `BashTool.mount()` and Node `mount()` accept a
+  per-mount `read_only` / `readOnly` flag (default writable) that wraps the
+  mounted tree in `ReadOnlyFs`; the recorded handle is the wrapped one so
+  `reset()` replays the protection. Host-enforced: POSIX mode bits remain
+  metadata-only and are not enforced — `chmod 444` alone does not stop a write.
 
 #### RealFs (Optional, `realfs` feature)
 - Direct access to a host directory as an `FsBackend`

--- a/site/src/content/apidocs/python.md
+++ b/site/src/content/apidocs/python.md
@@ -493,15 +493,22 @@ b'hello\n'
 ### `mount`
 
 ```python
-Bash.mount(vfs_path: str, fs: FileSystem) -> None
+Bash.mount(vfs_path: str, fs: FileSystem, read_only: bool = ...) -> None
 ```
 
 Mount an external filesystem at the given VFS path.
+
+With ``read_only=True`` the filesystem is wrapped in ``ReadOnlyFs``:
+reads keep working while mutations (and ``chmod``) fail at the host
+layer. This is host-enforced protection — POSIX mode bits remain
+metadata-only and are not enforced. Recorded, so ``reset()`` replays
+the protection. The default (``read_only=False``) mounts writable.
 
 **Parameters:**
 
 - **`vfs_path`** — Mount point inside the VFS.
 - **`fs`** — FileSystem instance to mount.
+- **`read_only`** — Mount read-only via ``ReadOnlyFs``.
 
 Example:
 
@@ -1073,10 +1080,16 @@ b'data\n'
 ### `mount`
 
 ```python
-BashTool.mount(vfs_path: str, fs: FileSystem) -> None
+BashTool.mount(vfs_path: str, fs: FileSystem, read_only: bool = ...) -> None
 ```
 
 Mount an external filesystem at the given VFS path.
+
+With ``read_only=True`` the filesystem is wrapped in ``ReadOnlyFs``:
+reads keep working while mutations (and ``chmod``) fail at the host
+layer. This is host-enforced protection — POSIX mode bits remain
+metadata-only and are not enforced. Recorded, so ``reset()`` replays
+the protection. The default (``read_only=False``) mounts writable.
 
 Example:
 


### PR DESCRIPTION
Closes #2387. Read-only corpus mounts for agent workflows: nothing inside the sandbox can rewrite the mounted tree.

- Python `Bash.mount()`/`BashTool.mount()` gain `read_only=True`; Node `mount()` gains `readOnly` for FileSystem handles. Either wraps the mounted tree in the existing Rust `ReadOnlyFs`. Default stays writable.
- Reads work; mutations (shell redirections, `cp`/`mv`/`mkdir`/`rm`) and `chmod` fail at the host layer; `/tmp` stays writable.
- The recorded handle is the wrapped one, so `reset()` replays the protection.
- Documented as host-enforced protection: POSIX mode bits remain metadata-only (`chmod 444` alone never stopped a write).

Before / After (issue repro, now with a read-only corpus mount):

```python
bash.mount("/corpus", corpus, read_only=True)
bash.execute_sync("echo 'revenue 999' > /corpus/report.txt; echo rc=$?")
# before: rc=0, file rewritten. after: rc=1, content unchanged.
```

Proof: 7 new Python tests (`test_readonly_mounts.py`) pass; 4 new Node tests in `runtime-extension.spec.ts` pass (20/20 file, 456/456 suite); existing mount/security/tool suites green; clippy/fmt/ruff/tsc/`check-okf`/`check-doc-links` clean.

Produced by [yolop](https://everruns.com/yolop)
