### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,20 @@
 
 ### Highlights
 
-- **Read-only filesystem mounts for host bindings.** Hosts can share directories with
-  sandboxed scripts without granting write access, tightening the default posture for
-  filesystem-backed tools.
-- **Host-directory mounts over the C ABI.** Native hosts can expose host directories
-  through the versioned C interface, bringing C embeddings to parity with other
-  bindings.
-- **Targeted correctness fixes** across `awk`, the Windows filesystem backend, `sqlite`
-  progress accounting, and the `uutils` coreutils sync.
+- **Faster ported coreutils builtins.** Ported coreutils builtins reuse pre-built clap
+  `Command` definitions instead of rebuilding them per invocation
+  ([#2347](https://github.com/everruns/bashkit/pull/2347)).
+- **Security hardening.** The Rust update takes `russh` 0.63.1 security fixes
+  ([#2365](https://github.com/everruns/bashkit/pull/2365)), `sqlite` budgets account
+  for work performed inside a single engine step (TM-SQL-014)
+  ([#2369](https://github.com/everruns/bashkit/pull/2369)), the host-environment hole
+  in builtins is closed
+  ([#2385](https://github.com/everruns/bashkit/pull/2385)), and `tabled` 0.22 retires
+  RUSTSEC-2026-0173
+  ([#2379](https://github.com/everruns/bashkit/pull/2379)).
+- **C ABI improvements.** The C ABI exposes host-directory mounts, bringing native
+  embeddings to parity with other host bindings
+  ([#2371](https://github.com/everruns/bashkit/pull/2371)).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,46 @@
 # Changelog
 
-## [Unreleased]
+## [0.18.0] - 2026-09-10
+
+### Highlights
+
+- **Read-only filesystem mounts for host bindings.** Hosts can share directories with
+  sandboxed scripts without granting write access, tightening the default posture for
+  filesystem-backed tools.
+- **Host-directory mounts over the C ABI.** Native hosts can expose host directories
+  through the versioned C interface, bringing C embeddings to parity with other
+  bindings.
+- **Targeted correctness fixes** across `awk`, the Windows filesystem backend, `sqlite`
+  progress accounting, and the `uutils` coreutils sync.
+
+### Added
+
+- Bindings now support read-only filesystem mounts, so hosts can share directories with
+  sandboxed scripts without granting write access
+  ([#2393](https://github.com/everruns/bashkit/pull/2393))
+- The C ABI exposes host-directory mounts, bringing native embeddings to parity with
+  other host bindings
+  ([#2371](https://github.com/everruns/bashkit/pull/2371))
 
 ### Fixed
 
-- Host calls enforce execution deadlines while parked.
-- Runtime mounts use canonical replay keys across binding rebuilds.
-- SQLite budgets account for work within a single engine step.
-- Documentation preserves inline SVG diagrams during Markdown rendering.
+- Host calls enforce execution deadlines while parked
+  ([#2349](https://github.com/everruns/bashkit/pull/2349)).
+- Runtime mounts use canonical replay keys across binding rebuilds
+  ([#2366](https://github.com/everruns/bashkit/pull/2366)).
+- SQLite budgets account for work within a single engine step
+  ([#2369](https://github.com/everruns/bashkit/pull/2369)).
+- Rust dependency update takes `russh` 0.63.1 security fixes
+  ([#2365](https://github.com/everruns/bashkit/pull/2365)).
+- Documentation preserves inline SVG diagrams during Markdown rendering
+  ([#2368](https://github.com/everruns/bashkit/pull/2368)).
+- The `awk` number lexer no longer swallows a following `+`/`-` operator
+  ([#2392](https://github.com/everruns/bashkit/pull/2392)).
+- `RealFs` sets mtime with `FILE_WRITE_ATTRIBUTES` on Windows so read-only files keep
+  updatable timestamps
+  ([#2391](https://github.com/everruns/bashkit/pull/2391)).
+- Synced `uutils` coreutils drift and closed the host-environment hole in builtins
+  ([#2385](https://github.com/everruns/bashkit/pull/2385)).
 - CI's aggregate check includes WASM validation, and secret-backed examples
   fetch scoped API keys in separate steps that end before repository code runs.
 - Browser persistence preserves the previous save when directory traversal fails.
@@ -29,6 +62,44 @@
   green CI and merge, including common misspellings.
 - Refresh benchmark baselines; select a supported Bash from `PATH` and record
   its version instead of silently using macOS's obsolete system shell.
+- README lists Java and Elixir community bindings
+  ([#2390](https://github.com/everruns/bashkit/pull/2390)).
+
+### What's Changed
+
+* fix(host-call): enforce the execution deadline while parked by @chaliy in #2349
+* chore(ci): bump taiki-e/install-action from 2.86.3 to 2.86.5 in the github-actions group by @app/dependabot in #2354
+* chore(deps): bump @langchain/core from 1.2.8 to 1.2.9 in /crates/bashkit-js in the js-npm group by @app/dependabot in #2350
+* chore(deps): bump the site-npm group in /site with 3 updates by @app/dependabot in #2352
+* chore(deps): bump the examples-npm group across 2 directories with 6 updates by @app/dependabot in #2353
+* chore(deps): bump wasmtime from 47.0.4 to 48.0.0 in /examples/hyperlight/host in the example-cargo group across 1 directory by @app/dependabot in #2355
+* chore(deps): bump turso_core from 0.8.0-pre.4 to 0.8.0-pre.7 by @chaliy in #2356
+* chore(deps): move chacha20 off yanked 0.10.1 by @chaliy in #2357
+* chore(security): record why the rsa advisory suppression stops matching by @app/claude in #2358
+* chore(deps): bump the js-npm group in /crates/bashkit-js with 2 updates by @app/dependabot in #2359
+* chore(deps): bump the site-npm group in /site with 3 updates by @app/dependabot in #2361
+* chore(deps): bump the examples-npm group across 1 directory with 4 updates by @app/dependabot in #2362
+* chore(ci): bump taiki-e/install-action from 2.86.5 to 2.87.0 in the github-actions group by @app/dependabot in #2363
+* chore(deps): bump the example-cargo group across 2 directories with 3 updates by @app/dependabot in #2364
+* fix(deps): bump rust-dependencies group, taking russh 0.63.1 security fixes by @chaliy in #2365
+* fix(bindings): canonicalize runtime mount replay keys by @chaliy in #2366
+* fix(sqlite): count work performed inside a single engine step (TM-SQL-014) by @chaliy in #2369
+* fix(docs): render inline SVG diagrams correctly by @chaliy in #2368
+* chore(bench): add vm-linux-x86_64 benchmark run 2026-09-02 by @chaliy in #2370
+* feat(capi): expose host-directory mounts over the C ABI by @tersePrompts in #2371
+* chore(maintenance): refresh dependencies and resolve security findings by @chaliy in #2378
+* chore(deps): upgrade tabled to 0.22 and retire RUSTSEC-2026-0173 by @chaliy in #2379
+* chore(ci): bump the github-actions group with 2 updates by @app/dependabot in #2383
+* chore(deps): bump the example-cargo group across 1 directory with 3 updates by @app/dependabot in #2384
+* chore(deps): bump the examples-npm group across 1 directory with 3 updates by @app/dependabot in #2382
+* fix(builtins): sync uutils coreutils drift and close host-env hole by @chaliy in #2385
+* chore(deps): stop dependabot reopening the unbuildable get-size2 bump by @chaliy in #2386
+* docs(readme): add Java and Elixir community bindings by @chaliy in #2390
+* fix(fs): set RealFs mtime with FILE_WRITE_ATTRIBUTES on Windows by @chaliy in #2391
+* fix(awk): stop number lexer swallowing following +/- operators by @chaliy in #2392
+* feat(bindings): add read-only filesystem mounts by @chaliy in #2393
+
+**Full Changelog**: https://github.com/everruns/bashkit/compare/v0.17.1...v0.18.0
 
 ## [0.17.1] - 2026-08-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bashkit"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-bench"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-capi"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "bashkit",
  "serde",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-cli"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bashkit",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-coreutils-port"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-eval"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-js"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "bashkit",
  "napi",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-python"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "bashkit",
  "num-bigint 0.4.8",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "bashkit-wasm"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "bashkit",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.17.1"
+version = "0.18.0"
 edition = "2024"
 license = "MIT"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns"]

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Enable the `sqlite` feature to embed [Turso](https://github.com/tursodatabase/tu
 
 ```toml
 [dependencies]
-bashkit = { version = "0.17.1", features = ["sqlite"] }
+bashkit = { version = "0.18.0", features = ["sqlite"] }
 ```
 
 ```rust

--- a/crates/bashkit-cli/Cargo.toml
+++ b/crates/bashkit-cli/Cargo.toml
@@ -37,7 +37,7 @@ interactive = ["dep:rustyline", "dep:terminal_size", "dep:signal-hook"]
 # `tzdata` is listed explicitly: an interactive shell must keep honouring
 # named `TZ=` zones in `date`, which stopped being implied when chrono-tz
 # moved behind a feature.
-bashkit = { path = "../bashkit", version = "0.17.1", default-features = false, features = ["http_client", "ring", "git", "jq", "tzdata"] }
+bashkit = { path = "../bashkit", version = "0.18.0", default-features = false, features = ["http_client", "ring", "git", "jq", "tzdata"] }
 tokio = { workspace = true, features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/bashkit-js/package.json
+++ b/crates/bashkit-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Sandboxed bash interpreter for JavaScript/TypeScript",
   "packageManager": "pnpm@10.33.0",
   "main": "wrapper.js",

--- a/crates/bashkit-wasm/package.json
+++ b/crates/bashkit-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@everruns/bashkit-wasm",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "Sandboxed bash interpreter for the browser (WebAssembly). Single-threaded — no SharedArrayBuffer, no COOP/COEP headers.",
   "type": "module",
   "main": "index.js",

--- a/crates/bashkit/docs/logging.md
+++ b/crates/bashkit/docs/logging.md
@@ -14,7 +14,7 @@ Add the `logging` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.17.1", features = ["logging"] }
+bashkit = { version = "0.18.0", features = ["logging"] }
 tracing-subscriber = "0.3"  # or your preferred subscriber
 ```
 

--- a/crates/bashkit/docs/sqlite.md
+++ b/crates/bashkit/docs/sqlite.md
@@ -13,7 +13,7 @@ the `sqlite` feature. The engine is [Turso](https://github.com/tursodatabase/tur
 
 ```toml
 # Cargo.toml
-bashkit = { version = "0.17.1", features = ["sqlite"] }
+bashkit = { version = "0.18.0", features = ["sqlite"] }
 ```
 
 ```rust,ignore

--- a/crates/bashkit/src/lib.rs
+++ b/crates/bashkit/src/lib.rs
@@ -322,7 +322,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.17.1", features = ["git"] }
+//! bashkit = { version = "0.18.0", features = ["git"] }
 //! ```
 //!
 //! ```rust,ignore
@@ -353,7 +353,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! bashkit = { version = "0.17.1", features = ["python"] }
+//! bashkit = { version = "0.18.0", features = ["python"] }
 //! ```
 //!
 //! ```rust,ignore

--- a/docs/builtin_typescript.md
+++ b/docs/builtin_typescript.md
@@ -12,7 +12,7 @@ Add the `typescript` feature to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-bashkit = { version = "0.17.1", features = ["typescript"] }
+bashkit = { version = "0.18.0", features = ["typescript"] }
 ```
 
 Enable TypeScript in the builder:


### PR DESCRIPTION
## What changed
Release preparation for v0.18.0: version bumped to 0.18.0 across Cargo workspace, JS/WASM packages, and doc examples; CHANGELOG entry with Highlights, Added, Fixed, Changed, and What's Changed for the 31 PRs since v0.17.1.

Headliners: read-only filesystem mounts for host bindings (#2393) and host-directory mounts over the C ABI (#2371), plus targeted correctness fixes (awk lexer #2392, Windows RealFs mtime #2391, uutils drift #2385, sqlite budgeting #2369, SVG docs #2368, russh 0.63.1 #2365).

## Why
Monthly minor release per release process.

## Before / After
No runtime behavior change in this PR itself — version metadata + changelog only. `just release-check` running as the gate.

## Risk
- Low: version strings and changelog prose only.

## Checklist
- [x] Changelog entry added
- [x] Version bumped (Cargo, JS/WASM, docs)
- [ ] `just release-check` green
